### PR TITLE
feat(api): add correction factor analysis with ISF suggestions (Story 5.5)

### DIFF
--- a/apps/api/migrations/versions/012_create_correction_analyses.py
+++ b/apps/api/migrations/versions/012_create_correction_analyses.py
@@ -1,0 +1,86 @@
+"""Story 5.5: Create correction_analyses table.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-02-08
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "012_correction_analyses"
+down_revision: str | None = "011_meal_analyses"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "correction_analyses",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("total_corrections", sa.Integer(), nullable=False),
+        sa.Column("under_corrections", sa.Integer(), nullable=False),
+        sa.Column("over_corrections", sa.Integer(), nullable=False),
+        sa.Column("avg_observed_isf", sa.Float(), nullable=False),
+        sa.Column("time_periods_data", postgresql.JSON(), nullable=False),
+        sa.Column("ai_analysis", sa.Text(), nullable=False),
+        sa.Column("ai_model", sa.String(100), nullable=False),
+        sa.Column("ai_provider", sa.String(20), nullable=False),
+        sa.Column(
+            "input_tokens",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "output_tokens",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "ix_correction_analyses_user_period",
+        "correction_analyses",
+        ["user_id", "period_start"],
+    )
+
+    op.create_index(
+        "ix_correction_analyses_user_id",
+        "correction_analyses",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_correction_analyses_user_id")
+    op.drop_index("ix_correction_analyses_user_period")
+    op.drop_table("correction_analyses")

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -14,6 +14,7 @@ from src.routers import (
     ai,
     auth,
     briefs,
+    correction_analysis,
     disclaimer,
     glucose_stream,
     health,
@@ -83,6 +84,7 @@ app.include_router(glucose_stream.router)
 app.include_router(ai.router)
 app.include_router(briefs.router)
 app.include_router(meal_analysis.router)
+app.include_router(correction_analysis.router)
 
 
 @app.get("/")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -1,6 +1,7 @@
 # Database Models
 from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProviderType
 from src.models.base import Base, TimestampMixin
+from src.models.correction_analysis import CorrectionAnalysis
 from src.models.daily_brief import DailyBrief
 from src.models.disclaimer import DisclaimerAcknowledgment
 from src.models.glucose import GlucoseReading, TrendDirection
@@ -18,6 +19,7 @@ __all__ = [
     "AIProviderStatus",
     "AIProviderType",
     "Base",
+    "CorrectionAnalysis",
     "TimestampMixin",
     "DailyBrief",
     "DisclaimerAcknowledgment",

--- a/apps/api/src/models/correction_analysis.py
+++ b/apps/api/src/models/correction_analysis.py
@@ -1,0 +1,120 @@
+"""Story 5.5: Correction factor analysis model.
+
+Stores AI-generated correction factor analyses and ISF adjustment suggestions.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class CorrectionAnalysis(Base, TimestampMixin):
+    """Stores correction factor analyses with ISF adjustment suggestions.
+
+    Each analysis covers a configurable period and evaluates correction bolus
+    outcomes grouped by time-of-day period (overnight, morning, afternoon,
+    evening). The AI generates specific correction factor adjustment
+    suggestions based on under- or over-correction patterns.
+    """
+
+    __tablename__ = "correction_analyses"
+
+    __table_args__ = (
+        Index("ix_correction_analyses_user_period", "user_id", "period_start"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Analysis period
+    period_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    period_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # Aggregate stats
+    total_corrections: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+
+    under_corrections: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+
+    over_corrections: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+
+    avg_observed_isf: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+    )
+
+    # Per-time-period breakdown (JSON array)
+    # [{period, correction_count, under_count, over_count, avg_isf, avg_drop}]
+    time_periods_data: Mapped[list] = mapped_column(
+        JSON,
+        nullable=False,
+    )
+
+    # AI output
+    ai_analysis: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+
+    ai_model: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+    )
+
+    ai_provider: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+    )
+
+    # Token usage tracking
+    input_tokens: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+    )
+
+    output_tokens: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+    )
+
+    # Relationship to user
+    user = relationship("User", back_populates="correction_analyses")
+
+    def __repr__(self) -> str:
+        return (
+            f"<CorrectionAnalysis(user_id={self.user_id}, "
+            f"corrections={self.total_corrections}, "
+            f"under={self.under_corrections}, over={self.over_corrections})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -114,6 +114,11 @@ class User(Base, TimestampMixin):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    correction_analyses = relationship(
+        "CorrectionAnalysis",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/routers/correction_analysis.py
+++ b/apps/api/src/routers/correction_analysis.py
@@ -1,0 +1,102 @@
+"""Story 5.5: Correction factor analysis router.
+
+API endpoints for correction bolus outcome analysis and ISF adjustment suggestions.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import DiabeticOrAdminUser
+from src.database import get_db
+from src.schemas.auth import ErrorResponse
+from src.schemas.correction_analysis import (
+    AnalyzeCorrectionsRequest,
+    CorrectionAnalysisListResponse,
+    CorrectionAnalysisResponse,
+)
+from src.services.correction_analysis import (
+    generate_correction_analysis,
+    get_correction_analysis_by_id,
+    list_correction_analyses,
+)
+
+router = APIRouter(prefix="/api/ai/corrections", tags=["ai-corrections"])
+
+
+@router.post(
+    "/analyze",
+    response_model=CorrectionAnalysisResponse,
+    status_code=201,
+    responses={
+        201: {"description": "Correction factor analysis generated"},
+        400: {
+            "model": ErrorResponse,
+            "description": "Insufficient correction data",
+        },
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+        404: {
+            "model": ErrorResponse,
+            "description": "No AI provider configured",
+        },
+    },
+)
+async def analyze_corrections(
+    request: AnalyzeCorrectionsRequest,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> CorrectionAnalysisResponse:
+    """Analyze correction bolus outcomes and generate ISF suggestions.
+
+    Examines manual correction boluses and subsequent glucose readings
+    to identify under- and over-correction patterns by time of day.
+    """
+    analysis = await generate_correction_analysis(current_user, db, days=request.days)
+    return CorrectionAnalysisResponse.model_validate(analysis)
+
+
+@router.get(
+    "",
+    response_model=CorrectionAnalysisListResponse,
+    responses={
+        200: {"description": "List of correction analyses"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+    },
+)
+async def get_correction_analyses(
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(default=10, ge=1, le=50),
+    offset: int = Query(default=0, ge=0),
+) -> CorrectionAnalysisListResponse:
+    """List correction factor analyses for the current user."""
+    analyses, total = await list_correction_analyses(
+        current_user.id, db, limit=limit, offset=offset
+    )
+    return CorrectionAnalysisListResponse(
+        analyses=[CorrectionAnalysisResponse.model_validate(a) for a in analyses],
+        total=total,
+    )
+
+
+@router.get(
+    "/{analysis_id}",
+    response_model=CorrectionAnalysisResponse,
+    responses={
+        200: {"description": "Correction analysis details"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+        404: {"model": ErrorResponse, "description": "Analysis not found"},
+    },
+)
+async def get_correction_analysis(
+    analysis_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> CorrectionAnalysisResponse:
+    """Get a specific correction factor analysis by ID."""
+    analysis = await get_correction_analysis_by_id(analysis_id, current_user.id, db)
+    return CorrectionAnalysisResponse.model_validate(analysis)

--- a/apps/api/src/schemas/correction_analysis.py
+++ b/apps/api/src/schemas/correction_analysis.py
@@ -1,0 +1,68 @@
+"""Story 5.5: Correction factor analysis schemas.
+
+Request and response schemas for correction factor outcome analysis
+and ISF adjustment suggestions.
+"""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class TimePeriodData(BaseModel):
+    """Metrics for a single time-of-day period."""
+
+    period: str = Field(..., description="Time-of-day period name")
+    correction_count: int = Field(..., description="Number of correction boluses")
+    under_count: int = Field(
+        ..., description="Corrections that left glucose above target"
+    )
+    over_count: int = Field(
+        ..., description="Corrections that dropped glucose below low threshold"
+    )
+    avg_observed_isf: float = Field(
+        ..., description="Average observed ISF (mg/dL drop per unit)"
+    )
+    avg_glucose_drop: float = Field(
+        ..., description="Average glucose drop in mg/dL after correction"
+    )
+
+
+class CorrectionAnalysisResponse(BaseModel):
+    """Response schema for a correction factor analysis."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    period_start: datetime
+    period_end: datetime
+    total_corrections: int
+    under_corrections: int
+    over_corrections: int
+    avg_observed_isf: float
+    time_periods_data: list[TimePeriodData]
+    ai_analysis: str
+    ai_model: str
+    ai_provider: str
+    input_tokens: int
+    output_tokens: int
+    created_at: datetime
+
+
+class CorrectionAnalysisListResponse(BaseModel):
+    """Response schema for listing correction analyses."""
+
+    analyses: list[CorrectionAnalysisResponse]
+    total: int
+
+
+class AnalyzeCorrectionsRequest(BaseModel):
+    """Request schema for triggering correction factor analysis."""
+
+    days: int = Field(
+        default=7,
+        ge=3,
+        le=30,
+        description="Number of days to analyze (default 7, min 3)",
+    )

--- a/apps/api/src/services/correction_analysis.py
+++ b/apps/api/src/services/correction_analysis.py
@@ -1,0 +1,443 @@
+"""Story 5.5: Correction factor analysis service.
+
+Evaluates correction bolus outcomes and generates AI-powered
+insulin sensitivity factor (ISF) adjustment suggestions.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.correction_analysis import CorrectionAnalysis
+from src.models.glucose import GlucoseReading
+from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.user import User
+from src.schemas.ai_response import AIMessage
+from src.schemas.correction_analysis import TimePeriodData
+from src.services.ai_client import get_ai_client
+
+logger = get_logger(__name__)
+
+# Glucose target range for evaluating correction outcomes
+TARGET_GLUCOSE = 120  # mg/dL — target after correction
+LOW_THRESHOLD = 70  # mg/dL — below this = over-correction
+
+# Post-correction evaluation window (hours)
+POST_CORRECTION_WINDOW_HOURS = 3
+
+# Minimum BG at event to consider it a correction (not a meal bolus)
+CORRECTION_BG_THRESHOLD = 150  # mg/dL
+
+# Minimum corrections needed for meaningful analysis
+MIN_CORRECTIONS = 5
+
+# Time-of-day period definitions (hour ranges, inclusive start, exclusive end)
+TIME_PERIODS = {
+    "overnight": (22, 6),  # Wraps around midnight
+    "morning": (6, 12),
+    "afternoon": (12, 17),
+    "evening": (17, 22),
+}
+
+SYSTEM_PROMPT = """\
+You are a diabetes management assistant analyzing correction bolus outcomes \
+for a person with Type 1 diabetes using a Tandem t:slim X2 pump with Control-IQ \
+and a Dexcom G7 CGM.
+
+You are reviewing correction factor (insulin sensitivity factor / ISF) data \
+organized by time of day. For each time period, you have the number of \
+corrections analyzed, how many under-corrected (glucose stayed above target) \
+vs over-corrected (glucose dropped below 70 mg/dL), the average observed ISF \
+(mg/dL drop per unit of insulin), and the average glucose drop.
+
+Guidelines:
+- Identify which time periods show consistent under- or over-correction
+- For problematic periods, suggest a specific correction factor direction \
+(e.g., "consider a stronger correction factor for mornings, such as moving \
+from 1:50 to 1:45")
+- Explain reasoning: "Your morning corrections average only X mg/dL drop per \
+unit, suggesting your ISF may be too weak for this period"
+- Use encouraging, non-judgmental language
+- Clearly state that these are observations to discuss with their endocrinologist
+- Do NOT provide specific dosing instructions; suggest directional changes only
+- If data shows effective corrections for a period, acknowledge it
+- If insufficient data for a period, note that more data is needed
+- Account for the fact that Control-IQ may have also delivered automated \
+corrections that affect the observed glucose response\
+"""
+
+
+def _classify_time_period(hour: int) -> str:
+    """Classify an hour of day into a time-of-day period.
+
+    Args:
+        hour: Hour of day (0-23).
+
+    Returns:
+        Time period name.
+    """
+    for period, hours_range in TIME_PERIODS.items():
+        start, end = hours_range
+        if start <= end:
+            # Normal range (e.g., morning: 6-12)
+            if start <= hour < end:
+                return period
+        else:
+            # Wraps around midnight (e.g., overnight: 22-6)
+            if hour >= start or hour < end:
+                return period
+    return "overnight"
+
+
+def _build_correction_prompt(
+    time_periods: list[TimePeriodData],
+    total_corrections: int,
+    days: int,
+) -> str:
+    """Build the analysis prompt with time period data.
+
+    Args:
+        time_periods: Per-period metrics.
+        total_corrections: Total corrections analyzed.
+        days: Number of days in the analysis window.
+
+    Returns:
+        Formatted prompt string.
+    """
+    lines = [
+        f"Analyze the following {days}-day correction bolus outcome data:",
+        f"Total correction boluses analyzed: {total_corrections}",
+        "",
+    ]
+
+    for tp in time_periods:
+        lines.append(
+            f"**{tp.period.capitalize()}** ({tp.correction_count} corrections):"
+        )
+        lines.append(
+            f"  - Under-corrections (glucose stayed >120 mg/dL): {tp.under_count}"
+        )
+        lines.append(
+            f"  - Over-corrections (glucose dropped <70 mg/dL): {tp.over_count}"
+        )
+        lines.append(
+            f"  - Average observed ISF: {tp.avg_observed_isf:.1f} mg/dL per unit"
+        )
+        lines.append(f"  - Average glucose drop: {tp.avg_glucose_drop:.0f} mg/dL")
+        if tp.correction_count > 0:
+            effective = tp.correction_count - tp.under_count - tp.over_count
+            eff_pct = (effective / tp.correction_count) * 100
+            lines.append(f"  - Effective correction rate: {eff_pct:.0f}%")
+        lines.append("")
+
+    lines.append(
+        "Identify time periods with consistent under- or over-correction "
+        "and suggest correction factor adjustment directions. "
+        "Acknowledge periods with effective corrections."
+    )
+
+    return "\n".join(lines)
+
+
+async def analyze_correction_outcomes(
+    user_id: "str | object",
+    db: AsyncSession,
+    period_start: datetime,
+    period_end: datetime,
+) -> list[TimePeriodData]:
+    """Analyze correction bolus outcomes grouped by time-of-day period.
+
+    For each manual correction bolus, examines glucose readings in the
+    3-hour window after the bolus to evaluate whether the correction
+    was effective, under-corrected, or over-corrected.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+        period_start: Start of analysis period.
+        period_end: End of analysis period.
+
+    Returns:
+        List of TimePeriodData with per-period metrics.
+    """
+    # Get all manual boluses with BG context (correction boluses have high BG)
+    bolus_result = await db.execute(
+        select(PumpEvent).where(
+            PumpEvent.user_id == user_id,
+            PumpEvent.event_type == PumpEventType.BOLUS,
+            PumpEvent.is_automated.is_(False),
+            PumpEvent.bg_at_event >= CORRECTION_BG_THRESHOLD,
+            PumpEvent.units > 0,
+            PumpEvent.event_timestamp >= period_start,
+            PumpEvent.event_timestamp < period_end,
+        )
+    )
+    corrections = list(bolus_result.scalars().all())
+
+    # Fetch all glucose readings for the full period plus correction window
+    extended_end = period_end + timedelta(hours=POST_CORRECTION_WINDOW_HOURS)
+    all_readings_result = await db.execute(
+        select(GlucoseReading.reading_timestamp, GlucoseReading.value)
+        .where(
+            GlucoseReading.user_id == user_id,
+            GlucoseReading.reading_timestamp >= period_start,
+            GlucoseReading.reading_timestamp <= extended_end,
+        )
+        .order_by(GlucoseReading.reading_timestamp)
+    )
+    all_readings = [(row[0], row[1]) for row in all_readings_result.all()]
+
+    # Group corrections by time period and analyze outcomes
+    period_data: dict[str, dict] = {}
+    for period_name in ["overnight", "morning", "afternoon", "evening"]:
+        period_data[period_name] = {
+            "drops": [],
+            "isf_values": [],
+            "under_count": 0,
+            "over_count": 0,
+            "correction_count": 0,
+        }
+
+    for correction in corrections:
+        period = _classify_time_period(correction.event_timestamp.hour)
+        window_start = correction.event_timestamp
+        window_end = window_start + timedelta(hours=POST_CORRECTION_WINDOW_HOURS)
+
+        # Filter readings after the correction (strict lower bound excludes
+        # the reading at correction time itself)
+        readings = [
+            value for ts, value in all_readings if window_start < ts <= window_end
+        ]
+
+        if not readings or correction.units is None or correction.units <= 0:
+            continue
+
+        starting_bg = correction.bg_at_event
+        # Use the last reading as the approximate post-correction value
+        final_glucose = readings[-1]
+        glucose_drop = starting_bg - final_glucose
+
+        # Skip corrections where glucose rose (likely concurrent meal)
+        if glucose_drop <= 0:
+            continue
+
+        observed_isf = glucose_drop / correction.units
+
+        period_data[period]["drops"].append(glucose_drop)
+        period_data[period]["isf_values"].append(observed_isf)
+        period_data[period]["correction_count"] += 1
+
+        # Evaluate outcome
+        if final_glucose > TARGET_GLUCOSE:
+            period_data[period]["under_count"] += 1
+        elif final_glucose < LOW_THRESHOLD:
+            period_data[period]["over_count"] += 1
+
+    # Build TimePeriodData for each period
+    result = []
+    for period_name in ["overnight", "morning", "afternoon", "evening"]:
+        data = period_data[period_name]
+        correction_count = data["correction_count"]
+
+        if correction_count == 0:
+            result.append(
+                TimePeriodData(
+                    period=period_name,
+                    correction_count=0,
+                    under_count=0,
+                    over_count=0,
+                    avg_observed_isf=0.0,
+                    avg_glucose_drop=0.0,
+                )
+            )
+            continue
+
+        avg_isf = sum(data["isf_values"]) / len(data["isf_values"])
+        avg_drop = sum(data["drops"]) / len(data["drops"])
+
+        result.append(
+            TimePeriodData(
+                period=period_name,
+                correction_count=correction_count,
+                under_count=data["under_count"],
+                over_count=data["over_count"],
+                avg_observed_isf=round(avg_isf, 1),
+                avg_glucose_drop=round(avg_drop, 1),
+            )
+        )
+
+    return result
+
+
+async def generate_correction_analysis(
+    user: User,
+    db: AsyncSession,
+    days: int = 7,
+) -> CorrectionAnalysis:
+    """Generate a correction factor analysis with ISF suggestions.
+
+    Args:
+        user: The authenticated user.
+        db: Database session.
+        days: Number of days to analyze.
+
+    Returns:
+        The created CorrectionAnalysis record.
+
+    Raises:
+        HTTPException: 400 if insufficient data, 404 if no AI provider.
+    """
+    period_end = datetime.now(UTC)
+    period_start = period_end - timedelta(days=days)
+
+    # Analyze correction outcomes
+    time_periods = await analyze_correction_outcomes(
+        user.id, db, period_start, period_end
+    )
+
+    total_corrections = sum(tp.correction_count for tp in time_periods)
+
+    if total_corrections < MIN_CORRECTIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Insufficient correction data: {total_corrections} corrections "
+                f"found, minimum {MIN_CORRECTIONS} required for analysis."
+            ),
+        )
+
+    total_under = sum(tp.under_count for tp in time_periods)
+    total_over = sum(tp.over_count for tp in time_periods)
+
+    # Weighted average of observed ISF across all time periods
+    weighted_sum = sum(
+        tp.avg_observed_isf * tp.correction_count
+        for tp in time_periods
+        if tp.correction_count > 0
+    )
+    avg_observed_isf = (
+        round(weighted_sum / total_corrections, 1) if total_corrections > 0 else 0.0
+    )
+
+    # Get AI client
+    ai_client = await get_ai_client(user, db)
+
+    # Build prompt and generate
+    user_prompt = _build_correction_prompt(time_periods, total_corrections, days)
+
+    logger.info(
+        "Generating correction factor analysis",
+        user_id=str(user.id),
+        corrections=total_corrections,
+        under=total_under,
+        over=total_over,
+        days=days,
+    )
+
+    ai_response = await ai_client.generate(
+        messages=[AIMessage(role="user", content=user_prompt)],
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+    # Store the analysis
+    analysis = CorrectionAnalysis(
+        user_id=user.id,
+        period_start=period_start,
+        period_end=period_end,
+        total_corrections=total_corrections,
+        under_corrections=total_under,
+        over_corrections=total_over,
+        avg_observed_isf=avg_observed_isf,
+        time_periods_data=[tp.model_dump() for tp in time_periods],
+        ai_analysis=ai_response.content,
+        ai_model=ai_response.model,
+        ai_provider=ai_response.provider.value,
+        input_tokens=ai_response.usage.input_tokens,
+        output_tokens=ai_response.usage.output_tokens,
+    )
+
+    db.add(analysis)
+    await db.commit()
+    await db.refresh(analysis)
+
+    logger.info(
+        "Correction factor analysis generated",
+        user_id=str(user.id),
+        analysis_id=str(analysis.id),
+        under=total_under,
+        over=total_over,
+    )
+
+    return analysis
+
+
+async def list_correction_analyses(
+    user_id: "str | object",
+    db: AsyncSession,
+    limit: int = 10,
+    offset: int = 0,
+) -> tuple[list[CorrectionAnalysis], int]:
+    """List correction analyses for a user.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+        limit: Maximum number of analyses to return.
+        offset: Number of analyses to skip.
+
+    Returns:
+        Tuple of (analyses list, total count).
+    """
+    count_result = await db.execute(
+        select(func.count()).where(CorrectionAnalysis.user_id == user_id)
+    )
+    total = count_result.scalar() or 0
+
+    result = await db.execute(
+        select(CorrectionAnalysis)
+        .where(CorrectionAnalysis.user_id == user_id)
+        .order_by(CorrectionAnalysis.period_end.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    analyses = list(result.scalars().all())
+
+    return analyses, total
+
+
+async def get_correction_analysis_by_id(
+    analysis_id: "str | object",
+    user_id: "str | object",
+    db: AsyncSession,
+) -> CorrectionAnalysis:
+    """Get a specific correction analysis by ID.
+
+    Args:
+        analysis_id: Analysis UUID.
+        user_id: User's UUID (for ownership check).
+        db: Database session.
+
+    Returns:
+        The requested CorrectionAnalysis.
+
+    Raises:
+        HTTPException: 404 if not found.
+    """
+    result = await db.execute(
+        select(CorrectionAnalysis).where(
+            CorrectionAnalysis.id == analysis_id,
+            CorrectionAnalysis.user_id == user_id,
+        )
+    )
+    analysis = result.scalar_one_or_none()
+
+    if not analysis:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Correction analysis not found",
+        )
+
+    return analysis

--- a/apps/api/tests/test_correction_analysis.py
+++ b/apps/api/tests/test_correction_analysis.py
@@ -1,0 +1,966 @@
+"""Story 5.5: Tests for correction factor analysis and ISF suggestions."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.config import settings
+from src.main import app
+from src.models.ai_provider import AIProviderType
+from src.schemas.ai_response import AIResponse, AIUsage
+from src.schemas.correction_analysis import TimePeriodData
+from src.services.correction_analysis import (
+    _build_correction_prompt,
+    _classify_time_period,
+    analyze_correction_outcomes,
+)
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client: AsyncClient) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("correction")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+def _mock_ai_response(
+    content: str = "Morning corrections consistently under-correct.",
+) -> AIResponse:
+    """Create a mock AI response for testing."""
+    return AIResponse(
+        content=content,
+        model="claude-sonnet-4-5-20250929",
+        provider=AIProviderType.CLAUDE,
+        usage=AIUsage(input_tokens=250, output_tokens=180),
+    )
+
+
+class TestClassifyTimePeriod:
+    """Tests for _classify_time_period."""
+
+    def test_morning_hours(self):
+        """Test hours 6-11 classify as morning."""
+        for hour in [6, 7, 8, 9, 10, 11]:
+            assert _classify_time_period(hour) == "morning"
+
+    def test_afternoon_hours(self):
+        """Test hours 12-16 classify as afternoon."""
+        for hour in [12, 13, 14, 15, 16]:
+            assert _classify_time_period(hour) == "afternoon"
+
+    def test_evening_hours(self):
+        """Test hours 17-21 classify as evening."""
+        for hour in [17, 18, 19, 20, 21]:
+            assert _classify_time_period(hour) == "evening"
+
+    def test_overnight_hours(self):
+        """Test hours 22-5 classify as overnight (wraps midnight)."""
+        for hour in [22, 23, 0, 1, 2, 3, 4, 5]:
+            assert _classify_time_period(hour) == "overnight"
+
+    def test_boundary_morning_start(self):
+        """Test hour 6 is morning, hour 5 is overnight."""
+        assert _classify_time_period(6) == "morning"
+        assert _classify_time_period(5) == "overnight"
+
+    def test_boundary_evening_end(self):
+        """Test hour 21 is evening, hour 22 is overnight."""
+        assert _classify_time_period(21) == "evening"
+        assert _classify_time_period(22) == "overnight"
+
+    def test_boundary_afternoon(self):
+        """Test hour 11 is morning, hour 12 is afternoon, hour 17 is evening."""
+        assert _classify_time_period(11) == "morning"
+        assert _classify_time_period(12) == "afternoon"
+        assert _classify_time_period(17) == "evening"
+
+
+class TestBuildCorrectionPrompt:
+    """Tests for _build_correction_prompt."""
+
+    def test_prompt_includes_all_periods(self):
+        """Test that the prompt includes data for all time periods."""
+        periods = [
+            TimePeriodData(
+                period="morning",
+                correction_count=5,
+                under_count=3,
+                over_count=0,
+                avg_observed_isf=40.0,
+                avg_glucose_drop=80.0,
+            ),
+            TimePeriodData(
+                period="evening",
+                correction_count=4,
+                under_count=0,
+                over_count=2,
+                avg_observed_isf=60.0,
+                avg_glucose_drop=120.0,
+            ),
+        ]
+
+        prompt = _build_correction_prompt(periods, 9, 7)
+
+        assert "7-day" in prompt
+        assert "9" in prompt  # total corrections
+        assert "Morning" in prompt
+        assert "Evening" in prompt
+        assert "40.0" in prompt  # ISF
+        assert "60.0" in prompt
+        assert "Effective correction rate: 40%" in prompt  # (5-3-0)/5
+        assert "Effective correction rate: 50%" in prompt  # (4-0-2)/4
+
+    def test_prompt_with_zero_corrections_period(self):
+        """Test that zero-correction periods don't produce effectiveness rate."""
+        periods = [
+            TimePeriodData(
+                period="overnight",
+                correction_count=0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=0.0,
+                avg_glucose_drop=0.0,
+            ),
+        ]
+
+        prompt = _build_correction_prompt(periods, 0, 7)
+
+        assert "Overnight" in prompt
+        assert "Effective correction rate" not in prompt
+
+
+class TestAnalyzeCorrectionOutcomes:
+    """Tests for analyze_correction_outcomes."""
+
+    async def test_no_corrections_returns_empty_periods(self):
+        """Test that no corrections returns zeroed time periods."""
+        mock_db = AsyncMock()
+
+        # First query: corrections (empty)
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = []
+        bolus_result.scalars.return_value = scalars_mock
+
+        # Second query: all glucose readings
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = []
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_correction_outcomes(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        assert len(periods) == 4
+        for p in periods:
+            assert p.correction_count == 0
+            assert p.under_count == 0
+            assert p.over_count == 0
+
+    async def test_under_correction_detected(self):
+        """Test that a correction leaving glucose high is detected."""
+        mock_db = AsyncMock()
+
+        # Morning correction at 8 AM, BG 220, 2 units
+        correction_time = datetime(2026, 2, 7, 8, 0, tzinfo=UTC)
+        mock_correction = SimpleNamespace(
+            event_timestamp=correction_time,
+            event_type="bolus",
+            is_automated=False,
+            bg_at_event=220,
+            units=2.0,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [mock_correction]
+        bolus_result.scalars.return_value = scalars_mock
+
+        # Glucose only drops to 160 (above target 120) = under-correction
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [
+            (correction_time + timedelta(minutes=30), 200),
+            (correction_time + timedelta(minutes=60), 185),
+            (correction_time + timedelta(minutes=120), 170),
+            (correction_time + timedelta(minutes=180), 160),
+        ]
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_correction_outcomes(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        morning = next(p for p in periods if p.period == "morning")
+        assert morning.correction_count == 1
+        assert morning.under_count == 1  # final 160 > 120 target
+        assert morning.over_count == 0
+        # ISF = (220 - 160) / 2.0 = 30.0
+        assert morning.avg_observed_isf == 30.0
+        assert morning.avg_glucose_drop == 60.0
+
+    async def test_over_correction_detected(self):
+        """Test that a correction dropping glucose too low is detected."""
+        mock_db = AsyncMock()
+
+        # Evening correction at 7 PM, BG 200, 3 units
+        correction_time = datetime(2026, 2, 7, 19, 0, tzinfo=UTC)
+        mock_correction = SimpleNamespace(
+            event_timestamp=correction_time,
+            event_type="bolus",
+            is_automated=False,
+            bg_at_event=200,
+            units=3.0,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [mock_correction]
+        bolus_result.scalars.return_value = scalars_mock
+
+        # Glucose drops to 60 (below 70 low threshold) = over-correction
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [
+            (correction_time + timedelta(minutes=30), 170),
+            (correction_time + timedelta(minutes=60), 130),
+            (correction_time + timedelta(minutes=120), 85),
+            (correction_time + timedelta(minutes=180), 60),
+        ]
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_correction_outcomes(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        evening = next(p for p in periods if p.period == "evening")
+        assert evening.correction_count == 1
+        assert evening.under_count == 0
+        assert evening.over_count == 1  # final 60 < 70
+        # ISF = (200 - 60) / 3.0 = 46.7
+        assert evening.avg_observed_isf == 46.7
+        assert evening.avg_glucose_drop == 140.0
+
+    async def test_effective_correction(self):
+        """Test that a correction reaching target is counted as effective."""
+        mock_db = AsyncMock()
+
+        # Afternoon correction at 2 PM, BG 180, 2 units
+        correction_time = datetime(2026, 2, 7, 14, 0, tzinfo=UTC)
+        mock_correction = SimpleNamespace(
+            event_timestamp=correction_time,
+            event_type="bolus",
+            is_automated=False,
+            bg_at_event=180,
+            units=2.0,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [mock_correction]
+        bolus_result.scalars.return_value = scalars_mock
+
+        # Glucose drops to 100 (between 70 and 120) = effective
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [
+            (correction_time + timedelta(minutes=60), 150),
+            (correction_time + timedelta(minutes=120), 120),
+            (correction_time + timedelta(minutes=180), 100),
+        ]
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_correction_outcomes(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        afternoon = next(p for p in periods if p.period == "afternoon")
+        assert afternoon.correction_count == 1
+        assert afternoon.under_count == 0
+        assert afternoon.over_count == 0
+        # ISF = (180 - 100) / 2.0 = 40.0
+        assert afternoon.avg_observed_isf == 40.0
+
+    async def test_correction_with_no_readings_skipped(self):
+        """Test that corrections with no subsequent readings are skipped."""
+        mock_db = AsyncMock()
+
+        correction_time = datetime(2026, 2, 7, 23, 0, tzinfo=UTC)
+        mock_correction = SimpleNamespace(
+            event_timestamp=correction_time,
+            event_type="bolus",
+            is_automated=False,
+            bg_at_event=200,
+            units=2.0,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [mock_correction]
+        bolus_result.scalars.return_value = scalars_mock
+
+        # No glucose readings in the window
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = []
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_correction_outcomes(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        overnight = next(p for p in periods if p.period == "overnight")
+        assert overnight.correction_count == 0  # skipped
+
+    async def test_correction_with_zero_units_skipped(self):
+        """Test that corrections with zero units are skipped."""
+        mock_db = AsyncMock()
+
+        correction_time = datetime(2026, 2, 7, 8, 0, tzinfo=UTC)
+        mock_correction = SimpleNamespace(
+            event_timestamp=correction_time,
+            event_type="bolus",
+            is_automated=False,
+            bg_at_event=200,
+            units=0.0,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [mock_correction]
+        bolus_result.scalars.return_value = scalars_mock
+
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [
+            (correction_time + timedelta(minutes=60), 180),
+        ]
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_correction_outcomes(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        morning = next(p for p in periods if p.period == "morning")
+        assert morning.correction_count == 0  # skipped due to zero units
+
+    async def test_glucose_rise_after_correction_skipped(self):
+        """Test that corrections where glucose rose (concurrent meal) are skipped."""
+        mock_db = AsyncMock()
+
+        # Morning correction at 8 AM, BG 180, 2 units
+        correction_time = datetime(2026, 2, 7, 8, 0, tzinfo=UTC)
+        mock_correction = SimpleNamespace(
+            event_timestamp=correction_time,
+            event_type="bolus",
+            is_automated=False,
+            bg_at_event=180,
+            units=2.0,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [mock_correction]
+        bolus_result.scalars.return_value = scalars_mock
+
+        # Glucose rises to 220 (likely concurrent meal) — negative drop
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [
+            (correction_time + timedelta(minutes=30), 190),
+            (correction_time + timedelta(minutes=60), 210),
+            (correction_time + timedelta(minutes=120), 220),
+        ]
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_correction_outcomes(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        morning = next(p for p in periods if p.period == "morning")
+        assert morning.correction_count == 0  # skipped due to glucose rise
+
+    async def test_multiple_corrections_same_period(self):
+        """Test averaging across multiple corrections in the same period."""
+        mock_db = AsyncMock()
+
+        corr1_time = datetime(2026, 2, 6, 8, 0, tzinfo=UTC)
+        corr2_time = datetime(2026, 2, 7, 9, 0, tzinfo=UTC)
+        corr1 = SimpleNamespace(
+            event_timestamp=corr1_time,
+            event_type="bolus",
+            is_automated=False,
+            bg_at_event=200,
+            units=2.0,
+        )
+        corr2 = SimpleNamespace(
+            event_timestamp=corr2_time,
+            event_type="bolus",
+            is_automated=False,
+            bg_at_event=220,
+            units=3.0,
+        )
+
+        bolus_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [corr1, corr2]
+        bolus_result.scalars.return_value = scalars_mock
+
+        # All readings sorted by timestamp
+        glucose_result = MagicMock()
+        glucose_result.all.return_value = [
+            # Corr 1 window: BG 200 -> 140 (drop 60, ISF = 60/2 = 30)
+            (corr1_time + timedelta(minutes=60), 170),
+            (corr1_time + timedelta(minutes=180), 140),
+            # Corr 2 window: BG 220 -> 130 (drop 90, ISF = 90/3 = 30)
+            (corr2_time + timedelta(minutes=60), 175),
+            (corr2_time + timedelta(minutes=180), 130),
+        ]
+
+        mock_db.execute.side_effect = [bolus_result, glucose_result]
+
+        now = datetime.now(UTC)
+        periods = await analyze_correction_outcomes(
+            uuid.uuid4(), mock_db, now - timedelta(days=7), now
+        )
+
+        morning = next(p for p in periods if p.period == "morning")
+        assert morning.correction_count == 2
+        assert morning.under_count == 2  # both final > 120
+        assert morning.over_count == 0
+        # ISF: avg of 30 and 30 = 30.0
+        assert morning.avg_observed_isf == 30.0
+        # Avg drop: (60 + 90) / 2 = 75.0
+        assert morning.avg_glucose_drop == 75.0
+
+
+class TestGenerateCorrectionAnalysis:
+    """Tests for generate_correction_analysis service function."""
+
+    @patch("src.services.correction_analysis.get_ai_client")
+    @patch("src.services.correction_analysis.analyze_correction_outcomes")
+    async def test_generate_analysis_success(self, mock_analyze, mock_get_client):
+        """Test successful correction analysis generation."""
+        from src.services.correction_analysis import (
+            generate_correction_analysis,
+        )
+
+        mock_analyze.return_value = [
+            TimePeriodData(
+                period="overnight",
+                correction_count=2,
+                under_count=1,
+                over_count=0,
+                avg_observed_isf=35.0,
+                avg_glucose_drop=70.0,
+            ),
+            TimePeriodData(
+                period="morning",
+                correction_count=4,
+                under_count=3,
+                over_count=0,
+                avg_observed_isf=30.0,
+                avg_glucose_drop=60.0,
+            ),
+            TimePeriodData(
+                period="afternoon",
+                correction_count=3,
+                under_count=0,
+                over_count=1,
+                avg_observed_isf=50.0,
+                avg_glucose_drop=100.0,
+            ),
+            TimePeriodData(
+                period="evening",
+                correction_count=1,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=45.0,
+                avg_glucose_drop=90.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response()
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        analysis = await generate_correction_analysis(mock_user, mock_db, days=7)
+
+        assert analysis.total_corrections == 10
+        assert analysis.under_corrections == 4
+        assert analysis.over_corrections == 1
+        # Weighted avg ISF: (35*2 + 30*4 + 50*3 + 45*1) / 10 = 385/10 = 38.5
+        assert analysis.avg_observed_isf == 38.5
+        assert analysis.ai_analysis == "Morning corrections consistently under-correct."
+        assert len(analysis.time_periods_data) == 4
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    @patch("src.services.correction_analysis.analyze_correction_outcomes")
+    async def test_generate_analysis_insufficient_data(self, mock_analyze):
+        """Test that insufficient corrections raises 400."""
+        from fastapi import HTTPException
+
+        from src.services.correction_analysis import (
+            generate_correction_analysis,
+        )
+
+        mock_analyze.return_value = [
+            TimePeriodData(
+                period="overnight",
+                correction_count=1,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=40.0,
+                avg_glucose_drop=80.0,
+            ),
+            TimePeriodData(
+                period="morning",
+                correction_count=2,
+                under_count=1,
+                over_count=0,
+                avg_observed_isf=35.0,
+                avg_glucose_drop=70.0,
+            ),
+            TimePeriodData(
+                period="afternoon",
+                correction_count=0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=0.0,
+                avg_glucose_drop=0.0,
+            ),
+            TimePeriodData(
+                period="evening",
+                correction_count=0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=0.0,
+                avg_glucose_drop=0.0,
+            ),
+        ]
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await generate_correction_analysis(mock_user, mock_db)
+
+        assert exc_info.value.status_code == 400
+        assert "Insufficient correction data" in exc_info.value.detail
+
+    @patch("src.services.correction_analysis.get_ai_client")
+    @patch("src.services.correction_analysis.analyze_correction_outcomes")
+    async def test_generate_analysis_ai_error_propagates(
+        self, mock_analyze, mock_get_client
+    ):
+        """Test that AI provider errors propagate."""
+        from src.services.correction_analysis import (
+            generate_correction_analysis,
+        )
+
+        mock_analyze.return_value = [
+            TimePeriodData(
+                period="overnight",
+                correction_count=3,
+                under_count=1,
+                over_count=0,
+                avg_observed_isf=40.0,
+                avg_glucose_drop=80.0,
+            ),
+            TimePeriodData(
+                period="morning",
+                correction_count=3,
+                under_count=2,
+                over_count=0,
+                avg_observed_isf=30.0,
+                avg_glucose_drop=60.0,
+            ),
+            TimePeriodData(
+                period="afternoon",
+                correction_count=0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=0.0,
+                avg_glucose_drop=0.0,
+            ),
+            TimePeriodData(
+                period="evening",
+                correction_count=0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=0.0,
+                avg_glucose_drop=0.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.side_effect = RuntimeError("AI failed")
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="AI failed"):
+            await generate_correction_analysis(mock_user, mock_db)
+
+
+class TestListCorrectionAnalyses:
+    """Tests for list_correction_analyses."""
+
+    async def test_list_empty(self):
+        """Test listing when no analyses exist."""
+        from src.services.correction_analysis import list_correction_analyses
+
+        mock_db = AsyncMock()
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        analyses_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = []
+        analyses_result.scalars.return_value = scalars_mock
+        mock_db.execute.side_effect = [count_result, analyses_result]
+
+        analyses, total = await list_correction_analyses(uuid.uuid4(), mock_db)
+
+        assert analyses == []
+        assert total == 0
+
+
+class TestGetCorrectionAnalysisById:
+    """Tests for get_correction_analysis_by_id."""
+
+    async def test_not_found(self):
+        """Test that missing analysis raises 404."""
+        from fastapi import HTTPException
+
+        from src.services.correction_analysis import (
+            get_correction_analysis_by_id,
+        )
+
+        mock_db = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = result
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_correction_analysis_by_id(uuid.uuid4(), uuid.uuid4(), mock_db)
+
+        assert exc_info.value.status_code == 404
+
+    async def test_found(self):
+        """Test successful retrieval."""
+        from src.services.correction_analysis import (
+            get_correction_analysis_by_id,
+        )
+
+        mock_analysis = SimpleNamespace(id=uuid.uuid4(), user_id=uuid.uuid4())
+        mock_db = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = mock_analysis
+        mock_db.execute.return_value = result
+
+        analysis = await get_correction_analysis_by_id(
+            mock_analysis.id, mock_analysis.user_id, mock_db
+        )
+
+        assert analysis.id == mock_analysis.id
+
+
+class TestCorrectionAnalysisEndpoints:
+    """Integration tests for correction analysis API endpoints."""
+
+    @patch("src.services.correction_analysis.get_ai_client")
+    @patch("src.services.correction_analysis.analyze_correction_outcomes")
+    async def test_analyze_endpoint(self, mock_analyze, mock_get_client):
+        """Test POST /api/ai/corrections/analyze returns 201."""
+        mock_analyze.return_value = [
+            TimePeriodData(
+                period="overnight",
+                correction_count=3,
+                under_count=1,
+                over_count=0,
+                avg_observed_isf=35.0,
+                avg_glucose_drop=70.0,
+            ),
+            TimePeriodData(
+                period="morning",
+                correction_count=5,
+                under_count=4,
+                over_count=0,
+                avg_observed_isf=28.0,
+                avg_glucose_drop=56.0,
+            ),
+            TimePeriodData(
+                period="afternoon",
+                correction_count=3,
+                under_count=0,
+                over_count=1,
+                avg_observed_isf=55.0,
+                avg_glucose_drop=110.0,
+            ),
+            TimePeriodData(
+                period="evening",
+                correction_count=2,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=45.0,
+                avg_glucose_drop=90.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response(
+            "Your morning correction factor may need strengthening."
+        )
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/corrections/analyze",
+                json={"days": 7},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["total_corrections"] == 13
+        assert data["under_corrections"] == 5
+        assert data["over_corrections"] == 1
+        assert (
+            data["ai_analysis"]
+            == "Your morning correction factor may need strengthening."
+        )
+        assert len(data["time_periods_data"]) == 4
+        assert "id" in data
+        assert "created_at" in data
+
+    @patch("src.services.correction_analysis.analyze_correction_outcomes")
+    async def test_analyze_insufficient_data_endpoint(self, mock_analyze):
+        """Test POST /api/ai/corrections/analyze returns 400."""
+        mock_analyze.return_value = [
+            TimePeriodData(
+                period=p,
+                correction_count=1 if p == "morning" else 0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=40.0 if p == "morning" else 0.0,
+                avg_glucose_drop=80.0 if p == "morning" else 0.0,
+            )
+            for p in ["overnight", "morning", "afternoon", "evening"]
+        ]
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/corrections/analyze",
+                json={"days": 7},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 400
+        assert "Insufficient correction data" in response.json()["detail"]
+
+    async def test_analyze_unauthenticated(self):
+        """Test POST /api/ai/corrections/analyze returns 401 without auth."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/api/ai/corrections/analyze",
+                json={"days": 7},
+            )
+
+        assert response.status_code == 401
+
+    async def test_list_analyses_endpoint(self):
+        """Test GET /api/ai/corrections returns 200."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.get(
+                "/api/ai/corrections",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "analyses" in data
+        assert "total" in data
+
+    async def test_list_analyses_unauthenticated(self):
+        """Test GET /api/ai/corrections returns 401 without auth."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/ai/corrections")
+
+        assert response.status_code == 401
+
+    async def test_get_analysis_not_found(self):
+        """Test GET /api/ai/corrections/{id} returns 404."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            fake_id = uuid.uuid4()
+            response = await client.get(
+                f"/api/ai/corrections/{fake_id}",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 404
+
+    @patch("src.services.correction_analysis.get_ai_client")
+    @patch("src.services.correction_analysis.analyze_correction_outcomes")
+    async def test_analyze_then_list_and_get(self, mock_analyze, mock_get_client):
+        """Test generating an analysis, then listing and getting it."""
+        mock_analyze.return_value = [
+            TimePeriodData(
+                period="overnight",
+                correction_count=2,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=45.0,
+                avg_glucose_drop=90.0,
+            ),
+            TimePeriodData(
+                period="morning",
+                correction_count=4,
+                under_count=2,
+                over_count=0,
+                avg_observed_isf=32.0,
+                avg_glucose_drop=64.0,
+            ),
+            TimePeriodData(
+                period="afternoon",
+                correction_count=0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=0.0,
+                avg_glucose_drop=0.0,
+            ),
+            TimePeriodData(
+                period="evening",
+                correction_count=0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=0.0,
+                avg_glucose_drop=0.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = _mock_ai_response()
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+            cookies = {settings.jwt_cookie_name: cookie}
+
+            # Generate analysis
+            gen_response = await client.post(
+                "/api/ai/corrections/analyze",
+                json={"days": 7},
+                cookies=cookies,
+            )
+            assert gen_response.status_code == 201
+            analysis_id = gen_response.json()["id"]
+
+            # List analyses
+            list_response = await client.get(
+                "/api/ai/corrections",
+                cookies=cookies,
+            )
+            assert list_response.status_code == 200
+            assert list_response.json()["total"] >= 1
+
+            # Get specific analysis
+            get_response = await client.get(
+                f"/api/ai/corrections/{analysis_id}",
+                cookies=cookies,
+            )
+            assert get_response.status_code == 200
+            assert get_response.json()["id"] == analysis_id
+
+    async def test_analyze_invalid_days(self):
+        """Test POST /api/ai/corrections/analyze rejects days < 3."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/corrections/analyze",
+                json={"days": 1},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 422
+
+    async def test_analyze_days_too_large(self):
+        """Test POST /api/ai/corrections/analyze rejects days > 30."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/corrections/analyze",
+                json={"days": 60},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Evaluate correction bolus outcomes to detect consistent under- or over-correction patterns
- Group analysis by time-of-day periods (overnight, morning, afternoon, evening) with midnight wrap-around
- Generate AI-powered insulin sensitivity factor (ISF) adjustment suggestions with reasoning
- Filter out concurrent-meal confounders (negative glucose drops) and zero-unit corrections

## What's Included
- **Model:** `CorrectionAnalysis` with JSON time period breakdown, AI output, and token tracking
- **Service:** `analyze_correction_outcomes()` correlates manual correction boluses (BG >= 150) with 3hr post-correction glucose windows; `generate_correction_analysis()` orchestrates AI generation
- **API:** `POST /api/ai/corrections/analyze`, `GET /api/ai/corrections`, `GET /api/ai/corrections/{analysis_id}`
- **Migration:** `012_create_correction_analyses` with composite index on `(user_id, period_start)`
- **Tests:** 32 tests covering unit, service, and integration layers

## Test plan
- [x] 276 tests pass (32 new for Story 5.5)
- [x] Ruff lint + format clean
- [x] Subagent review round 1: APPROVED (5 Low findings)
- [x] Fixes applied: negative glucose drop filter, strict window bound, new edge case test
- [x] Subagent review round 2: APPROVED (all fixes verified)
- [x] Playwright MCP visual check: dashboard, briefs, settings all rendering correctly
- [x] N+1 query optimization verified (2 DB queries total)
- [x] Weighted average ISF calculation verified with explicit arithmetic test

🤖 Generated with [Claude Code](https://claude.com/claude-code)