### PR TITLE
fix(ci): use homebot.0 for Renovate to enable dependency dashboard

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,11 +14,19 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token for homebot.0
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -26,7 +34,7 @@ jobs:
         uses: renovatebot/github-action@v44.0.2
         with:
           configurationFile: .github/renovate.json5
-          token: ${{ secrets.RENOVATE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
         env:
           LOG_LEVEL: info
           RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary
GITHUB_TOKEN doesn't have permission to create issues. Use homebot.0 GitHub App token so Renovate can create the Dependency Dashboard issue.

## Changes
- Generate homebot.0 token using `actions/create-github-app-token`
- Added `issues: write` permission
- Pass the App token to Renovate instead of GITHUB_TOKEN

## Test plan
- [ ] Merge this PR
- [ ] Verify Renovate creates the Dependency Dashboard issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)