### PR TITLE
feat(web): add dashboard layout and navigation

### DIFF
--- a/apps/web/__tests__/components/layout/dashboard-layout.test.tsx
+++ b/apps/web/__tests__/components/layout/dashboard-layout.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests for the Dashboard Layout component.
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ */
+
+import { render, screen } from "@testing-library/react";
+import { DashboardLayout } from "../../../src/components/layout/dashboard-layout";
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(() => "/dashboard"),
+}));
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+describe("DashboardLayout", () => {
+  it("renders children content", () => {
+    render(
+      <DashboardLayout>
+        <div data-testid="test-content">Test Content</div>
+      </DashboardLayout>
+    );
+
+    expect(screen.getByTestId("test-content")).toBeInTheDocument();
+    expect(screen.getByText("Test Content")).toBeInTheDocument();
+  });
+
+  it("renders the sidebar", () => {
+    render(
+      <DashboardLayout>
+        <div>Content</div>
+      </DashboardLayout>
+    );
+
+    // Sidebar should have navigation items
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Daily Briefs")).toBeInTheDocument();
+  });
+
+  it("renders the header", () => {
+    render(
+      <DashboardLayout>
+        <div>Content</div>
+      </DashboardLayout>
+    );
+
+    // Header should have account button
+    expect(screen.getByText("Account")).toBeInTheDocument();
+  });
+
+  it("applies correct layout structure", () => {
+    const { container } = render(
+      <DashboardLayout>
+        <div>Content</div>
+      </DashboardLayout>
+    );
+
+    // Should have the main container with dark background
+    const mainContainer = container.firstChild;
+    expect(mainContainer).toHaveClass("min-h-screen", "bg-slate-950");
+  });
+});

--- a/apps/web/__tests__/components/layout/header.test.tsx
+++ b/apps/web/__tests__/components/layout/header.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for the Header component.
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Header } from "../../../src/components/layout/header";
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(() => "/dashboard"),
+}));
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+describe("Header", () => {
+  it("renders the mobile logo", () => {
+    render(<Header />);
+    expect(screen.getByText("GlycemicGPT")).toBeInTheDocument();
+  });
+
+  it("renders the account button", () => {
+    render(<Header />);
+    expect(screen.getByText("Account")).toBeInTheDocument();
+  });
+
+  it("opens user menu when account button is clicked", () => {
+    render(<Header />);
+    const accountButton = screen.getByText("Account").closest("button");
+
+    fireEvent.click(accountButton!);
+
+    // Menu should now be visible
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("Sign out")).toBeInTheDocument();
+  });
+
+  it("has a settings link in the user menu", () => {
+    render(<Header />);
+    const accountButton = screen.getByText("Account").closest("button");
+
+    fireEvent.click(accountButton!);
+
+    const settingsLink = screen.getByText("Settings").closest("a");
+    expect(settingsLink).toHaveAttribute("href", "/dashboard/settings");
+  });
+
+  it("closes user menu when clicking outside", () => {
+    render(<Header />);
+    const accountButton = screen.getByText("Account").closest("button");
+
+    // Open menu
+    fireEvent.click(accountButton!);
+    expect(screen.getByText("Sign out")).toBeInTheDocument();
+
+    // Click outside (simulate by clicking on the header itself)
+    fireEvent.mouseDown(document.body);
+
+    // Menu should be closed
+    expect(screen.queryByText("Sign out")).not.toBeInTheDocument();
+  });
+
+  it("has aria-expanded attribute on account button", () => {
+    render(<Header />);
+    const accountButton = screen.getByText("Account").closest("button");
+
+    expect(accountButton).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(accountButton!);
+
+    expect(accountButton).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/apps/web/__tests__/components/layout/sidebar.test.tsx
+++ b/apps/web/__tests__/components/layout/sidebar.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Tests for the Sidebar Navigation component.
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Sidebar, MobileNav } from "../../../src/components/layout/sidebar";
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(() => "/dashboard"),
+}));
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+describe("Sidebar", () => {
+  it("renders the logo", () => {
+    render(<Sidebar />);
+    expect(screen.getByText("GlycemicGPT")).toBeInTheDocument();
+  });
+
+  it("renders all navigation items", () => {
+    render(<Sidebar />);
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Daily Briefs")).toBeInTheDocument();
+    expect(screen.getByText("Alerts")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("renders navigation links with correct hrefs", () => {
+    render(<Sidebar />);
+    expect(screen.getByText("Dashboard").closest("a")).toHaveAttribute(
+      "href",
+      "/dashboard"
+    );
+    expect(screen.getByText("Daily Briefs").closest("a")).toHaveAttribute(
+      "href",
+      "/dashboard/briefs"
+    );
+    expect(screen.getByText("Alerts").closest("a")).toHaveAttribute(
+      "href",
+      "/dashboard/alerts"
+    );
+    expect(screen.getByText("Settings").closest("a")).toHaveAttribute(
+      "href",
+      "/dashboard/settings"
+    );
+  });
+
+  it("displays 'Not medical advice' footer", () => {
+    render(<Sidebar />);
+    expect(screen.getByText("Not medical advice")).toBeInTheDocument();
+  });
+
+  it("highlights the active navigation item", () => {
+    render(<Sidebar />);
+    const dashboardLink = screen.getByText("Dashboard").closest("a");
+    expect(dashboardLink).toHaveClass("bg-blue-600");
+  });
+});
+
+describe("MobileNav", () => {
+  it("renders the menu button", () => {
+    render(<MobileNav />);
+    expect(
+      screen.getByRole("button", { name: /open navigation menu/i })
+    ).toBeInTheDocument();
+  });
+
+  it("opens the mobile menu when button is clicked", () => {
+    render(<MobileNav />);
+    const menuButton = screen.getByRole("button", {
+      name: /open navigation menu/i,
+    });
+
+    fireEvent.click(menuButton);
+
+    // Menu should now be visible
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Daily Briefs")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /close navigation menu/i })
+    ).toBeInTheDocument();
+  });
+
+  it("closes the mobile menu when close button is clicked", () => {
+    render(<MobileNav />);
+    const menuButton = screen.getByRole("button", {
+      name: /open navigation menu/i,
+    });
+
+    // Open menu
+    fireEvent.click(menuButton);
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+
+    // Close menu
+    const closeButton = screen.getByRole("button", {
+      name: /close navigation menu/i,
+    });
+    fireEvent.click(closeButton);
+
+    // Menu should be closed (navigation items not visible)
+    expect(screen.queryByText("Daily Briefs")).not.toBeInTheDocument();
+  });
+
+  it("closes the mobile menu when a navigation link is clicked", () => {
+    render(<MobileNav />);
+    const menuButton = screen.getByRole("button", {
+      name: /open navigation menu/i,
+    });
+
+    // Open menu
+    fireEvent.click(menuButton);
+
+    // Click a navigation link
+    fireEvent.click(screen.getByText("Settings"));
+
+    // Menu should be closed
+    expect(screen.queryByText("Daily Briefs")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/dashboard/alerts/page.tsx
+++ b/apps/web/src/app/dashboard/alerts/page.tsx
@@ -1,0 +1,45 @@
+/**
+ * Alerts Page
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ * Placeholder page for alerts - will be implemented in Epic 6.
+ */
+
+import { Bell } from "lucide-react";
+
+export default function AlertsPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <h1 className="text-2xl font-bold">Alerts</h1>
+        <p className="text-slate-400">
+          Predictive alerts and emergency notifications
+        </p>
+      </div>
+
+      {/* Placeholder content */}
+      <div className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center">
+        <div className="flex justify-center mb-4">
+          <div className="p-4 bg-amber-500/10 rounded-full">
+            <Bell className="h-12 w-12 text-amber-400" />
+          </div>
+        </div>
+        <h2 className="text-xl font-semibold mb-2">Coming Soon</h2>
+        <p className="text-slate-400 max-w-md mx-auto">
+          The alerting system will provide predictive glucose alerts, emergency
+          escalation to caregivers, and customizable thresholds. This feature
+          will be implemented in Epic 6.
+        </p>
+      </div>
+
+      {/* No active alerts message */}
+      <div className="bg-slate-900/50 rounded-xl p-6 border border-slate-800">
+        <div className="flex items-center gap-3">
+          <div className="h-3 w-3 rounded-full bg-green-500" />
+          <span className="text-slate-300">No active alerts</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/briefs/page.tsx
+++ b/apps/web/src/app/dashboard/briefs/page.tsx
@@ -1,0 +1,37 @@
+/**
+ * Daily Briefs Page
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ * Placeholder page for daily briefs - will be implemented in Epic 5.
+ */
+
+import { FileText } from "lucide-react";
+
+export default function BriefsPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <h1 className="text-2xl font-bold">Daily Briefs</h1>
+        <p className="text-slate-400">
+          AI-powered analysis of your glucose patterns
+        </p>
+      </div>
+
+      {/* Placeholder content */}
+      <div className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center">
+        <div className="flex justify-center mb-4">
+          <div className="p-4 bg-blue-500/10 rounded-full">
+            <FileText className="h-12 w-12 text-blue-400" />
+          </div>
+        </div>
+        <h2 className="text-xl font-semibold mb-2">Coming Soon</h2>
+        <p className="text-slate-400 max-w-md mx-auto">
+          Daily briefs will provide AI-generated summaries of your glucose
+          patterns, trends, and actionable suggestions. This feature will be
+          implemented in Epic 5.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,0 +1,12 @@
+/**
+ * Dashboard Layout
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ * Wraps all dashboard pages with the DashboardLayout component.
+ */
+
+import { DashboardLayout } from "@/components/layout";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <DashboardLayout>{children}</DashboardLayout>;
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,94 @@
+/**
+ * Dashboard Page
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ * Main dashboard view showing glucose data and metrics.
+ * Placeholder content - glucose components will be added in Stories 4.2-4.5.
+ */
+
+import { Activity, TrendingUp, Droplets, Clock } from "lucide-react";
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        <p className="text-slate-400">Your glucose overview at a glance</p>
+      </div>
+
+      {/* Glucose hero placeholder - Story 4.2 */}
+      <div className="bg-slate-900 rounded-xl p-8 border border-slate-800">
+        <div className="flex flex-col items-center justify-center text-center">
+          <div className="flex items-center gap-4 mb-4">
+            <span className="text-7xl font-bold text-green-400">142</span>
+            <TrendingUp className="h-12 w-12 text-green-400" />
+          </div>
+          <p className="text-slate-400 text-lg">mg/dL</p>
+          <p className="text-slate-500 text-sm mt-2">
+            Placeholder - GlucoseHero component coming in Story 4.2
+          </p>
+        </div>
+      </div>
+
+      {/* Metrics grid */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {/* IoB Card */}
+        <div className="bg-slate-900 rounded-xl p-6 border border-slate-800">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="p-2 bg-blue-500/10 rounded-lg">
+              <Droplets className="h-5 w-5 text-blue-400" />
+            </div>
+            <span className="text-slate-400 text-sm">Insulin on Board</span>
+          </div>
+          <p className="text-3xl font-bold">2.4u</p>
+          <p className="text-slate-500 text-xs mt-1">
+            Projected from last sync
+          </p>
+        </div>
+
+        {/* Time in Range Card */}
+        <div className="bg-slate-900 rounded-xl p-6 border border-slate-800">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="p-2 bg-green-500/10 rounded-lg">
+              <Activity className="h-5 w-5 text-green-400" />
+            </div>
+            <span className="text-slate-400 text-sm">Time in Range (24h)</span>
+          </div>
+          <p className="text-3xl font-bold text-green-400">78%</p>
+          <p className="text-slate-500 text-xs mt-1">Target: 70-180 mg/dL</p>
+        </div>
+
+        {/* Last Updated Card */}
+        <div className="bg-slate-900 rounded-xl p-6 border border-slate-800">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="p-2 bg-emerald-500/10 rounded-lg">
+              <Clock className="h-5 w-5 text-emerald-400" />
+            </div>
+            <span className="text-slate-400 text-sm">Last Updated</span>
+          </div>
+          <p className="text-3xl font-bold text-emerald-400">2m ago</p>
+          <p className="text-slate-500 text-xs mt-1">Data is fresh</p>
+        </div>
+      </div>
+
+      {/* Time in Range bar placeholder - Story 4.4 */}
+      <div className="bg-slate-900 rounded-xl p-6 border border-slate-800">
+        <h2 className="text-lg font-semibold mb-4">Time in Range</h2>
+        <div className="h-8 rounded-full overflow-hidden flex">
+          <div className="bg-red-500 w-[5%]" title="Below range: 5%" />
+          <div className="bg-green-500 w-[78%]" title="In range: 78%" />
+          <div className="bg-orange-500 w-[17%]" title="Above range: 17%" />
+        </div>
+        <div className="flex justify-between mt-2 text-xs text-slate-500">
+          <span>Low: 5%</span>
+          <span>In Range: 78%</span>
+          <span>High: 17%</span>
+        </div>
+        <p className="text-slate-500 text-xs mt-4 text-center">
+          Placeholder - TimeInRangeBar component coming in Story 4.4
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,82 @@
+/**
+ * Settings Page
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ * Placeholder page for settings - will be expanded in Epic 9.
+ */
+
+import { Settings, User, Bell, Database, Link2 } from "lucide-react";
+
+const settingsSections = [
+  {
+    title: "Profile",
+    description: "Manage your account and personal information",
+    icon: User,
+    href: "/dashboard/settings/profile",
+  },
+  {
+    title: "Integrations",
+    description: "Connect Dexcom, Tandem, and other data sources",
+    icon: Link2,
+    href: "/dashboard/settings/integrations",
+  },
+  {
+    title: "Alerts",
+    description: "Configure alert thresholds and escalation",
+    icon: Bell,
+    href: "/dashboard/settings/alerts",
+  },
+  {
+    title: "Data",
+    description: "Manage data retention and export options",
+    icon: Database,
+    href: "/dashboard/settings/data",
+  },
+];
+
+export default function SettingsPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <h1 className="text-2xl font-bold">Settings</h1>
+        <p className="text-slate-400">Manage your account and preferences</p>
+      </div>
+
+      {/* Settings sections grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {settingsSections.map((section) => (
+          <a
+            key={section.title}
+            href={section.href}
+            className="bg-slate-900 rounded-xl p-6 border border-slate-800 hover:border-slate-700 transition-colors group"
+          >
+            <div className="flex items-start gap-4">
+              <div className="p-3 bg-slate-800 rounded-lg group-hover:bg-slate-700 transition-colors">
+                <section.icon className="h-6 w-6 text-slate-400 group-hover:text-white transition-colors" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold group-hover:text-white transition-colors">
+                  {section.title}
+                </h2>
+                <p className="text-slate-400 text-sm mt-1">
+                  {section.description}
+                </p>
+              </div>
+            </div>
+          </a>
+        ))}
+      </div>
+
+      {/* Disclaimer */}
+      <div className="bg-slate-900/50 rounded-xl p-4 border border-slate-800">
+        <div className="flex items-center gap-2 text-slate-500 text-sm">
+          <Settings className="h-4 w-4" />
+          <span>
+            Additional settings will be available as features are implemented.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/dashboard-layout.tsx
+++ b/apps/web/src/components/layout/dashboard-layout.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+/**
+ * Dashboard Layout Component
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ * Main layout wrapper for all dashboard pages.
+ * Includes sidebar (desktop), header, and main content area.
+ */
+
+import { Sidebar } from "./sidebar";
+import { Header } from "./header";
+
+interface DashboardLayoutProps {
+  children: React.ReactNode;
+}
+
+export function DashboardLayout({ children }: DashboardLayoutProps) {
+  return (
+    <div className="min-h-screen bg-slate-950">
+      {/* Desktop sidebar */}
+      <Sidebar />
+
+      {/* Main content area */}
+      <div className="lg:pl-64">
+        {/* Header */}
+        <Header />
+
+        {/* Page content */}
+        <main className="p-4 lg:p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+/**
+ * Header Component
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ * Displays logo (mobile), user menu, and mobile navigation toggle.
+ */
+
+import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+import { clsx } from "clsx";
+import { User, LogOut, Settings, ChevronDown, Activity } from "lucide-react";
+import { MobileNav } from "./sidebar";
+
+interface HeaderProps {
+  className?: string;
+}
+
+export function Header({ className }: HeaderProps) {
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsUserMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <header
+      className={clsx(
+        "sticky top-0 z-40 flex items-center justify-between h-16 px-4 lg:px-6",
+        "bg-slate-900/95 backdrop-blur border-b border-slate-800",
+        className
+      )}
+    >
+      {/* Left side - Mobile nav toggle and logo */}
+      <div className="flex items-center gap-4">
+        <MobileNav />
+
+        {/* Mobile logo */}
+        <Link href="/dashboard" className="flex items-center gap-2 lg:hidden">
+          <Activity className="h-6 w-6 text-blue-500" />
+          <span className="text-lg font-bold">GlycemicGPT</span>
+        </Link>
+      </div>
+
+      {/* Right side - User menu */}
+      <div className="relative" ref={menuRef}>
+        <button
+          type="button"
+          onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
+          className={clsx(
+            "flex items-center gap-2 px-3 py-2 rounded-lg transition-colors",
+            "text-slate-400 hover:text-white hover:bg-slate-800",
+            isUserMenuOpen && "bg-slate-800 text-white"
+          )}
+          aria-expanded={isUserMenuOpen}
+          aria-haspopup="true"
+        >
+          <div className="flex items-center justify-center h-8 w-8 rounded-full bg-blue-600">
+            <User className="h-4 w-4 text-white" />
+          </div>
+          <span className="hidden sm:block text-sm font-medium">Account</span>
+          <ChevronDown
+            className={clsx(
+              "h-4 w-4 transition-transform",
+              isUserMenuOpen && "rotate-180"
+            )}
+          />
+        </button>
+
+        {/* Dropdown menu */}
+        {isUserMenuOpen && (
+          <div className="absolute right-0 mt-2 w-48 bg-slate-800 rounded-lg shadow-lg border border-slate-700 py-1">
+            <Link
+              href="/dashboard/settings"
+              onClick={() => setIsUserMenuOpen(false)}
+              className="flex items-center gap-2 px-4 py-2 text-sm text-slate-300 hover:text-white hover:bg-slate-700"
+            >
+              <Settings className="h-4 w-4" />
+              Settings
+            </Link>
+            <hr className="my-1 border-slate-700" />
+            <button
+              type="button"
+              onClick={() => {
+                setIsUserMenuOpen(false);
+                // TODO: Implement logout
+                window.location.href = "/";
+              }}
+              className="flex items-center gap-2 w-full px-4 py-2 text-sm text-red-400 hover:text-red-300 hover:bg-slate-700"
+            >
+              <LogOut className="h-4 w-4" />
+              Sign out
+            </button>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Layout Components
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ */
+
+export { DashboardLayout } from "./dashboard-layout";
+export { Sidebar, MobileNav } from "./sidebar";
+export { Header } from "./header";

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+/**
+ * Sidebar Navigation Component
+ *
+ * Story 4.1: Dashboard Layout & Navigation
+ * Provides navigation to Dashboard, Daily Briefs, Alerts, and Settings.
+ * Collapses to hamburger menu on mobile.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { clsx } from "clsx";
+import {
+  LayoutDashboard,
+  FileText,
+  Bell,
+  Settings,
+  Menu,
+  X,
+  Activity,
+} from "lucide-react";
+
+interface NavItem {
+  name: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+const navigation: NavItem[] = [
+  { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { name: "Daily Briefs", href: "/dashboard/briefs", icon: FileText },
+  { name: "Alerts", href: "/dashboard/alerts", icon: Bell },
+  { name: "Settings", href: "/dashboard/settings", icon: Settings },
+];
+
+interface SidebarProps {
+  className?: string;
+}
+
+export function Sidebar({ className }: SidebarProps) {
+  const pathname = usePathname();
+
+  return (
+    <aside
+      className={clsx(
+        "hidden lg:flex lg:flex-col lg:w-64 lg:fixed lg:inset-y-0",
+        "bg-slate-900 border-r border-slate-800",
+        className
+      )}
+    >
+      {/* Logo */}
+      <div className="flex items-center gap-2 h-16 px-6 border-b border-slate-800">
+        <Activity className="h-8 w-8 text-blue-500" />
+        <span className="text-xl font-bold">GlycemicGPT</span>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 px-4 py-4 space-y-1">
+        {navigation.map((item) => {
+          const isActive =
+            pathname === item.href ||
+            (item.href !== "/dashboard" && pathname.startsWith(item.href));
+
+          return (
+            <Link
+              key={item.name}
+              href={item.href}
+              className={clsx(
+                "flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-blue-600 text-white"
+                  : "text-slate-400 hover:text-white hover:bg-slate-800"
+              )}
+            >
+              <item.icon className="h-5 w-5" />
+              {item.name}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Footer */}
+      <div className="px-4 py-4 border-t border-slate-800">
+        <p className="text-xs text-slate-500 text-center">
+          Not medical advice
+        </p>
+      </div>
+    </aside>
+  );
+}
+
+export function MobileNav() {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+
+  return (
+    <>
+      {/* Mobile menu button */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="lg:hidden p-2 text-slate-400 hover:text-white"
+        aria-label="Open navigation menu"
+      >
+        <Menu className="h-6 w-6" />
+      </button>
+
+      {/* Mobile menu overlay */}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden">
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 bg-black/50"
+            onClick={() => setIsOpen(false)}
+          />
+
+          {/* Sidebar */}
+          <div className="fixed inset-y-0 left-0 w-64 bg-slate-900 shadow-xl">
+            {/* Header */}
+            <div className="flex items-center justify-between h-16 px-4 border-b border-slate-800">
+              <div className="flex items-center gap-2">
+                <Activity className="h-8 w-8 text-blue-500" />
+                <span className="text-xl font-bold">GlycemicGPT</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="p-2 text-slate-400 hover:text-white"
+                aria-label="Close navigation menu"
+              >
+                <X className="h-6 w-6" />
+              </button>
+            </div>
+
+            {/* Navigation */}
+            <nav className="px-4 py-4 space-y-1">
+              {navigation.map((item) => {
+                const isActive =
+                  pathname === item.href ||
+                  (item.href !== "/dashboard" && pathname.startsWith(item.href));
+
+                return (
+                  <Link
+                    key={item.name}
+                    href={item.href}
+                    onClick={() => setIsOpen(false)}
+                    className={clsx(
+                      "flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+                      isActive
+                        ? "bg-blue-600 text-white"
+                        : "text-slate-400 hover:text-white hover:bg-slate-800"
+                    )}
+                  >
+                    <item.icon className="h-5 w-5" />
+                    {item.name}
+                  </Link>
+                );
+              })}
+            </nav>
+
+            {/* Footer */}
+            <div className="absolute bottom-0 left-0 right-0 px-4 py-4 border-t border-slate-800">
+              <p className="text-xs text-slate-500 text-center">
+                Not medical advice
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Implements Story 4.1: Dashboard Layout & Navigation - adds a responsive dashboard layout with sidebar navigation.

## Changes Made

### Layout Components
- **Sidebar** - Fixed sidebar on desktop with navigation to Dashboard, Daily Briefs, Alerts, Settings
- **Header** - Sticky header with user menu dropdown (Settings, Sign out)
- **DashboardLayout** - Main wrapper combining sidebar and header
- **MobileNav** - Hamburger menu with slide-out drawer for mobile

### Dashboard Routes
- `/dashboard` - Main glucose dashboard (with placeholder content)
- `/dashboard/briefs` - Daily briefs placeholder (Epic 5)
- `/dashboard/alerts` - Alerts placeholder (Epic 6)
- `/dashboard/settings` - Settings hub with navigation cards

### Test Coverage
- 19 tests across 3 test files
- Sidebar navigation tests
- Header user menu tests
- Layout structure tests

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

- [x] Unit tests pass (`npm test`)
- [x] Manual testing performed
- [x] New tests added for new functionality

## Acceptance Criteria

- [x] Responsive layout with header and user menu
- [x] Main content area for glucose display
- [x] Navigation to Daily Briefs, Alerts, and Settings
- [x] Mobile: navigation collapses to hamburger menu
- [x] Desktop: navigation shows as sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)