### PR TITLE
feat(api): add BYOAI abstraction layer (Story 5.2)

### DIFF
--- a/apps/api/src/integrations/claude.py
+++ b/apps/api/src/integrations/claude.py
@@ -32,9 +32,9 @@ class ClaudeClient(BaseAIClient):
             max_tokens: Maximum tokens in the response.
 
         Returns:
-            Normalised AIResponse.
+            Normalized AIResponse.
         """
-        client = anthropic.AsyncAnthropic(api_key=self.api_key)
+        client = anthropic.AsyncAnthropic(api_key=self._api_key)
 
         kwargs: dict[str, Any] = {
             "model": self.model,
@@ -61,12 +61,16 @@ class ClaudeClient(BaseAIClient):
 
         content = response.content[0].text if response.content else ""
 
+        usage = AIUsage()
+        if response.usage:
+            usage = AIUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+            )
+
         return AIResponse(
             content=content,
             model=response.model,
             provider=AIProviderType.CLAUDE,
-            usage=AIUsage(
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
-            ),
+            usage=usage,
         )

--- a/apps/api/src/schemas/ai_response.py
+++ b/apps/api/src/schemas/ai_response.py
@@ -23,7 +23,7 @@ class AIUsage(BaseModel):
 
 
 class AIResponse(BaseModel):
-    """Normalised response from any AI provider."""
+    """Normalized response from any AI provider."""
 
     content: str = Field(..., description="Generated text content")
     model: str = Field(..., description="Model that generated the response")

--- a/apps/api/src/services/ai_client.py
+++ b/apps/api/src/services/ai_client.py
@@ -28,11 +28,11 @@ class BaseAIClient(abc.ABC):
     """Abstract base class for AI provider clients.
 
     Subclasses implement provider-specific API calls while
-    returning a normalised AIResponse.
+    returning a normalized AIResponse.
     """
 
     def __init__(self, api_key: str, model: str) -> None:
-        self.api_key = api_key
+        self._api_key = api_key
         self.model = model
 
     @abc.abstractmethod
@@ -50,7 +50,7 @@ class BaseAIClient(abc.ABC):
             max_tokens: Maximum tokens in the response.
 
         Returns:
-            Normalised AIResponse with content, model, provider, and usage.
+            Normalized AIResponse with content, model, provider, and usage.
         """
 
 


### PR DESCRIPTION
## Summary
- Adds abstract base class (`BaseAIClient`) and factory pattern for AI provider clients
- Unified `generate()` interface works with both Claude and OpenAI providers
- Responses normalized to common `AIResponse` schema with token usage tracking
- Foundation for Stories 5.3-5.5 (daily brief, pattern recognition, correction factor)

## Changes
### New Files
| File | Purpose |
|------|---------|
| `apps/api/src/services/ai_client.py` | BaseAIClient ABC + `get_ai_client()` factory |
| `apps/api/src/schemas/ai_response.py` | AIResponse, AIMessage, AIUsage schemas |
| `apps/api/src/integrations/claude.py` | ClaudeClient (Anthropic AsyncAnthropic SDK) |
| `apps/api/src/integrations/openai_client.py` | OpenAIClient (OpenAI AsyncOpenAI SDK) |
| `apps/api/tests/test_ai_client.py` | 20 comprehensive tests |

No existing files modified — purely additive.

## Test plan
- [x] 20 tests passing (8 Claude, 7 OpenAI, 1 normalization, 4 factory)
- [x] Full regression: 185 passed, 1 skipped, 0 failures
- [x] Ruff lint and format clean
- [x] 2 code review rounds — APPROVED
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)