### PR TITLE
feat(web): add TimeInRangeBar component for dashboard

### DIFF
--- a/apps/web/__tests__/components/dashboard/time-in-range-bar.test.tsx
+++ b/apps/web/__tests__/components/dashboard/time-in-range-bar.test.tsx
@@ -1,0 +1,551 @@
+/**
+ * Tests for the TimeInRangeBar component.
+ *
+ * Story 4.4: Time in Range Bar Component
+ */
+
+import { render, screen } from "@testing-library/react";
+import {
+  TimeInRangeBar,
+  normalizePercentages,
+  sanitizeRangeData,
+  formatPercentage,
+  getQualityAssessment,
+  PERIOD_LABELS,
+  type RangeData,
+  type TimePeriod,
+} from "../../../src/components/dashboard/time-in-range-bar";
+import TimeInRangeBarDefault from "../../../src/components/dashboard/time-in-range-bar";
+
+// Mock framer-motion
+const mockUseReducedMotion = jest.fn(() => false);
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      style,
+      ...props
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      style?: React.CSSProperties;
+      [key: string]: unknown;
+    }) => (
+      <div className={className} style={style} {...props}>
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+beforeEach(() => {
+  mockUseReducedMotion.mockReturnValue(false);
+});
+
+describe("PERIOD_LABELS constant", () => {
+  it("contains all time periods", () => {
+    expect(PERIOD_LABELS["24h"]).toBe("24 Hours");
+    expect(PERIOD_LABELS["7d"]).toBe("7 Days");
+    expect(PERIOD_LABELS["14d"]).toBe("14 Days");
+    expect(PERIOD_LABELS["30d"]).toBe("30 Days");
+    expect(PERIOD_LABELS["90d"]).toBe("90 Days");
+  });
+});
+
+describe("normalizePercentages", () => {
+  it("returns data unchanged if already sums to 100", () => {
+    const data: RangeData = { low: 10, inRange: 70, high: 20 };
+    const result = normalizePercentages(data);
+
+    expect(result).toEqual(data);
+  });
+
+  it("normalizes data that sums to more than 100", () => {
+    const data: RangeData = { low: 20, inRange: 80, high: 20 };
+    const result = normalizePercentages(data);
+
+    expect(result.low + result.inRange + result.high).toBeCloseTo(100, 1);
+  });
+
+  it("normalizes data that sums to less than 100", () => {
+    const data: RangeData = { low: 5, inRange: 35, high: 10 };
+    const result = normalizePercentages(data);
+
+    expect(result.low + result.inRange + result.high).toBeCloseTo(100, 1);
+  });
+
+  it("returns 100% inRange for all zeros", () => {
+    const data: RangeData = { low: 0, inRange: 0, high: 0 };
+    const result = normalizePercentages(data);
+
+    expect(result).toEqual({ low: 0, inRange: 100, high: 0 });
+  });
+
+  it("handles floating point near 100", () => {
+    const data: RangeData = { low: 5.001, inRange: 70.002, high: 24.997 };
+    const result = normalizePercentages(data);
+
+    // Should return unchanged since it's within 0.01 of 100
+    expect(result).toEqual(data);
+  });
+
+  it("ensures inRange is never negative", () => {
+    // Edge case with extreme rounding
+    const data: RangeData = { low: 50.3, inRange: 0, high: 50.3 };
+    const result = normalizePercentages(data);
+    expect(result.inRange).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("sanitizeRangeData", () => {
+  it("returns valid data unchanged", () => {
+    const data: RangeData = { low: 10, inRange: 70, high: 20 };
+    const result = sanitizeRangeData(data);
+
+    expect(result).toEqual(data);
+  });
+
+  it("converts NaN to 0", () => {
+    const data: RangeData = { low: NaN, inRange: 70, high: 20 };
+    const result = sanitizeRangeData(data);
+
+    expect(result.low).toBe(0);
+    expect(result.inRange).toBe(70);
+    expect(result.high).toBe(20);
+  });
+
+  it("converts Infinity to 0", () => {
+    const data: RangeData = { low: Infinity, inRange: 70, high: 20 };
+    const result = sanitizeRangeData(data);
+
+    expect(result.low).toBe(0);
+  });
+
+  it("converts negative Infinity to 0", () => {
+    const data: RangeData = { low: -Infinity, inRange: 70, high: 20 };
+    const result = sanitizeRangeData(data);
+
+    expect(result.low).toBe(0);
+  });
+
+  it("converts negative numbers to 0", () => {
+    const data: RangeData = { low: -5, inRange: 70, high: 20 };
+    const result = sanitizeRangeData(data);
+
+    expect(result.low).toBe(0);
+  });
+
+  it("caps values at 100", () => {
+    const data: RangeData = { low: 150, inRange: 70, high: 20 };
+    const result = sanitizeRangeData(data);
+
+    expect(result.low).toBe(100);
+  });
+
+  it("handles multiple invalid values", () => {
+    const data: RangeData = { low: NaN, inRange: -10, high: Infinity };
+    const result = sanitizeRangeData(data);
+
+    expect(result).toEqual({ low: 0, inRange: 0, high: 0 });
+  });
+});
+
+describe("formatPercentage", () => {
+  it("formats 0 as '0%'", () => {
+    expect(formatPercentage(0)).toBe("0%");
+  });
+
+  it("formats values less than 0.5 as '<1%'", () => {
+    expect(formatPercentage(0.1)).toBe("<1%");
+    expect(formatPercentage(0.4)).toBe("<1%");
+  });
+
+  it("formats 0.5 as '1%' (rounds up)", () => {
+    expect(formatPercentage(0.5)).toBe("1%");
+  });
+
+  it("formats 0.9 as '1%' (rounds to 1)", () => {
+    expect(formatPercentage(0.9)).toBe("1%");
+  });
+
+  it("formats 99.4 as '99%' (rounds down)", () => {
+    expect(formatPercentage(99.4)).toBe("99%");
+  });
+
+  it("formats 99.5 as '>99%' (at threshold)", () => {
+    expect(formatPercentage(99.5)).toBe(">99%");
+  });
+
+  it("formats 99.9 as '>99%' (above threshold)", () => {
+    expect(formatPercentage(99.9)).toBe(">99%");
+  });
+
+  it("rounds values to nearest integer", () => {
+    expect(formatPercentage(50)).toBe("50%");
+    expect(formatPercentage(75.4)).toBe("75%");
+    expect(formatPercentage(75.6)).toBe("76%");
+  });
+
+  it("formats 100 as '100%'", () => {
+    expect(formatPercentage(100)).toBe("100%");
+  });
+});
+
+describe("getQualityAssessment", () => {
+  it("returns Excellent for 70% or higher", () => {
+    expect(getQualityAssessment(70)).toEqual({
+      label: "Excellent",
+      colorClass: "text-green-400",
+    });
+    expect(getQualityAssessment(85)).toEqual({
+      label: "Excellent",
+      colorClass: "text-green-400",
+    });
+    expect(getQualityAssessment(100)).toEqual({
+      label: "Excellent",
+      colorClass: "text-green-400",
+    });
+  });
+
+  it("returns Good for 50-69%", () => {
+    expect(getQualityAssessment(50)).toEqual({
+      label: "Good",
+      colorClass: "text-amber-400",
+    });
+    expect(getQualityAssessment(60)).toEqual({
+      label: "Good",
+      colorClass: "text-amber-400",
+    });
+    expect(getQualityAssessment(69)).toEqual({
+      label: "Good",
+      colorClass: "text-amber-400",
+    });
+  });
+
+  it("returns Needs Improvement for below 50%", () => {
+    expect(getQualityAssessment(49)).toEqual({
+      label: "Needs Improvement",
+      colorClass: "text-red-400",
+    });
+    expect(getQualityAssessment(30)).toEqual({
+      label: "Needs Improvement",
+      colorClass: "text-red-400",
+    });
+    expect(getQualityAssessment(0)).toEqual({
+      label: "Needs Improvement",
+      colorClass: "text-red-400",
+    });
+  });
+
+  it("returns Good for exactly 50%", () => {
+    expect(getQualityAssessment(50)).toEqual({
+      label: "Good",
+      colorClass: "text-amber-400",
+    });
+  });
+
+  it("returns Needs Improvement for 49.9%", () => {
+    expect(getQualityAssessment(49.9)).toEqual({
+      label: "Needs Improvement",
+      colorClass: "text-red-400",
+    });
+  });
+
+  it("returns Excellent for exactly 70%", () => {
+    expect(getQualityAssessment(70)).toEqual({
+      label: "Excellent",
+      colorClass: "text-green-400",
+    });
+  });
+
+  it("returns Good for 69.9%", () => {
+    expect(getQualityAssessment(69.9)).toEqual({
+      label: "Good",
+      colorClass: "text-amber-400",
+    });
+  });
+});
+
+describe("TimeInRangeBar component", () => {
+  const defaultData: RangeData = { low: 5, inRange: 78, high: 17 };
+
+  describe("rendering", () => {
+    it("renders with data-testid", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+    });
+
+    it("displays the Time in Range heading", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      expect(screen.getByText("Time in Range")).toBeInTheDocument();
+    });
+
+    it("displays the default period label", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      expect(screen.getByTestId("period-label")).toHaveTextContent("24 Hours");
+    });
+
+    it("displays custom period label", () => {
+      render(<TimeInRangeBar data={defaultData} period="7d" />);
+
+      expect(screen.getByTestId("period-label")).toHaveTextContent("7 Days");
+    });
+
+    it("displays all period options correctly", () => {
+      const periods: TimePeriod[] = ["24h", "7d", "14d", "30d", "90d"];
+      const labels = ["24 Hours", "7 Days", "14 Days", "30 Days", "90 Days"];
+
+      periods.forEach((period, index) => {
+        const { unmount } = render(
+          <TimeInRangeBar data={defaultData} period={period} />
+        );
+        expect(screen.getByTestId("period-label")).toHaveTextContent(
+          labels[index]
+        );
+        unmount();
+      });
+    });
+
+    it("displays quality assessment", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      expect(screen.getByText("Excellent")).toBeInTheDocument();
+    });
+
+    it("displays correct quality for Good range", () => {
+      render(<TimeInRangeBar data={{ low: 10, inRange: 55, high: 35 }} />);
+
+      expect(screen.getByText("Good")).toBeInTheDocument();
+    });
+
+    it("displays correct quality for Needs Improvement range", () => {
+      render(<TimeInRangeBar data={{ low: 20, inRange: 40, high: 40 }} />);
+
+      expect(screen.getByText("Needs Improvement")).toBeInTheDocument();
+    });
+
+    it("displays target range info", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      expect(screen.getByText("Target: 70-180 mg/dL")).toBeInTheDocument();
+    });
+
+    it("displays custom target range", () => {
+      render(
+        <TimeInRangeBar data={defaultData} targetRange="80-140 mg/dL" />
+      );
+
+      expect(screen.getByText("Target: 80-140 mg/dL")).toBeInTheDocument();
+    });
+  });
+
+  describe("legend", () => {
+    it("shows legend by default", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      expect(screen.getByTestId("range-legend")).toBeInTheDocument();
+    });
+
+    it("hides legend when showLegend is false", () => {
+      render(<TimeInRangeBar data={defaultData} showLegend={false} />);
+
+      expect(screen.queryByTestId("range-legend")).not.toBeInTheDocument();
+    });
+
+    it("displays legend percentages", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      const legend = screen.getByTestId("range-legend");
+      expect(legend).toHaveTextContent("Low: 5%");
+      expect(legend).toHaveTextContent("In Range: 78%");
+      expect(legend).toHaveTextContent("High: 17%");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has accessible bar with role=img", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      const bar = screen.getByRole("img");
+      expect(bar).toBeInTheDocument();
+    });
+
+    it("has descriptive aria-label on bar", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      const bar = screen.getByRole("img");
+      expect(bar).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("Time in range for 24 Hours")
+      );
+      expect(bar).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("5% below range")
+      );
+      expect(bar).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("78% in range")
+      );
+      expect(bar).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("17% above range")
+      );
+    });
+
+    it("includes target range in aria-label", () => {
+      render(<TimeInRangeBar data={defaultData} targetRange="70-180 mg/dL" />);
+
+      const bar = screen.getByRole("img");
+      expect(bar).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("Target range: 70-180 mg/dL")
+      );
+    });
+  });
+
+  describe("data handling", () => {
+    it("normalizes data that doesn't sum to 100", () => {
+      render(<TimeInRangeBar data={{ low: 10, inRange: 40, high: 10 }} />);
+
+      const legend = screen.getByTestId("range-legend");
+      // Should normalize to approximately 17%, 67%, 17%
+      expect(legend).toBeInTheDocument();
+    });
+
+    it("handles all zeros gracefully", () => {
+      render(<TimeInRangeBar data={{ low: 0, inRange: 0, high: 0 }} />);
+
+      const legend = screen.getByTestId("range-legend");
+      expect(legend).toHaveTextContent("In Range: 100%");
+    });
+
+    it("sanitizes NaN values", () => {
+      render(<TimeInRangeBar data={{ low: NaN, inRange: 70, high: 20 }} />);
+
+      // Should render without crashing
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+    });
+
+    it("sanitizes negative values", () => {
+      render(<TimeInRangeBar data={{ low: -5, inRange: 70, high: 20 }} />);
+
+      // Should render without crashing
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+    });
+  });
+
+  describe("styling", () => {
+    it("applies custom className", () => {
+      render(
+        <TimeInRangeBar data={defaultData} className="custom-test-class" />
+      );
+
+      expect(screen.getByTestId("time-in-range-bar")).toHaveClass(
+        "custom-test-class"
+      );
+    });
+
+    it("has correct base styling classes", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      expect(screen.getByTestId("time-in-range-bar")).toHaveClass(
+        "bg-slate-900",
+        "rounded-xl",
+        "border",
+        "border-slate-800"
+      );
+    });
+  });
+
+  describe("animation", () => {
+    it("renders with animation by default", () => {
+      render(<TimeInRangeBar data={defaultData} />);
+
+      // Should render the bar (animation is mocked)
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+    });
+
+    it("renders without animation when animated is false", () => {
+      render(<TimeInRangeBar data={defaultData} animated={false} />);
+
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+    });
+  });
+
+  describe("reduced motion", () => {
+    it("respects prefers-reduced-motion preference", () => {
+      mockUseReducedMotion.mockReturnValue(true);
+      const data: RangeData = { low: 5, inRange: 78, high: 17 };
+      render(<TimeInRangeBar data={data} animated={true} />);
+
+      // Component should still render correctly
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+    });
+  });
+
+  describe("segment labels", () => {
+    it("shows labels on segments >= 10%", () => {
+      render(
+        <TimeInRangeBar
+          data={{ low: 15, inRange: 70, high: 15 }}
+          showLabels={true}
+        />
+      );
+
+      // Segments should have their percentage labels
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+    });
+
+    it("hides labels when showLabels is false", () => {
+      render(
+        <TimeInRangeBar
+          data={{ low: 15, inRange: 70, high: 15 }}
+          showLabels={false}
+        />
+      );
+
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows skeleton when isLoading is true", () => {
+      const data: RangeData = { low: 5, inRange: 78, high: 17 };
+      render(<TimeInRangeBar data={data} isLoading={true} />);
+
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+      expect(screen.getByRole("region")).toHaveAttribute("aria-busy", "true");
+    });
+
+    it("does not show legend when loading", () => {
+      const data: RangeData = { low: 5, inRange: 78, high: 17 };
+      render(<TimeInRangeBar data={data} isLoading={true} />);
+
+      expect(screen.queryByTestId("range-legend")).not.toBeInTheDocument();
+    });
+
+    it("has accessible loading label", () => {
+      const data: RangeData = { low: 5, inRange: 78, high: 17 };
+      render(<TimeInRangeBar data={data} isLoading={true} />);
+
+      expect(screen.getByRole("region")).toHaveAttribute(
+        "aria-label",
+        "Loading time in range data"
+      );
+    });
+  });
+
+  describe("exports", () => {
+    it("default export works", () => {
+      render(<TimeInRangeBarDefault data={defaultData} />);
+
+      expect(screen.getByTestId("time-in-range-bar")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -3,11 +3,12 @@
  *
  * Story 4.1: Dashboard Layout & Navigation
  * Story 4.2: GlucoseHero Component
+ * Story 4.4: Time in Range Bar Component
  * Main dashboard view showing glucose data and metrics.
  */
 
 import { Activity, Clock } from "lucide-react";
-import { GlucoseHero } from "@/components/dashboard";
+import { GlucoseHero, TimeInRangeBar } from "@/components/dashboard";
 
 export default function DashboardPage() {
   // Mock data - will be replaced with real data from API in Story 4.5
@@ -16,6 +17,12 @@ export default function DashboardPage() {
     trend: "Stable" as const,
     iob: 2.4,
     cob: 15,
+  };
+
+  const mockTimeInRangeData = {
+    low: 5,
+    inRange: 78,
+    high: 17,
   };
 
   return (
@@ -61,23 +68,11 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      {/* Time in Range bar placeholder - Story 4.4 */}
-      <div className="bg-slate-900 rounded-xl p-6 border border-slate-800">
-        <h2 className="text-lg font-semibold mb-4">Time in Range</h2>
-        <div className="h-8 rounded-full overflow-hidden flex">
-          <div className="bg-red-500 w-[5%]" title="Below range: 5%" />
-          <div className="bg-green-500 w-[78%]" title="In range: 78%" />
-          <div className="bg-orange-500 w-[17%]" title="Above range: 17%" />
-        </div>
-        <div className="flex justify-between mt-2 text-xs text-slate-500">
-          <span>Low: 5%</span>
-          <span>In Range: 78%</span>
-          <span>High: 17%</span>
-        </div>
-        <p className="text-slate-500 text-xs mt-4 text-center">
-          Placeholder - TimeInRangeBar component coming in Story 4.4
-        </p>
-      </div>
+      {/* Time in Range bar - Story 4.4 */}
+      <TimeInRangeBar
+        data={mockTimeInRangeData}
+        period="24h"
+      />
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -28,3 +28,15 @@ export {
   isStable,
   isUnknown,
 } from "./trend-arrow";
+
+export {
+  TimeInRangeBar,
+  type TimeInRangeBarProps,
+  type RangeData,
+  type TimePeriod,
+  normalizePercentages,
+  sanitizeRangeData,
+  formatPercentage,
+  getQualityAssessment,
+  PERIOD_LABELS,
+} from "./time-in-range-bar";

--- a/apps/web/src/components/dashboard/time-in-range-bar.tsx
+++ b/apps/web/src/components/dashboard/time-in-range-bar.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+/**
+ * TimeInRangeBar Component
+ *
+ * Story 4.4: Time in Range Bar Component
+ * Displays a horizontal stacked bar showing the percentage of time
+ * spent in different glucose ranges (low, in-range, high).
+ */
+
+import { motion, useReducedMotion } from "framer-motion";
+import clsx from "clsx";
+
+/** Time period options for the display */
+export type TimePeriod = "24h" | "7d" | "14d" | "30d" | "90d";
+
+/** Data for each glucose range segment */
+export interface RangeData {
+  /** Percentage of time below range (0-100) */
+  low: number;
+  /** Percentage of time in range (0-100) */
+  inRange: number;
+  /** Percentage of time above range (0-100) */
+  high: number;
+}
+
+export interface TimeInRangeBarProps {
+  /** Range percentages (must sum to ~100) */
+  data: RangeData;
+  /** Time period label (default: 24h) */
+  period?: TimePeriod;
+  /** Whether to show the legend below the bar (default: true) */
+  showLegend?: boolean;
+  /** Whether to show percentage labels on segments (default: true) */
+  showLabels?: boolean;
+  /** Whether to animate the bar on mount (default: true) */
+  animated?: boolean;
+  /** Target range description (default: "70-180 mg/dL") */
+  targetRange?: string;
+  /** Whether data is loading */
+  isLoading?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/** Period display labels */
+export const PERIOD_LABELS: Record<TimePeriod, string> = {
+  "24h": "24 Hours",
+  "7d": "7 Days",
+  "14d": "14 Days",
+  "30d": "30 Days",
+  "90d": "90 Days",
+};
+
+/** Color classes for each range */
+const RANGE_COLORS = {
+  low: {
+    bg: "bg-red-500",
+    text: "text-red-400",
+  },
+  inRange: {
+    bg: "bg-green-500",
+    text: "text-green-400",
+  },
+  high: {
+    bg: "bg-amber-500",
+    text: "text-amber-400",
+  },
+} as const;
+
+/**
+ * Normalize percentages to ensure they sum to 100.
+ * Handles floating point precision issues.
+ */
+export function normalizePercentages(data: RangeData): RangeData {
+  const total = data.low + data.inRange + data.high;
+
+  if (total === 0) {
+    return { low: 0, inRange: 100, high: 0 };
+  }
+
+  if (Math.abs(total - 100) < 0.01) {
+    return data;
+  }
+
+  // Normalize to 100%
+  const factor = 100 / total;
+  const low = Math.round(data.low * factor * 10) / 10;
+  const high = Math.round(data.high * factor * 10) / 10;
+  // inRange absorbs any rounding differences to ensure sum is exactly 100
+  // Math.max(0, ...) prevents negative values from extreme rounding edge cases
+  const inRange = Math.max(0, Math.round((100 - low - high) * 10) / 10);
+
+  return { low, inRange, high };
+}
+
+/**
+ * Validate and sanitize range data.
+ * Returns safe values for invalid inputs.
+ */
+export function sanitizeRangeData(data: RangeData): RangeData {
+  const sanitize = (value: number): number => {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+      return 0;
+    }
+    return Math.min(value, 100);
+  };
+
+  return {
+    low: sanitize(data.low),
+    inRange: sanitize(data.inRange),
+    high: sanitize(data.high),
+  };
+}
+
+/**
+ * Format percentage for display.
+ */
+export function formatPercentage(value: number): string {
+  if (value === 0) return "0%";
+  if (value > 0 && value < 0.5) return "<1%";
+  if (value >= 99.5 && value < 100) return ">99%";
+  return `${Math.round(value)}%`;
+}
+
+/**
+ * Get quality assessment based on time in range.
+ */
+export function getQualityAssessment(inRangePercent: number): {
+  label: string;
+  colorClass: string;
+} {
+  if (inRangePercent >= 70) {
+    return { label: "Excellent", colorClass: "text-green-400" };
+  }
+  if (inRangePercent >= 50) {
+    return { label: "Good", colorClass: "text-amber-400" };
+  }
+  return { label: "Needs Improvement", colorClass: "text-red-400" };
+}
+
+/** Props for individual bar segments */
+interface BarSegmentProps {
+  percentage: number;
+  color: string;
+  label: string;
+  position: "start" | "middle" | "end";
+  showLabels: boolean;
+}
+
+/** Individual segment of the time-in-range bar */
+function BarSegment({
+  percentage,
+  color,
+  label,
+  position,
+  showLabels,
+}: BarSegmentProps) {
+  if (percentage === 0) return null;
+
+  const roundedClasses = clsx({
+    "rounded-l-full": position === "start",
+    "rounded-r-full": position === "end",
+  });
+
+  return (
+    <div
+      className={clsx(
+        color,
+        roundedClasses,
+        "h-full flex items-center justify-center transition-all duration-300"
+      )}
+      style={{ width: `${percentage}%` }}
+      title={`${label}: ${formatPercentage(percentage)}`}
+    >
+      {showLabels && percentage >= 10 && (
+        <span className="text-xs font-medium text-white/90 drop-shadow-sm">
+          {formatPercentage(percentage)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function TimeInRangeBar({
+  data,
+  period = "24h",
+  showLegend = true,
+  showLabels = true,
+  animated = true,
+  targetRange = "70-180 mg/dL",
+  isLoading = false,
+  className,
+}: TimeInRangeBarProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  // Loading skeleton
+  if (isLoading) {
+    return (
+      <div
+        className={clsx(
+          "bg-slate-900 rounded-xl p-6 border border-slate-800 animate-pulse",
+          className
+        )}
+        data-testid="time-in-range-bar"
+        role="region"
+        aria-label="Loading time in range data"
+        aria-busy="true"
+      >
+        <div className="flex items-center justify-between mb-4">
+          <div className="h-6 w-32 bg-slate-700 rounded" />
+          <div className="h-6 w-20 bg-slate-700 rounded" />
+        </div>
+        <div className="h-8 bg-slate-700 rounded-full" />
+        <div className="flex justify-between mt-3">
+          <div className="h-4 w-16 bg-slate-700 rounded" />
+          <div className="h-4 w-20 bg-slate-700 rounded" />
+          <div className="h-4 w-16 bg-slate-700 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  // Sanitize and normalize data
+  const safeData = sanitizeRangeData(data);
+  const normalizedData = normalizePercentages(safeData);
+
+  const periodLabel = PERIOD_LABELS[period];
+  const quality = getQualityAssessment(normalizedData.inRange);
+
+  // Build aria description (single line to avoid awkward screen reader pauses)
+  const ariaDescription = `Time in range for ${periodLabel}: ${formatPercentage(normalizedData.low)} below range, ${formatPercentage(normalizedData.inRange)} in range, ${formatPercentage(normalizedData.high)} above range. Target range: ${targetRange}.`;
+
+  // Animation variants
+  const barVariants = {
+    hidden: { scaleX: 0 },
+    visible: { scaleX: 1, transition: { duration: 0.6, ease: "easeOut" } },
+  };
+
+  // Determine positions for rounded corners
+  const getPosition = (
+    range: "low" | "inRange" | "high"
+  ): "start" | "middle" | "end" => {
+    const hasLow = normalizedData.low > 0;
+    const hasHigh = normalizedData.high > 0;
+
+    if (range === "low") return "start";
+    if (range === "high") return "end";
+    // inRange
+    if (!hasLow && !hasHigh) return "start"; // Only inRange
+    if (!hasLow) return "start";
+    if (!hasHigh) return "end";
+    return "middle";
+  };
+
+  const barContent = (
+    <div
+      className="h-8 rounded-full overflow-hidden flex bg-slate-700"
+      role="img"
+      aria-label={ariaDescription}
+    >
+      <BarSegment
+        percentage={normalizedData.low}
+        color={RANGE_COLORS.low.bg}
+        label="Below range"
+        position={getPosition("low")}
+        showLabels={showLabels}
+      />
+      <BarSegment
+        percentage={normalizedData.inRange}
+        color={RANGE_COLORS.inRange.bg}
+        label="In range"
+        position={getPosition("inRange")}
+        showLabels={showLabels}
+      />
+      <BarSegment
+        percentage={normalizedData.high}
+        color={RANGE_COLORS.high.bg}
+        label="Above range"
+        position={getPosition("high")}
+        showLabels={showLabels}
+      />
+    </div>
+  );
+
+  return (
+    <div
+      className={clsx("bg-slate-900 rounded-xl p-6 border border-slate-800", className)}
+      data-testid="time-in-range-bar"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold">Time in Range</h2>
+        <div className="flex items-center gap-3">
+          <span className={clsx("text-sm font-medium", quality.colorClass)}>
+            {quality.label}
+          </span>
+          <span
+            className="text-sm text-slate-400 bg-slate-800 px-2 py-1 rounded"
+            data-testid="period-label"
+          >
+            {periodLabel}
+          </span>
+        </div>
+      </div>
+
+      {/* Bar */}
+      {animated && !prefersReducedMotion ? (
+        <motion.div
+          initial="hidden"
+          animate="visible"
+          variants={barVariants}
+          style={{ originX: 0 }}
+        >
+          {barContent}
+        </motion.div>
+      ) : (
+        barContent
+      )}
+
+      {/* Legend */}
+      {showLegend && (
+        <div
+          className="flex justify-between mt-3 text-sm"
+          data-testid="range-legend"
+        >
+          <div className="flex items-center gap-2">
+            <div className={clsx("w-3 h-3 rounded-full", RANGE_COLORS.low.bg)} aria-hidden="true" />
+            <span className={RANGE_COLORS.low.text}>
+              Low: {formatPercentage(normalizedData.low)}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className={clsx("w-3 h-3 rounded-full", RANGE_COLORS.inRange.bg)} aria-hidden="true" />
+            <span className={RANGE_COLORS.inRange.text}>
+              In Range: {formatPercentage(normalizedData.inRange)}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className={clsx("w-3 h-3 rounded-full", RANGE_COLORS.high.bg)} aria-hidden="true" />
+            <span className={RANGE_COLORS.high.text}>
+              High: {formatPercentage(normalizedData.high)}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Target range info */}
+      <p className="text-slate-500 text-xs mt-3 text-center">
+        Target: {targetRange}
+      </p>
+    </div>
+  );
+}
+
+export default TimeInRangeBar;


### PR DESCRIPTION
## Summary
- Add TimeInRangeBar component (Story 4.4) displaying stacked horizontal bar for time-in-range visualization
- Support multiple time periods (24h, 7d, 14d, 30d, 90d) with quality assessment labels
- Include loading skeleton, prefers-reduced-motion support, and comprehensive accessibility features

## Changes
- **New component**: `apps/web/src/components/dashboard/time-in-range-bar.tsx`
  - Stacked bar with low (red), in-range (green), high (amber) segments
  - Utility functions: `normalizePercentages`, `sanitizeRangeData`, `formatPercentage`, `getQualityAssessment`
  - Defensive handling for NaN, Infinity, negative values
  - Loading skeleton with `aria-busy` and `aria-label`
  - `useReducedMotion` hook for accessibility
- **Tests**: 61 comprehensive tests covering all functionality
- **Dashboard integration**: Replaced placeholder with actual component

## Test plan
- [x] All 244 tests passing
- [x] ESLint clean
- [x] Visual verification with Playwright
- [x] Code review completed (2 rounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)