### PR TITLE
feat(api): add pre-validation safety layer for AI suggestions (Story 5.6)

### DIFF
--- a/apps/api/migrations/versions/013_create_safety_logs.py
+++ b/apps/api/migrations/versions/013_create_safety_logs.py
@@ -1,0 +1,74 @@
+"""Story 5.6: Create safety_logs table.
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-02-08
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "013_safety_logs"
+down_revision: str | None = "012_correction_analyses"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "safety_logs",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("analysis_type", sa.String(30), nullable=False),
+        sa.Column("analysis_id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("flagged_items", postgresql.JSON(), nullable=False),
+        sa.Column(
+            "has_dangerous_content",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "ix_safety_logs_user_analysis",
+        "safety_logs",
+        ["user_id", "analysis_type", "analysis_id"],
+    )
+
+    op.create_index(
+        "ix_safety_logs_user_id",
+        "safety_logs",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_safety_logs_user_id")
+    op.drop_index("ix_safety_logs_user_analysis")
+    op.drop_table("safety_logs")

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -20,6 +20,7 @@ from src.routers import (
     health,
     integrations,
     meal_analysis,
+    safety,
     system,
 )
 from src.services.scheduler import start_scheduler, stop_scheduler
@@ -85,6 +86,7 @@ app.include_router(ai.router)
 app.include_router(briefs.router)
 app.include_router(meal_analysis.router)
 app.include_router(correction_analysis.router)
+app.include_router(safety.router)
 
 
 @app.get("/")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -12,6 +12,7 @@ from src.models.integration import (
 )
 from src.models.meal_analysis import MealAnalysis
 from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.safety_log import SafetyLog
 from src.models.user import User, UserRole
 
 __all__ = [
@@ -31,6 +32,7 @@ __all__ = [
     "IntegrationType",
     "PumpEvent",
     "PumpEventType",
+    "SafetyLog",
     "User",
     "UserRole",
 ]

--- a/apps/api/src/models/safety_log.py
+++ b/apps/api/src/models/safety_log.py
@@ -1,0 +1,81 @@
+"""Story 5.6: Safety validation audit log model.
+
+Stores validation decisions for AI-generated suggestions.
+"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class SafetyLog(Base, TimestampMixin):
+    """Audit log for AI suggestion safety validations.
+
+    Records every validation decision including the status
+    (approved/flagged/rejected), any flagged items, and the
+    analysis that was validated.
+    """
+
+    __tablename__ = "safety_logs"
+
+    __table_args__ = (
+        Index(
+            "ix_safety_logs_user_analysis", "user_id", "analysis_type", "analysis_id"
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Which analysis was validated
+    analysis_type: Mapped[str] = mapped_column(
+        String(30),
+        nullable=False,
+    )
+
+    analysis_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=False,
+    )
+
+    # Validation outcome
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+    )
+
+    # Flagged items detail (JSON array)
+    flagged_items: Mapped[list] = mapped_column(
+        JSON,
+        nullable=False,
+        default=list,
+    )
+
+    # Whether dangerous content was detected
+    has_dangerous_content: Mapped[bool] = mapped_column(
+        default=False,
+        nullable=False,
+    )
+
+    # Relationship to user
+    user = relationship("User", back_populates="safety_logs")
+
+    def __repr__(self) -> str:
+        return (
+            f"<SafetyLog(user_id={self.user_id}, "
+            f"type={self.analysis_type}, status={self.status})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -119,6 +119,11 @@ class User(Base, TimestampMixin):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    safety_logs = relationship(
+        "SafetyLog",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/routers/safety.py
+++ b/apps/api/src/routers/safety.py
@@ -1,0 +1,40 @@
+"""Story 5.6: Safety validation router.
+
+API endpoint for querying safety validation audit logs.
+"""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import DiabeticOrAdminUser
+from src.database import get_db
+from src.schemas.auth import ErrorResponse
+from src.schemas.safety_validation import SafetyLogListResponse, SafetyLogResponse
+from src.services.safety_validation import list_safety_logs
+
+router = APIRouter(prefix="/api/ai/safety", tags=["ai-safety"])
+
+
+@router.get(
+    "/logs",
+    response_model=SafetyLogListResponse,
+    responses={
+        200: {"description": "List of safety validation logs"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+    },
+)
+async def get_safety_logs(
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(default=10, ge=1, le=50),
+    offset: int = Query(default=0, ge=0),
+) -> SafetyLogListResponse:
+    """List safety validation logs for the current user."""
+    logs, total = await list_safety_logs(
+        current_user.id, db, limit=limit, offset=offset
+    )
+    return SafetyLogListResponse(
+        logs=[SafetyLogResponse.model_validate(log) for log in logs],
+        total=total,
+    )

--- a/apps/api/src/schemas/safety_validation.py
+++ b/apps/api/src/schemas/safety_validation.py
@@ -1,0 +1,73 @@
+"""Story 5.6: Pre-validation safety layer schemas.
+
+Schemas for AI suggestion safety validation results.
+"""
+
+import enum
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SafetyStatus(str, enum.Enum):
+    """Validation outcome for an AI suggestion."""
+
+    APPROVED = "approved"
+    FLAGGED = "flagged"  # Contains flagged items but still shown
+    REJECTED = "rejected"  # Blocked from display
+
+
+class SuggestionType(str, enum.Enum):
+    """Types of AI suggestions that can be validated."""
+
+    CARB_RATIO = "carb_ratio"
+    CORRECTION_FACTOR = "correction_factor"
+
+
+class FlaggedSuggestion(BaseModel):
+    """A single flagged suggestion extracted from AI output."""
+
+    suggestion_type: SuggestionType
+    original_value: float = Field(..., description="Original ratio/factor value")
+    suggested_value: float = Field(..., description="Suggested ratio/factor value")
+    change_pct: float = Field(..., description="Percentage change from original")
+    max_allowed_pct: float = Field(
+        default=20.0, description="Maximum allowed percentage change"
+    )
+    reason: str = Field(..., description="Why this was flagged")
+
+
+class ValidationResult(BaseModel):
+    """Result of validating AI-generated suggestions."""
+
+    status: SafetyStatus
+    flagged_items: list[FlaggedSuggestion] = Field(default_factory=list)
+    original_text: str = Field(..., description="Original AI output")
+    sanitized_text: str = Field(
+        ..., description="AI output with safety annotations added"
+    )
+    has_dangerous_content: bool = Field(
+        default=False, description="Whether dangerous keywords were detected"
+    )
+
+
+class SafetyLogResponse(BaseModel):
+    """Response schema for a safety validation log entry."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    user_id: uuid.UUID
+    analysis_type: str
+    analysis_id: uuid.UUID
+    status: str
+    flagged_items: list[dict]
+    created_at: datetime
+
+
+class SafetyLogListResponse(BaseModel):
+    """Response schema for listing safety logs."""
+
+    logs: list[SafetyLogResponse]
+    total: int

--- a/apps/api/src/services/safety_validation.py
+++ b/apps/api/src/services/safety_validation.py
@@ -1,0 +1,325 @@
+"""Story 5.6: Pre-validation safety layer service.
+
+Validates AI-generated suggestions against safety bounds before
+they are shown to users. Detects dangerous content and ensures
+ratio/factor changes stay within ±20% limits.
+"""
+
+import re
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.safety_log import SafetyLog
+from src.schemas.safety_validation import (
+    FlaggedSuggestion,
+    SafetyStatus,
+    SuggestionType,
+    ValidationResult,
+)
+
+logger = get_logger(__name__)
+
+# Maximum allowed percentage change for any single suggestion
+MAX_CHANGE_PCT = 20.0
+
+# Safety disclaimer that must appear in validated output
+SAFETY_DISCLAIMER = (
+    "\n\n---\n"
+    "**Safety Notice:** These are AI-generated observations, not medical advice. "
+    "Always discuss changes with your endocrinologist before adjusting pump settings."
+)
+
+# Dangerous keywords/phrases that indicate unsafe content
+DANGEROUS_PATTERNS = [
+    r"(?i)\bdouble\s+(?:your|the)\s+(?:dose|insulin|bolus)",
+    r"(?i)\bhalf\s+(?:your|the)\s+(?:dose|insulin|bolus)",
+    r"(?i)\bstop\s+(?:taking|your)\s+(?:insulin|medication)",
+    r"(?i)\bskip\s+(?:your|the)\s+(?:dose|insulin|bolus|medication)",
+    r"(?i)\bincrease.*\b(?:by|to)\s+(?:200|300|400|500)\s*%",
+    r"(?i)\btriple\s+(?:your|the)\s+(?:dose|insulin|bolus)",
+    r"(?i)\bimmediately\s+(?:change|adjust|modify)\s+(?:your|the|all)",
+    r"(?i)\bdiscontinue\s+(?:your\s+|the\s+)?(?:insulin|medication)",
+    r"(?i)\b(?:take|bolus|inject|give)\s+\d+\s*(?:units?|u)\b",
+]
+
+# Pattern to extract carb ratio suggestions like "1:8 to 1:7" or "from 1:10 to 1:8"
+# Negative lookahead excludes matches followed by mg/dL (those are ISF values)
+# (?!\d) prevents backtracking from consuming fewer digits to bypass the lookahead
+CARB_RATIO_PATTERN = re.compile(
+    r"(?:from\s+)?1\s*:\s*(\d+(?:\.\d+)?)\s+"
+    r"(?:to|→|->)\s+"
+    r"1\s*:\s*(\d+(?:\.\d+)?)"
+    r"(?!\d|\s*(?:mg/dL|mg\b))",
+    re.IGNORECASE,
+)
+
+# Pattern to extract ISF suggestions with 1:X notation requiring mg/dL suffix
+# e.g., "from 1:50 to 1:45 mg/dL" — the mg/dL suffix distinguishes ISF from carb ratios
+ISF_PATTERN = re.compile(
+    r"(?:from\s+)?1\s*:\s*(\d+(?:\.\d+)?)\s+"
+    r"(?:to|→|->)\s+"
+    r"(?:1\s*:\s*)?(\d+(?:\.\d+)?)"
+    r"\s*(?:mg/dL|mg)",
+    re.IGNORECASE,
+)
+
+# ISF pattern with context keywords (does not require 1: prefix)
+# e.g., "correction factor from 50 to 45 mg/dL" or "ISF should be 50 to 45 mg/dL"
+ISF_CONTEXT_PATTERN = re.compile(
+    r"(?:ISF|correction\s+factor|sensitivity\s+factor|CF)"
+    r".*?(?:from\s+)?(\d+(?:\.\d+)?)\s+"
+    r"(?:to|→|->)\s+"
+    r"(\d+(?:\.\d+)?)"
+    r"\s*(?:mg/dL|mg)",
+    re.IGNORECASE,
+)
+
+
+def _check_dangerous_content(text: str) -> bool:
+    """Check if AI output contains dangerous content.
+
+    Args:
+        text: The AI-generated text to check.
+
+    Returns:
+        True if dangerous content was detected.
+    """
+    return any(re.search(pattern, text) for pattern in DANGEROUS_PATTERNS)
+
+
+def _extract_carb_ratio_changes(text: str) -> list[FlaggedSuggestion]:
+    """Extract and validate carb ratio change suggestions.
+
+    Looks for patterns like "1:8 to 1:7" in the AI text
+    and checks if the change exceeds ±20%.
+
+    Args:
+        text: The AI-generated text.
+
+    Returns:
+        List of flagged suggestions that exceed bounds.
+    """
+    flagged = []
+    for match in CARB_RATIO_PATTERN.finditer(text):
+        original = float(match.group(1))
+        suggested = float(match.group(2))
+
+        if original == 0:
+            continue
+
+        # For carb ratios (1:X), a smaller X = stronger ratio = more insulin
+        change_pct = abs((suggested - original) / original) * 100
+
+        if change_pct > MAX_CHANGE_PCT:
+            flagged.append(
+                FlaggedSuggestion(
+                    suggestion_type=SuggestionType.CARB_RATIO,
+                    original_value=original,
+                    suggested_value=suggested,
+                    change_pct=round(change_pct, 1),
+                    max_allowed_pct=MAX_CHANGE_PCT,
+                    reason=(
+                        f"Carb ratio change of {change_pct:.0f}% "
+                        f"(1:{original} to 1:{suggested}) exceeds "
+                        f"maximum allowed change of {MAX_CHANGE_PCT:.0f}%"
+                    ),
+                )
+            )
+    return flagged
+
+
+def _extract_isf_changes(text: str) -> list[FlaggedSuggestion]:
+    """Extract and validate ISF/correction factor change suggestions.
+
+    Looks for patterns like "1:50 to 1:45" or "correction factor from 50 to 45 mg/dL"
+    in the AI text and checks if the change exceeds ±20%.
+
+    Requires either a 1: prefix (ISF_PATTERN) or a context keyword like
+    "ISF", "correction factor", or "sensitivity factor" (ISF_CONTEXT_PATTERN)
+    to avoid false positives from glucose reading text.
+
+    Args:
+        text: The AI-generated text.
+
+    Returns:
+        List of flagged suggestions that exceed bounds.
+    """
+    flagged = []
+    seen: set[tuple[float, float]] = set()
+
+    for pattern in (ISF_PATTERN, ISF_CONTEXT_PATTERN):
+        for match in pattern.finditer(text):
+            original = float(match.group(1))
+            suggested = float(match.group(2))
+
+            if original == 0:
+                continue
+
+            # Deduplicate matches found by both patterns
+            key = (original, suggested)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            change_pct = abs((suggested - original) / original) * 100
+
+            if change_pct > MAX_CHANGE_PCT:
+                flagged.append(
+                    FlaggedSuggestion(
+                        suggestion_type=SuggestionType.CORRECTION_FACTOR,
+                        original_value=original,
+                        suggested_value=suggested,
+                        change_pct=round(change_pct, 1),
+                        max_allowed_pct=MAX_CHANGE_PCT,
+                        reason=(
+                            f"Correction factor change of {change_pct:.0f}% "
+                            f"({original} to {suggested} mg/dL) exceeds "
+                            f"maximum allowed change of {MAX_CHANGE_PCT:.0f}%"
+                        ),
+                    )
+                )
+    return flagged
+
+
+def validate_ai_suggestion(
+    ai_text: str,
+    suggestion_type: str,
+) -> ValidationResult:
+    """Validate an AI-generated suggestion against safety bounds.
+
+    Checks for:
+    1. Dangerous content (e.g., "double your dose")
+    2. Carb ratio changes exceeding ±20%
+    3. Correction factor changes exceeding ±20%
+
+    Args:
+        ai_text: The AI-generated analysis text.
+        suggestion_type: Type of analysis ("meal_analysis" or "correction_analysis").
+
+    Returns:
+        ValidationResult with status and any flagged items.
+    """
+    has_dangerous = _check_dangerous_content(ai_text)
+    flagged_items: list[FlaggedSuggestion] = []
+
+    # Check both ratio and factor changes regardless of type
+    # (AI might mention both in any analysis)
+    flagged_items.extend(_extract_carb_ratio_changes(ai_text))
+    flagged_items.extend(_extract_isf_changes(ai_text))
+
+    # Determine status
+    if has_dangerous:
+        status = SafetyStatus.REJECTED
+    elif flagged_items:
+        status = SafetyStatus.FLAGGED
+    else:
+        status = SafetyStatus.APPROVED
+
+    # Build sanitized text
+    sanitized = ai_text
+    if has_dangerous:
+        sanitized = (
+            "**This suggestion has been blocked by the safety system due to "
+            "potentially dangerous content. Please consult your healthcare "
+            "provider directly for guidance.**"
+        )
+    elif flagged_items:
+        warnings = []
+        for item in flagged_items:
+            warnings.append(f"- {item.reason}")
+        warning_block = (
+            "\n\n**Safety Warning:** The following suggestions exceed "
+            "recommended change limits:\n" + "\n".join(warnings) + "\n"
+            "Discuss these with your endocrinologist before making changes."
+        )
+        sanitized = ai_text + warning_block
+
+    # Always append safety disclaimer
+    sanitized += SAFETY_DISCLAIMER
+
+    return ValidationResult(
+        status=status,
+        flagged_items=flagged_items,
+        original_text=ai_text,
+        sanitized_text=sanitized,
+        has_dangerous_content=has_dangerous,
+    )
+
+
+async def log_safety_validation(
+    user_id: "str | object",
+    analysis_type: str,
+    analysis_id: "str | object",
+    result: ValidationResult,
+    db: AsyncSession,
+) -> SafetyLog:
+    """Log a safety validation decision for audit.
+
+    Args:
+        user_id: User's UUID.
+        analysis_type: Type of analysis validated.
+        analysis_id: ID of the analysis that was validated.
+        result: The validation result.
+        db: Database session.
+
+    Returns:
+        The created SafetyLog record.
+    """
+    log_entry = SafetyLog(
+        user_id=user_id,
+        analysis_type=analysis_type,
+        analysis_id=analysis_id,
+        status=result.status.value,
+        flagged_items=[item.model_dump() for item in result.flagged_items],
+        has_dangerous_content=result.has_dangerous_content,
+    )
+
+    db.add(log_entry)
+
+    logger.info(
+        "Safety validation logged",
+        user_id=str(user_id),
+        analysis_type=analysis_type,
+        analysis_id=str(analysis_id),
+        status=result.status.value,
+        flagged_count=len(result.flagged_items),
+        dangerous=result.has_dangerous_content,
+    )
+
+    return log_entry
+
+
+async def list_safety_logs(
+    user_id: "str | object",
+    db: AsyncSession,
+    limit: int = 10,
+    offset: int = 0,
+) -> tuple[list[SafetyLog], int]:
+    """List safety validation logs for a user.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+        limit: Maximum number of logs to return.
+        offset: Number of logs to skip.
+
+    Returns:
+        Tuple of (logs list, total count).
+    """
+    count_result = await db.execute(
+        select(func.count()).where(SafetyLog.user_id == user_id)
+    )
+    total = count_result.scalar() or 0
+
+    result = await db.execute(
+        select(SafetyLog)
+        .where(SafetyLog.user_id == user_id)
+        .order_by(SafetyLog.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    logs = list(result.scalars().all())
+
+    return logs, total

--- a/apps/api/tests/test_correction_analysis.py
+++ b/apps/api/tests/test_correction_analysis.py
@@ -522,9 +522,11 @@ class TestGenerateCorrectionAnalysis:
         assert analysis.over_corrections == 1
         # Weighted avg ISF: (35*2 + 30*4 + 50*3 + 45*1) / 10 = 385/10 = 38.5
         assert analysis.avg_observed_isf == 38.5
-        assert analysis.ai_analysis == "Morning corrections consistently under-correct."
+        assert "Morning corrections consistently under-correct." in analysis.ai_analysis
+        assert "Safety Notice" in analysis.ai_analysis
         assert len(analysis.time_periods_data) == 4
-        mock_db.add.assert_called_once()
+        # db.add called twice: once for analysis, once for safety log
+        assert mock_db.add.call_count == 2
         mock_db.commit.assert_called_once()
 
     @patch("src.services.correction_analysis.analyze_correction_outcomes")
@@ -764,9 +766,10 @@ class TestCorrectionAnalysisEndpoints:
         assert data["under_corrections"] == 5
         assert data["over_corrections"] == 1
         assert (
-            data["ai_analysis"]
-            == "Your morning correction factor may need strengthening."
+            "Your morning correction factor may need strengthening."
+            in data["ai_analysis"]
         )
+        assert "Safety Notice" in data["ai_analysis"]
         assert len(data["time_periods_data"]) == 4
         assert "id" in data
         assert "created_at" in data

--- a/apps/api/tests/test_meal_analysis.py
+++ b/apps/api/tests/test_meal_analysis.py
@@ -384,9 +384,11 @@ class TestGenerateMealAnalysis:
         assert analysis.total_spikes == 4
         # Weighted avg: (195*5 + 165*4 + 155*3) / 12 = 2100/12 = 175.0
         assert analysis.avg_post_meal_peak == 175.0
-        assert analysis.ai_analysis == "Breakfast shows consistent spikes."
+        assert "Breakfast shows consistent spikes." in analysis.ai_analysis
+        assert "Safety Notice" in analysis.ai_analysis
         assert len(analysis.meal_periods_data) == 4
-        mock_db.add.assert_called_once()
+        # db.add called twice: once for analysis, once for safety log
+        assert mock_db.add.call_count == 2
         mock_db.commit.assert_called_once()
 
     @patch("src.services.meal_analysis.analyze_post_meal_patterns")
@@ -604,7 +606,8 @@ class TestMealAnalysisEndpoints:
         data = response.json()
         assert data["total_boluses"] == 15
         assert data["total_spikes"] == 5
-        assert data["ai_analysis"] == "Your breakfast carb ratio may need adjustment."
+        assert "Your breakfast carb ratio may need adjustment." in data["ai_analysis"]
+        assert "Safety Notice" in data["ai_analysis"]
         assert len(data["meal_periods_data"]) == 4
         assert "id" in data
         assert "created_at" in data

--- a/apps/api/tests/test_safety_validation.py
+++ b/apps/api/tests/test_safety_validation.py
@@ -1,0 +1,575 @@
+"""Story 5.6: Tests for pre-validation safety layer."""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from src.config import settings
+from src.main import app
+from src.schemas.safety_validation import SafetyStatus, SuggestionType
+from src.services.safety_validation import (
+    _check_dangerous_content,
+    _extract_carb_ratio_changes,
+    _extract_isf_changes,
+    validate_ai_suggestion,
+)
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client: AsyncClient) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("safety")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+class TestCheckDangerousContent:
+    """Tests for _check_dangerous_content."""
+
+    def test_double_dose_detected(self):
+        """Test that 'double your dose' is flagged."""
+        assert _check_dangerous_content("You should double your dose immediately")
+
+    def test_half_dose_detected(self):
+        """Test that 'half your dose' is flagged."""
+        assert _check_dangerous_content("Try to half your insulin amount")
+
+    def test_stop_insulin_detected(self):
+        """Test that 'stop taking insulin' is flagged."""
+        assert _check_dangerous_content("Stop taking insulin for a day")
+
+    def test_skip_dose_detected(self):
+        """Test that 'skip your dose' is flagged."""
+        assert _check_dangerous_content("Skip your bolus tonight")
+
+    def test_triple_dose_detected(self):
+        """Test that 'triple your dose' is flagged."""
+        assert _check_dangerous_content("Triple your bolus for this meal")
+
+    def test_immediately_change_detected(self):
+        """Test that 'immediately change your' is flagged."""
+        assert _check_dangerous_content(
+            "Immediately change your carb ratios across all periods"
+        )
+
+    def test_safe_text_not_flagged(self):
+        """Test that normal suggestion text is not flagged."""
+        safe_text = (
+            "Consider discussing a slightly stronger breakfast carb ratio "
+            "with your endocrinologist, such as moving from 1:8 to 1:7."
+        )
+        assert not _check_dangerous_content(safe_text)
+
+    def test_case_insensitive(self):
+        """Test that dangerous content detection is case-insensitive."""
+        assert _check_dangerous_content("DOUBLE YOUR DOSE")
+        assert _check_dangerous_content("Double Your Insulin")
+
+    def test_large_percentage_increase_detected(self):
+        """Test that 'increase by 200%' is flagged."""
+        assert _check_dangerous_content("Increase your bolus by 200%")
+
+    def test_discontinue_insulin_detected(self):
+        """Test that 'discontinue insulin' is flagged."""
+        assert _check_dangerous_content("Discontinue your insulin regimen")
+
+    def test_specific_dose_instruction_detected(self):
+        """Test that specific dose instructions are flagged."""
+        assert _check_dangerous_content("Take 10 units before your meal")
+        assert _check_dangerous_content("Bolus 15 units now")
+
+    def test_empty_text_not_flagged(self):
+        """Test that empty text is not flagged."""
+        assert not _check_dangerous_content("")
+
+
+class TestValidateEmptyText:
+    """Tests for edge case of empty AI text."""
+
+    def test_empty_text_approved(self):
+        """Test that empty AI text is approved with disclaimer."""
+        result = validate_ai_suggestion("", "meal_analysis")
+        assert result.status == SafetyStatus.APPROVED
+        assert "Safety Notice" in result.sanitized_text
+
+
+class TestExtractCarbRatioChanges:
+    """Tests for _extract_carb_ratio_changes."""
+
+    def test_within_bounds_not_flagged(self):
+        """Test that a ±20% change is not flagged."""
+        # 1:10 to 1:9 = 10% change
+        text = "Consider moving from 1:10 to 1:9 for breakfast."
+        flagged = _extract_carb_ratio_changes(text)
+        assert len(flagged) == 0
+
+    def test_exceeds_bounds_flagged(self):
+        """Test that a >20% change is flagged."""
+        # 1:10 to 1:7 = 30% change
+        text = "Consider moving from 1:10 to 1:7 for breakfast."
+        flagged = _extract_carb_ratio_changes(text)
+        assert len(flagged) == 1
+        assert flagged[0].suggestion_type == SuggestionType.CARB_RATIO
+        assert flagged[0].original_value == 10.0
+        assert flagged[0].suggested_value == 7.0
+        assert flagged[0].change_pct == 30.0
+
+    def test_exactly_20_pct_not_flagged(self):
+        """Test that exactly 20% change is not flagged."""
+        # 1:10 to 1:8 = 20% change
+        text = "Consider moving from 1:10 to 1:8 for lunch."
+        flagged = _extract_carb_ratio_changes(text)
+        assert len(flagged) == 0
+
+    def test_multiple_ratios_in_text(self):
+        """Test extracting multiple ratio suggestions."""
+        text = (
+            "For breakfast, move from 1:10 to 1:7. For lunch, move from 1:12 to 1:11."
+        )
+        flagged = _extract_carb_ratio_changes(text)
+        # Only breakfast (30%) exceeds, lunch (8.3%) does not
+        assert len(flagged) == 1
+        assert flagged[0].original_value == 10.0
+
+    def test_arrow_notation(self):
+        """Test ratio extraction with arrow notation."""
+        text = "Breakfast ratio: 1:8 → 1:6"
+        flagged = _extract_carb_ratio_changes(text)
+        assert len(flagged) == 1  # 25% change
+        assert flagged[0].change_pct == 25.0
+
+    def test_no_ratios_returns_empty(self):
+        """Test that text without ratios returns empty list."""
+        text = "Your breakfast patterns look good. No changes needed."
+        flagged = _extract_carb_ratio_changes(text)
+        assert len(flagged) == 0
+
+
+class TestExtractISFChanges:
+    """Tests for _extract_isf_changes."""
+
+    def test_within_bounds_not_flagged(self):
+        """Test that a ±20% ISF change is not flagged."""
+        # 1:50 to 1:45 = 10% change
+        text = "Consider moving from 1:50 to 1:45 mg/dL for mornings."
+        flagged = _extract_isf_changes(text)
+        assert len(flagged) == 0
+
+    def test_exceeds_bounds_flagged(self):
+        """Test that a >20% ISF change is flagged."""
+        # 1:50 to 1:35 = 30% change
+        text = "Consider adjusting correction factor from 1:50 to 1:35 mg/dL."
+        flagged = _extract_isf_changes(text)
+        assert len(flagged) == 1
+        assert flagged[0].suggestion_type == SuggestionType.CORRECTION_FACTOR
+        assert flagged[0].original_value == 50.0
+        assert flagged[0].suggested_value == 35.0
+        assert flagged[0].change_pct == 30.0
+
+    def test_context_keyword_without_prefix(self):
+        """Test ISF extraction with context keyword and no 1: prefix."""
+        text = "Your ISF should change from 50 to 35 mg/dL for mornings."
+        flagged = _extract_isf_changes(text)
+        assert len(flagged) == 1
+        assert flagged[0].change_pct == 30.0
+
+    def test_glucose_reading_not_flagged(self):
+        """Test that glucose readings are not misidentified as ISF changes."""
+        text = "Your glucose dropped from 220 to 160 mg/dL after correction."
+        flagged = _extract_isf_changes(text)
+        assert len(flagged) == 0
+
+    def test_ratio_notation_with_mg(self):
+        """Test ISF extraction with 1:X mg/dL notation."""
+        # 1:60 to 1:40 = 33.3% change
+        text = "Move from 1:60 to 1:40 mg/dL"
+        flagged = _extract_isf_changes(text)
+        assert len(flagged) == 1
+        assert flagged[0].change_pct == 33.3
+
+    def test_no_isf_changes_returns_empty(self):
+        """Test that text without ISF changes returns empty list."""
+        text = "Your corrections are effective. Keep current settings."
+        flagged = _extract_isf_changes(text)
+        assert len(flagged) == 0
+
+
+class TestValidateAISuggestion:
+    """Tests for validate_ai_suggestion."""
+
+    def test_safe_text_approved(self):
+        """Test that safe text gets approved status."""
+        text = (
+            "Your breakfast patterns show good control. "
+            "Consider discussing a slight adjustment from 1:10 to 1:9 "
+            "with your endocrinologist."
+        )
+        result = validate_ai_suggestion(text, "meal_analysis")
+
+        assert result.status == SafetyStatus.APPROVED
+        assert len(result.flagged_items) == 0
+        assert not result.has_dangerous_content
+        assert "Safety Notice" in result.sanitized_text
+
+    def test_dangerous_content_rejected(self):
+        """Test that dangerous content gets rejected status."""
+        text = "You should double your dose for breakfast immediately."
+        result = validate_ai_suggestion(text, "meal_analysis")
+
+        assert result.status == SafetyStatus.REJECTED
+        assert result.has_dangerous_content
+        assert "blocked by the safety system" in result.sanitized_text
+        assert result.original_text == text
+
+    def test_excessive_change_flagged(self):
+        """Test that excessive ratio changes get flagged status."""
+        text = (
+            "Your breakfast carb ratio should be adjusted. "
+            "Consider moving from 1:10 to 1:6 to reduce spikes."
+        )
+        result = validate_ai_suggestion(text, "meal_analysis")
+
+        assert result.status == SafetyStatus.FLAGGED
+        assert len(result.flagged_items) == 1
+        assert not result.has_dangerous_content
+        assert "Safety Warning" in result.sanitized_text
+        assert "exceeds" in result.sanitized_text
+
+    def test_correction_analysis_validation(self):
+        """Test validation of correction analysis output."""
+        text = (
+            "Morning corrections are under-correcting. "
+            "Consider adjusting correction factor from 1:50 to 1:30 mg/dL."
+        )
+        result = validate_ai_suggestion(text, "correction_analysis")
+
+        assert result.status == SafetyStatus.FLAGGED
+        assert len(result.flagged_items) == 1
+        assert (
+            result.flagged_items[0].suggestion_type == SuggestionType.CORRECTION_FACTOR
+        )
+
+    def test_safety_disclaimer_always_appended(self):
+        """Test that safety disclaimer is always in sanitized text."""
+        text = "Everything looks good."
+        result = validate_ai_suggestion(text, "meal_analysis")
+
+        assert "Safety Notice" in result.sanitized_text
+        assert "not medical advice" in result.sanitized_text
+
+    def test_original_text_preserved(self):
+        """Test that original text is preserved in result."""
+        text = "Some analysis text here."
+        result = validate_ai_suggestion(text, "meal_analysis")
+
+        assert result.original_text == text
+
+
+class TestLogSafetyValidation:
+    """Tests for log_safety_validation."""
+
+    async def test_log_created(self):
+        """Test that a safety log entry is created."""
+        from src.services.safety_validation import log_safety_validation
+
+        mock_db = AsyncMock()
+        user_id = uuid.uuid4()
+        analysis_id = uuid.uuid4()
+
+        result = validate_ai_suggestion("Safe suggestion text.", "meal_analysis")
+
+        log_entry = await log_safety_validation(
+            user_id, "meal_analysis", analysis_id, result, mock_db
+        )
+
+        assert log_entry.user_id == user_id
+        assert log_entry.analysis_type == "meal_analysis"
+        assert log_entry.analysis_id == analysis_id
+        assert log_entry.status == "approved"
+        assert log_entry.flagged_items == []
+        mock_db.add.assert_called_once()
+
+    async def test_flagged_log_includes_items(self):
+        """Test that flagged items are included in the log."""
+        from src.services.safety_validation import log_safety_validation
+
+        mock_db = AsyncMock()
+        user_id = uuid.uuid4()
+        analysis_id = uuid.uuid4()
+
+        result = validate_ai_suggestion(
+            "Move from 1:10 to 1:6 for breakfast.", "meal_analysis"
+        )
+
+        log_entry = await log_safety_validation(
+            user_id, "meal_analysis", analysis_id, result, mock_db
+        )
+
+        assert log_entry.status == "flagged"
+        assert len(log_entry.flagged_items) == 1
+
+
+class TestListSafetyLogs:
+    """Tests for list_safety_logs."""
+
+    async def test_list_empty(self):
+        """Test listing when no logs exist."""
+        from src.services.safety_validation import list_safety_logs
+
+        mock_db = AsyncMock()
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        logs_result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = []
+        logs_result.scalars.return_value = scalars_mock
+        mock_db.execute.side_effect = [count_result, logs_result]
+
+        logs, total = await list_safety_logs(uuid.uuid4(), mock_db)
+
+        assert logs == []
+        assert total == 0
+
+
+class TestMealAnalysisSafetyIntegration:
+    """Tests verifying safety layer integration in meal analysis."""
+
+    @patch("src.services.meal_analysis.get_ai_client")
+    @patch("src.services.meal_analysis.analyze_post_meal_patterns")
+    async def test_safe_analysis_includes_disclaimer(
+        self, mock_analyze, mock_get_client
+    ):
+        """Test that safe meal analysis includes safety disclaimer."""
+        from src.models.ai_provider import AIProviderType
+        from src.schemas.ai_response import AIResponse, AIUsage
+        from src.schemas.meal_analysis import MealPeriodData
+        from src.services.meal_analysis import generate_meal_analysis
+
+        mock_analyze.return_value = [
+            MealPeriodData(
+                period="breakfast",
+                bolus_count=5,
+                spike_count=2,
+                avg_peak_glucose=185.0,
+                avg_2hr_glucose=165.0,
+            ),
+            MealPeriodData(
+                period="lunch",
+                bolus_count=3,
+                spike_count=0,
+                avg_peak_glucose=155.0,
+                avg_2hr_glucose=135.0,
+            ),
+            MealPeriodData(
+                period="dinner",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+            MealPeriodData(
+                period="snack",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = AIResponse(
+            content="Breakfast shows consistent spikes. Consider 1:10 to 1:9.",
+            model="claude-sonnet-4-5-20250929",
+            provider=AIProviderType.CLAUDE,
+            usage=AIUsage(input_tokens=200, output_tokens=150),
+        )
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        analysis = await generate_meal_analysis(mock_user, mock_db, days=7)
+
+        # Should include safety disclaimer
+        assert "Safety Notice" in analysis.ai_analysis
+        # Original content should still be present
+        assert "Breakfast shows consistent spikes" in analysis.ai_analysis
+
+    @patch("src.services.meal_analysis.get_ai_client")
+    @patch("src.services.meal_analysis.analyze_post_meal_patterns")
+    async def test_dangerous_analysis_blocked(self, mock_analyze, mock_get_client):
+        """Test that dangerous meal analysis content is blocked."""
+        from src.models.ai_provider import AIProviderType
+        from src.schemas.ai_response import AIResponse, AIUsage
+        from src.schemas.meal_analysis import MealPeriodData
+        from src.services.meal_analysis import generate_meal_analysis
+
+        mock_analyze.return_value = [
+            MealPeriodData(
+                period="breakfast",
+                bolus_count=5,
+                spike_count=3,
+                avg_peak_glucose=195.0,
+                avg_2hr_glucose=175.0,
+            ),
+            MealPeriodData(
+                period="lunch",
+                bolus_count=3,
+                spike_count=0,
+                avg_peak_glucose=155.0,
+                avg_2hr_glucose=135.0,
+            ),
+            MealPeriodData(
+                period="dinner",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+            MealPeriodData(
+                period="snack",
+                bolus_count=0,
+                spike_count=0,
+                avg_peak_glucose=0.0,
+                avg_2hr_glucose=0.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = AIResponse(
+            content="Double your dose for breakfast to fix spikes.",
+            model="claude-sonnet-4-5-20250929",
+            provider=AIProviderType.CLAUDE,
+            usage=AIUsage(input_tokens=200, output_tokens=150),
+        )
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        analysis = await generate_meal_analysis(mock_user, mock_db, days=7)
+
+        # Dangerous content should be blocked
+        assert "blocked by the safety system" in analysis.ai_analysis
+        assert "Double your dose" not in analysis.ai_analysis
+
+
+class TestCorrectionAnalysisSafetyIntegration:
+    """Tests verifying safety layer integration in correction analysis."""
+
+    @patch("src.services.correction_analysis.get_ai_client")
+    @patch("src.services.correction_analysis.analyze_correction_outcomes")
+    async def test_flagged_correction_includes_warning(
+        self, mock_analyze, mock_get_client
+    ):
+        """Test that flagged correction analysis includes safety warning."""
+        from src.models.ai_provider import AIProviderType
+        from src.schemas.ai_response import AIResponse, AIUsage
+        from src.schemas.correction_analysis import TimePeriodData
+        from src.services.correction_analysis import (
+            generate_correction_analysis,
+        )
+
+        mock_analyze.return_value = [
+            TimePeriodData(
+                period="overnight",
+                correction_count=2,
+                under_count=1,
+                over_count=0,
+                avg_observed_isf=35.0,
+                avg_glucose_drop=70.0,
+            ),
+            TimePeriodData(
+                period="morning",
+                correction_count=4,
+                under_count=3,
+                over_count=0,
+                avg_observed_isf=30.0,
+                avg_glucose_drop=60.0,
+            ),
+            TimePeriodData(
+                period="afternoon",
+                correction_count=0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=0.0,
+                avg_glucose_drop=0.0,
+            ),
+            TimePeriodData(
+                period="evening",
+                correction_count=0,
+                under_count=0,
+                over_count=0,
+                avg_observed_isf=0.0,
+                avg_glucose_drop=0.0,
+            ),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = AIResponse(
+            content="Morning ISF needs work. Consider from 1:50 to 1:30 mg/dL.",
+            model="claude-sonnet-4-5-20250929",
+            provider=AIProviderType.CLAUDE,
+            usage=AIUsage(input_tokens=250, output_tokens=180),
+        )
+        mock_get_client.return_value = mock_client
+
+        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_db = AsyncMock()
+
+        analysis = await generate_correction_analysis(mock_user, mock_db, days=7)
+
+        # Should include safety warning for 40% ISF change
+        assert "Safety Warning" in analysis.ai_analysis
+        assert "exceeds" in analysis.ai_analysis
+        # Original content should still be present
+        assert "Morning ISF needs work" in analysis.ai_analysis
+
+
+class TestSafetyLogsEndpoint:
+    """Integration tests for safety logs API endpoint."""
+
+    async def test_list_logs_endpoint(self):
+        """Test GET /api/ai/safety/logs returns 200."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.get(
+                "/api/ai/safety/logs",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "logs" in data
+        assert "total" in data
+
+    async def test_list_logs_unauthenticated(self):
+        """Test GET /api/ai/safety/logs returns 401 without auth."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/ai/safety/logs")
+
+        assert response.status_code == 401


### PR DESCRIPTION
## Summary
- Add pre-validation safety layer that checks AI-generated suggestions before displaying to users
- Detect dangerous content (9 patterns: double dose, stop insulin, specific dose instructions, etc.) and block from display
- Extract and validate carb ratio (1:X to 1:Y) and ISF (correction factor) change suggestions against ±20% bounds
- Flag excessive changes with warnings, append safety disclaimer to all AI output
- SafetyLog audit model with migration for tracking all validation decisions
- GET /api/ai/safety/logs endpoint for admin audit log access
- Integrated safety validation into existing meal_analysis and correction_analysis services
- Anti-backtracking regex prevents carb ratio/ISF pattern confusion (mg/dL disambiguation)

## Test plan
- [x] 39 new safety validation tests (dangerous content, ratio extraction, ISF extraction, validation flow, logging, integration)
- [x] Updated existing meal_analysis (24 tests) and correction_analysis (37 tests) for safety layer integration
- [x] Full test suite: 315 passed, 0 failures
- [x] Ruff lint and format clean
- [x] Subagent code review: APPROVED
- [x] Subagent re-review after fixes: APPROVED (all 8 findings addressed)
- [x] Playwright MCP visual check: dashboard, briefs, landing page render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)