### PR TITLE
feat(web): add TrendArrow component for reusable trend display

### DIFF
--- a/apps/web/__tests__/components/dashboard/trend-arrow.test.tsx
+++ b/apps/web/__tests__/components/dashboard/trend-arrow.test.tsx
@@ -1,0 +1,454 @@
+/**
+ * Tests for the TrendArrow component.
+ *
+ * Story 4.3: Trend Arrow Component
+ */
+
+import { render, screen } from "@testing-library/react";
+import {
+  TrendArrow,
+  TREND_ARROWS,
+  TREND_DESCRIPTIONS,
+  getTrendArrow,
+  getTrendDescription,
+  isRising,
+  isFalling,
+  isRapidChange,
+  isStable,
+  isUnknown,
+  type TrendDirection,
+} from "../../../src/components/dashboard/trend-arrow";
+import TrendArrowDefault from "../../../src/components/dashboard/trend-arrow";
+
+// Mock framer-motion
+const mockUseReducedMotion = jest.fn(() => false);
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    span: ({
+      children,
+      className,
+      ...props
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      [key: string]: unknown;
+    }) => (
+      <span className={className} {...props}>
+        {children}
+      </span>
+    ),
+  },
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+beforeEach(() => {
+  mockUseReducedMotion.mockReturnValue(false);
+});
+
+describe("TREND_ARROWS constant", () => {
+  it("contains all trend directions", () => {
+    expect(TREND_ARROWS.RisingFast).toBe("↑↑");
+    expect(TREND_ARROWS.Rising).toBe("↗");
+    expect(TREND_ARROWS.Stable).toBe("→");
+    expect(TREND_ARROWS.Falling).toBe("↘");
+    expect(TREND_ARROWS.FallingFast).toBe("↓↓");
+    expect(TREND_ARROWS.Unknown).toBe("?");
+  });
+});
+
+describe("TREND_DESCRIPTIONS constant", () => {
+  it("contains all trend descriptions", () => {
+    expect(TREND_DESCRIPTIONS.RisingFast).toBe("rising fast");
+    expect(TREND_DESCRIPTIONS.Rising).toBe("rising");
+    expect(TREND_DESCRIPTIONS.Stable).toBe("stable");
+    expect(TREND_DESCRIPTIONS.Falling).toBe("falling");
+    expect(TREND_DESCRIPTIONS.FallingFast).toBe("falling fast");
+    expect(TREND_DESCRIPTIONS.Unknown).toBe("unknown trend");
+  });
+});
+
+describe("getTrendArrow", () => {
+  it.each([
+    ["RisingFast", "↑↑"],
+    ["Rising", "↗"],
+    ["Stable", "→"],
+    ["Falling", "↘"],
+    ["FallingFast", "↓↓"],
+    ["Unknown", "?"],
+  ] as const)("returns %s arrow for %s direction", (direction, expectedArrow) => {
+    expect(getTrendArrow(direction)).toBe(expectedArrow);
+  });
+});
+
+describe("getTrendDescription", () => {
+  it.each([
+    ["RisingFast", "rising fast"],
+    ["Rising", "rising"],
+    ["Stable", "stable"],
+    ["Falling", "falling"],
+    ["FallingFast", "falling fast"],
+    ["Unknown", "unknown trend"],
+  ] as const)("returns %s description for %s direction", (direction, expectedDesc) => {
+    expect(getTrendDescription(direction)).toBe(expectedDesc);
+  });
+});
+
+describe("isRising", () => {
+  it("returns true for RisingFast", () => {
+    expect(isRising("RisingFast")).toBe(true);
+  });
+
+  it("returns true for Rising", () => {
+    expect(isRising("Rising")).toBe(true);
+  });
+
+  it("returns false for Stable", () => {
+    expect(isRising("Stable")).toBe(false);
+  });
+
+  it("returns false for Falling", () => {
+    expect(isRising("Falling")).toBe(false);
+  });
+
+  it("returns false for FallingFast", () => {
+    expect(isRising("FallingFast")).toBe(false);
+  });
+
+  it("returns false for Unknown", () => {
+    expect(isRising("Unknown")).toBe(false);
+  });
+});
+
+describe("isFalling", () => {
+  it("returns true for FallingFast", () => {
+    expect(isFalling("FallingFast")).toBe(true);
+  });
+
+  it("returns true for Falling", () => {
+    expect(isFalling("Falling")).toBe(true);
+  });
+
+  it("returns false for Stable", () => {
+    expect(isFalling("Stable")).toBe(false);
+  });
+
+  it("returns false for Rising", () => {
+    expect(isFalling("Rising")).toBe(false);
+  });
+
+  it("returns false for RisingFast", () => {
+    expect(isFalling("RisingFast")).toBe(false);
+  });
+
+  it("returns false for Unknown", () => {
+    expect(isFalling("Unknown")).toBe(false);
+  });
+});
+
+describe("isRapidChange", () => {
+  it("returns true for RisingFast", () => {
+    expect(isRapidChange("RisingFast")).toBe(true);
+  });
+
+  it("returns true for FallingFast", () => {
+    expect(isRapidChange("FallingFast")).toBe(true);
+  });
+
+  it("returns false for Rising", () => {
+    expect(isRapidChange("Rising")).toBe(false);
+  });
+
+  it("returns false for Falling", () => {
+    expect(isRapidChange("Falling")).toBe(false);
+  });
+
+  it("returns false for Stable", () => {
+    expect(isRapidChange("Stable")).toBe(false);
+  });
+
+  it("returns false for Unknown", () => {
+    expect(isRapidChange("Unknown")).toBe(false);
+  });
+});
+
+describe("isStable", () => {
+  it("returns true for Stable", () => {
+    expect(isStable("Stable")).toBe(true);
+  });
+
+  it("returns false for Rising", () => {
+    expect(isStable("Rising")).toBe(false);
+  });
+
+  it("returns false for RisingFast", () => {
+    expect(isStable("RisingFast")).toBe(false);
+  });
+
+  it("returns false for Falling", () => {
+    expect(isStable("Falling")).toBe(false);
+  });
+
+  it("returns false for FallingFast", () => {
+    expect(isStable("FallingFast")).toBe(false);
+  });
+
+  it("returns false for Unknown", () => {
+    expect(isStable("Unknown")).toBe(false);
+  });
+});
+
+describe("isUnknown", () => {
+  it("returns true for Unknown", () => {
+    expect(isUnknown("Unknown")).toBe(true);
+  });
+
+  it("returns false for Stable", () => {
+    expect(isUnknown("Stable")).toBe(false);
+  });
+
+  it("returns false for Rising", () => {
+    expect(isUnknown("Rising")).toBe(false);
+  });
+
+  it("returns false for RisingFast", () => {
+    expect(isUnknown("RisingFast")).toBe(false);
+  });
+
+  it("returns false for Falling", () => {
+    expect(isUnknown("Falling")).toBe(false);
+  });
+
+  it("returns false for FallingFast", () => {
+    expect(isUnknown("FallingFast")).toBe(false);
+  });
+});
+
+describe("TrendArrow component", () => {
+  describe("arrow display", () => {
+    it.each([
+      ["RisingFast", "↑↑"],
+      ["Rising", "↗"],
+      ["Stable", "→"],
+      ["Falling", "↘"],
+      ["FallingFast", "↓↓"],
+      ["Unknown", "?"],
+    ] as const)(
+      "displays correct arrow for %s direction",
+      (direction: TrendDirection, expectedArrow: string) => {
+        render(<TrendArrow direction={direction} />);
+
+        const arrow = screen.getByTestId("trend-arrow");
+        expect(arrow).toHaveTextContent(expectedArrow);
+      }
+    );
+
+    it("sets data-direction attribute", () => {
+      render(<TrendArrow direction="Stable" />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveAttribute("data-direction", "Stable");
+    });
+  });
+
+  describe("size variants", () => {
+    it("uses md size by default", () => {
+      render(<TrendArrow direction="Stable" />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-2xl");
+    });
+
+    it("applies sm size class", () => {
+      render(<TrendArrow direction="Stable" size="sm" />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-lg");
+    });
+
+    it("applies lg size class", () => {
+      render(<TrendArrow direction="Stable" size="lg" />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-4xl");
+    });
+
+    it("applies xl size class", () => {
+      render(<TrendArrow direction="Stable" size="xl" />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-5xl");
+    });
+  });
+
+  describe("color handling", () => {
+    it("uses trend-based color when useTrendColor is true", () => {
+      render(<TrendArrow direction="Stable" useTrendColor />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-green-400");
+    });
+
+    it("uses red for RisingFast when useTrendColor is true", () => {
+      render(<TrendArrow direction="RisingFast" useTrendColor />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-red-400");
+    });
+
+    it("uses amber for Rising when useTrendColor is true", () => {
+      render(<TrendArrow direction="Rising" useTrendColor />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-amber-400");
+    });
+
+    it("uses red for FallingFast when useTrendColor is true", () => {
+      render(<TrendArrow direction="FallingFast" useTrendColor />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-red-400");
+    });
+
+    it("uses slate for Unknown when useTrendColor is true", () => {
+      render(<TrendArrow direction="Unknown" useTrendColor />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-slate-400");
+    });
+
+    it("uses custom colorClass when provided", () => {
+      render(<TrendArrow direction="Stable" colorClass="text-blue-500" />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-blue-500");
+    });
+
+    it("colorClass overrides useTrendColor", () => {
+      render(
+        <TrendArrow direction="Stable" useTrendColor colorClass="text-purple-500" />
+      );
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-purple-500");
+      expect(arrow).not.toHaveClass("text-green-400");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("is decorative by default (aria-hidden)", () => {
+      render(<TrendArrow direction="Stable" />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("does not have role when decorative", () => {
+      render(<TrendArrow direction="Stable" decorative />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).not.toHaveAttribute("role");
+    });
+
+    it("has role=img when not decorative", () => {
+      render(<TrendArrow direction="Stable" decorative={false} />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveAttribute("role", "img");
+    });
+
+    it("has aria-label when not decorative", () => {
+      render(<TrendArrow direction="Rising" decorative={false} />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveAttribute("aria-label", "Glucose trend: rising");
+    });
+
+    it("has correct aria-label for all directions when not decorative", () => {
+      const directions: TrendDirection[] = [
+        "RisingFast",
+        "Rising",
+        "Stable",
+        "Falling",
+        "FallingFast",
+        "Unknown",
+      ];
+
+      directions.forEach((direction) => {
+        const { unmount } = render(
+          <TrendArrow direction={direction} decorative={false} />
+        );
+
+        const arrow = screen.getByTestId("trend-arrow");
+        expect(arrow).toHaveAttribute(
+          "aria-label",
+          `Glucose trend: ${TREND_DESCRIPTIONS[direction]}`
+        );
+
+        unmount();
+      });
+    });
+  });
+
+  describe("custom className", () => {
+    it("applies additional className", () => {
+      render(<TrendArrow direction="Stable" className="my-custom-class" />);
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("my-custom-class");
+    });
+
+    it("combines className with size class", () => {
+      render(
+        <TrendArrow direction="Stable" size="lg" className="font-bold" />
+      );
+
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toHaveClass("text-4xl", "font-bold");
+    });
+  });
+
+  describe("animation", () => {
+    it("renders without animation by default", () => {
+      render(<TrendArrow direction="RisingFast" />);
+
+      // Should render as regular span, not motion.span
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow.tagName.toLowerCase()).toBe("span");
+    });
+
+    it("renders animated when animated=true", () => {
+      render(<TrendArrow direction="RisingFast" animated />);
+
+      // Component should still render (motion.span becomes span in mock)
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toBeInTheDocument();
+    });
+
+    it("respects reduced motion preference", () => {
+      mockUseReducedMotion.mockReturnValue(true);
+
+      render(<TrendArrow direction="RisingFast" animated />);
+
+      // Should render as regular span when reduced motion is preferred
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toBeInTheDocument();
+    });
+
+    it("does not animate Stable direction", () => {
+      render(<TrendArrow direction="Stable" animated />);
+
+      // Stable has no animation defined
+      const arrow = screen.getByTestId("trend-arrow");
+      expect(arrow).toBeInTheDocument();
+    });
+  });
+
+  describe("exports", () => {
+    it("default export works", () => {
+      render(<TrendArrowDefault direction="Stable" />);
+
+      expect(screen.getByTestId("trend-arrow")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/dashboard/glucose-hero.tsx
+++ b/apps/web/src/components/dashboard/glucose-hero.tsx
@@ -10,15 +10,11 @@
 
 import { motion, useReducedMotion } from "framer-motion";
 import clsx from "clsx";
-
-// Trend direction enum matching API values
-export type TrendDirection =
-  | "RisingFast"
-  | "Rising"
-  | "Stable"
-  | "Falling"
-  | "FallingFast"
-  | "Unknown";
+import {
+  type TrendDirection,
+  TREND_ARROWS,
+  TREND_DESCRIPTIONS,
+} from "./trend-arrow";
 
 // Glucose range classification
 export type GlucoseRange =
@@ -55,25 +51,6 @@ export interface GlucoseHeroProps {
   isLoading?: boolean;
 }
 
-// Trend arrow mapping
-const trendArrows: Record<TrendDirection, string> = {
-  RisingFast: "↑↑",
-  Rising: "↗",
-  Stable: "→",
-  Falling: "↘",
-  FallingFast: "↓↓",
-  Unknown: "?",
-};
-
-// Trend descriptions for screen readers
-const trendDescriptions: Record<TrendDirection, string> = {
-  RisingFast: "rising fast",
-  Rising: "rising",
-  Stable: "stable",
-  Falling: "falling",
-  FallingFast: "falling fast",
-  Unknown: "unknown trend",
-};
 
 /**
  * Classify glucose value into range category.
@@ -181,8 +158,8 @@ export function GlucoseHero({
   const range = classifyGlucose(safeValue);
   const colors = rangeColors[range];
   const pulseType = shouldPulse(range);
-  const arrow = trendArrows[trend];
-  const trendDescription = trendDescriptions[trend];
+  const arrow = TREND_ARROWS[trend];
+  const trendDescription = TREND_DESCRIPTIONS[trend];
 
   // Format display value
   const displayValue = safeValue !== null ? Math.round(safeValue).toString() : "--";
@@ -294,5 +271,9 @@ export function GlucoseHero({
     </div>
   );
 }
+
+// Re-export TrendDirection for backwards compatibility
+// Primary source is now trend-arrow.tsx
+export { type TrendDirection } from "./trend-arrow";
 
 export default GlucoseHero;

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -7,9 +7,24 @@
 export {
   GlucoseHero,
   type GlucoseHeroProps,
-  type TrendDirection,
   type GlucoseRange,
   classifyGlucose,
   shouldPulse,
   GLUCOSE_THRESHOLDS,
 } from "./glucose-hero";
+
+export {
+  TrendArrow,
+  type TrendArrowProps,
+  type TrendDirection,
+  type TrendArrowSize,
+  TREND_ARROWS,
+  TREND_DESCRIPTIONS,
+  getTrendArrow,
+  getTrendDescription,
+  isRising,
+  isFalling,
+  isRapidChange,
+  isStable,
+  isUnknown,
+} from "./trend-arrow";

--- a/apps/web/src/components/dashboard/trend-arrow.tsx
+++ b/apps/web/src/components/dashboard/trend-arrow.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+/**
+ * TrendArrow Component
+ *
+ * Story 4.3: Trend Arrow Component
+ * Reusable component that displays glucose trend direction as an arrow.
+ * Can be used standalone or embedded in other components.
+ */
+
+import { motion, useReducedMotion } from "framer-motion";
+import clsx from "clsx";
+
+/**
+ * Trend direction enum matching CGM API values.
+ * - RisingFast: Glucose increasing > 3 mg/dL/min
+ * - Rising: Glucose increasing 1-3 mg/dL/min
+ * - Stable: Glucose change -1 to +1 mg/dL/min
+ * - Falling: Glucose decreasing 1-3 mg/dL/min
+ * - FallingFast: Glucose decreasing > 3 mg/dL/min
+ * - Unknown: Trend data unavailable
+ */
+export type TrendDirection =
+  | "RisingFast"
+  | "Rising"
+  | "Stable"
+  | "Falling"
+  | "FallingFast"
+  | "Unknown";
+
+/** Size variants for the trend arrow */
+export type TrendArrowSize = "sm" | "md" | "lg" | "xl";
+
+export interface TrendArrowProps {
+  /** The trend direction to display */
+  direction: TrendDirection;
+  /** Size variant (default: md) */
+  size?: TrendArrowSize;
+  /** Custom color class (overrides trend-based color) */
+  colorClass?: string;
+  /** Whether to use trend-based coloring (default: false) */
+  useTrendColor?: boolean;
+  /** Whether arrow is decorative (hidden from screen readers) (default: true) */
+  decorative?: boolean;
+  /** Whether to animate the arrow (default: false) */
+  animated?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/** Arrow symbols for each trend direction */
+export const TREND_ARROWS: Record<TrendDirection, string> = {
+  RisingFast: "↑↑",
+  Rising: "↗",
+  Stable: "→",
+  Falling: "↘",
+  FallingFast: "↓↓",
+  Unknown: "?",
+};
+
+/** Human-readable descriptions for screen readers */
+export const TREND_DESCRIPTIONS: Record<TrendDirection, string> = {
+  RisingFast: "rising fast",
+  Rising: "rising",
+  Stable: "stable",
+  Falling: "falling",
+  FallingFast: "falling fast",
+  Unknown: "unknown trend",
+};
+
+/** Trend-based color classes (for when useTrendColor is true) */
+const TREND_COLORS: Record<TrendDirection, string> = {
+  RisingFast: "text-red-400",
+  Rising: "text-amber-400",
+  Stable: "text-green-400",
+  Falling: "text-amber-400",
+  FallingFast: "text-red-400",
+  Unknown: "text-slate-400",
+};
+
+/** Size classes for different arrow sizes */
+const SIZE_CLASSES: Record<TrendArrowSize, string> = {
+  sm: "text-lg",
+  md: "text-2xl",
+  lg: "text-4xl",
+  xl: "text-5xl",
+};
+
+/** Animation variants for the arrow */
+const arrowAnimation = {
+  RisingFast: {
+    y: [0, -3, 0],
+    transition: { duration: 0.8, repeat: Infinity, ease: "easeInOut" },
+  },
+  Rising: {
+    y: [0, -2, 0],
+    transition: { duration: 1.2, repeat: Infinity, ease: "easeInOut" },
+  },
+  Stable: undefined,
+  Falling: {
+    y: [0, 2, 0],
+    transition: { duration: 1.2, repeat: Infinity, ease: "easeInOut" },
+  },
+  FallingFast: {
+    y: [0, 3, 0],
+    transition: { duration: 0.8, repeat: Infinity, ease: "easeInOut" },
+  },
+  Unknown: undefined,
+};
+
+/**
+ * Get the arrow symbol for a given trend direction.
+ */
+export function getTrendArrow(direction: TrendDirection): string {
+  return TREND_ARROWS[direction];
+}
+
+/**
+ * Get the human-readable description for a trend direction.
+ */
+export function getTrendDescription(direction: TrendDirection): string {
+  return TREND_DESCRIPTIONS[direction];
+}
+
+/**
+ * Check if a trend direction indicates rising glucose.
+ */
+export function isRising(direction: TrendDirection): boolean {
+  return direction === "RisingFast" || direction === "Rising";
+}
+
+/**
+ * Check if a trend direction indicates falling glucose.
+ */
+export function isFalling(direction: TrendDirection): boolean {
+  return direction === "FallingFast" || direction === "Falling";
+}
+
+/**
+ * Check if a trend direction indicates rapid change (either direction).
+ */
+export function isRapidChange(direction: TrendDirection): boolean {
+  return direction === "RisingFast" || direction === "FallingFast";
+}
+
+/**
+ * Check if a trend direction indicates stable glucose.
+ */
+export function isStable(direction: TrendDirection): boolean {
+  return direction === "Stable";
+}
+
+/**
+ * Check if a trend direction is unknown.
+ */
+export function isUnknown(direction: TrendDirection): boolean {
+  return direction === "Unknown";
+}
+
+export function TrendArrow({
+  direction,
+  size = "md",
+  colorClass,
+  useTrendColor = false,
+  decorative = true,
+  animated = false,
+  className,
+}: TrendArrowProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  const arrow = TREND_ARROWS[direction];
+  const description = TREND_DESCRIPTIONS[direction];
+
+  // Determine color class
+  const color = colorClass ?? (useTrendColor ? TREND_COLORS[direction] : "");
+
+  // Should we animate?
+  const shouldAnimate = animated && !prefersReducedMotion && arrowAnimation[direction];
+
+  // Build common props
+  const ariaProps = decorative
+    ? { "aria-hidden": "true" as const }
+    : { role: "img" as const, "aria-label": `Glucose trend: ${description}` };
+
+  const commonProps = {
+    "data-testid": "trend-arrow",
+    "data-direction": direction,
+    ...ariaProps,
+  };
+
+  // Wrap in motion.span if animated
+  if (shouldAnimate) {
+    return (
+      <motion.span
+        className={clsx(SIZE_CLASSES[size], color, className, "inline-block")}
+        animate={arrowAnimation[direction]}
+        {...commonProps}
+      >
+        {arrow}
+      </motion.span>
+    );
+  }
+
+  return (
+    <span
+      className={clsx(SIZE_CLASSES[size], color, className)}
+      {...commonProps}
+    >
+      {arrow}
+    </span>
+  );
+}
+
+export default TrendArrow;


### PR DESCRIPTION
## Summary

Implements **Story 4.3: TrendArrow Component** - a reusable component for displaying glucose trend direction as arrows.

### Features
- Arrow symbols for all directions (↑↑, ↗, →, ↘, ↓↓, ?)
- Size variants: sm, md (default), lg, xl
- Color modes: custom colorClass, trend-based colors (useTrendColor), or inherit
- Accessibility: decorative mode (aria-hidden) or standalone mode (role=img + aria-label)
- Animation support with reduced motion respect (SSR-safe)

### Utility Functions
| Function | Description |
|----------|-------------|
| `getTrendArrow(direction)` | Get arrow symbol for direction |
| `getTrendDescription(direction)` | Get screen reader text |
| `isRising(direction)` | Check if trend is rising |
| `isFalling(direction)` | Check if trend is falling |
| `isRapidChange(direction)` | Check if rapid change |
| `isStable(direction)` | Check if stable |
| `isUnknown(direction)` | Check if unknown |

### Refactoring
- GlucoseHero now imports shared `TREND_ARROWS` and `TREND_DESCRIPTIONS` from trend-arrow
- `TrendDirection` re-exported from glucose-hero for backwards compatibility

### Files Changed
| File | Description |
|------|-------------|
| `apps/web/src/components/dashboard/trend-arrow.tsx` | New TrendArrow component |
| `apps/web/src/components/dashboard/index.ts` | Updated barrel export |
| `apps/web/__tests__/components/dashboard/trend-arrow.test.tsx` | 74 tests |
| `apps/web/src/components/dashboard/glucose-hero.tsx` | Refactored + re-export |

## Test plan
- [x] All 183 tests pass (74 new for TrendArrow)
- [x] ESLint passes with no warnings
- [x] Visual verification with Playwright MCP
- [x] GlucoseHero still works correctly after refactor
- [x] Backwards compatibility for TrendDirection import

🤖 Generated with [Claude Code](https://claude.com/claude-code)