### PR TITLE
feat: add AI insight card and unified insights feed (Story 5.7)

### DIFF
--- a/apps/api/migrations/versions/014_create_suggestion_responses.py
+++ b/apps/api/migrations/versions/014_create_suggestion_responses.py
@@ -1,0 +1,66 @@
+"""Story 5.7: Create suggestion_responses table.
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-02-08
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "014_suggestion_responses"
+down_revision: str | None = "013_safety_logs"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "suggestion_responses",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("analysis_type", sa.String(30), nullable=False),
+        sa.Column("analysis_id", sa.UUID(), nullable=False),
+        sa.Column("response", sa.String(20), nullable=False),
+        sa.Column("reason", sa.String(500), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "ix_suggestion_responses_user_analysis",
+        "suggestion_responses",
+        ["user_id", "analysis_type", "analysis_id"],
+    )
+
+    op.create_index(
+        "ix_suggestion_responses_user_id",
+        "suggestion_responses",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_suggestion_responses_user_id")
+    op.drop_index("ix_suggestion_responses_user_analysis")
+    op.drop_table("suggestion_responses")

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -18,6 +18,7 @@ from src.routers import (
     disclaimer,
     glucose_stream,
     health,
+    insights,
     integrations,
     meal_analysis,
     safety,
@@ -87,6 +88,7 @@ app.include_router(briefs.router)
 app.include_router(meal_analysis.router)
 app.include_router(correction_analysis.router)
 app.include_router(safety.router)
+app.include_router(insights.router)
 
 
 @app.get("/")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -13,6 +13,7 @@ from src.models.integration import (
 from src.models.meal_analysis import MealAnalysis
 from src.models.pump_data import PumpEvent, PumpEventType
 from src.models.safety_log import SafetyLog
+from src.models.suggestion_response import SuggestionResponse
 from src.models.user import User, UserRole
 
 __all__ = [
@@ -33,6 +34,7 @@ __all__ = [
     "PumpEvent",
     "PumpEventType",
     "SafetyLog",
+    "SuggestionResponse",
     "User",
     "UserRole",
 ]

--- a/apps/api/src/models/suggestion_response.py
+++ b/apps/api/src/models/suggestion_response.py
@@ -1,0 +1,76 @@
+"""Story 5.7: Suggestion response model.
+
+Stores user responses (acknowledge/dismiss) to AI-generated suggestions.
+"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class SuggestionResponse(Base, TimestampMixin):
+    """User response to an AI suggestion.
+
+    Records when a user acknowledges or dismisses an AI-generated
+    suggestion, enabling feedback tracking and outcome analysis.
+    """
+
+    __tablename__ = "suggestion_responses"
+
+    __table_args__ = (
+        Index(
+            "ix_suggestion_responses_user_analysis",
+            "user_id",
+            "analysis_type",
+            "analysis_id",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Which analysis the response is for
+    analysis_type: Mapped[str] = mapped_column(
+        String(30),
+        nullable=False,
+    )
+
+    analysis_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=False,
+    )
+
+    # User's response
+    response: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+    )
+
+    # Optional user feedback
+    reason: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+    )
+
+    # Relationship to user
+    user = relationship("User", back_populates="suggestion_responses")
+
+    def __repr__(self) -> str:
+        return (
+            f"<SuggestionResponse(user_id={self.user_id}, "
+            f"type={self.analysis_type}, response={self.response})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -124,6 +124,11 @@ class User(Base, TimestampMixin):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    suggestion_responses = relationship(
+        "SuggestionResponse",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/routers/insights.py
+++ b/apps/api/src/routers/insights.py
@@ -1,0 +1,80 @@
+"""Story 5.7: AI insights router.
+
+Provides endpoints for listing AI insights and recording user responses.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import get_current_user
+from src.database import get_db
+from src.models.user import User
+from src.schemas.suggestion_response import (
+    InsightsListResponse,
+    SuggestionResponseRequest,
+    SuggestionResponseResponse,
+)
+from src.services.insights import (
+    list_insights,
+    record_suggestion_response,
+    verify_analysis_ownership,
+)
+
+router = APIRouter(prefix="/api/ai/insights", tags=["insights"])
+
+VALID_ANALYSIS_TYPES = {"daily_brief", "meal_analysis", "correction_analysis"}
+
+
+@router.get("", response_model=InsightsListResponse)
+async def get_insights(
+    limit: int = Query(default=10, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> InsightsListResponse:
+    """List recent AI insights for the current user.
+
+    Aggregates daily briefs, meal analyses, and correction analyses
+    into a unified insights feed.
+    """
+    insights, total = await list_insights(user.id, db, limit=limit)
+    return InsightsListResponse(insights=insights, total=total)
+
+
+@router.post(
+    "/{analysis_type}/{analysis_id}/respond",
+    response_model=SuggestionResponseResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def respond_to_insight(
+    analysis_type: str,
+    analysis_id: uuid.UUID,
+    body: SuggestionResponseRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SuggestionResponseResponse:
+    """Record a user's response to an AI insight.
+
+    Accepts 'acknowledged' or 'dismissed' as valid responses.
+    """
+    if analysis_type not in VALID_ANALYSIS_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid analysis type: {analysis_type}. "
+            f"Must be one of: {', '.join(sorted(VALID_ANALYSIS_TYPES))}",
+        )
+
+    # Verify the analysis exists and belongs to this user (F4)
+    await verify_analysis_ownership(user.id, analysis_type, analysis_id, db)
+
+    entry = await record_suggestion_response(
+        user_id=user.id,
+        analysis_type=analysis_type,
+        analysis_id=analysis_id,
+        response=body.response,
+        reason=body.reason,
+        db=db,
+    )
+
+    return SuggestionResponseResponse.model_validate(entry)

--- a/apps/api/src/schemas/suggestion_response.py
+++ b/apps/api/src/schemas/suggestion_response.py
@@ -1,0 +1,52 @@
+"""Story 5.7: Suggestion response schemas."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SuggestionResponseRequest(BaseModel):
+    """Request to record a user's response to an AI suggestion."""
+
+    response: str = Field(
+        ...,
+        pattern="^(acknowledged|dismissed)$",
+        description="User's response: 'acknowledged' or 'dismissed'",
+    )
+    reason: str | None = Field(
+        default=None,
+        max_length=500,
+        description="Optional reason for the response",
+    )
+
+
+class SuggestionResponseResponse(BaseModel):
+    """Response schema for a recorded suggestion response."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    analysis_type: str
+    analysis_id: uuid.UUID
+    response: str
+    reason: str | None
+    created_at: datetime
+
+
+class InsightSummary(BaseModel):
+    """Summary of an AI insight for display in the frontend."""
+
+    id: uuid.UUID
+    analysis_type: str
+    title: str
+    content: str
+    created_at: datetime
+    status: str = "pending"  # pending, acknowledged, dismissed
+
+
+class InsightsListResponse(BaseModel):
+    """Response for listing AI insights."""
+
+    insights: list[InsightSummary]
+    total: int

--- a/apps/api/src/services/insights.py
+++ b/apps/api/src/services/insights.py
@@ -1,0 +1,283 @@
+"""Story 5.7: AI insights service.
+
+Aggregates AI analyses into a unified insights feed and tracks
+user responses (acknowledge/dismiss).
+"""
+
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.correction_analysis import CorrectionAnalysis
+from src.models.daily_brief import DailyBrief
+from src.models.meal_analysis import MealAnalysis
+from src.models.suggestion_response import SuggestionResponse
+from src.schemas.suggestion_response import InsightSummary
+
+logger = get_logger(__name__)
+
+# Map analysis type to its model class
+ANALYSIS_MODELS: dict[str, type] = {
+    "daily_brief": DailyBrief,
+    "meal_analysis": MealAnalysis,
+    "correction_analysis": CorrectionAnalysis,
+}
+
+
+def _brief_title(brief: DailyBrief) -> str:
+    """Generate a title for a daily brief."""
+    return f"Daily Brief — {brief.period_end.strftime('%b %d, %Y')}"
+
+
+def _meal_title(analysis: MealAnalysis) -> str:
+    """Generate a title for a meal analysis."""
+    return f"Meal Pattern Analysis — {analysis.total_spikes} spike{'s' if analysis.total_spikes != 1 else ''} detected"
+
+
+def _correction_title(analysis: CorrectionAnalysis) -> str:
+    """Generate a title for a correction analysis."""
+    return f"Correction Factor Analysis — {analysis.total_corrections} correction{'s' if analysis.total_corrections != 1 else ''} analyzed"
+
+
+async def list_insights(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+    limit: int = 10,
+) -> tuple[list[InsightSummary], int]:
+    """List recent AI insights aggregated from all analysis types.
+
+    Combines daily briefs, meal analyses, and correction analyses
+    into a unified feed sorted by creation date.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+        limit: Maximum insights to return.
+
+    Returns:
+        Tuple of (insights list, total count).
+    """
+    insights: list[InsightSummary] = []
+
+    # Fetch recent daily briefs
+    briefs_result = await db.execute(
+        select(DailyBrief)
+        .where(DailyBrief.user_id == user_id)
+        .order_by(DailyBrief.created_at.desc())
+        .limit(limit)
+    )
+    briefs = list(briefs_result.scalars().all())
+
+    # Fetch recent meal analyses
+    meals_result = await db.execute(
+        select(MealAnalysis)
+        .where(MealAnalysis.user_id == user_id)
+        .order_by(MealAnalysis.created_at.desc())
+        .limit(limit)
+    )
+    meals = list(meals_result.scalars().all())
+
+    # Fetch recent correction analyses
+    corrections_result = await db.execute(
+        select(CorrectionAnalysis)
+        .where(CorrectionAnalysis.user_id == user_id)
+        .order_by(CorrectionAnalysis.created_at.desc())
+        .limit(limit)
+    )
+    corrections = list(corrections_result.scalars().all())
+
+    # Collect all fetched IDs for scoped response lookup
+    all_ids = (
+        [brief.id for brief in briefs]
+        + [meal.id for meal in meals]
+        + [c.id for c in corrections]
+    )
+
+    # Fetch responses only for the fetched analyses (F6: scoped query)
+    response_map: dict[tuple[str, uuid.UUID], str] = {}
+    if all_ids:
+        responses_result = await db.execute(
+            select(
+                SuggestionResponse.analysis_type,
+                SuggestionResponse.analysis_id,
+                SuggestionResponse.response,
+            ).where(
+                SuggestionResponse.user_id == user_id,
+                SuggestionResponse.analysis_id.in_(all_ids),
+            )
+        )
+        for row in responses_result.all():
+            response_map[(row[0], row[1])] = row[2]
+
+    # Build unified insights
+    for brief in briefs:
+        insight_status = response_map.get(("daily_brief", brief.id), "pending")
+        insights.append(
+            InsightSummary(
+                id=brief.id,
+                analysis_type="daily_brief",
+                title=_brief_title(brief),
+                content=brief.ai_summary,
+                created_at=brief.created_at,
+                status=insight_status,
+            )
+        )
+
+    for meal in meals:
+        insight_status = response_map.get(("meal_analysis", meal.id), "pending")
+        insights.append(
+            InsightSummary(
+                id=meal.id,
+                analysis_type="meal_analysis",
+                title=_meal_title(meal),
+                content=meal.ai_analysis,
+                created_at=meal.created_at,
+                status=insight_status,
+            )
+        )
+
+    for correction in corrections:
+        insight_status = response_map.get(
+            ("correction_analysis", correction.id), "pending"
+        )
+        insights.append(
+            InsightSummary(
+                id=correction.id,
+                analysis_type="correction_analysis",
+                title=_correction_title(correction),
+                content=correction.ai_analysis,
+                created_at=correction.created_at,
+                status=insight_status,
+            )
+        )
+
+    # Sort by created_at descending and limit
+    insights.sort(key=lambda x: x.created_at, reverse=True)
+    total = len(insights)
+    insights = insights[:limit]
+
+    return insights, total
+
+
+async def verify_analysis_ownership(
+    user_id: uuid.UUID,
+    analysis_type: str,
+    analysis_id: uuid.UUID,
+    db: AsyncSession,
+) -> None:
+    """Verify that an analysis exists and belongs to the user.
+
+    Args:
+        user_id: User's UUID.
+        analysis_type: Type of analysis.
+        analysis_id: ID of the analysis.
+        db: Database session.
+
+    Raises:
+        HTTPException: 404 if not found or not owned by user.
+    """
+    model = ANALYSIS_MODELS.get(analysis_type)
+    if model is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid analysis type: {analysis_type}",
+        )
+
+    result = await db.execute(
+        select(model.id).where(
+            model.id == analysis_id,
+            model.user_id == user_id,
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Analysis not found",
+        )
+
+
+async def record_suggestion_response(
+    user_id: uuid.UUID,
+    analysis_type: str,
+    analysis_id: uuid.UUID,
+    response: str,
+    reason: str | None,
+    db: AsyncSession,
+) -> SuggestionResponse:
+    """Record a user's response to an AI suggestion.
+
+    If the user has already responded to this analysis, returns 409 Conflict.
+
+    Args:
+        user_id: User's UUID.
+        analysis_type: Type of analysis (daily_brief, meal_analysis, correction_analysis).
+        analysis_id: ID of the analysis.
+        response: User's response (acknowledged or dismissed).
+        reason: Optional reason for the response.
+        db: Database session.
+
+    Returns:
+        The created SuggestionResponse record.
+
+    Raises:
+        HTTPException: 409 if a response already exists.
+    """
+    # Check for existing response (F3: prevent duplicates)
+    existing = await get_response_for_analysis(user_id, analysis_type, analysis_id, db)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A response has already been recorded for this analysis",
+        )
+
+    entry = SuggestionResponse(
+        user_id=user_id,
+        analysis_type=analysis_type,
+        analysis_id=analysis_id,
+        response=response,
+        reason=reason,
+    )
+
+    db.add(entry)
+    await db.commit()
+    await db.refresh(entry)
+
+    logger.info(
+        "Suggestion response recorded",
+        user_id=str(user_id),
+        analysis_type=analysis_type,
+        analysis_id=str(analysis_id),
+        response=response,
+    )
+
+    return entry
+
+
+async def get_response_for_analysis(
+    user_id: uuid.UUID,
+    analysis_type: str,
+    analysis_id: uuid.UUID,
+    db: AsyncSession,
+) -> SuggestionResponse | None:
+    """Get the user's response for a specific analysis.
+
+    Args:
+        user_id: User's UUID.
+        analysis_type: Type of analysis.
+        analysis_id: ID of the analysis.
+        db: Database session.
+
+    Returns:
+        The SuggestionResponse if found, None otherwise.
+    """
+    result = await db.execute(
+        select(SuggestionResponse).where(
+            SuggestionResponse.user_id == user_id,
+            SuggestionResponse.analysis_type == analysis_type,
+            SuggestionResponse.analysis_id == analysis_id,
+        )
+    )
+    return result.scalar_one_or_none()

--- a/apps/api/tests/test_insights.py
+++ b/apps/api/tests/test_insights.py
@@ -1,0 +1,682 @@
+"""Story 5.7: Tests for AI insights service and router."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.config import settings
+from src.main import app
+from src.services.insights import (
+    _brief_title,
+    _correction_title,
+    _meal_title,
+    list_insights,
+    record_suggestion_response,
+    verify_analysis_ownership,
+)
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client: AsyncClient) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("insights")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+# --- Title generation tests ---
+
+
+class TestBriefTitle:
+    """Tests for _brief_title helper."""
+
+    def test_formats_date(self):
+        brief = SimpleNamespace(period_end=datetime(2026, 2, 8, tzinfo=UTC))
+        assert _brief_title(brief) == "Daily Brief — Feb 08, 2026"
+
+    def test_formats_different_date(self):
+        brief = SimpleNamespace(period_end=datetime(2025, 12, 25, tzinfo=UTC))
+        assert _brief_title(brief) == "Daily Brief — Dec 25, 2025"
+
+
+class TestMealTitle:
+    """Tests for _meal_title helper."""
+
+    def test_singular_spike(self):
+        analysis = SimpleNamespace(total_spikes=1)
+        assert _meal_title(analysis) == "Meal Pattern Analysis — 1 spike detected"
+
+    def test_plural_spikes(self):
+        analysis = SimpleNamespace(total_spikes=3)
+        assert _meal_title(analysis) == "Meal Pattern Analysis — 3 spikes detected"
+
+    def test_zero_spikes(self):
+        analysis = SimpleNamespace(total_spikes=0)
+        assert _meal_title(analysis) == "Meal Pattern Analysis — 0 spikes detected"
+
+
+class TestCorrectionTitle:
+    """Tests for _correction_title helper."""
+
+    def test_singular_correction(self):
+        analysis = SimpleNamespace(total_corrections=1)
+        assert (
+            _correction_title(analysis)
+            == "Correction Factor Analysis — 1 correction analyzed"
+        )
+
+    def test_plural_corrections(self):
+        analysis = SimpleNamespace(total_corrections=5)
+        assert (
+            _correction_title(analysis)
+            == "Correction Factor Analysis — 5 corrections analyzed"
+        )
+
+
+# --- Service tests ---
+
+
+class TestListInsights:
+    """Tests for list_insights service function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_data(self):
+        """Returns empty list and zero total when no analyses exist."""
+        user_id = uuid.uuid4()
+
+        mock_db = AsyncMock()
+        empty_result = MagicMock()
+        empty_result.scalars.return_value.all.return_value = []
+        empty_result.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=empty_result)
+
+        insights, total = await list_insights(user_id, mock_db)
+
+        assert insights == []
+        assert total == 0
+
+    @pytest.mark.asyncio
+    async def test_aggregates_briefs_with_ai_summary(self):
+        """Aggregates daily briefs using ai_summary field (not ai_analysis)."""
+        user_id = uuid.uuid4()
+        brief_id = uuid.uuid4()
+        now = datetime.now(UTC)
+
+        # F1/F10: Use ai_summary to match the real DailyBrief model
+        brief = SimpleNamespace(
+            id=brief_id,
+            period_end=now,
+            ai_summary="Test analysis content from brief",
+            created_at=now,
+        )
+
+        mock_db = AsyncMock()
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+
+            result = MagicMock()
+            if call_count == 1:
+                result.scalars.return_value.all.return_value = [brief]
+            elif call_count in (2, 3):
+                result.scalars.return_value.all.return_value = []
+            else:
+                result.all.return_value = []
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=mock_execute)
+
+        insights, total = await list_insights(user_id, mock_db)
+
+        assert total == 1
+        assert len(insights) == 1
+        assert insights[0].analysis_type == "daily_brief"
+        assert insights[0].id == brief_id
+        assert "Daily Brief" in insights[0].title
+        assert insights[0].content == "Test analysis content from brief"
+        assert insights[0].status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_aggregates_mixed_types_sorted_by_date(self):
+        """Aggregates and sorts insights from all three analysis types."""
+        user_id = uuid.uuid4()
+        now = datetime.now(UTC)
+
+        brief = SimpleNamespace(
+            id=uuid.uuid4(),
+            period_end=now,
+            ai_summary="Brief content",
+            created_at=now - timedelta(hours=2),
+        )
+        meal = SimpleNamespace(
+            id=uuid.uuid4(),
+            total_spikes=2,
+            ai_analysis="Meal content",
+            created_at=now,  # Most recent
+        )
+        correction = SimpleNamespace(
+            id=uuid.uuid4(),
+            total_corrections=3,
+            ai_analysis="Correction content",
+            created_at=now - timedelta(hours=1),
+        )
+
+        mock_db = AsyncMock()
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+
+            result = MagicMock()
+            if call_count == 1:
+                result.scalars.return_value.all.return_value = [brief]
+            elif call_count == 2:
+                result.scalars.return_value.all.return_value = [meal]
+            elif call_count == 3:
+                result.scalars.return_value.all.return_value = [correction]
+            else:
+                result.all.return_value = []
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=mock_execute)
+
+        insights, total = await list_insights(user_id, mock_db)
+
+        assert total == 3
+        assert len(insights) == 3
+        # Verify sorted by created_at descending
+        assert insights[0].analysis_type == "meal_analysis"
+        assert insights[1].analysis_type == "correction_analysis"
+        assert insights[2].analysis_type == "daily_brief"
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(self):
+        """Returns at most `limit` insights."""
+        user_id = uuid.uuid4()
+        now = datetime.now(UTC)
+
+        briefs = [
+            SimpleNamespace(
+                id=uuid.uuid4(),
+                period_end=now - timedelta(hours=i),
+                ai_summary=f"Brief {i}",
+                created_at=now - timedelta(hours=i),
+            )
+            for i in range(5)
+        ]
+
+        mock_db = AsyncMock()
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+
+            result = MagicMock()
+            if call_count == 1:
+                result.scalars.return_value.all.return_value = briefs
+            elif call_count in (2, 3):
+                result.scalars.return_value.all.return_value = []
+            else:
+                result.all.return_value = []
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=mock_execute)
+
+        insights, total = await list_insights(user_id, mock_db, limit=3)
+
+        assert total == 5
+        assert len(insights) == 3
+
+    @pytest.mark.asyncio
+    async def test_status_from_responses(self):
+        """Insights show acknowledged/dismissed status from user responses."""
+        user_id = uuid.uuid4()
+        brief_id = uuid.uuid4()
+        now = datetime.now(UTC)
+
+        brief = SimpleNamespace(
+            id=brief_id,
+            period_end=now,
+            ai_summary="Test",
+            created_at=now,
+        )
+
+        mock_db = AsyncMock()
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+
+            result = MagicMock()
+            if call_count == 1:
+                result.scalars.return_value.all.return_value = [brief]
+            elif call_count in (2, 3):
+                result.scalars.return_value.all.return_value = []
+            else:
+                # Response lookup: this brief was acknowledged
+                result.all.return_value = [("daily_brief", brief_id, "acknowledged")]
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=mock_execute)
+
+        insights, total = await list_insights(user_id, mock_db)
+
+        assert insights[0].status == "acknowledged"
+
+
+class TestRecordSuggestionResponse:
+    """Tests for record_suggestion_response service function."""
+
+    @pytest.mark.asyncio
+    async def test_creates_response_record(self):
+        """Creates a SuggestionResponse and commits."""
+        user_id = uuid.uuid4()
+        analysis_id = uuid.uuid4()
+        mock_db = AsyncMock()
+
+        # Mock get_response_for_analysis to return None (no existing)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        entry = await record_suggestion_response(
+            user_id=user_id,
+            analysis_type="daily_brief",
+            analysis_id=analysis_id,
+            response="acknowledged",
+            reason="Helpful insight",
+            db=mock_db,
+        )
+
+        assert entry.user_id == user_id
+        assert entry.analysis_type == "daily_brief"
+        assert entry.analysis_id == analysis_id
+        assert entry.response == "acknowledged"
+        assert entry.reason == "Helpful insight"
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_awaited_once()
+        mock_db.refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_creates_dismissed_response(self):
+        """Creates a dismissed response without reason."""
+        user_id = uuid.uuid4()
+        analysis_id = uuid.uuid4()
+        mock_db = AsyncMock()
+
+        # Mock get_response_for_analysis to return None (no existing)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        entry = await record_suggestion_response(
+            user_id=user_id,
+            analysis_type="meal_analysis",
+            analysis_id=analysis_id,
+            response="dismissed",
+            reason=None,
+            db=mock_db,
+        )
+
+        assert entry.response == "dismissed"
+        assert entry.reason is None
+
+    @pytest.mark.asyncio
+    async def test_duplicate_response_returns_409(self):
+        """Attempting to respond twice to the same analysis returns 409."""
+        from fastapi import HTTPException
+
+        user_id = uuid.uuid4()
+        analysis_id = uuid.uuid4()
+        mock_db = AsyncMock()
+
+        # Mock get_response_for_analysis to return an existing response
+        existing = SimpleNamespace(
+            id=uuid.uuid4(),
+            response="acknowledged",
+        )
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await record_suggestion_response(
+                user_id=user_id,
+                analysis_type="daily_brief",
+                analysis_id=analysis_id,
+                response="dismissed",
+                reason=None,
+                db=mock_db,
+            )
+
+        assert exc_info.value.status_code == 409
+        assert "already been recorded" in exc_info.value.detail
+
+
+class TestVerifyAnalysisOwnership:
+    """Tests for verify_analysis_ownership."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_type_raises_400(self):
+        """Invalid analysis type raises 400."""
+        from fastapi import HTTPException
+
+        mock_db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_analysis_ownership(
+                uuid.uuid4(), "invalid_type", uuid.uuid4(), mock_db
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises_404(self):
+        """Non-existent analysis raises 404."""
+        from fastapi import HTTPException
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_analysis_ownership(
+                uuid.uuid4(), "daily_brief", uuid.uuid4(), mock_db
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_found_passes_silently(self):
+        """Existing analysis owned by user passes without exception."""
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = uuid.uuid4()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        # Should not raise
+        await verify_analysis_ownership(
+            uuid.uuid4(), "daily_brief", uuid.uuid4(), mock_db
+        )
+
+
+# --- Router / endpoint tests ---
+
+
+class TestGetInsightsEndpoint:
+    """Tests for GET /api/ai/insights."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self):
+        """Unauthenticated request returns 401."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/ai/insights")
+            assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authenticated_returns_insights(self):
+        """Authenticated request returns insights list."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie = await register_and_login(client)
+
+            with patch(
+                "src.routers.insights.list_insights",
+                new_callable=AsyncMock,
+                return_value=([], 0),
+            ):
+                response = await client.get(
+                    "/api/ai/insights",
+                    cookies={settings.jwt_cookie_name: cookie},
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+                assert data["insights"] == []
+                assert data["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_limit_bounded_rejects_over_100(self):
+        """Limit >100 returns 422 validation error."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.get(
+                "/api/ai/insights?limit=101",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+            assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_limit_bounded_rejects_zero(self):
+        """Limit 0 returns 422 validation error."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.get(
+                "/api/ai/insights?limit=0",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+            assert response.status_code == 422
+
+
+class TestRespondToInsightEndpoint:
+    """Tests for POST /api/ai/insights/{type}/{id}/respond."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self):
+        """Unauthenticated request returns 401."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            analysis_id = uuid.uuid4()
+            response = await client.post(
+                f"/api/ai/insights/daily_brief/{analysis_id}/respond",
+                json={"response": "acknowledged"},
+            )
+            assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_analysis_type_returns_400(self):
+        """Invalid analysis type returns 400."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie = await register_and_login(client)
+            analysis_id = uuid.uuid4()
+
+            response = await client.post(
+                f"/api/ai/insights/invalid_type/{analysis_id}/respond",
+                json={"response": "acknowledged"},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+            assert response.status_code == 400
+            assert "Invalid analysis type" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_uuid_returns_422(self):
+        """Non-UUID analysis_id returns 422 validation error."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/insights/daily_brief/not-a-uuid/respond",
+                json={"response": "acknowledged"},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+            assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_invalid_response_value_returns_422(self):
+        """Invalid response value returns 422 (validation error)."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie = await register_and_login(client)
+            analysis_id = uuid.uuid4()
+
+            response = await client.post(
+                f"/api/ai/insights/daily_brief/{analysis_id}/respond",
+                json={"response": "invalid_value"},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+
+            assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_acknowledge_creates_response(self):
+        """Valid acknowledge request creates response record."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie = await register_and_login(client)
+            analysis_id = uuid.uuid4()
+
+            mock_entry = SimpleNamespace(
+                id=uuid.uuid4(),
+                analysis_type="daily_brief",
+                analysis_id=analysis_id,
+                response="acknowledged",
+                reason=None,
+                created_at=datetime.now(UTC),
+            )
+
+            with (
+                patch(
+                    "src.routers.insights.verify_analysis_ownership",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.routers.insights.record_suggestion_response",
+                    new_callable=AsyncMock,
+                    return_value=mock_entry,
+                ),
+            ):
+                response = await client.post(
+                    f"/api/ai/insights/daily_brief/{analysis_id}/respond",
+                    json={"response": "acknowledged"},
+                    cookies={settings.jwt_cookie_name: cookie},
+                )
+
+                assert response.status_code == 201
+                data = response.json()
+                assert data["response"] == "acknowledged"
+                assert data["analysis_type"] == "daily_brief"
+
+    @pytest.mark.asyncio
+    async def test_dismiss_with_reason(self):
+        """Dismiss with reason creates response record."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie = await register_and_login(client)
+            analysis_id = uuid.uuid4()
+
+            mock_entry = SimpleNamespace(
+                id=uuid.uuid4(),
+                analysis_type="meal_analysis",
+                analysis_id=analysis_id,
+                response="dismissed",
+                reason="Not relevant to me",
+                created_at=datetime.now(UTC),
+            )
+
+            with (
+                patch(
+                    "src.routers.insights.verify_analysis_ownership",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.routers.insights.record_suggestion_response",
+                    new_callable=AsyncMock,
+                    return_value=mock_entry,
+                ),
+            ):
+                response = await client.post(
+                    f"/api/ai/insights/meal_analysis/{analysis_id}/respond",
+                    json={
+                        "response": "dismissed",
+                        "reason": "Not relevant to me",
+                    },
+                    cookies={settings.jwt_cookie_name: cookie},
+                )
+
+                assert response.status_code == 201
+                data = response.json()
+                assert data["response"] == "dismissed"
+                assert data["reason"] == "Not relevant to me"
+
+    @pytest.mark.asyncio
+    async def test_correction_analysis_type_accepted(self):
+        """correction_analysis type is accepted."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie = await register_and_login(client)
+            analysis_id = uuid.uuid4()
+
+            mock_entry = SimpleNamespace(
+                id=uuid.uuid4(),
+                analysis_type="correction_analysis",
+                analysis_id=analysis_id,
+                response="acknowledged",
+                reason=None,
+                created_at=datetime.now(UTC),
+            )
+
+            with (
+                patch(
+                    "src.routers.insights.verify_analysis_ownership",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.routers.insights.record_suggestion_response",
+                    new_callable=AsyncMock,
+                    return_value=mock_entry,
+                ),
+            ):
+                response = await client.post(
+                    f"/api/ai/insights/correction_analysis/{analysis_id}/respond",
+                    json={"response": "acknowledged"},
+                    cookies={settings.jwt_cookie_name: cookie},
+                )
+
+                assert response.status_code == 201

--- a/apps/web/src/app/dashboard/briefs/page.tsx
+++ b/apps/web/src/app/dashboard/briefs/page.tsx
@@ -1,37 +1,177 @@
+"use client";
+
 /**
- * Daily Briefs Page
+ * AI Insights Page (formerly Daily Briefs)
  *
- * Story 4.1: Dashboard Layout & Navigation
- * Placeholder page for daily briefs - will be implemented in Epic 5.
+ * Story 5.7: AI Insight Card
+ * Displays a unified feed of AI-generated insights including
+ * daily briefs, meal analyses, and correction analyses.
+ *
+ * Users can acknowledge or dismiss insights to track which
+ * suggestions they've reviewed.
  */
 
-import { FileText } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { FileText, Loader2, RefreshCw } from "lucide-react";
+import { AIInsightCard, type InsightData } from "@/components/dashboard";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+interface InsightsResponse {
+  insights: InsightData[];
+  total: number;
+}
 
 export default function BriefsPage() {
+  const [insights, setInsights] = useState<InsightData[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchInsights = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await fetch(`${API_BASE_URL}/api/ai/insights?limit=20`, {
+        credentials: "include",
+      });
+
+      if (response.status === 401) {
+        // Not authenticated - show empty state
+        setInsights([]);
+        setTotal(0);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch insights: ${response.status}`);
+      }
+
+      const data: InsightsResponse = await response.json();
+      setInsights(data.insights);
+      setTotal(data.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load insights");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchInsights();
+  }, [fetchInsights]);
+
+  const handleRespond = async (
+    analysisType: string,
+    analysisId: string,
+    response: "acknowledged" | "dismissed",
+    reason?: string
+  ) => {
+    const res = await fetch(
+      `${API_BASE_URL}/api/ai/insights/${analysisType}/${analysisId}/respond`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ response, reason }),
+      }
+    );
+
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({}));
+      throw new Error(errorData.detail || "Failed to respond");
+    }
+  };
+
   return (
     <div className="space-y-6">
       {/* Page header */}
-      <div>
-        <h1 className="text-2xl font-bold">Daily Briefs</h1>
-        <p className="text-slate-400">
-          AI-powered analysis of your glucose patterns
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">AI Insights</h1>
+          <p className="text-slate-400">
+            AI-powered analysis of your glucose patterns
+          </p>
+        </div>
+        {!isLoading && (
+          <button
+            onClick={() => {
+              setIsLoading(true);
+              fetchInsights();
+            }}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-800 text-slate-300 hover:bg-slate-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            aria-label="Refresh insights"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            Refresh
+          </button>
+        )}
       </div>
 
-      {/* Placeholder content */}
-      <div className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center">
-        <div className="flex justify-center mb-4">
-          <div className="p-4 bg-blue-500/10 rounded-full">
-            <FileText className="h-12 w-12 text-blue-400" />
-          </div>
+      {/* Loading state */}
+      {isLoading && (
+        <div
+          className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+          role="status"
+          aria-label="Loading insights"
+        >
+          <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+          <p className="text-slate-400">Loading insights...</p>
         </div>
-        <h2 className="text-xl font-semibold mb-2">Coming Soon</h2>
-        <p className="text-slate-400 max-w-md mx-auto">
-          Daily briefs will provide AI-generated summaries of your glucose
-          patterns, trends, and actionable suggestions. This feature will be
-          implemented in Epic 5.
-        </p>
-      </div>
+      )}
+
+      {/* Error state */}
+      {error && !isLoading && (
+        <div
+          className="bg-red-500/10 rounded-xl p-6 border border-red-500/20 text-center"
+          role="alert"
+        >
+          <p className="text-red-400">{error}</p>
+          <button
+            onClick={() => {
+              setIsLoading(true);
+              fetchInsights();
+            }}
+            className="mt-3 text-sm text-red-300 hover:text-red-200 underline"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !error && insights.length === 0 && (
+        <div className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center">
+          <div className="flex justify-center mb-4">
+            <div className="p-4 bg-blue-500/10 rounded-full">
+              <FileText className="h-12 w-12 text-blue-400" />
+            </div>
+          </div>
+          <h2 className="text-xl font-semibold mb-2">No Insights Yet</h2>
+          <p className="text-slate-400 max-w-md mx-auto">
+            AI insights will appear here once you have enough glucose data.
+            Connect your Dexcom CGM and Tandem pump to get started.
+          </p>
+        </div>
+      )}
+
+      {/* Insights feed */}
+      {!isLoading && !error && insights.length > 0 && (
+        <>
+          <p className="text-sm text-slate-500">
+            Showing {insights.length} of {total} insights
+          </p>
+          <div className="grid gap-4">
+            {insights.map((insight) => (
+              <AIInsightCard
+                key={insight.id}
+                insight={insight}
+                onRespond={handleRespond}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/ai-insight-card.tsx
+++ b/apps/web/src/components/dashboard/ai-insight-card.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+/**
+ * AIInsightCard Component
+ *
+ * Story 5.7: AI Insight Card
+ * Displays an AI-generated insight (daily brief, meal analysis,
+ * or correction analysis) with acknowledge/dismiss actions.
+ *
+ * Accessibility features:
+ * - Semantic article element with aria-label
+ * - Keyboard-navigable action buttons
+ * - Screen reader status announcements via aria-live
+ * - Visible focus rings
+ * - Respects reduced motion preferences
+ */
+
+import { useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import clsx from "clsx";
+import {
+  FileText,
+  Utensils,
+  Syringe,
+  Check,
+  X,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+
+// Analysis type configuration
+const ANALYSIS_CONFIG = {
+  daily_brief: {
+    icon: FileText,
+    color: "text-blue-400",
+    bg: "bg-blue-500/10",
+    border: "border-blue-500/20",
+    label: "Daily Brief",
+  },
+  meal_analysis: {
+    icon: Utensils,
+    color: "text-amber-400",
+    bg: "bg-amber-500/10",
+    border: "border-amber-500/20",
+    label: "Meal Analysis",
+  },
+  correction_analysis: {
+    icon: Syringe,
+    color: "text-purple-400",
+    bg: "bg-purple-500/10",
+    border: "border-purple-500/20",
+    label: "Correction Analysis",
+  },
+} as const;
+
+type AnalysisType = keyof typeof ANALYSIS_CONFIG;
+
+export interface InsightData {
+  id: string;
+  analysis_type: AnalysisType;
+  title: string;
+  content: string;
+  created_at: string;
+  status: "pending" | "acknowledged" | "dismissed";
+}
+
+export interface AIInsightCardProps {
+  insight: InsightData;
+  onRespond?: (
+    analysisType: AnalysisType,
+    analysisId: string,
+    response: "acknowledged" | "dismissed",
+    reason?: string
+  ) => Promise<void>;
+}
+
+/**
+ * Format a date string for display.
+ */
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return "Unknown date";
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Status badge component.
+ */
+function StatusBadge({ status }: { status: InsightData["status"] }) {
+  const config = {
+    pending: {
+      text: "New",
+      className: "bg-blue-500/20 text-blue-300",
+    },
+    acknowledged: {
+      text: "Acknowledged",
+      className: "bg-green-500/20 text-green-300",
+    },
+    dismissed: {
+      text: "Dismissed",
+      className: "bg-slate-500/20 text-slate-400",
+    },
+  };
+
+  const { text, className } = config[status];
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium",
+        className
+      )}
+    >
+      {text}
+    </span>
+  );
+}
+
+export function AIInsightCard({ insight, onRespond }: AIInsightCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isResponding, setIsResponding] = useState(false);
+  const [localStatus, setLocalStatus] = useState(insight.status);
+  const [error, setError] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState<string | null>(null);
+  const prefersReducedMotion = useReducedMotion();
+
+  const config = ANALYSIS_CONFIG[insight.analysis_type];
+  const Icon = config.icon;
+
+  // Truncate content for collapsed view
+  const maxPreviewLength = 200;
+  const needsTruncation = insight.content.length > maxPreviewLength;
+  const previewContent = needsTruncation
+    ? insight.content.slice(0, maxPreviewLength) + "..."
+    : insight.content;
+
+  const handleRespond = async (response: "acknowledged" | "dismissed") => {
+    if (!onRespond || isResponding) return;
+
+    setIsResponding(true);
+    setError(null);
+    try {
+      await onRespond(
+        insight.analysis_type,
+        insight.id,
+        response
+      );
+      setLocalStatus(response);
+      setAnnouncement(
+        `Insight ${response === "acknowledged" ? "acknowledged" : "dismissed"}`
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to record response"
+      );
+    } finally {
+      setIsResponding(false);
+    }
+  };
+
+  return (
+    <motion.article
+      className={clsx(
+        "rounded-xl border p-5 transition-colors",
+        "bg-slate-900",
+        config.border,
+        "focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 focus-within:ring-offset-slate-950"
+      )}
+      initial={prefersReducedMotion ? false : { opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      aria-label={`${config.label}: ${insight.title}`}
+    >
+      {/* Screen reader announcement for status changes */}
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </div>
+
+      {/* Header row */}
+      <div className="flex items-start gap-3 mb-3">
+        <div
+          className={clsx(
+            "p-2 rounded-lg shrink-0",
+            config.bg
+          )}
+          aria-hidden="true"
+        >
+          <Icon className={clsx("h-5 w-5", config.color)} />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              className={clsx("text-xs font-medium uppercase tracking-wider", config.color)}
+            >
+              {config.label}
+            </span>
+            <StatusBadge status={localStatus} />
+          </div>
+          <h3 className="text-sm font-semibold text-slate-200 leading-tight">
+            {insight.title}
+          </h3>
+          <time
+            className="text-xs text-slate-500 mt-0.5 block"
+            dateTime={insight.created_at}
+          >
+            {formatDate(insight.created_at)}
+          </time>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="text-sm text-slate-300 leading-relaxed whitespace-pre-line">
+        {isExpanded ? insight.content : previewContent}
+      </div>
+
+      {/* Expand/collapse toggle */}
+      {needsTruncation && (
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className={clsx(
+            "mt-2 text-xs font-medium flex items-center gap-1",
+            "text-slate-400 hover:text-slate-200 transition-colors",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+          )}
+          aria-expanded={isExpanded}
+          aria-label={isExpanded ? "Show less" : "Show more"}
+        >
+          {isExpanded ? (
+            <>
+              Show less <ChevronUp className="h-3 w-3" />
+            </>
+          ) : (
+            <>
+              Show more <ChevronDown className="h-3 w-3" />
+            </>
+          )}
+        </button>
+      )}
+
+      {/* Error message */}
+      {error && (
+        <p className="mt-2 text-xs text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* Action buttons (only show for pending insights) */}
+      {localStatus === "pending" && onRespond && (
+        <div
+          className="flex items-center gap-2 mt-4 pt-3 border-t border-slate-800"
+          role="group"
+          aria-label="Insight actions"
+        >
+          <button
+            onClick={() => handleRespond("acknowledged")}
+            disabled={isResponding}
+            className={clsx(
+              "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium",
+              "bg-green-500/10 text-green-400 hover:bg-green-500/20",
+              "transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500",
+              "disabled:opacity-50 disabled:cursor-not-allowed"
+            )}
+            aria-label="Acknowledge this insight"
+          >
+            <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            Acknowledge
+          </button>
+          <button
+            onClick={() => handleRespond("dismissed")}
+            disabled={isResponding}
+            className={clsx(
+              "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium",
+              "bg-slate-700/50 text-slate-400 hover:bg-slate-700",
+              "transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500",
+              "disabled:opacity-50 disabled:cursor-not-allowed"
+            )}
+            aria-label="Dismiss this insight"
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+            Dismiss
+          </button>
+        </div>
+      )}
+    </motion.article>
+  );
+}

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -45,3 +45,9 @@ export {
   ConnectionStatusBanner,
   type ConnectionStatusBannerProps,
 } from "./connection-status-banner";
+
+export {
+  AIInsightCard,
+  type AIInsightCardProps,
+  type InsightData,
+} from "./ai-insight-card";

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -97,3 +97,78 @@ export async function getDisclaimerContent(): Promise<DisclaimerContent> {
 
   return response.json();
 }
+
+/**
+ * AI Insights API types (Story 5.7)
+ */
+export interface InsightSummary {
+  id: string;
+  analysis_type: "daily_brief" | "meal_analysis" | "correction_analysis";
+  title: string;
+  content: string;
+  created_at: string;
+  status: "pending" | "acknowledged" | "dismissed";
+}
+
+export interface InsightsListResponse {
+  insights: InsightSummary[];
+  total: number;
+}
+
+export interface SuggestionResponseResponse {
+  id: string;
+  analysis_type: string;
+  analysis_id: string;
+  response: string;
+  reason: string | null;
+  created_at: string;
+}
+
+/**
+ * Fetch AI insights for the current user
+ */
+export async function getInsights(
+  limit: number = 10
+): Promise<InsightsListResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/ai/insights?limit=${limit}`,
+    {
+      credentials: "include",
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch insights: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Record a response to an AI insight
+ */
+export async function respondToInsight(
+  analysisType: string,
+  analysisId: string,
+  response: "acknowledged" | "dismissed",
+  reason?: string
+): Promise<SuggestionResponseResponse> {
+  const res = await fetch(
+    `${API_BASE_URL}/api/ai/insights/${analysisType}/${analysisId}/respond`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify({ response, reason }),
+    }
+  );
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    throw new Error(error.detail || `Failed to respond to insight: ${res.status}`);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- Add unified AI insights feed aggregating daily briefs, meal analyses, and correction analyses
- Add `SuggestionResponse` model for tracking user acknowledge/dismiss actions
- Add `AIInsightCard` frontend component with type-specific icons, expand/collapse, and status badges
- Replace briefs page placeholder with live insights feed (loading, error, empty states)
- Full input validation: UUID path params, bounded limit, ownership verification, duplicate prevention

## Backend
- `SuggestionResponse` model + migration 014 for `suggestion_responses` table
- `GET /api/ai/insights` - unified feed with scoped response lookup
- `POST /api/ai/insights/{type}/{id}/respond` - record acknowledge/dismiss with ownership check
- 29 tests: service logic, title generation, ownership verification, duplicate prevention (409), limit bounds, auth guards

## Frontend
- `AIInsightCard` component: analysis-type coloring, expand/collapse, error feedback, status badges
- Briefs page: fetches insights, displays cards, refresh button, error/empty states
- Accessibility: `aria-live` announcements, keyboard navigation, focus rings, `prefers-reduced-motion`

## Test plan
- [x] 344 backend tests pass (29 new, 0 regressions)
- [x] Ruff lint + format clean
- [x] Migration 014 runs successfully
- [x] Playwright visual check: dashboard renders correctly, briefs page shows proper error/loading states
- [x] Subagent code review: approved (15 findings found, all 15 verified fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)