### PR TITLE
feat(api): add meal pattern analysis with carb ratio suggestions (Story 5.4)

### DIFF
--- a/apps/api/migrations/versions/011_create_meal_analyses.py
+++ b/apps/api/migrations/versions/011_create_meal_analyses.py
@@ -1,0 +1,75 @@
+"""Story 5.4: Create meal_analyses table.
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-02-08
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "011_meal_analyses"
+down_revision: str | None = "010_daily_briefs"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "meal_analyses",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("total_boluses", sa.Integer(), nullable=False),
+        sa.Column("total_spikes", sa.Integer(), nullable=False),
+        sa.Column("avg_post_meal_peak", sa.Float(), nullable=False),
+        sa.Column("meal_periods_data", postgresql.JSON(), nullable=False),
+        sa.Column("ai_analysis", sa.Text(), nullable=False),
+        sa.Column("ai_model", sa.String(100), nullable=False),
+        sa.Column("ai_provider", sa.String(20), nullable=False),
+        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "ix_meal_analyses_user_period",
+        "meal_analyses",
+        ["user_id", "period_start"],
+    )
+
+    op.create_index(
+        "ix_meal_analyses_user_id",
+        "meal_analyses",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_meal_analyses_user_id")
+    op.drop_index("ix_meal_analyses_user_period")
+    op.drop_table("meal_analyses")

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -18,6 +18,7 @@ from src.routers import (
     glucose_stream,
     health,
     integrations,
+    meal_analysis,
     system,
 )
 from src.services.scheduler import start_scheduler, stop_scheduler
@@ -81,6 +82,7 @@ app.include_router(integrations.router)
 app.include_router(glucose_stream.router)
 app.include_router(ai.router)
 app.include_router(briefs.router)
+app.include_router(meal_analysis.router)
 
 
 @app.get("/")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -9,6 +9,7 @@ from src.models.integration import (
     IntegrationStatus,
     IntegrationType,
 )
+from src.models.meal_analysis import MealAnalysis
 from src.models.pump_data import PumpEvent, PumpEventType
 from src.models.user import User, UserRole
 
@@ -20,6 +21,7 @@ __all__ = [
     "TimestampMixin",
     "DailyBrief",
     "DisclaimerAcknowledgment",
+    "MealAnalysis",
     "GlucoseReading",
     "TrendDirection",
     "IntegrationCredential",

--- a/apps/api/src/models/meal_analysis.py
+++ b/apps/api/src/models/meal_analysis.py
@@ -1,0 +1,112 @@
+"""Story 5.4: Meal pattern analysis model.
+
+Stores AI-generated post-meal glucose pattern analyses and carb ratio suggestions.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class MealAnalysis(Base, TimestampMixin):
+    """Stores meal pattern analyses with carb ratio suggestions.
+
+    Each analysis covers a configurable period and identifies post-meal
+    glucose spike patterns grouped by meal period (breakfast, lunch,
+    dinner, snack). The AI generates specific carb ratio adjustment
+    suggestions based on the patterns found.
+    """
+
+    __tablename__ = "meal_analyses"
+
+    __table_args__ = (Index("ix_meal_analyses_user_period", "user_id", "period_start"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Analysis period
+    period_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    period_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # Aggregate stats
+    total_boluses: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+
+    total_spikes: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+
+    avg_post_meal_peak: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+    )
+
+    # Per-meal-period breakdown (JSON array)
+    # [{period, bolus_count, avg_peak, spike_count, avg_2hr_glucose}]
+    meal_periods_data: Mapped[list] = mapped_column(
+        JSON,
+        nullable=False,
+    )
+
+    # AI output
+    ai_analysis: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+
+    ai_model: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+    )
+
+    ai_provider: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+    )
+
+    # Token usage tracking
+    input_tokens: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+    )
+
+    output_tokens: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+    )
+
+    # Relationship to user
+    user = relationship("User", back_populates="meal_analyses")
+
+    def __repr__(self) -> str:
+        return (
+            f"<MealAnalysis(user_id={self.user_id}, "
+            f"boluses={self.total_boluses}, spikes={self.total_spikes})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -109,6 +109,11 @@ class User(Base, TimestampMixin):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    meal_analyses = relationship(
+        "MealAnalysis",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/routers/meal_analysis.py
+++ b/apps/api/src/routers/meal_analysis.py
@@ -1,0 +1,96 @@
+"""Story 5.4: Meal pattern analysis router.
+
+API endpoints for post-meal glucose pattern recognition and carb ratio suggestions.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import DiabeticOrAdminUser
+from src.database import get_db
+from src.schemas.auth import ErrorResponse
+from src.schemas.meal_analysis import (
+    AnalyzeMealsRequest,
+    MealAnalysisListResponse,
+    MealAnalysisResponse,
+)
+from src.services.meal_analysis import (
+    generate_meal_analysis,
+    get_meal_analysis_by_id,
+    list_meal_analyses,
+)
+
+router = APIRouter(prefix="/api/ai/meals", tags=["ai-meals"])
+
+
+@router.post(
+    "/analyze",
+    response_model=MealAnalysisResponse,
+    status_code=201,
+    responses={
+        201: {"description": "Meal pattern analysis generated"},
+        400: {"model": ErrorResponse, "description": "Insufficient meal data"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+        404: {"model": ErrorResponse, "description": "No AI provider configured"},
+    },
+)
+async def analyze_meals(
+    request: AnalyzeMealsRequest,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> MealAnalysisResponse:
+    """Analyze post-meal glucose patterns and generate carb ratio suggestions.
+
+    Examines meal boluses and subsequent glucose readings to identify
+    post-meal spike patterns grouped by meal period.
+    """
+    analysis = await generate_meal_analysis(current_user, db, days=request.days)
+    return MealAnalysisResponse.model_validate(analysis)
+
+
+@router.get(
+    "",
+    response_model=MealAnalysisListResponse,
+    responses={
+        200: {"description": "List of meal analyses"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+    },
+)
+async def get_meal_analyses(
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(default=10, ge=1, le=50),
+    offset: int = Query(default=0, ge=0),
+) -> MealAnalysisListResponse:
+    """List meal pattern analyses for the current user."""
+    analyses, total = await list_meal_analyses(
+        current_user.id, db, limit=limit, offset=offset
+    )
+    return MealAnalysisListResponse(
+        analyses=[MealAnalysisResponse.model_validate(a) for a in analyses],
+        total=total,
+    )
+
+
+@router.get(
+    "/{analysis_id}",
+    response_model=MealAnalysisResponse,
+    responses={
+        200: {"description": "Meal analysis details"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+        404: {"model": ErrorResponse, "description": "Analysis not found"},
+    },
+)
+async def get_meal_analysis(
+    analysis_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> MealAnalysisResponse:
+    """Get a specific meal pattern analysis by ID."""
+    analysis = await get_meal_analysis_by_id(analysis_id, current_user.id, db)
+    return MealAnalysisResponse.model_validate(analysis)

--- a/apps/api/src/schemas/meal_analysis.py
+++ b/apps/api/src/schemas/meal_analysis.py
@@ -1,0 +1,60 @@
+"""Story 5.4: Meal pattern analysis schemas.
+
+Request and response schemas for post-meal pattern recognition
+and carb ratio suggestions.
+"""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class MealPeriodData(BaseModel):
+    """Metrics for a single meal period (breakfast, lunch, dinner, snack)."""
+
+    period: str = Field(..., description="Meal period name")
+    bolus_count: int = Field(..., description="Number of meal boluses")
+    spike_count: int = Field(..., description="Number of post-meal spikes >180 mg/dL")
+    avg_peak_glucose: float = Field(
+        ..., description="Average peak glucose within 2hr post-bolus"
+    )
+    avg_2hr_glucose: float = Field(..., description="Average glucose at 2hr post-bolus")
+
+
+class MealAnalysisResponse(BaseModel):
+    """Response schema for a meal pattern analysis."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    period_start: datetime
+    period_end: datetime
+    total_boluses: int
+    total_spikes: int
+    avg_post_meal_peak: float
+    meal_periods_data: list[MealPeriodData]
+    ai_analysis: str
+    ai_model: str
+    ai_provider: str
+    input_tokens: int
+    output_tokens: int
+    created_at: datetime
+
+
+class MealAnalysisListResponse(BaseModel):
+    """Response schema for listing meal analyses."""
+
+    analyses: list[MealAnalysisResponse]
+    total: int
+
+
+class AnalyzeMealsRequest(BaseModel):
+    """Request schema for triggering meal pattern analysis."""
+
+    days: int = Field(
+        default=7,
+        ge=3,
+        le=30,
+        description="Number of days to analyze (default 7, min 3)",
+    )

--- a/apps/api/src/services/meal_analysis.py
+++ b/apps/api/src/services/meal_analysis.py
@@ -1,0 +1,399 @@
+"""Story 5.4: Meal pattern analysis service.
+
+Detects post-meal glucose spike patterns and generates AI-powered
+carb ratio adjustment suggestions.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.glucose import GlucoseReading
+from src.models.meal_analysis import MealAnalysis
+from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.user import User
+from src.schemas.ai_response import AIMessage
+from src.schemas.meal_analysis import MealPeriodData
+from src.services.ai_client import get_ai_client
+
+logger = get_logger(__name__)
+
+# Post-meal spike threshold (mg/dL)
+SPIKE_THRESHOLD = 180
+
+# Post-meal analysis window (hours)
+POST_MEAL_WINDOW_HOURS = 2
+
+# Minimum boluses needed for meaningful analysis
+MIN_BOLUSES = 5
+
+# Meal period definitions (hour ranges, inclusive start, exclusive end)
+MEAL_PERIODS = {
+    "breakfast": (5, 10),
+    "lunch": (10, 14),
+    "dinner": (17, 21),
+    "snack": None,  # Everything else
+}
+
+SYSTEM_PROMPT = """\
+You are a diabetes management assistant analyzing post-meal glucose patterns \
+for a person with Type 1 diabetes using a Tandem t:slim X2 pump with Control-IQ \
+and a Dexcom G7 CGM.
+
+You are reviewing meal pattern data organized by meal period. For each meal \
+period, you have the number of boluses analyzed, the number of post-meal spikes \
+(>180 mg/dL within 2 hours), the average peak glucose, and the average glucose \
+at 2 hours post-bolus.
+
+Guidelines:
+- Identify which meal periods have consistent post-meal spikes
+- For problematic periods, suggest a specific carb ratio direction \
+(e.g., "consider a stronger ratio for breakfast, such as moving from 1:8 to 1:7")
+- Explain reasoning: "Your breakfast peaks average X mg/dL despite Control-IQ corrections"
+- Use encouraging, non-judgmental language
+- Clearly state that these are observations to discuss with their endocrinologist
+- Do NOT provide specific dosing instructions; suggest directional changes only
+- If data shows good control for a period, acknowledge it
+- If insufficient data for a period, note that more data is needed\
+"""
+
+
+def _classify_meal_period(hour: int) -> str:
+    """Classify an hour of day into a meal period.
+
+    Args:
+        hour: Hour of day (0-23).
+
+    Returns:
+        Meal period name.
+    """
+    for period, hours_range in MEAL_PERIODS.items():
+        if hours_range is not None:
+            start, end = hours_range
+            if start <= hour < end:
+                return period
+    return "snack"
+
+
+def _build_meal_prompt(
+    meal_periods: list[MealPeriodData],
+    total_boluses: int,
+    days: int,
+) -> str:
+    """Build the analysis prompt with meal period data.
+
+    Args:
+        meal_periods: Per-period metrics.
+        total_boluses: Total boluses analyzed.
+        days: Number of days in the analysis window.
+
+    Returns:
+        Formatted prompt string.
+    """
+    lines = [
+        f"Analyze the following {days}-day post-meal glucose pattern data:",
+        f"Total meal boluses analyzed: {total_boluses}",
+        "",
+    ]
+
+    for mp in meal_periods:
+        lines.append(f"**{mp.period.capitalize()}** ({mp.bolus_count} meals):")
+        lines.append(f"  - Post-meal spikes (>180 mg/dL): {mp.spike_count}")
+        lines.append(f"  - Average peak glucose: {mp.avg_peak_glucose:.0f} mg/dL")
+        lines.append(
+            f"  - Average 2hr post-meal glucose: {mp.avg_2hr_glucose:.0f} mg/dL"
+        )
+        if mp.bolus_count > 0:
+            spike_pct = (mp.spike_count / mp.bolus_count) * 100
+            lines.append(f"  - Spike rate: {spike_pct:.0f}%")
+        lines.append("")
+
+    lines.append(
+        "Identify problematic meal periods and suggest carb ratio adjustment "
+        "directions. Acknowledge periods with good control."
+    )
+
+    return "\n".join(lines)
+
+
+async def analyze_post_meal_patterns(
+    user_id: "str | object",
+    db: AsyncSession,
+    period_start: datetime,
+    period_end: datetime,
+) -> list[MealPeriodData]:
+    """Analyze post-meal glucose patterns grouped by meal period.
+
+    For each manual bolus event, examines glucose readings in the
+    2-hour window after the bolus to detect spikes and calculate
+    average post-meal glucose levels.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+        period_start: Start of analysis period.
+        period_end: End of analysis period.
+
+    Returns:
+        List of MealPeriodData with per-period metrics.
+    """
+    # Get all manual boluses in the period (meal boluses)
+    bolus_result = await db.execute(
+        select(PumpEvent).where(
+            PumpEvent.user_id == user_id,
+            PumpEvent.event_type == PumpEventType.BOLUS,
+            PumpEvent.is_automated.is_(False),
+            PumpEvent.event_timestamp >= period_start,
+            PumpEvent.event_timestamp < period_end,
+        )
+    )
+    boluses = list(bolus_result.scalars().all())
+
+    # Fetch all glucose readings for the full period plus 2hr buffer in one query
+    # to avoid N+1 queries (one per bolus)
+    extended_end = period_end + timedelta(hours=POST_MEAL_WINDOW_HOURS)
+    all_readings_result = await db.execute(
+        select(GlucoseReading.reading_timestamp, GlucoseReading.value)
+        .where(
+            GlucoseReading.user_id == user_id,
+            GlucoseReading.reading_timestamp >= period_start,
+            GlucoseReading.reading_timestamp <= extended_end,
+        )
+        .order_by(GlucoseReading.reading_timestamp)
+    )
+    all_readings = [(row[0], row[1]) for row in all_readings_result.all()]
+
+    # Group boluses by meal period and analyze post-meal glucose
+    period_data: dict[str, dict] = {}
+    for period_name in ["breakfast", "lunch", "dinner", "snack"]:
+        period_data[period_name] = {
+            "peaks": [],
+            "two_hr_values": [],
+            "spike_count": 0,
+            "bolus_count": 0,
+        }
+
+    for bolus in boluses:
+        period = _classify_meal_period(bolus.event_timestamp.hour)
+        window_start = bolus.event_timestamp
+        window_end = window_start + timedelta(hours=POST_MEAL_WINDOW_HOURS)
+
+        # Filter readings within the post-meal window (already sorted by timestamp)
+        readings = [
+            value for ts, value in all_readings if window_start <= ts <= window_end
+        ]
+
+        if not readings:
+            continue
+
+        peak = max(readings)
+        # Use the last reading as the approximate 2hr value
+        two_hr_value = readings[-1]
+
+        period_data[period]["peaks"].append(peak)
+        period_data[period]["two_hr_values"].append(two_hr_value)
+        period_data[period]["bolus_count"] += 1
+        if peak > SPIKE_THRESHOLD:
+            period_data[period]["spike_count"] += 1
+
+    # Build MealPeriodData for each period
+    result = []
+    for period_name in ["breakfast", "lunch", "dinner", "snack"]:
+        data = period_data[period_name]
+        bolus_count = data["bolus_count"]
+
+        if bolus_count == 0:
+            result.append(
+                MealPeriodData(
+                    period=period_name,
+                    bolus_count=0,
+                    spike_count=0,
+                    avg_peak_glucose=0.0,
+                    avg_2hr_glucose=0.0,
+                )
+            )
+            continue
+
+        avg_peak = sum(data["peaks"]) / len(data["peaks"])
+        avg_2hr = sum(data["two_hr_values"]) / len(data["two_hr_values"])
+
+        result.append(
+            MealPeriodData(
+                period=period_name,
+                bolus_count=bolus_count,
+                spike_count=data["spike_count"],
+                avg_peak_glucose=round(avg_peak, 1),
+                avg_2hr_glucose=round(avg_2hr, 1),
+            )
+        )
+
+    return result
+
+
+async def generate_meal_analysis(
+    user: User,
+    db: AsyncSession,
+    days: int = 7,
+) -> MealAnalysis:
+    """Generate a meal pattern analysis with carb ratio suggestions.
+
+    Args:
+        user: The authenticated user.
+        db: Database session.
+        days: Number of days to analyze.
+
+    Returns:
+        The created MealAnalysis record.
+
+    Raises:
+        HTTPException: 400 if insufficient data, 404 if no AI provider.
+    """
+    period_end = datetime.now(UTC)
+    period_start = period_end - timedelta(days=days)
+
+    # Analyze post-meal patterns
+    meal_periods = await analyze_post_meal_patterns(
+        user.id, db, period_start, period_end
+    )
+
+    total_boluses = sum(mp.bolus_count for mp in meal_periods)
+
+    if total_boluses < MIN_BOLUSES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Insufficient meal data: {total_boluses} boluses found, "
+                f"minimum {MIN_BOLUSES} required for pattern analysis."
+            ),
+        )
+
+    total_spikes = sum(mp.spike_count for mp in meal_periods)
+    # Weighted average of peaks across all meal periods
+    weighted_sum = sum(
+        mp.avg_peak_glucose * mp.bolus_count
+        for mp in meal_periods
+        if mp.bolus_count > 0
+    )
+    avg_post_meal_peak = (
+        round(weighted_sum / total_boluses, 1) if total_boluses > 0 else 0.0
+    )
+
+    # Get AI client
+    ai_client = await get_ai_client(user, db)
+
+    # Build prompt and generate
+    user_prompt = _build_meal_prompt(meal_periods, total_boluses, days)
+
+    logger.info(
+        "Generating meal pattern analysis",
+        user_id=str(user.id),
+        boluses=total_boluses,
+        spikes=total_spikes,
+        days=days,
+    )
+
+    ai_response = await ai_client.generate(
+        messages=[AIMessage(role="user", content=user_prompt)],
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+    # Store the analysis
+    analysis = MealAnalysis(
+        user_id=user.id,
+        period_start=period_start,
+        period_end=period_end,
+        total_boluses=total_boluses,
+        total_spikes=total_spikes,
+        avg_post_meal_peak=round(avg_post_meal_peak, 1),
+        meal_periods_data=[mp.model_dump() for mp in meal_periods],
+        ai_analysis=ai_response.content,
+        ai_model=ai_response.model,
+        ai_provider=ai_response.provider.value,
+        input_tokens=ai_response.usage.input_tokens,
+        output_tokens=ai_response.usage.output_tokens,
+    )
+
+    db.add(analysis)
+    await db.commit()
+    await db.refresh(analysis)
+
+    logger.info(
+        "Meal pattern analysis generated",
+        user_id=str(user.id),
+        analysis_id=str(analysis.id),
+        spikes=total_spikes,
+    )
+
+    return analysis
+
+
+async def list_meal_analyses(
+    user_id: "str | object",
+    db: AsyncSession,
+    limit: int = 10,
+    offset: int = 0,
+) -> tuple[list[MealAnalysis], int]:
+    """List meal analyses for a user.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+        limit: Maximum number of analyses to return.
+        offset: Number of analyses to skip.
+
+    Returns:
+        Tuple of (analyses list, total count).
+    """
+    count_result = await db.execute(
+        select(func.count()).where(MealAnalysis.user_id == user_id)
+    )
+    total = count_result.scalar() or 0
+
+    result = await db.execute(
+        select(MealAnalysis)
+        .where(MealAnalysis.user_id == user_id)
+        .order_by(MealAnalysis.period_end.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    analyses = list(result.scalars().all())
+
+    return analyses, total
+
+
+async def get_meal_analysis_by_id(
+    analysis_id: "str | object",
+    user_id: "str | object",
+    db: AsyncSession,
+) -> MealAnalysis:
+    """Get a specific meal analysis by ID.
+
+    Args:
+        analysis_id: Analysis UUID.
+        user_id: User's UUID (for ownership check).
+        db: Database session.
+
+    Returns:
+        The requested MealAnalysis.
+
+    Raises:
+        HTTPException: 404 if not found.
+    """
+    result = await db.execute(
+        select(MealAnalysis).where(
+            MealAnalysis.id == analysis_id,
+            MealAnalysis.user_id == user_id,
+        )
+    )
+    analysis = result.scalar_one_or_none()
+
+    if not analysis:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Meal analysis not found",
+        )
+
+    return analysis

--- a/apps/api/tests/test_meal_analysis.py
+++ b/apps/api/tests/test_meal_analysis.py
@@ -1,0 +1,799 @@
+"""Story 5.4: Tests for meal pattern analysis and carb ratio suggestions."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.config import settings
+from src.main import app
+from src.models.ai_provider import AIProviderType
+from src.schemas.ai_response import AIResponse, AIUsage
+from src.schemas.meal_analysis import MealPeriodData
+from src.services.meal_analysis import (
+    _build_meal_prompt,
+    _classify_meal_period,
+    analyze_post_meal_patterns,
+)
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client: AsyncClient) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("meal")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+def _mock_ai_response(
+    content: str = "Breakfast shows consistent spikes.",
+) -> AIResponse:
+    """Create a mock AI response for testing."""
+    return AIResponse(
+        content=content,
+        model="claude-sonnet-4-5-20250929",
+        provider=AIProviderType.CLAUDE,
+        usage=AIUsage(input_tokens=200, output_tokens=150),
+    )
+
+
+class TestClassifyMealPeriod:
+    """Tests for _classify_meal_period."""
+
+    def test_breakfast_hours(self):
+        """Test hours 5-9 classify as breakfast."""
+        for hour in [5, 6, 7, 8, 9]:
+            assert _classify_meal_period(hour) == "breakfast"
+
+    def test_lunch_hours(self):
+        """Test hours 10-13 classify as lunch."""
+        for hour in [10, 11, 12, 13]:
+            assert _classify_meal_period(hour) == "lunch"
+
+    def test_dinner_hours(self):
+        """Test hours 17-20 classify as dinner."""
+        for hour in [17, 18, 19, 20]:
+            assert _classify_meal_period(hour) == "dinner"
+
+    def test_snack_hours(self):
+        """Test all other hours classify as snack."""
+        for hour in [0, 1, 2, 3, 4, 14, 15, 16, 21, 22, 23]:
+            assert _classify_meal_period(hour) == "snack"
+
+    def test_boundary_breakfast_start(self):
+        """Test hour 5 is breakfast, hour 4 is snack."""
+        assert _classify_meal_period(5) == "breakfast"
+        assert _classify_meal_period(4) == "snack"
+
+    def test_boundary_breakfast_end(self):
+        """Test hour 9 is breakfast, hour 10 is lunch."""
+        assert _classify_meal_period(9) == "breakfast"
+        assert _classify_meal_period(10) == "lunch"
+
+    def test_boundary_dinner(self):
+        """Test dinner boundaries: 16 is snack, 17 is dinner, 21 is snack."""
+        assert _classify_meal_period(16) == "snack"
+        assert _classify_meal_period(17) == "dinner"
+        assert _classify_meal_period(21) == "snack"
+
+
+class TestBuildMealPrompt:
+    """Tests for _build_meal_prompt."""
+
+    def test_prompt_includes_all_periods(self):
+        """Test that the prompt includes data for all meal periods."""
+        periods = [
+            MealPeriodData(
+                period="breakfast",
+                bolus_count=5,
+                spike_count=3,
+                avg_peak_glucose=195.0,
+                avg_2hr_glucose=175.0,
+            ),
+            MealPeriodData(
+                period="lunch",
+                bolus_count=4,
+                spike_count=1,
+                avg_peak_glucose=160.0,
+                avg_2hr_glucose=140.0,
+            ),
+        ]
+
+        prompt = _build_meal_prompt(periods, 9, 7)
+
+        assert "7-day" in prompt
+        assert "9" in prompt  # total boluses
+        assert "Breakfast" in prompt
+        assert "Lunch" in prompt
+        assert "195" in prompt
+        assert "160" in prompt
+        assert "Spike rate: 60%" in prompt  # 3/5
+
+    def test_prompt_with_zero_bolus_period(self):
+        """Test that zero-bolus periods don't produce spike rate."""
+        periods = [
+            MealPeriodData(
+                period="snack",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+        ]
+
+        prompt = _build_meal_prompt(periods, 0, 7)
+
+        assert "Snack" in prompt
+        assert "Spike rate" not in prompt
+
+
+class TestAnalyzePostMealPatterns:
+    """Tests for analyze_post_meal_patterns."""
+
+    async def test_no_boluses_returns_empty_periods(self):
+        """Test that no boluses returns zeroed meal periods."""
+        mock_db = AsyncMock()
+
+        # First query: boluses (empty)
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = []
+        bolus_result.scalars.return_value = scalars_mock
+
+        # Second query: all glucose readings
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = []
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_post_meal_patterns(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        assert len(periods) == 4
+        for p in periods:
+            assert p.bolus_count == 0
+            assert p.spike_count == 0
+
+    async def test_bolus_with_spike(self):
+        """Test that a bolus followed by high readings detects a spike."""
+        mock_db = AsyncMock()
+
+        # Create a breakfast bolus at 7 AM
+        bolus_time = datetime(2026, 2, 7, 7, 0, tzinfo=UTC)
+        mock_bolus = SimpleNamespace(
+            event_timestamp=bolus_time,
+            event_type="bolus",
+            is_automated=False,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [mock_bolus]
+        bolus_result.scalars.return_value = scalars_mock
+
+        # All glucose readings (timestamp, value) sorted chronologically
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [
+            (bolus_time + timedelta(minutes=10), 150),
+            (bolus_time + timedelta(minutes=30), 180),
+            (bolus_time + timedelta(minutes=60), 200),
+            (bolus_time + timedelta(minutes=90), 190),
+            (bolus_time + timedelta(minutes=120), 170),
+        ]
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_post_meal_patterns(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        breakfast = next(p for p in periods if p.period == "breakfast")
+        assert breakfast.bolus_count == 1
+        assert breakfast.spike_count == 1  # peak 200 > 180
+        assert breakfast.avg_peak_glucose == 200.0
+        assert breakfast.avg_2hr_glucose == 170.0  # last reading
+
+    async def test_bolus_without_spike(self):
+        """Test that a bolus with good readings shows no spike."""
+        mock_db = AsyncMock()
+
+        # Lunch bolus at noon
+        bolus_time = datetime(2026, 2, 7, 12, 0, tzinfo=UTC)
+        mock_bolus = SimpleNamespace(
+            event_timestamp=bolus_time,
+            event_type="bolus",
+            is_automated=False,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [mock_bolus]
+        bolus_result.scalars.return_value = scalars_mock
+
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [
+            (bolus_time + timedelta(minutes=10), 130),
+            (bolus_time + timedelta(minutes=30), 150),
+            (bolus_time + timedelta(minutes=60), 160),
+            (bolus_time + timedelta(minutes=90), 145),
+            (bolus_time + timedelta(minutes=120), 130),
+        ]
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_post_meal_patterns(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        lunch = next(p for p in periods if p.period == "lunch")
+        assert lunch.bolus_count == 1
+        assert lunch.spike_count == 0  # peak 160 <= 180
+        assert lunch.avg_peak_glucose == 160.0
+
+    async def test_bolus_with_no_readings_skipped(self):
+        """Test that boluses with no subsequent readings are skipped."""
+        mock_db = AsyncMock()
+
+        bolus_time = datetime(2026, 2, 7, 18, 0, tzinfo=UTC)
+        mock_bolus = SimpleNamespace(
+            event_timestamp=bolus_time,
+            event_type="bolus",
+            is_automated=False,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [mock_bolus]
+        bolus_result.scalars.return_value = scalars_mock
+
+        # No glucose readings in the window
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = []
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_post_meal_patterns(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        dinner = next(p for p in periods if p.period == "dinner")
+        assert dinner.bolus_count == 0  # skipped because no readings
+
+    async def test_multiple_boluses_same_period(self):
+        """Test averaging across multiple meals in the same period."""
+        mock_db = AsyncMock()
+
+        bolus1_time = datetime(2026, 2, 6, 7, 0, tzinfo=UTC)
+        bolus2_time = datetime(2026, 2, 7, 8, 0, tzinfo=UTC)
+        bolus1 = SimpleNamespace(
+            event_timestamp=bolus1_time,
+            event_type="bolus",
+            is_automated=False,
+        )
+        bolus2 = SimpleNamespace(
+            event_timestamp=bolus2_time,
+            event_type="bolus",
+            is_automated=False,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [bolus1, bolus2]
+        bolus_result.scalars.return_value = scalars_mock
+
+        # All readings sorted by timestamp, covering both bolus windows
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [
+            # Bolus 1 window (Feb 6, 7:00-9:00): spike to 200
+            (bolus1_time + timedelta(minutes=30), 160),
+            (bolus1_time + timedelta(minutes=60), 200),
+            (bolus1_time + timedelta(minutes=120), 180),
+            # Bolus 2 window (Feb 7, 8:00-10:00): spike to 190
+            (bolus2_time + timedelta(minutes=30), 140),
+            (bolus2_time + timedelta(minutes=60), 190),
+            (bolus2_time + timedelta(minutes=120), 165),
+        ]
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_post_meal_patterns(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        breakfast = next(p for p in periods if p.period == "breakfast")
+        assert breakfast.bolus_count == 2
+        assert breakfast.spike_count == 2  # both > 180
+        assert breakfast.avg_peak_glucose == 195.0  # (200 + 190) / 2
+        assert breakfast.avg_2hr_glucose == 172.5  # (180 + 165) / 2
+
+
+class TestGenerateMealAnalysis:
+    """Tests for generate_meal_analysis service function."""
+
+    @patch("src.services.meal_analysis.get_ai_client")
+    @patch("src.services.meal_analysis.analyze_post_meal_patterns")
+    async def test_generate_analysis_success(self, mock_analyze, mock_get_client):
+        """Test successful meal analysis generation."""
+        from src.services.meal_analysis import generate_meal_analysis
+
+        mock_analyze.return_value = [
+            MealPeriodData(
+                period="breakfast",
+                bolus_count=5,
+                spike_count=3,
+                avg_peak_glucose=195.0,
+                avg_2hr_glucose=175.0,
+            ),
+            MealPeriodData(
+                period="lunch",
+                bolus_count=4,
+                spike_count=1,
+                avg_peak_glucose=165.0,
+                avg_2hr_glucose=145.0,
+            ),
+            MealPeriodData(
+                period="dinner",
+                bolus_count=3,
+                spike_count=0,
+                avg_peak_glucose=155.0,
+                avg_2hr_glucose=135.0,
+            ),
+            MealPeriodData(
+                period="snack",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response()
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        analysis = await generate_meal_analysis(mock_user, mock_db, days=7)
+
+        assert analysis.total_boluses == 12
+        assert analysis.total_spikes == 4
+        # Weighted avg: (195*5 + 165*4 + 155*3) / 12 = 2100/12 = 175.0
+        assert analysis.avg_post_meal_peak == 175.0
+        assert analysis.ai_analysis == "Breakfast shows consistent spikes."
+        assert len(analysis.meal_periods_data) == 4
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    @patch("src.services.meal_analysis.analyze_post_meal_patterns")
+    async def test_generate_analysis_insufficient_data(self, mock_analyze):
+        """Test that insufficient boluses raises 400."""
+        from fastapi import HTTPException
+
+        from src.services.meal_analysis import generate_meal_analysis
+
+        mock_analyze.return_value = [
+            MealPeriodData(
+                period="breakfast",
+                bolus_count=2,
+                spike_count=1,
+                avg_peak_glucose=190.0,
+                avg_2hr_glucose=170.0,
+            ),
+            MealPeriodData(
+                period="lunch",
+                bolus_count=1,
+                spike_count=0,
+                avg_peak_glucose=150.0,
+                avg_2hr_glucose=130.0,
+            ),
+            MealPeriodData(
+                period="dinner",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+            MealPeriodData(
+                period="snack",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+        ]
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await generate_meal_analysis(mock_user, mock_db)
+
+        assert exc_info.value.status_code == 400
+        assert "Insufficient meal data" in exc_info.value.detail
+
+    @patch("src.services.meal_analysis.get_ai_client")
+    @patch("src.services.meal_analysis.analyze_post_meal_patterns")
+    async def test_generate_analysis_ai_error_propagates(
+        self, mock_analyze, mock_get_client
+    ):
+        """Test that AI provider errors propagate."""
+        from src.services.meal_analysis import generate_meal_analysis
+
+        mock_analyze.return_value = [
+            MealPeriodData(
+                period="breakfast",
+                bolus_count=5,
+                spike_count=2,
+                avg_peak_glucose=185.0,
+                avg_2hr_glucose=165.0,
+            ),
+            MealPeriodData(
+                period="lunch",
+                bolus_count=3,
+                spike_count=0,
+                avg_peak_glucose=155.0,
+                avg_2hr_glucose=135.0,
+            ),
+            MealPeriodData(
+                period="dinner",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+            MealPeriodData(
+                period="snack",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.side_effect = RuntimeError("AI failed")
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="AI failed"):
+            await generate_meal_analysis(mock_user, mock_db)
+
+
+class TestListMealAnalyses:
+    """Tests for list_meal_analyses."""
+
+    async def test_list_empty(self):
+        """Test listing when no analyses exist."""
+        from src.services.meal_analysis import list_meal_analyses
+
+        mock_db = AsyncMock()
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        analyses_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = []
+        analyses_result.scalars.return_value = scalars_mock
+        mock_db.execute.side_effect = [count_result, analyses_result]
+
+        analyses, total = await list_meal_analyses(uuid.uuid4(), mock_db)
+
+        assert analyses == []
+        assert total == 0
+
+
+class TestGetMealAnalysisById:
+    """Tests for get_meal_analysis_by_id."""
+
+    async def test_not_found(self):
+        """Test that missing analysis raises 404."""
+        from fastapi import HTTPException
+
+        from src.services.meal_analysis import get_meal_analysis_by_id
+
+        mock_db = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = result
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_meal_analysis_by_id(uuid.uuid4(), uuid.uuid4(), mock_db)
+
+        assert exc_info.value.status_code == 404
+
+    async def test_found(self):
+        """Test successful retrieval."""
+        from src.services.meal_analysis import get_meal_analysis_by_id
+
+        mock_analysis = SimpleNamespace(id=uuid.uuid4(), user_id=uuid.uuid4())
+        mock_db = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = mock_analysis
+        mock_db.execute.return_value = result
+
+        analysis = await get_meal_analysis_by_id(
+            mock_analysis.id, mock_analysis.user_id, mock_db
+        )
+
+        assert analysis.id == mock_analysis.id
+
+
+class TestMealAnalysisEndpoints:
+    """Integration tests for meal analysis API endpoints."""
+
+    @patch("src.services.meal_analysis.get_ai_client")
+    @patch("src.services.meal_analysis.analyze_post_meal_patterns")
+    async def test_analyze_endpoint(self, mock_analyze, mock_get_client):
+        """Test POST /api/ai/meals/analyze returns 201."""
+        mock_analyze.return_value = [
+            MealPeriodData(
+                period="breakfast",
+                bolus_count=6,
+                spike_count=4,
+                avg_peak_glucose=200.0,
+                avg_2hr_glucose=180.0,
+            ),
+            MealPeriodData(
+                period="lunch",
+                bolus_count=5,
+                spike_count=1,
+                avg_peak_glucose=165.0,
+                avg_2hr_glucose=145.0,
+            ),
+            MealPeriodData(
+                period="dinner",
+                bolus_count=4,
+                spike_count=0,
+                avg_peak_glucose=155.0,
+                avg_2hr_glucose=135.0,
+            ),
+            MealPeriodData(
+                period="snack",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response(
+            "Your breakfast carb ratio may need adjustment."
+        )
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/meals/analyze",
+                json={"days": 7},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["total_boluses"] == 15
+        assert data["total_spikes"] == 5
+        assert data["ai_analysis"] == "Your breakfast carb ratio may need adjustment."
+        assert len(data["meal_periods_data"]) == 4
+        assert "id" in data
+        assert "created_at" in data
+
+    @patch("src.services.meal_analysis.analyze_post_meal_patterns")
+    async def test_analyze_insufficient_data_endpoint(self, mock_analyze):
+        """Test POST /api/ai/meals/analyze returns 400 with insufficient data."""
+        mock_analyze.return_value = [
+            MealPeriodData(
+                period=p,
+                bolus_count=1 if p == "breakfast" else 0,
+                spike_count=0,
+                avg_peak_glucose=150.0 if p == "breakfast" else 0.0,
+                avg_2hr_glucose=130.0 if p == "breakfast" else 0.0,
+            )
+            for p in ["breakfast", "lunch", "dinner", "snack"]
+        ]
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/meals/analyze",
+                json={"days": 7},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 400
+        assert "Insufficient meal data" in response.json()["detail"]
+
+    async def test_analyze_unauthenticated(self):
+        """Test POST /api/ai/meals/analyze returns 401 without auth."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/api/ai/meals/analyze",
+                json={"days": 7},
+            )
+
+        assert response.status_code == 401
+
+    async def test_list_analyses_endpoint(self):
+        """Test GET /api/ai/meals returns 200."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.get(
+                "/api/ai/meals",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "analyses" in data
+        assert "total" in data
+
+    async def test_list_analyses_unauthenticated(self):
+        """Test GET /api/ai/meals returns 401 without auth."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/ai/meals")
+
+        assert response.status_code == 401
+
+    async def test_get_analysis_not_found(self):
+        """Test GET /api/ai/meals/{id} returns 404."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            fake_id = uuid.uuid4()
+            response = await client.get(
+                f"/api/ai/meals/{fake_id}",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 404
+
+    @patch("src.services.meal_analysis.get_ai_client")
+    @patch("src.services.meal_analysis.analyze_post_meal_patterns")
+    async def test_analyze_then_list_and_get(self, mock_analyze, mock_get_client):
+        """Test generating an analysis, then listing and getting it."""
+        mock_analyze.return_value = [
+            MealPeriodData(
+                period="breakfast",
+                bolus_count=5,
+                spike_count=3,
+                avg_peak_glucose=190.0,
+                avg_2hr_glucose=170.0,
+            ),
+            MealPeriodData(
+                period="lunch",
+                bolus_count=3,
+                spike_count=0,
+                avg_peak_glucose=155.0,
+                avg_2hr_glucose=135.0,
+            ),
+            MealPeriodData(
+                period="dinner",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+            MealPeriodData(
+                period="snack",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response()
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+            cookies = {settings.jwt_cookie_name: cookie}
+
+            # Generate analysis
+            gen_response = await client.post(
+                "/api/ai/meals/analyze",
+                json={"days": 7},
+                cookies=cookies,
+            )
+            assert gen_response.status_code == 201
+            analysis_id = gen_response.json()["id"]
+
+            # List analyses
+            list_response = await client.get(
+                "/api/ai/meals",
+                cookies=cookies,
+            )
+            assert list_response.status_code == 200
+            assert list_response.json()["total"] >= 1
+
+            # Get specific analysis
+            get_response = await client.get(
+                f"/api/ai/meals/{analysis_id}",
+                cookies=cookies,
+            )
+            assert get_response.status_code == 200
+            assert get_response.json()["id"] == analysis_id
+
+    async def test_analyze_invalid_days(self):
+        """Test POST /api/ai/meals/analyze rejects days < 3."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/meals/analyze",
+                json={"days": 1},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 422
+
+    async def test_analyze_days_too_large(self):
+        """Test POST /api/ai/meals/analyze rejects days > 30."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/meals/analyze",
+                json={"days": 60},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Add post-meal glucose spike pattern detection grouped by meal period (breakfast, lunch, dinner, snack)
- Generate AI-powered carb ratio adjustment suggestions based on detected patterns
- Optimized single-query glucose fetch (no N+1), weighted average calculations, and proper type annotations

## What's Included
- **Model:** `MealAnalysis` with JSON meal period breakdown, AI output, and token tracking
- **Service:** `analyze_post_meal_patterns()` correlates bolus events with 2hr post-meal glucose windows; `generate_meal_analysis()` orchestrates AI generation
- **API:** `POST /api/ai/meals/analyze`, `GET /api/ai/meals`, `GET /api/ai/meals/{analysis_id}`
- **Migration:** `011_create_meal_analyses` with composite index on `(user_id, period_start)`
- **Tests:** 29 tests covering unit, service, and integration layers

## Test plan
- [x] 244 tests pass (29 new for Story 5.4)
- [x] Ruff lint + format clean
- [x] Subagent review round 1: APPROVED (2M, 5L findings)
- [x] All findings fixed and verified in review round 2: APPROVED
- [x] N+1 query optimization verified (2 DB queries total)
- [x] Weighted average calculation verified with explicit arithmetic test

🤖 Generated with [Claude Code](https://claude.com/claude-code)