### PR TITLE
ci(docker): add container build and push workflow for ghcr.io

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,21 @@
 # GlycemicGPT Environment Configuration
 # Copy this file to .env and update values
 
+# ===================
+# Docker Deployment
+# ===================
+
+# Image version to deploy (default: latest)
+# IMAGE_TAG=0.1.2
+
+# Port configuration (optional)
+# API_PORT=8000
+# WEB_PORT=3000
+
+# Public API URL for frontend (adjust for your domain in production)
+# NEXT_PUBLIC_API_URL=https://api.yourdomain.com
+
+# ===================
 # Database
 POSTGRES_USER=glycemicgpt
 POSTGRES_PASSWORD=glycemicgpt

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,150 @@
+name: Build and Push Container Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - '.github/workflows/container-build.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: 'Force build all images'
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/glycemicgpt
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.changes.outputs.api }}
+      web: ${{ steps.changes.outputs.web }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - 'apps/api/**'
+            web:
+              - 'apps/web/**'
+
+  build-api:
+    name: Build API Image
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: |
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.api == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}-api
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            type=sha,prefix=sha-
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/api
+          file: ./apps/api/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.event_name == 'release' && github.event.release.tag_name || 'latest' }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.release.created_at }}
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-web:
+    name: Build Web Image
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: |
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.web == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}-web
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            type=sha,prefix=sha-
+
+      - name: Build and push Web image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/web
+          file: ./apps/web/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.event_name == 'release' && github.event.release.tag_name || 'latest' }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.release.created_at }}
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,74 @@
+# Production docker-compose using pre-built images from GitHub Container Registry
+# Usage: docker compose -f docker-compose.prod.yml up -d
+#
+# Pull latest images:
+#   docker pull ghcr.io/jlengelbrecht/glycemicgpt-api:latest
+#   docker pull ghcr.io/jlengelbrecht/glycemicgpt-web:latest
+#
+# Or use a specific version:
+#   IMAGE_TAG=0.1.2 docker compose -f docker-compose.prod.yml up -d
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-glycemicgpt}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-glycemicgpt}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-glycemicgpt}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  api:
+    image: ghcr.io/jlengelbrecht/glycemicgpt-api:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    ports:
+      - "${API_PORT:-8000}:8000"
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-glycemicgpt}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-glycemicgpt}
+      REDIS_URL: redis://redis:6379/0
+      LOG_FORMAT: ${LOG_FORMAT:-json}
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  web:
+    image: ghcr.io/jlengelbrecht/glycemicgpt-web:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    ports:
+      - "${WEB_PORT:-3000}:3000"
+    environment:
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000}
+      API_URL: http://api:8000
+    depends_on:
+      api:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  redis_data:


### PR DESCRIPTION
## Summary

Adds CI/CD pipeline to automatically build and push Docker images to GitHub Container Registry (ghcr.io).

## Features

- **Automatic builds** on push to main (tagged as `latest`)
- **Version tags** on release (e.g., `0.1.2`, `0.1`)
- **Multi-architecture** support (amd64 + arm64)
- **Smart rebuilds** - only rebuilds when relevant files change
- **GitHub Actions cache** for faster builds
- **SHA tags** for traceability (e.g., `sha-abc1234`)

## Images Published

```
ghcr.io/jlengelbrecht/glycemicgpt-api:latest
ghcr.io/jlengelbrecht/glycemicgpt-web:latest
```

## Usage

```bash
# Pull latest images
docker pull ghcr.io/jlengelbrecht/glycemicgpt-api:latest
docker pull ghcr.io/jlengelbrecht/glycemicgpt-web:latest

# Deploy with docker-compose
cp .env.example .env
# Edit .env with your secrets
docker compose -f docker-compose.prod.yml up -d

# Or use a specific version
IMAGE_TAG=0.1.2 docker compose -f docker-compose.prod.yml up -d
```

## Test plan

- [ ] Merge PR and verify workflow runs on main push
- [ ] Verify images appear in GitHub Packages
- [ ] Test pulling images locally with `docker pull`

---
Generated with [Claude Code](https://claude.ai/code)