### PR TITLE
ci(docker): add release notes update and image cleanup

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -21,7 +21,7 @@ env:
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/glycemicgpt
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -49,6 +49,9 @@ jobs:
     name: Build API Image
     runs-on: ubuntu-latest
     needs: detect-changes
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      version: ${{ steps.meta.outputs.version }}
     if: |
       github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch' ||
@@ -101,6 +104,9 @@ jobs:
     name: Build Web Image
     runs-on: ubuntu-latest
     needs: detect-changes
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      version: ${{ steps.meta.outputs.version }}
     if: |
       github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch' ||
@@ -148,3 +154,51 @@ jobs:
             GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  update-release:
+    name: Update Release Notes
+    runs-on: ubuntu-latest
+    needs: [build-api, build-web]
+    if: github.event_name == 'release'
+    steps:
+      - name: Update release with container info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ github.event.release.tag_name }}'.replace('v', '');
+            const imagePrefix = 'ghcr.io/${{ github.repository_owner }}/glycemicgpt';
+
+            const containerSection = `
+
+            ---
+
+            ## 🐳 Container Images
+
+            | Image | Tags |
+            |-------|------|
+            | \`${imagePrefix}-api\` | \`${version}\`, \`latest\` |
+            | \`${imagePrefix}-web\` | \`${version}\`, \`latest\` |
+
+            **Pull commands:**
+            \`\`\`bash
+            docker pull ${imagePrefix}-api:${version}
+            docker pull ${imagePrefix}-web:${version}
+            \`\`\`
+            `;
+
+            const release = await github.rest.repos.getRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: context.payload.release.id
+            });
+
+            // Only append if not already present
+            if (!release.data.body.includes('Container Images')) {
+              await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: context.payload.release.id,
+                body: release.data.body + containerSection
+              });
+              console.log('Updated release notes with container info');
+            }

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -1,0 +1,50 @@
+name: Cleanup Container Images
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday at midnight
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup-api:
+    name: Cleanup API Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old API image versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: glycemicgpt-api
+          package-type: container
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: false
+          ignore-versions: '^(latest|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
+
+  cleanup-web:
+    name: Cleanup Web Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old Web image versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: glycemicgpt-web
+          package-type: container
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: false
+          ignore-versions: '^(latest|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
+
+  cleanup-untagged:
+    name: Cleanup Untagged Images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [glycemicgpt-api, glycemicgpt-web]
+    steps:
+      - name: Delete untagged versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.package }}
+          package-type: container
+          delete-only-untagged-versions: true


### PR DESCRIPTION
## Summary

Improves container image management with release tracking and automatic cleanup.

## Changes

### 1. Release Notes Update
After container builds complete on a release, the release notes are automatically updated with:
- Table of published images and tags
- Pull commands for easy copy/paste

Example addition to release notes:
```markdown
## 🐳 Container Images

| Image | Tags |
|-------|------|
| `ghcr.io/jlengelbrecht/glycemicgpt-api` | `0.1.4`, `latest` |
| `ghcr.io/jlengelbrecht/glycemicgpt-web` | `0.1.4`, `latest` |
```

### 2. Image Cleanup Workflow
Weekly cleanup (Sunday midnight) that:
- Keeps last 10 versions of each image
- Preserves all semver tags (`x.y.z`, `x.y`) and `latest`
- Deletes old `sha-*` tags
- Removes untagged/orphaned manifests

## Tagging Strategy (Renovate-friendly)

| Tag | Description | Use Case |
|-----|-------------|----------|
| `0.1.4` | Full semver | GitOps/Renovate (recommended) |
| `0.1` | Major.minor | Auto-update patches |
| `latest` | Most recent | Development only |
| `sha-abc123` | Git commit | Debugging/traceability |

**For GitOps:** Pin to `0.1.4` and Renovate will detect `0.1.5`, `0.2.0`, etc.

## Test plan

- [ ] Merge and wait for next release
- [ ] Verify release notes are updated with container info
- [ ] Run cleanup workflow manually to verify it works

---
Generated with [Claude Code](https://claude.ai/code)