### PR TITLE
feat(api): add daily brief generation (Story 5.3)

### DIFF
--- a/apps/api/migrations/versions/010_create_daily_briefs.py
+++ b/apps/api/migrations/versions/010_create_daily_briefs.py
@@ -1,0 +1,79 @@
+"""Story 5.3: Create daily_briefs table.
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-02-08
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "010_daily_briefs"
+down_revision: str | None = "009_ai_provider"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "daily_briefs",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("time_in_range_pct", sa.Float(), nullable=False),
+        sa.Column("average_glucose", sa.Float(), nullable=False),
+        sa.Column("low_count", sa.Integer(), nullable=False),
+        sa.Column("high_count", sa.Integer(), nullable=False),
+        sa.Column("readings_count", sa.Integer(), nullable=False),
+        sa.Column("correction_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_insulin", sa.Float(), nullable=True),
+        sa.Column("ai_summary", sa.Text(), nullable=False),
+        sa.Column("ai_model", sa.String(100), nullable=False),
+        sa.Column("ai_provider", sa.String(20), nullable=False),
+        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Index for querying briefs by user and period
+    op.create_index(
+        "ix_daily_briefs_user_period",
+        "daily_briefs",
+        ["user_id", "period_start"],
+    )
+
+    # Index for user_id lookups
+    op.create_index(
+        "ix_daily_briefs_user_id",
+        "daily_briefs",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_daily_briefs_user_id")
+    op.drop_index("ix_daily_briefs_user_period")
+    op.drop_table("daily_briefs")

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -13,6 +13,7 @@ from src.middleware import CorrelationIdMiddleware
 from src.routers import (
     ai,
     auth,
+    briefs,
     disclaimer,
     glucose_stream,
     health,
@@ -79,6 +80,7 @@ app.include_router(system.router)
 app.include_router(integrations.router)
 app.include_router(glucose_stream.router)
 app.include_router(ai.router)
+app.include_router(briefs.router)
 
 
 @app.get("/")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -1,6 +1,7 @@
 # Database Models
 from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProviderType
 from src.models.base import Base, TimestampMixin
+from src.models.daily_brief import DailyBrief
 from src.models.disclaimer import DisclaimerAcknowledgment
 from src.models.glucose import GlucoseReading, TrendDirection
 from src.models.integration import (
@@ -17,6 +18,7 @@ __all__ = [
     "AIProviderType",
     "Base",
     "TimestampMixin",
+    "DailyBrief",
     "DisclaimerAcknowledgment",
     "GlucoseReading",
     "TrendDirection",

--- a/apps/api/src/models/daily_brief.py
+++ b/apps/api/src/models/daily_brief.py
@@ -1,0 +1,126 @@
+"""Story 5.3: Daily brief model.
+
+Stores AI-generated daily glucose analysis briefs.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class DailyBrief(Base, TimestampMixin):
+    """Stores daily AI-generated glucose analysis briefs.
+
+    Each brief covers a 24-hour period and includes calculated metrics
+    from glucose readings and pump events, plus AI-generated analysis.
+    """
+
+    __tablename__ = "daily_briefs"
+
+    __table_args__ = (Index("ix_daily_briefs_user_period", "user_id", "period_start"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Analysis period
+    period_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    period_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # Calculated glucose metrics
+    time_in_range_pct: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+    )
+
+    average_glucose: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+    )
+
+    low_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+
+    high_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+
+    readings_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+
+    # Control-IQ summary
+    correction_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+    )
+
+    total_insulin: Mapped[float | None] = mapped_column(
+        Float,
+        nullable=True,
+    )
+
+    # AI output
+    ai_summary: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+
+    ai_model: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+    )
+
+    ai_provider: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+    )
+
+    # Token usage tracking
+    input_tokens: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+    )
+
+    output_tokens: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+    )
+
+    # Relationship to user
+    user = relationship("User", back_populates="daily_briefs")
+
+    def __repr__(self) -> str:
+        return (
+            f"<DailyBrief(user_id={self.user_id}, "
+            f"period={self.period_start} to {self.period_end}, "
+            f"tir={self.time_in_range_pct}%)>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -104,6 +104,11 @@ class User(Base, TimestampMixin):
         cascade="all, delete-orphan",
         uselist=False,
     )
+    daily_briefs = relationship(
+        "DailyBrief",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/routers/briefs.py
+++ b/apps/api/src/routers/briefs.py
@@ -1,0 +1,93 @@
+"""Story 5.3: Daily brief router.
+
+API endpoints for generating and retrieving AI-powered daily glucose briefs.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import DiabeticOrAdminUser
+from src.database import get_db
+from src.schemas.auth import ErrorResponse
+from src.schemas.daily_brief import (
+    DailyBriefListResponse,
+    DailyBriefResponse,
+    GenerateBriefRequest,
+)
+from src.services.daily_brief import generate_daily_brief, get_brief_by_id, list_briefs
+
+router = APIRouter(prefix="/api/ai/briefs", tags=["ai-briefs"])
+
+
+@router.post(
+    "/generate",
+    response_model=DailyBriefResponse,
+    status_code=201,
+    responses={
+        201: {"description": "Daily brief generated successfully"},
+        400: {"model": ErrorResponse, "description": "Insufficient data"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+        404: {"model": ErrorResponse, "description": "No AI provider configured"},
+    },
+)
+async def generate_brief(
+    request: GenerateBriefRequest,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> DailyBriefResponse:
+    """Generate an AI-powered daily brief.
+
+    Analyzes glucose readings and pump events for the specified period
+    and generates an AI summary.
+    """
+    brief = await generate_daily_brief(current_user, db, hours=request.hours)
+    return DailyBriefResponse.model_validate(brief)
+
+
+@router.get(
+    "",
+    response_model=DailyBriefListResponse,
+    responses={
+        200: {"description": "List of daily briefs"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+    },
+)
+async def get_briefs(
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(default=10, ge=1, le=50),
+    offset: int = Query(default=0, ge=0),
+) -> DailyBriefListResponse:
+    """List daily briefs for the current user.
+
+    Returns briefs ordered by most recent first, with pagination.
+    """
+    briefs, total = await list_briefs(current_user.id, db, limit=limit, offset=offset)
+    return DailyBriefListResponse(
+        briefs=[DailyBriefResponse.model_validate(b) for b in briefs],
+        total=total,
+    )
+
+
+@router.get(
+    "/{brief_id}",
+    response_model=DailyBriefResponse,
+    responses={
+        200: {"description": "Daily brief details"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+        404: {"model": ErrorResponse, "description": "Brief not found"},
+    },
+)
+async def get_brief(
+    brief_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> DailyBriefResponse:
+    """Get a specific daily brief by ID."""
+    brief = await get_brief_by_id(brief_id, current_user.id, db)
+    return DailyBriefResponse.model_validate(brief)

--- a/apps/api/src/schemas/daily_brief.py
+++ b/apps/api/src/schemas/daily_brief.py
@@ -1,0 +1,68 @@
+"""Story 5.3: Daily brief schemas.
+
+Request and response schemas for daily brief generation and retrieval.
+"""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class DailyBriefMetrics(BaseModel):
+    """Calculated glucose metrics for a 24-hour period."""
+
+    time_in_range_pct: float = Field(
+        ..., description="Percentage of readings in range (70-180 mg/dL)"
+    )
+    average_glucose: float = Field(..., description="Average glucose in mg/dL")
+    low_count: int = Field(..., description="Number of readings below 70 mg/dL")
+    high_count: int = Field(..., description="Number of readings above 180 mg/dL")
+    readings_count: int = Field(..., description="Total number of glucose readings")
+    correction_count: int = Field(
+        default=0, description="Number of Control-IQ corrections"
+    )
+    total_insulin: float | None = Field(
+        default=None, description="Total insulin delivered in units"
+    )
+
+
+class DailyBriefResponse(BaseModel):
+    """Response schema for a daily brief."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    period_start: datetime
+    period_end: datetime
+    time_in_range_pct: float
+    average_glucose: float
+    low_count: int
+    high_count: int
+    readings_count: int
+    correction_count: int
+    total_insulin: float | None
+    ai_summary: str
+    ai_model: str
+    ai_provider: str
+    input_tokens: int
+    output_tokens: int
+    created_at: datetime
+
+
+class DailyBriefListResponse(BaseModel):
+    """Response schema for listing daily briefs."""
+
+    briefs: list[DailyBriefResponse]
+    total: int
+
+
+class GenerateBriefRequest(BaseModel):
+    """Request schema for manually generating a daily brief."""
+
+    hours: int = Field(
+        default=24,
+        ge=1,
+        le=72,
+        description="Number of hours to analyze (default 24)",
+    )

--- a/apps/api/src/services/daily_brief.py
+++ b/apps/api/src/services/daily_brief.py
@@ -1,0 +1,313 @@
+"""Story 5.3: Daily brief generation service.
+
+Aggregates glucose and pump data, generates AI-powered analysis briefs.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.daily_brief import DailyBrief
+from src.models.glucose import GlucoseReading
+from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.user import User
+from src.schemas.ai_response import AIMessage
+from src.schemas.daily_brief import DailyBriefMetrics
+from src.services.ai_client import get_ai_client
+
+logger = get_logger(__name__)
+
+# Glucose range thresholds (mg/dL)
+LOW_THRESHOLD = 70
+HIGH_THRESHOLD = 180
+
+# Minimum readings required to generate a meaningful brief
+MIN_READINGS = 12
+
+SYSTEM_PROMPT = """\
+You are a diabetes management assistant analyzing glucose and insulin data. \
+Provide a concise, supportive daily brief for a person with Type 1 diabetes \
+using a Tandem t:slim X2 pump with Control-IQ and a Dexcom G7 CGM.
+
+Guidelines:
+- Be concise but informative (3-5 paragraphs)
+- Highlight patterns (post-meal spikes, overnight trends, time-in-range)
+- Note Control-IQ corrections and what they suggest
+- Use encouraging, non-judgmental language
+- Do NOT recommend specific insulin dose changes (that is for their endocrinologist)
+- Focus on actionable observations the user can discuss with their care team
+- Reference specific numbers from the data provided\
+"""
+
+
+def _build_analysis_prompt(metrics: DailyBriefMetrics, hours: int) -> str:
+    """Build the user prompt with glucose and pump metrics.
+
+    Args:
+        metrics: Calculated metrics for the period.
+        hours: Number of hours analyzed.
+
+    Returns:
+        Formatted prompt string for the AI provider.
+    """
+    lines = [
+        f"Analyze the following {hours}-hour glucose and insulin summary:",
+        "",
+        f"- Readings: {metrics.readings_count}",
+        f"- Average glucose: {metrics.average_glucose:.0f} mg/dL",
+        f"- Time in range (70-180): {metrics.time_in_range_pct:.1f}%",
+        f"- Low readings (<{LOW_THRESHOLD}): {metrics.low_count}",
+        f"- High readings (>{HIGH_THRESHOLD}): {metrics.high_count}",
+        f"- Control-IQ auto-corrections: {metrics.correction_count}",
+    ]
+
+    if metrics.total_insulin is not None:
+        lines.append(f"- Total insulin delivered: {metrics.total_insulin:.1f} units")
+
+    lines.append("")
+    lines.append(
+        "Provide a daily brief summarizing key patterns, "
+        "notable events, and observations."
+    )
+
+    return "\n".join(lines)
+
+
+async def calculate_metrics(
+    user_id: "str | object",
+    db: AsyncSession,
+    period_start: datetime,
+    period_end: datetime,
+) -> DailyBriefMetrics:
+    """Calculate glucose and pump metrics for a time period.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+        period_start: Start of analysis period.
+        period_end: End of analysis period.
+
+    Returns:
+        Calculated metrics for the period.
+    """
+    # Query glucose readings for the period
+    readings_result = await db.execute(
+        select(GlucoseReading.value).where(
+            GlucoseReading.user_id == user_id,
+            GlucoseReading.reading_timestamp >= period_start,
+            GlucoseReading.reading_timestamp < period_end,
+        )
+    )
+    values = [row[0] for row in readings_result.all()]
+
+    readings_count = len(values)
+    if readings_count == 0:
+        return DailyBriefMetrics(
+            time_in_range_pct=0.0,
+            average_glucose=0.0,
+            low_count=0,
+            high_count=0,
+            readings_count=0,
+            correction_count=0,
+            total_insulin=None,
+        )
+
+    in_range = sum(1 for v in values if LOW_THRESHOLD <= v <= HIGH_THRESHOLD)
+    low_count = sum(1 for v in values if v < LOW_THRESHOLD)
+    high_count = sum(1 for v in values if v > HIGH_THRESHOLD)
+    time_in_range_pct = (in_range / readings_count) * 100
+    average_glucose = sum(values) / readings_count
+
+    # Query pump events for Control-IQ corrections
+    correction_result = await db.execute(
+        select(func.count()).where(
+            PumpEvent.user_id == user_id,
+            PumpEvent.event_timestamp >= period_start,
+            PumpEvent.event_timestamp < period_end,
+            PumpEvent.event_type == PumpEventType.CORRECTION,
+            PumpEvent.is_automated.is_(True),
+        )
+    )
+    correction_count = correction_result.scalar() or 0
+
+    # Query total insulin delivered
+    insulin_result = await db.execute(
+        select(func.sum(PumpEvent.units)).where(
+            PumpEvent.user_id == user_id,
+            PumpEvent.event_timestamp >= period_start,
+            PumpEvent.event_timestamp < period_end,
+            PumpEvent.units.is_not(None),
+        )
+    )
+    total_insulin = insulin_result.scalar()
+
+    return DailyBriefMetrics(
+        time_in_range_pct=round(time_in_range_pct, 1),
+        average_glucose=round(average_glucose, 1),
+        low_count=low_count,
+        high_count=high_count,
+        readings_count=readings_count,
+        correction_count=correction_count,
+        total_insulin=round(total_insulin, 1) if total_insulin is not None else None,
+    )
+
+
+async def generate_daily_brief(
+    user: User,
+    db: AsyncSession,
+    hours: int = 24,
+) -> DailyBrief:
+    """Generate a daily brief for a user.
+
+    Aggregates glucose and pump data, calls the AI provider,
+    and stores the result.
+
+    Args:
+        user: The authenticated user.
+        db: Database session.
+        hours: Number of hours to analyze.
+
+    Returns:
+        The created DailyBrief record.
+
+    Raises:
+        HTTPException: 400 if insufficient data, 404 if no AI provider.
+    """
+    period_end = datetime.now(UTC)
+    period_start = period_end - timedelta(hours=hours)
+
+    # Calculate metrics
+    metrics = await calculate_metrics(user.id, db, period_start, period_end)
+
+    if metrics.readings_count < MIN_READINGS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Insufficient glucose data: {metrics.readings_count} readings "
+                f"found, minimum {MIN_READINGS} required for analysis."
+            ),
+        )
+
+    # Get AI client (raises 404 if not configured)
+    ai_client = await get_ai_client(user, db)
+
+    # Build prompt and generate
+    user_prompt = _build_analysis_prompt(metrics, hours)
+
+    logger.info(
+        "Generating daily brief",
+        user_id=str(user.id),
+        readings=metrics.readings_count,
+        hours=hours,
+    )
+
+    ai_response = await ai_client.generate(
+        messages=[AIMessage(role="user", content=user_prompt)],
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+    # Store the brief
+    brief = DailyBrief(
+        user_id=user.id,
+        period_start=period_start,
+        period_end=period_end,
+        time_in_range_pct=metrics.time_in_range_pct,
+        average_glucose=metrics.average_glucose,
+        low_count=metrics.low_count,
+        high_count=metrics.high_count,
+        readings_count=metrics.readings_count,
+        correction_count=metrics.correction_count,
+        total_insulin=metrics.total_insulin,
+        ai_summary=ai_response.content,
+        ai_model=ai_response.model,
+        ai_provider=ai_response.provider.value,
+        input_tokens=ai_response.usage.input_tokens,
+        output_tokens=ai_response.usage.output_tokens,
+    )
+
+    db.add(brief)
+    await db.commit()
+    await db.refresh(brief)
+
+    logger.info(
+        "Daily brief generated",
+        user_id=str(user.id),
+        brief_id=str(brief.id),
+        tir=metrics.time_in_range_pct,
+    )
+
+    return brief
+
+
+async def list_briefs(
+    user_id: "str | object",
+    db: AsyncSession,
+    limit: int = 10,
+    offset: int = 0,
+) -> tuple[list[DailyBrief], int]:
+    """List daily briefs for a user.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+        limit: Maximum number of briefs to return.
+        offset: Number of briefs to skip.
+
+    Returns:
+        Tuple of (briefs list, total count).
+    """
+    # Get total count
+    count_result = await db.execute(
+        select(func.count()).where(DailyBrief.user_id == user_id)
+    )
+    total = count_result.scalar() or 0
+
+    # Get paginated briefs
+    result = await db.execute(
+        select(DailyBrief)
+        .where(DailyBrief.user_id == user_id)
+        .order_by(DailyBrief.period_end.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    briefs = list(result.scalars().all())
+
+    return briefs, total
+
+
+async def get_brief_by_id(
+    brief_id: "str | object",
+    user_id: "str | object",
+    db: AsyncSession,
+) -> DailyBrief:
+    """Get a specific daily brief by ID.
+
+    Args:
+        brief_id: Brief UUID.
+        user_id: User's UUID (for ownership check).
+        db: Database session.
+
+    Returns:
+        The requested DailyBrief.
+
+    Raises:
+        HTTPException: 404 if not found.
+    """
+    result = await db.execute(
+        select(DailyBrief).where(
+            DailyBrief.id == brief_id,
+            DailyBrief.user_id == user_id,
+        )
+    )
+    brief = result.scalar_one_or_none()
+
+    if not brief:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Daily brief not found",
+        )
+
+    return brief

--- a/apps/api/tests/test_daily_brief.py
+++ b/apps/api/tests/test_daily_brief.py
@@ -1,0 +1,656 @@
+"""Story 5.3: Tests for daily brief generation."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.config import settings
+from src.main import app
+from src.models.ai_provider import AIProviderType
+from src.schemas.ai_response import AIResponse, AIUsage
+from src.schemas.daily_brief import DailyBriefMetrics
+from src.services.daily_brief import (
+    HIGH_THRESHOLD,
+    LOW_THRESHOLD,
+    MIN_READINGS,
+    _build_analysis_prompt,
+    calculate_metrics,
+)
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client: AsyncClient) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("brief")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+def _mock_ai_response(content: str = "Your glucose was well controlled.") -> AIResponse:
+    """Create a mock AI response for testing."""
+    return AIResponse(
+        content=content,
+        model="claude-sonnet-4-5-20250929",
+        provider=AIProviderType.CLAUDE,
+        usage=AIUsage(input_tokens=100, output_tokens=50),
+    )
+
+
+class TestCalculateMetrics:
+    """Tests for calculate_metrics function."""
+
+    async def test_no_readings_returns_zero_metrics(self):
+        """Test that zero readings returns all-zero metrics."""
+        mock_db = AsyncMock()
+
+        # Mock glucose query - no readings
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = []
+
+        mock_db.execute.return_value = glucose_result
+
+        user_id = uuid.uuid4()
+        now = datetime.now(UTC)
+        metrics = await calculate_metrics(
+            user_id, mock_db, now - timedelta(hours=24), now
+        )
+
+        assert metrics.readings_count == 0
+        assert metrics.average_glucose == 0.0
+        assert metrics.time_in_range_pct == 0.0
+        assert metrics.low_count == 0
+        assert metrics.high_count == 0
+
+    async def test_all_in_range_readings(self):
+        """Test metrics with all readings in range."""
+        mock_db = AsyncMock()
+
+        # Mock glucose query - all in range (70-180)
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [(120,), (130,), (110,), (140,), (100,)]
+
+        # Mock correction count query
+        correction_result = MagicMock()
+        correction_result.scalar.return_value = 0
+
+        # Mock total insulin query
+        insulin_result = MagicMock()
+        insulin_result.scalar.return_value = 25.5
+
+        mock_db.execute.side_effect = [
+            glucose_result,
+            correction_result,
+            insulin_result,
+        ]
+
+        user_id = uuid.uuid4()
+        now = datetime.now(UTC)
+        metrics = await calculate_metrics(
+            user_id, mock_db, now - timedelta(hours=24), now
+        )
+
+        assert metrics.readings_count == 5
+        assert metrics.time_in_range_pct == 100.0
+        assert metrics.average_glucose == 120.0
+        assert metrics.low_count == 0
+        assert metrics.high_count == 0
+        assert metrics.total_insulin == 25.5
+
+    async def test_mixed_readings_with_lows_and_highs(self):
+        """Test metrics with a mix of low, in-range, and high readings."""
+        mock_db = AsyncMock()
+
+        # 2 low, 3 in range, 1 high = 6 readings
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [(55,), (65,), (120,), (130,), (150,), (200,)]
+
+        correction_result = MagicMock()
+        correction_result.scalar.return_value = 3
+
+        insulin_result = MagicMock()
+        insulin_result.scalar.return_value = None
+
+        mock_db.execute.side_effect = [
+            glucose_result,
+            correction_result,
+            insulin_result,
+        ]
+
+        user_id = uuid.uuid4()
+        now = datetime.now(UTC)
+        metrics = await calculate_metrics(
+            user_id, mock_db, now - timedelta(hours=24), now
+        )
+
+        assert metrics.readings_count == 6
+        assert metrics.time_in_range_pct == 50.0
+        assert metrics.low_count == 2
+        assert metrics.high_count == 1
+        assert metrics.correction_count == 3
+        assert metrics.total_insulin is None
+
+    async def test_boundary_values(self):
+        """Test that boundary values are classified correctly."""
+        mock_db = AsyncMock()
+
+        # 70 is in range, 69 is low, 180 is in range, 181 is high
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [(69,), (70,), (180,), (181,)]
+
+        correction_result = MagicMock()
+        correction_result.scalar.return_value = 0
+
+        insulin_result = MagicMock()
+        insulin_result.scalar.return_value = None
+
+        mock_db.execute.side_effect = [
+            glucose_result,
+            correction_result,
+            insulin_result,
+        ]
+
+        user_id = uuid.uuid4()
+        now = datetime.now(UTC)
+        metrics = await calculate_metrics(
+            user_id, mock_db, now - timedelta(hours=24), now
+        )
+
+        assert metrics.low_count == 1  # 69
+        assert metrics.high_count == 1  # 181
+        assert metrics.time_in_range_pct == 50.0  # 70, 180 in range
+
+
+class TestBuildAnalysisPrompt:
+    """Tests for _build_analysis_prompt."""
+
+    def test_prompt_includes_metrics(self):
+        """Test that the prompt includes all metric values."""
+        metrics = DailyBriefMetrics(
+            time_in_range_pct=75.5,
+            average_glucose=142.3,
+            low_count=2,
+            high_count=5,
+            readings_count=288,
+            correction_count=4,
+            total_insulin=35.2,
+        )
+
+        prompt = _build_analysis_prompt(metrics, 24)
+
+        assert "24-hour" in prompt
+        assert "288" in prompt
+        assert "142" in prompt
+        assert "75.5%" in prompt
+        assert f"<{LOW_THRESHOLD}" in prompt
+        assert f">{HIGH_THRESHOLD}" in prompt
+        assert "2" in prompt  # lows
+        assert "5" in prompt  # highs
+        assert "4" in prompt  # corrections
+        assert "35.2 units" in prompt
+
+    def test_prompt_without_insulin_data(self):
+        """Test that insulin line is omitted when data is None."""
+        metrics = DailyBriefMetrics(
+            time_in_range_pct=80.0,
+            average_glucose=130.0,
+            low_count=0,
+            high_count=3,
+            readings_count=100,
+            correction_count=1,
+            total_insulin=None,
+        )
+
+        prompt = _build_analysis_prompt(metrics, 24)
+
+        assert "insulin delivered" not in prompt
+
+    def test_prompt_custom_hours(self):
+        """Test that custom hour count is reflected in the prompt."""
+        metrics = DailyBriefMetrics(
+            time_in_range_pct=80.0,
+            average_glucose=130.0,
+            low_count=0,
+            high_count=0,
+            readings_count=50,
+            correction_count=0,
+        )
+
+        prompt = _build_analysis_prompt(metrics, 48)
+
+        assert "48-hour" in prompt
+
+
+class TestGenerateDailyBrief:
+    """Tests for the generate_daily_brief service function."""
+
+    @patch("src.services.daily_brief.get_ai_client")
+    @patch("src.services.daily_brief.calculate_metrics")
+    async def test_generate_brief_success(self, mock_calc, mock_get_client):
+        """Test successful brief generation."""
+        from src.services.daily_brief import generate_daily_brief
+
+        mock_calc.return_value = DailyBriefMetrics(
+            time_in_range_pct=72.5,
+            average_glucose=145.0,
+            low_count=1,
+            high_count=8,
+            readings_count=288,
+            correction_count=5,
+            total_insulin=40.0,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response()
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        brief = await generate_daily_brief(mock_user, mock_db, hours=24)
+
+        assert brief.time_in_range_pct == 72.5
+        assert brief.average_glucose == 145.0
+        assert brief.low_count == 1
+        assert brief.high_count == 8
+        assert brief.readings_count == 288
+        assert brief.ai_summary == "Your glucose was well controlled."
+        assert brief.ai_model == "claude-sonnet-4-5-20250929"
+        assert brief.ai_provider == "claude"
+        assert brief.input_tokens == 100
+        assert brief.output_tokens == 50
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    @patch("src.services.daily_brief.calculate_metrics")
+    async def test_generate_brief_insufficient_data(self, mock_calc):
+        """Test that insufficient readings raises 400."""
+        from fastapi import HTTPException
+
+        from src.services.daily_brief import generate_daily_brief
+
+        mock_calc.return_value = DailyBriefMetrics(
+            time_in_range_pct=0.0,
+            average_glucose=0.0,
+            low_count=0,
+            high_count=0,
+            readings_count=MIN_READINGS - 1,
+            correction_count=0,
+        )
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await generate_daily_brief(mock_user, mock_db)
+
+        assert exc_info.value.status_code == 400
+        assert "Insufficient glucose data" in exc_info.value.detail
+
+    @patch("src.services.daily_brief.get_ai_client")
+    @patch("src.services.daily_brief.calculate_metrics")
+    async def test_generate_brief_ai_error_propagates(self, mock_calc, mock_get_client):
+        """Test that AI provider errors propagate."""
+        from src.services.daily_brief import generate_daily_brief
+
+        mock_calc.return_value = DailyBriefMetrics(
+            time_in_range_pct=80.0,
+            average_glucose=130.0,
+            low_count=0,
+            high_count=2,
+            readings_count=200,
+            correction_count=1,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.generate.side_effect = RuntimeError("AI provider failed")
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="AI provider failed"):
+            await generate_daily_brief(mock_user, mock_db)
+
+    @patch("src.services.daily_brief.get_ai_client")
+    @patch("src.services.daily_brief.calculate_metrics")
+    async def test_generate_brief_custom_hours(self, mock_calc, mock_get_client):
+        """Test that custom hours parameter is used."""
+        from src.services.daily_brief import generate_daily_brief
+
+        mock_calc.return_value = DailyBriefMetrics(
+            time_in_range_pct=80.0,
+            average_glucose=130.0,
+            low_count=0,
+            high_count=2,
+            readings_count=500,
+            correction_count=1,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response()
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        brief = await generate_daily_brief(mock_user, mock_db, hours=48)
+
+        # Verify period is roughly 48 hours
+        delta = brief.period_end - brief.period_start
+        assert abs(delta.total_seconds() - 48 * 3600) < 5
+
+
+class TestListBriefs:
+    """Tests for list_briefs service function."""
+
+    async def test_list_briefs_empty(self):
+        """Test listing briefs when none exist."""
+        from src.services.daily_brief import list_briefs
+
+        mock_db = AsyncMock()
+
+        # Mock count query
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+
+        # Mock briefs query
+        briefs_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = []
+        briefs_result.scalars.return_value = scalars_mock
+
+        mock_db.execute.side_effect = [count_result, briefs_result]
+
+        briefs, total = await list_briefs(uuid.uuid4(), mock_db)
+
+        assert briefs == []
+        assert total == 0
+
+    async def test_list_briefs_with_pagination(self):
+        """Test that pagination parameters are passed to the query."""
+        from src.services.daily_brief import list_briefs
+
+        mock_db = AsyncMock()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 25
+
+        briefs_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = ["brief1", "brief2"]
+        briefs_result.scalars.return_value = scalars_mock
+
+        mock_db.execute.side_effect = [count_result, briefs_result]
+
+        briefs, total = await list_briefs(uuid.uuid4(), mock_db, limit=2, offset=10)
+
+        assert len(briefs) == 2
+        assert total == 25
+
+
+class TestGetBriefById:
+    """Tests for get_brief_by_id service function."""
+
+    async def test_get_brief_not_found(self):
+        """Test that missing brief raises 404."""
+        from fastapi import HTTPException
+
+        from src.services.daily_brief import get_brief_by_id
+
+        mock_db = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = result
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_brief_by_id(uuid.uuid4(), uuid.uuid4(), mock_db)
+
+        assert exc_info.value.status_code == 404
+
+    async def test_get_brief_found(self):
+        """Test successful brief retrieval."""
+        from src.services.daily_brief import get_brief_by_id
+
+        mock_brief = SimpleNamespace(id=uuid.uuid4(), user_id=uuid.uuid4())
+
+        mock_db = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = mock_brief
+        mock_db.execute.return_value = result
+
+        brief = await get_brief_by_id(mock_brief.id, mock_brief.user_id, mock_db)
+
+        assert brief.id == mock_brief.id
+
+
+class TestBriefsEndpoints:
+    """Integration tests for daily brief API endpoints."""
+
+    @patch("src.services.daily_brief.get_ai_client")
+    @patch("src.services.daily_brief.calculate_metrics")
+    async def test_generate_brief_endpoint(self, mock_calc, mock_get_client):
+        """Test POST /api/ai/briefs/generate returns 201."""
+        mock_calc.return_value = DailyBriefMetrics(
+            time_in_range_pct=75.0,
+            average_glucose=140.0,
+            low_count=1,
+            high_count=5,
+            readings_count=288,
+            correction_count=3,
+            total_insulin=38.0,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response(
+            "Good day overall with some highs."
+        )
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/briefs/generate",
+                json={"hours": 24},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["time_in_range_pct"] == 75.0
+        assert data["average_glucose"] == 140.0
+        assert data["ai_summary"] == "Good day overall with some highs."
+        assert data["ai_model"] == "claude-sonnet-4-5-20250929"
+        assert "id" in data
+        assert "created_at" in data
+
+    @patch("src.services.daily_brief.calculate_metrics")
+    async def test_generate_brief_insufficient_data_endpoint(self, mock_calc):
+        """Test POST /api/ai/briefs/generate returns 400 with insufficient data."""
+        mock_calc.return_value = DailyBriefMetrics(
+            time_in_range_pct=0.0,
+            average_glucose=0.0,
+            low_count=0,
+            high_count=0,
+            readings_count=5,
+            correction_count=0,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/briefs/generate",
+                json={"hours": 24},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 400
+        assert "Insufficient glucose data" in response.json()["detail"]
+
+    async def test_generate_brief_unauthenticated(self):
+        """Test POST /api/ai/briefs/generate returns 401 without auth."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/api/ai/briefs/generate",
+                json={"hours": 24},
+            )
+
+        assert response.status_code == 401
+
+    async def test_list_briefs_endpoint(self):
+        """Test GET /api/ai/briefs returns 200."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.get(
+                "/api/ai/briefs",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "briefs" in data
+        assert "total" in data
+        assert data["total"] == 0
+
+    async def test_list_briefs_unauthenticated(self):
+        """Test GET /api/ai/briefs returns 401 without auth."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/ai/briefs")
+
+        assert response.status_code == 401
+
+    async def test_get_brief_not_found_endpoint(self):
+        """Test GET /api/ai/briefs/{id} returns 404 for missing brief."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            fake_id = uuid.uuid4()
+            response = await client.get(
+                f"/api/ai/briefs/{fake_id}",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 404
+
+    @patch("src.services.daily_brief.get_ai_client")
+    @patch("src.services.daily_brief.calculate_metrics")
+    async def test_generate_then_list_and_get(self, mock_calc, mock_get_client):
+        """Test generating a brief, then listing and getting it by ID."""
+        mock_calc.return_value = DailyBriefMetrics(
+            time_in_range_pct=85.0,
+            average_glucose=125.0,
+            low_count=0,
+            high_count=2,
+            readings_count=280,
+            correction_count=1,
+            total_insulin=32.0,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response("Great control today!")
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+            cookies = {settings.jwt_cookie_name: cookie}
+
+            # Generate a brief
+            gen_response = await client.post(
+                "/api/ai/briefs/generate",
+                json={"hours": 24},
+                cookies=cookies,
+            )
+            assert gen_response.status_code == 201
+            brief_id = gen_response.json()["id"]
+
+            # List briefs
+            list_response = await client.get(
+                "/api/ai/briefs",
+                cookies=cookies,
+            )
+            assert list_response.status_code == 200
+            list_data = list_response.json()
+            assert list_data["total"] >= 1
+
+            # Get specific brief
+            get_response = await client.get(
+                f"/api/ai/briefs/{brief_id}",
+                cookies=cookies,
+            )
+            assert get_response.status_code == 200
+            assert get_response.json()["id"] == brief_id
+            assert get_response.json()["ai_summary"] == "Great control today!"
+
+    async def test_generate_brief_invalid_hours(self):
+        """Test POST /api/ai/briefs/generate rejects invalid hours."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/briefs/generate",
+                json={"hours": 0},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 422
+
+    async def test_generate_brief_hours_too_large(self):
+        """Test POST /api/ai/briefs/generate rejects hours > 72."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/briefs/generate",
+                json={"hours": 100},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Add AI-powered daily glucose analysis brief generation service
- Aggregates glucose readings and pump events, calculates metrics (TIR%, average glucose, lows, highs, Control-IQ corrections, total insulin)
- Generates AI summaries via the BYOAI abstraction layer (Story 5.2)
- New endpoints: `POST /api/ai/briefs/generate`, `GET /api/ai/briefs`, `GET /api/ai/briefs/{id}`
- DailyBrief SQLAlchemy model with Alembic migration 010
- 24 tests (unit, service, and integration)

## New Files
- `apps/api/src/models/daily_brief.py` - DailyBrief model
- `apps/api/src/schemas/daily_brief.py` - Request/response schemas
- `apps/api/src/services/daily_brief.py` - Metrics calculation + AI generation
- `apps/api/src/routers/briefs.py` - API endpoints
- `apps/api/migrations/versions/010_create_daily_briefs.py` - Migration
- `apps/api/tests/test_daily_brief.py` - 24 tests

## Test plan
- [x] All 215 tests pass locally (24 new + 191 existing)
- [x] Ruff lint + format clean
- [x] Subagent code review: APPROVED (no blocking findings)
- [x] Migration applies and rolls back cleanly
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)