### PR TITLE
feat: add predictive alert engine with IoB escalation (Story 6.2)

### DIFF
--- a/apps/api/migrations/versions/016_create_alerts.py
+++ b/apps/api/migrations/versions/016_create_alerts.py
@@ -1,0 +1,116 @@
+"""Story 6.2: Create alerts table for predictive alert engine.
+
+Revision ID: 016_alerts
+Revises: 015_alert_thresholds
+Create Date: 2026-02-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "016_alerts"
+down_revision = "015_alert_thresholds"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create enum types using raw SQL to avoid checkfirst issues with asyncpg
+    op.execute(sa.text(
+        "DO $$ BEGIN "
+        "CREATE TYPE alerttype AS ENUM "
+        "('low_urgent', 'low_warning', 'high_warning', 'high_urgent', 'iob_warning'); "
+        "EXCEPTION WHEN duplicate_object THEN NULL; "
+        "END $$"
+    ))
+    op.execute(sa.text(
+        "DO $$ BEGIN "
+        "CREATE TYPE alertseverity AS ENUM "
+        "('info', 'warning', 'urgent', 'emergency'); "
+        "EXCEPTION WHEN duplicate_object THEN NULL; "
+        "END $$"
+    ))
+
+    op.create_table(
+        "alerts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "alert_type",
+            postgresql.ENUM(name="alerttype", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "severity",
+            postgresql.ENUM(name="alertseverity", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("current_value", sa.Float(), nullable=False),
+        sa.Column("predicted_value", sa.Float(), nullable=True),
+        sa.Column("prediction_minutes", sa.Integer(), nullable=True),
+        sa.Column("iob_value", sa.Float(), nullable=True),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("trend_rate", sa.Float(), nullable=True),
+        sa.Column(
+            "source",
+            sa.String(50),
+            nullable=False,
+            server_default="predictive",
+        ),
+        sa.Column(
+            "acknowledged",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+        sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "expires_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+    )
+
+    # Index for querying active alerts for a user
+    op.create_index(
+        "ix_alerts_user_id",
+        "alerts",
+        ["user_id"],
+    )
+
+    # Index for querying unacknowledged alerts
+    op.create_index(
+        "ix_alerts_user_acknowledged",
+        "alerts",
+        ["user_id", "acknowledged"],
+    )
+
+    # Index for deduplication: prevent duplicate alerts of same type within window
+    op.create_index(
+        "ix_alerts_user_type_created",
+        "alerts",
+        ["user_id", "alert_type", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_alerts_user_type_created")
+    op.drop_index("ix_alerts_user_acknowledged")
+    op.drop_index("ix_alerts_user_id")
+    op.drop_table("alerts")
+
+    # Drop enum types
+    op.execute("DROP TYPE IF EXISTS alertseverity")
+    op.execute("DROP TYPE IF EXISTS alerttype")

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -55,6 +55,10 @@ class Settings(BaseSettings):
     tandem_sync_enabled: bool = True  # Enable/disable automatic sync
     tandem_sync_hours_back: int = 24  # Hours of history to fetch per sync
 
+    # Predictive Alert Engine (Story 6.2)
+    alert_check_interval_minutes: int = 5  # Run alert engine every 5 minutes
+    alert_check_enabled: bool = True  # Enable/disable automatic alert checking
+
     # Testing
     testing: bool = False  # Set to True during tests to disable connection pooling
 

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -12,6 +12,7 @@ from src.logging_config import get_logger, setup_logging
 from src.middleware import CorrelationIdMiddleware
 from src.routers import (
     ai,
+    alerts,
     auth,
     briefs,
     correction_analysis,
@@ -93,6 +94,7 @@ app.include_router(correction_analysis.router)
 app.include_router(safety.router)
 app.include_router(insights.router)
 app.include_router(settings_router.router)
+app.include_router(alerts.router)
 
 
 @app.get("/")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -1,5 +1,6 @@
 # Database Models
 from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProviderType
+from src.models.alert import Alert, AlertSeverity, AlertType
 from src.models.alert_threshold import AlertThreshold
 from src.models.base import Base, TimestampMixin
 from src.models.correction_analysis import CorrectionAnalysis
@@ -21,7 +22,10 @@ __all__ = [
     "AIProviderConfig",
     "AIProviderStatus",
     "AIProviderType",
+    "Alert",
+    "AlertSeverity",
     "AlertThreshold",
+    "AlertType",
     "Base",
     "CorrectionAnalysis",
     "TimestampMixin",

--- a/apps/api/src/models/alert.py
+++ b/apps/api/src/models/alert.py
@@ -1,0 +1,155 @@
+"""Story 6.2: Predictive alert model.
+
+Stores generated alerts from the predictive alert engine,
+including glucose trajectory predictions and IoB risk assessments.
+"""
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Enum, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+
+
+class AlertType(str, enum.Enum):
+    """Type of alert triggered."""
+
+    LOW_URGENT = "low_urgent"
+    LOW_WARNING = "low_warning"
+    HIGH_WARNING = "high_warning"
+    HIGH_URGENT = "high_urgent"
+    IOB_WARNING = "iob_warning"
+
+
+class AlertSeverity(str, enum.Enum):
+    """Severity level for alert escalation."""
+
+    INFO = "info"
+    WARNING = "warning"
+    URGENT = "urgent"
+    EMERGENCY = "emergency"
+
+
+class Alert(Base):
+    """Stores predictive and threshold-based alerts.
+
+    Each alert records the current and predicted values, the timeframe
+    of the prediction, and whether the user has acknowledged it.
+    """
+
+    __tablename__ = "alerts"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    alert_type: Mapped[AlertType] = mapped_column(
+        Enum(
+            AlertType,
+            name="alerttype",
+            create_type=False,
+            values_callable=lambda e: [member.value for member in e],
+        ),
+        nullable=False,
+    )
+
+    severity: Mapped[AlertSeverity] = mapped_column(
+        Enum(
+            AlertSeverity,
+            name="alertseverity",
+            create_type=False,
+            values_callable=lambda e: [member.value for member in e],
+        ),
+        nullable=False,
+    )
+
+    # Current glucose value at time of alert (mg/dL)
+    current_value: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+    )
+
+    # Predicted glucose value (mg/dL) - null for IoB-only alerts
+    predicted_value: Mapped[float | None] = mapped_column(
+        Float,
+        nullable=True,
+    )
+
+    # Minutes into the future for the prediction
+    prediction_minutes: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+
+    # IoB at time of alert (units) - null if unavailable
+    iob_value: Mapped[float | None] = mapped_column(
+        Float,
+        nullable=True,
+    )
+
+    # Human-readable alert message
+    message: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+
+    # Trend rate at time of alert (mg/dL/min)
+    trend_rate: Mapped[float | None] = mapped_column(
+        Float,
+        nullable=True,
+    )
+
+    # Source of alert: "predictive", "current", "iob"
+    source: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        default="predictive",
+    )
+
+    # Acknowledgment tracking
+    acknowledged: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+    )
+
+    acknowledged_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    # Alert creation timestamp
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # Expiration - alerts auto-expire after this time
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # Relationship to user
+    user = relationship("User", back_populates="alerts")
+
+    def __repr__(self) -> str:
+        return (
+            f"<Alert(type={self.alert_type.value}, "
+            f"severity={self.severity.value}, "
+            f"current={self.current_value}, "
+            f"predicted={self.predicted_value})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -135,6 +135,11 @@ class User(Base, TimestampMixin):
         cascade="all, delete-orphan",
         uselist=False,
     )
+    alerts = relationship(
+        "Alert",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/routers/alerts.py
+++ b/apps/api/src/routers/alerts.py
@@ -1,0 +1,83 @@
+"""Story 6.2: Alerts router.
+
+Provides endpoints for retrieving active alerts and acknowledging them.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import get_current_user
+from src.database import get_db
+from src.models.user import User
+from src.schemas.alert import (
+    ActiveAlertsResponse,
+    AlertAcknowledgeResponse,
+    AlertResponse,
+)
+from src.services.predictive_alerts import acknowledge_alert, get_active_alerts
+
+router = APIRouter(prefix="/api/alerts", tags=["alerts"])
+
+
+@router.get("/active", response_model=ActiveAlertsResponse)
+async def get_alerts(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ActiveAlertsResponse:
+    """Get all active (unacknowledged, non-expired) alerts for the current user."""
+    alerts = await get_active_alerts(db, user.id)
+    return ActiveAlertsResponse(
+        alerts=[
+            AlertResponse(
+                id=str(alert.id),
+                alert_type=alert.alert_type.value,
+                severity=alert.severity.value,
+                current_value=alert.current_value,
+                predicted_value=alert.predicted_value,
+                prediction_minutes=alert.prediction_minutes,
+                iob_value=alert.iob_value,
+                message=alert.message,
+                trend_rate=alert.trend_rate,
+                source=alert.source,
+                acknowledged=alert.acknowledged,
+                acknowledged_at=alert.acknowledged_at,
+                created_at=alert.created_at,
+                expires_at=alert.expires_at,
+            )
+            for alert in alerts
+        ],
+        count=len(alerts),
+    )
+
+
+@router.patch(
+    "/{alert_id}/acknowledge",
+    response_model=AlertAcknowledgeResponse,
+)
+async def acknowledge(
+    alert_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> AlertAcknowledgeResponse:
+    """Acknowledge an alert by ID.
+
+    Only the alert's owner can acknowledge it.
+    """
+    alert = await acknowledge_alert(db, user.id, alert_id)
+
+    if alert is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Alert not found",
+        )
+
+    await db.commit()
+    await db.refresh(alert)
+
+    return AlertAcknowledgeResponse(
+        id=str(alert.id),
+        acknowledged=alert.acknowledged,
+        acknowledged_at=alert.acknowledged_at,
+    )

--- a/apps/api/src/schemas/alert.py
+++ b/apps/api/src/schemas/alert.py
@@ -1,0 +1,46 @@
+"""Story 6.2: Alert schemas for predictive alert engine.
+
+Response schemas for alert data returned by the API.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AlertResponse(BaseModel):
+    """Single alert response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    alert_type: str
+    severity: str
+    current_value: float
+    predicted_value: float | None
+    prediction_minutes: int | None
+    iob_value: float | None
+    message: str
+    trend_rate: float | None
+    source: str
+    acknowledged: bool
+    acknowledged_at: datetime | None
+    created_at: datetime
+    expires_at: datetime
+
+
+class AlertAcknowledgeResponse(BaseModel):
+    """Response after acknowledging an alert."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    acknowledged: bool
+    acknowledged_at: datetime | None
+
+
+class ActiveAlertsResponse(BaseModel):
+    """Response for listing active alerts."""
+
+    alerts: list[AlertResponse]
+    count: int

--- a/apps/api/src/services/predictive_alerts.py
+++ b/apps/api/src/services/predictive_alerts.py
@@ -1,0 +1,637 @@
+"""Story 6.2: Predictive Alert Engine.
+
+Calculates glucose trajectory at 20/30/45 minutes, detects threshold
+crossings, and escalates urgency based on IoB. Deduplicates alerts
+to avoid spamming the user.
+"""
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import and_, desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.alert import Alert, AlertSeverity, AlertType
+from src.models.alert_threshold import AlertThreshold
+from src.models.glucose import GlucoseReading
+from src.services.alert_threshold import get_or_create_thresholds
+from src.services.iob_projection import get_iob_projection
+
+logger = get_logger(__name__)
+
+# Prediction time horizons in minutes
+PREDICTION_HORIZONS = [20, 30, 45]
+
+# Deduplication window: don't create same alert type within this period
+DEDUP_WINDOW_MINUTES = 30
+
+# Alert expiration: alerts expire after this period
+ALERT_EXPIRY_MINUTES = 60
+
+# IoB escalation threshold: escalate severity when IoB exceeds this
+# relative to the user's configured iob_warning threshold
+IOB_ESCALATION_FACTOR = 0.8
+
+# Glucose staleness: ignore readings older than this
+GLUCOSE_STALE_MINUTES = 10
+
+
+@dataclass
+class GlucoseTrajectory:
+    """Predicted glucose values at future time points."""
+
+    current_value: float
+    trend_rate: float  # mg/dL/min
+    predictions: dict[int, float]  # minutes -> predicted mg/dL
+
+
+@dataclass
+class AlertCandidate:
+    """A potential alert before deduplication."""
+
+    alert_type: AlertType
+    severity: AlertSeverity
+    current_value: float
+    predicted_value: float | None
+    prediction_minutes: int | None
+    iob_value: float | None
+    message: str
+    trend_rate: float | None
+    source: str  # "predictive", "current", "iob"
+
+
+def calculate_trajectory(
+    current_value: float,
+    trend_rate: float,
+    horizons: list[int] | None = None,
+) -> GlucoseTrajectory:
+    """Calculate linear glucose trajectory at future time points.
+
+    Uses the current trend rate (mg/dL/min) for linear projection.
+    While glucose curves are not perfectly linear, this provides
+    a reasonable short-term prediction (< 1 hour).
+
+    Args:
+        current_value: Current glucose in mg/dL.
+        trend_rate: Rate of change in mg/dL/min.
+        horizons: Prediction horizons in minutes (default: 20, 30, 45).
+
+    Returns:
+        GlucoseTrajectory with predictions at each horizon.
+    """
+    if horizons is None:
+        horizons = PREDICTION_HORIZONS
+
+    predictions = {}
+    for minutes in horizons:
+        predicted = current_value + (trend_rate * minutes)
+        # Clamp to physiological range (glucose can't go below 0)
+        predictions[minutes] = max(0.0, round(predicted, 1))
+
+    return GlucoseTrajectory(
+        current_value=current_value,
+        trend_rate=trend_rate,
+        predictions=predictions,
+    )
+
+
+def determine_severity(
+    alert_type: AlertType,
+    iob_value: float | None,
+    iob_threshold: float,
+) -> AlertSeverity:
+    """Determine alert severity, escalating based on IoB if applicable.
+
+    When glucose is dropping AND IoB is high, the situation is more
+    dangerous because more insulin is still active. Similarly, when
+    glucose is rising with low IoB, there's less correction available.
+
+    Args:
+        alert_type: The type of alert being generated.
+        iob_value: Current IoB in units (None if unavailable).
+        iob_threshold: User's configured IoB warning threshold.
+
+    Returns:
+        Appropriate AlertSeverity level.
+    """
+    # Base severity by alert type
+    base_severity = {
+        AlertType.LOW_URGENT: AlertSeverity.URGENT,
+        AlertType.LOW_WARNING: AlertSeverity.WARNING,
+        AlertType.HIGH_WARNING: AlertSeverity.WARNING,
+        AlertType.HIGH_URGENT: AlertSeverity.URGENT,
+        AlertType.IOB_WARNING: AlertSeverity.WARNING,
+    }
+
+    severity = base_severity[alert_type]
+
+    # IoB-based escalation for low glucose alerts
+    if iob_value is not None and alert_type in (
+        AlertType.LOW_WARNING,
+        AlertType.LOW_URGENT,
+    ):
+        # High IoB + dropping glucose = escalate
+        if iob_value >= iob_threshold * IOB_ESCALATION_FACTOR:
+            if severity == AlertSeverity.WARNING:
+                severity = AlertSeverity.URGENT
+            elif severity == AlertSeverity.URGENT:
+                severity = AlertSeverity.EMERGENCY
+
+    return severity
+
+
+def check_threshold_crossings(
+    trajectory: GlucoseTrajectory,
+    thresholds: AlertThreshold,
+    iob_value: float | None,
+) -> list[AlertCandidate]:
+    """Check if glucose trajectory crosses any configured thresholds.
+
+    Checks both current value and predicted values. For predicted
+    values, reports the earliest crossing time.
+
+    Args:
+        trajectory: Calculated glucose trajectory.
+        thresholds: User's configured alert thresholds.
+        iob_value: Current IoB value (for severity escalation).
+
+    Returns:
+        List of AlertCandidate objects for threshold crossings found.
+    """
+    candidates: list[AlertCandidate] = []
+    current = trajectory.current_value
+
+    # Check current value against thresholds
+    if current <= thresholds.urgent_low:
+        candidates.append(
+            AlertCandidate(
+                alert_type=AlertType.LOW_URGENT,
+                severity=determine_severity(
+                    AlertType.LOW_URGENT, iob_value, thresholds.iob_warning
+                ),
+                current_value=current,
+                predicted_value=None,
+                prediction_minutes=None,
+                iob_value=iob_value,
+                message=(
+                    f"Urgent low glucose: {current:.0f} mg/dL "
+                    f"(threshold: {thresholds.urgent_low:.0f})"
+                ),
+                trend_rate=trajectory.trend_rate,
+                source="current",
+            )
+        )
+    elif current <= thresholds.low_warning:
+        candidates.append(
+            AlertCandidate(
+                alert_type=AlertType.LOW_WARNING,
+                severity=determine_severity(
+                    AlertType.LOW_WARNING, iob_value, thresholds.iob_warning
+                ),
+                current_value=current,
+                predicted_value=None,
+                prediction_minutes=None,
+                iob_value=iob_value,
+                message=(
+                    f"Low glucose warning: {current:.0f} mg/dL "
+                    f"(threshold: {thresholds.low_warning:.0f})"
+                ),
+                trend_rate=trajectory.trend_rate,
+                source="current",
+            )
+        )
+
+    if current >= thresholds.urgent_high:
+        candidates.append(
+            AlertCandidate(
+                alert_type=AlertType.HIGH_URGENT,
+                severity=determine_severity(
+                    AlertType.HIGH_URGENT, iob_value, thresholds.iob_warning
+                ),
+                current_value=current,
+                predicted_value=None,
+                prediction_minutes=None,
+                iob_value=iob_value,
+                message=(
+                    f"Urgent high glucose: {current:.0f} mg/dL "
+                    f"(threshold: {thresholds.urgent_high:.0f})"
+                ),
+                trend_rate=trajectory.trend_rate,
+                source="current",
+            )
+        )
+    elif current >= thresholds.high_warning:
+        candidates.append(
+            AlertCandidate(
+                alert_type=AlertType.HIGH_WARNING,
+                severity=determine_severity(
+                    AlertType.HIGH_WARNING, iob_value, thresholds.iob_warning
+                ),
+                current_value=current,
+                predicted_value=None,
+                prediction_minutes=None,
+                iob_value=iob_value,
+                message=(
+                    f"High glucose warning: {current:.0f} mg/dL "
+                    f"(threshold: {thresholds.high_warning:.0f})"
+                ),
+                trend_rate=trajectory.trend_rate,
+                source="current",
+            )
+        )
+
+    # Check predicted values (only if current is not already alerting for same type)
+    current_alert_types = {c.alert_type for c in candidates}
+
+    for minutes, predicted in sorted(trajectory.predictions.items()):
+        # Low predictions
+        if (
+            predicted <= thresholds.urgent_low
+            and AlertType.LOW_URGENT not in current_alert_types
+        ):
+            candidates.append(
+                AlertCandidate(
+                    alert_type=AlertType.LOW_URGENT,
+                    severity=determine_severity(
+                        AlertType.LOW_URGENT, iob_value, thresholds.iob_warning
+                    ),
+                    current_value=current,
+                    predicted_value=predicted,
+                    prediction_minutes=minutes,
+                    iob_value=iob_value,
+                    message=(
+                        f"Predicted urgent low: {predicted:.0f} mg/dL "
+                        f"in {minutes} min (current: {current:.0f}, "
+                        f"threshold: {thresholds.urgent_low:.0f})"
+                    ),
+                    trend_rate=trajectory.trend_rate,
+                    source="predictive",
+                )
+            )
+            current_alert_types.add(AlertType.LOW_URGENT)
+
+        elif (
+            predicted <= thresholds.low_warning
+            and AlertType.LOW_WARNING not in current_alert_types
+            and AlertType.LOW_URGENT not in current_alert_types
+        ):
+            candidates.append(
+                AlertCandidate(
+                    alert_type=AlertType.LOW_WARNING,
+                    severity=determine_severity(
+                        AlertType.LOW_WARNING, iob_value, thresholds.iob_warning
+                    ),
+                    current_value=current,
+                    predicted_value=predicted,
+                    prediction_minutes=minutes,
+                    iob_value=iob_value,
+                    message=(
+                        f"Predicted low glucose: {predicted:.0f} mg/dL "
+                        f"in {minutes} min (current: {current:.0f}, "
+                        f"threshold: {thresholds.low_warning:.0f})"
+                    ),
+                    trend_rate=trajectory.trend_rate,
+                    source="predictive",
+                )
+            )
+            current_alert_types.add(AlertType.LOW_WARNING)
+
+        # High predictions
+        if (
+            predicted >= thresholds.urgent_high
+            and AlertType.HIGH_URGENT not in current_alert_types
+        ):
+            candidates.append(
+                AlertCandidate(
+                    alert_type=AlertType.HIGH_URGENT,
+                    severity=determine_severity(
+                        AlertType.HIGH_URGENT, iob_value, thresholds.iob_warning
+                    ),
+                    current_value=current,
+                    predicted_value=predicted,
+                    prediction_minutes=minutes,
+                    iob_value=iob_value,
+                    message=(
+                        f"Predicted urgent high: {predicted:.0f} mg/dL "
+                        f"in {minutes} min (current: {current:.0f}, "
+                        f"threshold: {thresholds.urgent_high:.0f})"
+                    ),
+                    trend_rate=trajectory.trend_rate,
+                    source="predictive",
+                )
+            )
+            current_alert_types.add(AlertType.HIGH_URGENT)
+
+        elif (
+            predicted >= thresholds.high_warning
+            and AlertType.HIGH_WARNING not in current_alert_types
+            and AlertType.HIGH_URGENT not in current_alert_types
+        ):
+            candidates.append(
+                AlertCandidate(
+                    alert_type=AlertType.HIGH_WARNING,
+                    severity=determine_severity(
+                        AlertType.HIGH_WARNING, iob_value, thresholds.iob_warning
+                    ),
+                    current_value=current,
+                    predicted_value=predicted,
+                    prediction_minutes=minutes,
+                    iob_value=iob_value,
+                    message=(
+                        f"Predicted high glucose: {predicted:.0f} mg/dL "
+                        f"in {minutes} min (current: {current:.0f}, "
+                        f"threshold: {thresholds.high_warning:.0f})"
+                    ),
+                    trend_rate=trajectory.trend_rate,
+                    source="predictive",
+                )
+            )
+            current_alert_types.add(AlertType.HIGH_WARNING)
+
+    return candidates
+
+
+def check_iob_threshold(
+    current_glucose: float,
+    iob_value: float,
+    iob_threshold: float,
+    trend_rate: float | None,
+) -> AlertCandidate | None:
+    """Check if IoB exceeds the configured threshold.
+
+    Args:
+        current_glucose: Current glucose value.
+        iob_value: Current IoB value.
+        iob_threshold: User's configured IoB warning threshold.
+        trend_rate: Current trend rate.
+
+    Returns:
+        AlertCandidate if IoB exceeds threshold, None otherwise.
+    """
+    if iob_value >= iob_threshold:
+        return AlertCandidate(
+            alert_type=AlertType.IOB_WARNING,
+            severity=AlertSeverity.WARNING,
+            current_value=current_glucose,
+            predicted_value=None,
+            prediction_minutes=None,
+            iob_value=iob_value,
+            message=(
+                f"High insulin on board: {iob_value:.1f} units "
+                f"(threshold: {iob_threshold:.1f})"
+            ),
+            trend_rate=trend_rate,
+            source="iob",
+        )
+    return None
+
+
+async def has_recent_alert(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    alert_type: AlertType,
+    window_minutes: int = DEDUP_WINDOW_MINUTES,
+) -> bool:
+    """Check if a recent alert of the same type exists.
+
+    Prevents alert spam by checking if the user already has
+    an unacknowledged alert of the same type within the dedup window.
+
+    Args:
+        db: Database session.
+        user_id: User's UUID.
+        alert_type: Type of alert to check for.
+        window_minutes: Deduplication window in minutes.
+
+    Returns:
+        True if a recent alert exists.
+    """
+    cutoff = datetime.now(UTC) - timedelta(minutes=window_minutes)
+
+    result = await db.execute(
+        select(Alert.id)
+        .where(
+            and_(
+                Alert.user_id == user_id,
+                Alert.alert_type == alert_type,
+                Alert.created_at >= cutoff,
+                Alert.acknowledged.is_(False),
+            )
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def create_alert(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    candidate: AlertCandidate,
+) -> Alert:
+    """Persist an alert candidate to the database.
+
+    Args:
+        db: Database session.
+        user_id: User's UUID.
+        candidate: The alert candidate to persist.
+
+    Returns:
+        The created Alert record.
+    """
+    now = datetime.now(UTC)
+    alert = Alert(
+        user_id=user_id,
+        alert_type=candidate.alert_type,
+        severity=candidate.severity,
+        current_value=candidate.current_value,
+        predicted_value=candidate.predicted_value,
+        prediction_minutes=candidate.prediction_minutes,
+        iob_value=candidate.iob_value,
+        message=candidate.message,
+        trend_rate=candidate.trend_rate,
+        source=candidate.source,
+        created_at=now,
+        expires_at=now + timedelta(minutes=ALERT_EXPIRY_MINUTES),
+    )
+    db.add(alert)
+    return alert
+
+
+async def get_active_alerts(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    limit: int = 50,
+) -> list[Alert]:
+    """Get all active (unacknowledged, non-expired) alerts for a user.
+
+    Args:
+        db: Database session.
+        user_id: User's UUID.
+        limit: Maximum number of alerts to return.
+
+    Returns:
+        List of active Alert records, newest first.
+    """
+    now = datetime.now(UTC)
+
+    result = await db.execute(
+        select(Alert)
+        .where(
+            and_(
+                Alert.user_id == user_id,
+                Alert.acknowledged.is_(False),
+                Alert.expires_at > now,
+            )
+        )
+        .order_by(desc(Alert.created_at))
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def acknowledge_alert(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    alert_id: uuid.UUID,
+) -> Alert | None:
+    """Acknowledge an alert.
+
+    Args:
+        db: Database session.
+        user_id: User's UUID (for ownership check).
+        alert_id: The alert to acknowledge.
+
+    Returns:
+        The updated Alert, or None if not found / not owned by user.
+    """
+    result = await db.execute(
+        select(Alert).where(
+            and_(
+                Alert.id == alert_id,
+                Alert.user_id == user_id,
+            )
+        )
+    )
+    alert = result.scalar_one_or_none()
+
+    if alert is None:
+        return None
+
+    alert.acknowledged = True
+    alert.acknowledged_at = datetime.now(UTC)
+    return alert
+
+
+async def evaluate_alerts_for_user(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> list[Alert]:
+    """Run the full predictive alert evaluation for a user.
+
+    This is the main entry point for the alert engine. It:
+    1. Gets the latest glucose reading
+    2. Calculates trajectory at 20/30/45 min
+    3. Gets user's alert thresholds
+    4. Gets IoB projection
+    5. Checks for threshold crossings
+    6. Deduplicates against recent alerts
+    7. Persists new alerts
+
+    Args:
+        db: Database session.
+        user_id: User's UUID.
+
+    Returns:
+        List of newly created Alert records.
+    """
+    # Get latest glucose reading
+    result = await db.execute(
+        select(GlucoseReading)
+        .where(GlucoseReading.user_id == user_id)
+        .order_by(desc(GlucoseReading.reading_timestamp))
+        .limit(1)
+    )
+    latest_reading = result.scalar_one_or_none()
+
+    if latest_reading is None:
+        logger.debug("No glucose readings for user", user_id=str(user_id))
+        return []
+
+    # Check staleness
+    now = datetime.now(UTC)
+    reading_time = latest_reading.reading_timestamp
+    if reading_time.tzinfo is None:
+        reading_time = reading_time.replace(tzinfo=UTC)
+
+    minutes_ago = (now - reading_time).total_seconds() / 60
+    if minutes_ago > GLUCOSE_STALE_MINUTES:
+        logger.debug(
+            "Glucose reading is stale, skipping alert evaluation",
+            user_id=str(user_id),
+            minutes_ago=round(minutes_ago, 1),
+        )
+        return []
+
+    # Get trend rate (default to 0 if unavailable)
+    trend_rate = (
+        latest_reading.trend_rate if latest_reading.trend_rate is not None else 0.0
+    )
+
+    # Calculate trajectory
+    trajectory = calculate_trajectory(
+        current_value=float(latest_reading.value),
+        trend_rate=trend_rate,
+    )
+
+    # Get user's thresholds
+    thresholds = await get_or_create_thresholds(user_id, db)
+
+    # Get IoB projection
+    iob_value = None
+    try:
+        iob_projection = await get_iob_projection(db, user_id)
+        if iob_projection and not iob_projection.is_stale:
+            iob_value = iob_projection.projected_iob
+    except Exception as e:
+        logger.warning(
+            "Failed to get IoB projection for alert evaluation",
+            user_id=str(user_id),
+            error=str(e),
+        )
+
+    # Check threshold crossings
+    candidates = check_threshold_crossings(trajectory, thresholds, iob_value)
+
+    # Check IoB threshold
+    if iob_value is not None:
+        iob_candidate = check_iob_threshold(
+            current_glucose=float(latest_reading.value),
+            iob_value=iob_value,
+            iob_threshold=thresholds.iob_warning,
+            trend_rate=trend_rate,
+        )
+        if iob_candidate:
+            candidates.append(iob_candidate)
+
+    # Deduplicate and persist
+    new_alerts: list[Alert] = []
+    for candidate in candidates:
+        if not await has_recent_alert(db, user_id, candidate.alert_type):
+            alert = await create_alert(db, user_id, candidate)
+            new_alerts.append(alert)
+
+    if new_alerts:
+        await db.commit()
+        for alert in new_alerts:
+            await db.refresh(alert)
+
+        logger.info(
+            "Created predictive alerts",
+            user_id=str(user_id),
+            alert_count=len(new_alerts),
+            types=[a.alert_type.value for a in new_alerts],
+        )
+
+    return new_alerts

--- a/apps/api/tests/test_predictive_alerts.py
+++ b/apps/api/tests/test_predictive_alerts.py
@@ -1,0 +1,445 @@
+"""Story 6.2: Tests for predictive alert engine."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from src.config import settings
+from src.models.alert import AlertSeverity, AlertType
+from src.services.predictive_alerts import (
+    calculate_trajectory,
+    check_iob_threshold,
+    check_threshold_crossings,
+    determine_severity,
+)
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client: AsyncClient) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("alerts")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+# ── Trajectory calculation tests ──
+
+
+class TestCalculateTrajectory:
+    """Tests for glucose trajectory calculation."""
+
+    def test_flat_trajectory(self):
+        """Flat trend rate should predict same value at all horizons."""
+        trajectory = calculate_trajectory(100.0, 0.0)
+        assert trajectory.current_value == 100.0
+        assert trajectory.predictions[20] == 100.0
+        assert trajectory.predictions[30] == 100.0
+        assert trajectory.predictions[45] == 100.0
+
+    def test_falling_trajectory(self):
+        """Negative trend rate should predict decreasing values."""
+        trajectory = calculate_trajectory(100.0, -2.0)
+        assert trajectory.predictions[20] == 60.0  # 100 - 2*20
+        assert trajectory.predictions[30] == 40.0  # 100 - 2*30
+        assert trajectory.predictions[45] == 10.0  # 100 - 2*45
+
+    def test_rising_trajectory(self):
+        """Positive trend rate should predict increasing values."""
+        trajectory = calculate_trajectory(150.0, 1.5)
+        assert trajectory.predictions[20] == 180.0  # 150 + 1.5*20
+        assert trajectory.predictions[30] == 195.0  # 150 + 1.5*30
+        assert trajectory.predictions[45] == 217.5  # 150 + 1.5*45
+
+    def test_clamps_to_zero(self):
+        """Predicted values should not go below 0."""
+        trajectory = calculate_trajectory(20.0, -3.0)
+        assert trajectory.predictions[20] == 0.0  # 20 - 3*20 = -40 -> 0
+        assert trajectory.predictions[30] == 0.0
+
+    def test_custom_horizons(self):
+        """Should support custom prediction horizons."""
+        trajectory = calculate_trajectory(100.0, -1.0, horizons=[10, 60])
+        assert 10 in trajectory.predictions
+        assert 60 in trajectory.predictions
+        assert 20 not in trajectory.predictions
+
+    def test_stores_trend_rate(self):
+        """Trajectory should preserve the trend rate."""
+        trajectory = calculate_trajectory(100.0, -1.5)
+        assert trajectory.trend_rate == -1.5
+
+
+# ── Severity determination tests ──
+
+
+class TestDetermineSeverity:
+    """Tests for severity determination with IoB escalation."""
+
+    def test_base_severity_low_warning(self):
+        """LOW_WARNING should default to WARNING."""
+        severity = determine_severity(AlertType.LOW_WARNING, None, 3.0)
+        assert severity == AlertSeverity.WARNING
+
+    def test_base_severity_low_urgent(self):
+        """LOW_URGENT should default to URGENT."""
+        severity = determine_severity(AlertType.LOW_URGENT, None, 3.0)
+        assert severity == AlertSeverity.URGENT
+
+    def test_base_severity_high_warning(self):
+        """HIGH_WARNING should default to WARNING."""
+        severity = determine_severity(AlertType.HIGH_WARNING, None, 3.0)
+        assert severity == AlertSeverity.WARNING
+
+    def test_iob_escalation_warning_to_urgent(self):
+        """High IoB should escalate LOW_WARNING from WARNING to URGENT."""
+        # iob_threshold=3.0, factor=0.8, so 2.4 triggers escalation
+        severity = determine_severity(AlertType.LOW_WARNING, 2.5, 3.0)
+        assert severity == AlertSeverity.URGENT
+
+    def test_iob_escalation_urgent_to_emergency(self):
+        """High IoB should escalate LOW_URGENT from URGENT to EMERGENCY."""
+        severity = determine_severity(AlertType.LOW_URGENT, 3.0, 3.0)
+        assert severity == AlertSeverity.EMERGENCY
+
+    def test_no_escalation_low_iob(self):
+        """Low IoB should not escalate severity."""
+        severity = determine_severity(AlertType.LOW_WARNING, 1.0, 3.0)
+        assert severity == AlertSeverity.WARNING
+
+    def test_no_escalation_for_high_alerts(self):
+        """IoB escalation should not apply to HIGH alerts."""
+        severity = determine_severity(AlertType.HIGH_WARNING, 5.0, 3.0)
+        assert severity == AlertSeverity.WARNING
+
+    def test_no_escalation_none_iob(self):
+        """None IoB should not cause escalation."""
+        severity = determine_severity(AlertType.LOW_WARNING, None, 3.0)
+        assert severity == AlertSeverity.WARNING
+
+
+# ── Threshold crossing tests ──
+
+
+class TestCheckThresholdCrossings:
+    """Tests for threshold crossing detection."""
+
+    def _make_thresholds(self, **overrides):
+        """Create mock thresholds with defaults."""
+        mock = MagicMock()
+        mock.urgent_low = overrides.get("urgent_low", 55.0)
+        mock.low_warning = overrides.get("low_warning", 70.0)
+        mock.high_warning = overrides.get("high_warning", 180.0)
+        mock.urgent_high = overrides.get("urgent_high", 250.0)
+        mock.iob_warning = overrides.get("iob_warning", 3.0)
+        return mock
+
+    def test_no_crossings_in_range(self):
+        """Normal glucose should produce no alerts."""
+        trajectory = calculate_trajectory(100.0, 0.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        assert len(candidates) == 0
+
+    def test_current_low_warning(self):
+        """Current glucose at low_warning should trigger LOW_WARNING."""
+        trajectory = calculate_trajectory(70.0, 0.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        assert len(candidates) == 1
+        assert candidates[0].alert_type == AlertType.LOW_WARNING
+        assert candidates[0].source == "current"
+
+    def test_current_urgent_low(self):
+        """Current glucose at urgent_low should trigger LOW_URGENT."""
+        trajectory = calculate_trajectory(50.0, 0.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        assert len(candidates) == 1
+        assert candidates[0].alert_type == AlertType.LOW_URGENT
+
+    def test_current_high_warning(self):
+        """Current glucose at high_warning should trigger HIGH_WARNING."""
+        trajectory = calculate_trajectory(180.0, 0.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        assert len(candidates) == 1
+        assert candidates[0].alert_type == AlertType.HIGH_WARNING
+
+    def test_current_urgent_high(self):
+        """Current glucose at urgent_high should trigger HIGH_URGENT."""
+        trajectory = calculate_trajectory(260.0, 0.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        assert len(candidates) == 1
+        assert candidates[0].alert_type == AlertType.HIGH_URGENT
+
+    def test_predicted_low_crossing(self):
+        """Dropping glucose should trigger predictive low warning."""
+        # 95 mg/dL falling at 2 mg/dL/min = 55 at 20min, below low_warning (70) at 13min
+        trajectory = calculate_trajectory(95.0, -2.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        # Should get LOW_WARNING (predicted at 20min: 55) and LOW_URGENT (at 20min: 55)
+        types = {c.alert_type for c in candidates}
+        assert AlertType.LOW_URGENT in types
+        assert all(c.source == "predictive" for c in candidates)
+
+    def test_predicted_high_crossing(self):
+        """Rising glucose should trigger predictive high warning."""
+        # 160 mg/dL rising at 1.5 mg/dL/min = 190 at 20min
+        trajectory = calculate_trajectory(160.0, 1.5)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        types = {c.alert_type for c in candidates}
+        assert AlertType.HIGH_WARNING in types
+
+    def test_no_duplicate_types(self):
+        """Current alert should suppress predicted alert of same type."""
+        # Current is already LOW_URGENT, should not also get predicted LOW_URGENT
+        trajectory = calculate_trajectory(50.0, -2.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        type_counts = {}
+        for c in candidates:
+            type_counts[c.alert_type] = type_counts.get(c.alert_type, 0) + 1
+        for count in type_counts.values():
+            assert count == 1
+
+    def test_predicted_includes_prediction_minutes(self):
+        """Predictive alerts should include prediction timeframe."""
+        trajectory = calculate_trajectory(160.0, 1.5)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        predictive = [c for c in candidates if c.source == "predictive"]
+        for c in predictive:
+            assert c.prediction_minutes is not None
+            assert c.predicted_value is not None
+
+
+# ── IoB threshold tests ──
+
+
+class TestCheckIoBThreshold:
+    """Tests for IoB threshold checking."""
+
+    def test_below_threshold(self):
+        """IoB below threshold should return None."""
+        result = check_iob_threshold(100.0, 2.0, 3.0, -1.0)
+        assert result is None
+
+    def test_at_threshold(self):
+        """IoB at threshold should trigger alert."""
+        result = check_iob_threshold(100.0, 3.0, 3.0, -1.0)
+        assert result is not None
+        assert result.alert_type == AlertType.IOB_WARNING
+        assert result.source == "iob"
+
+    def test_above_threshold(self):
+        """IoB above threshold should trigger alert."""
+        result = check_iob_threshold(100.0, 5.0, 3.0, -1.0)
+        assert result is not None
+        assert result.iob_value == 5.0
+
+
+# ── Service-level tests (with mocked DB) ──
+
+
+class TestEvaluateAlertsForUser:
+    """Tests for the full alert evaluation pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_no_readings_returns_empty(self):
+        """Should return empty list when no glucose readings exist."""
+        from src.services.predictive_alerts import evaluate_alerts_for_user
+
+        user_id = uuid.uuid4()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await evaluate_alerts_for_user(mock_db, user_id)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_stale_reading_returns_empty(self):
+        """Should skip alert evaluation for stale readings."""
+        from src.services.predictive_alerts import evaluate_alerts_for_user
+
+        user_id = uuid.uuid4()
+        stale_reading = MagicMock()
+        stale_reading.value = 50
+        stale_reading.trend_rate = -2.0
+        stale_reading.reading_timestamp = datetime.now(UTC) - timedelta(minutes=15)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = stale_reading
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await evaluate_alerts_for_user(mock_db, user_id)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_low_glucose_creates_alert(self):
+        """Should create a LOW_URGENT alert for very low glucose."""
+        from src.services.predictive_alerts import evaluate_alerts_for_user
+
+        user_id = uuid.uuid4()
+
+        # Fresh low glucose reading
+        low_reading = MagicMock()
+        low_reading.value = 50
+        low_reading.trend_rate = -1.0
+        low_reading.reading_timestamp = datetime.now(UTC) - timedelta(minutes=2)
+
+        # Mock thresholds
+        mock_thresholds = MagicMock()
+        mock_thresholds.urgent_low = 55.0
+        mock_thresholds.low_warning = 70.0
+        mock_thresholds.high_warning = 180.0
+        mock_thresholds.urgent_high = 250.0
+        mock_thresholds.iob_warning = 3.0
+
+        # First execute call returns the glucose reading
+        reading_result = MagicMock()
+        reading_result.scalar_one_or_none.return_value = low_reading
+
+        # Subsequent execute calls for has_recent_alert return no duplicates
+        dedup_result = MagicMock()
+        dedup_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.side_effect = [reading_result, dedup_result]
+        mock_db.add = MagicMock()  # add() is synchronous
+
+        with (
+            patch(
+                "src.services.predictive_alerts.get_or_create_thresholds",
+                new_callable=AsyncMock,
+                return_value=mock_thresholds,
+            ),
+            patch(
+                "src.services.predictive_alerts.get_iob_projection",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await evaluate_alerts_for_user(mock_db, user_id)
+
+        assert len(result) == 1
+        assert result[0].alert_type == AlertType.LOW_URGENT
+        # Verify commit was called
+        mock_db.commit.assert_awaited_once()
+
+
+# ── Deduplication tests ──
+
+
+class TestHasRecentAlert:
+    """Tests for alert deduplication."""
+
+    @pytest.mark.asyncio
+    async def test_no_recent_alert(self):
+        """Should return False when no recent alert exists."""
+        from src.services.predictive_alerts import has_recent_alert
+
+        user_id = uuid.uuid4()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await has_recent_alert(mock_db, user_id, AlertType.LOW_WARNING)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_recent_alert_exists(self):
+        """Should return True when a recent alert exists."""
+        from src.services.predictive_alerts import has_recent_alert
+
+        user_id = uuid.uuid4()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = uuid.uuid4()
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await has_recent_alert(mock_db, user_id, AlertType.LOW_WARNING)
+        assert result is True
+
+
+# ── Endpoint tests ──
+
+
+class TestGetActiveAlertsEndpoint:
+    """Tests for GET /api/alerts/active."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.get("/api/alerts/active")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authenticated_returns_empty_list(self, client):
+        """New user should have no active alerts."""
+        cookie = await register_and_login(client)
+        response = await client.get(
+            "/api/alerts/active",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["alerts"] == []
+        assert data["count"] == 0
+
+
+class TestAcknowledgeAlertEndpoint:
+    """Tests for PATCH /api/alerts/{alert_id}/acknowledge."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        fake_id = str(uuid.uuid4())
+        response = await client.patch(f"/api/alerts/{fake_id}/acknowledge")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_alert_returns_404(self, client):
+        cookie = await register_and_login(client)
+        fake_id = str(uuid.uuid4())
+        response = await client.patch(
+            f"/api/alerts/{fake_id}/acknowledge",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_uuid_returns_422(self, client):
+        cookie = await register_and_login(client)
+        response = await client.patch(
+            "/api/alerts/not-a-uuid/acknowledge",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 422

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -295,3 +295,76 @@ export async function updateAlertThresholds(
 
   return response.json();
 }
+
+/**
+ * Predictive Alert API types (Story 6.2)
+ */
+export interface PredictiveAlert {
+  id: string;
+  alert_type: string;
+  severity: string;
+  current_value: number;
+  predicted_value: number | null;
+  prediction_minutes: number | null;
+  iob_value: number | null;
+  message: string;
+  trend_rate: number | null;
+  source: string;
+  acknowledged: boolean;
+  acknowledged_at: string | null;
+  created_at: string;
+  expires_at: string;
+}
+
+export interface ActiveAlertsResponse {
+  alerts: PredictiveAlert[];
+  count: number;
+}
+
+export interface AlertAcknowledgeResponse {
+  id: string;
+  acknowledged: boolean;
+  acknowledged_at: string | null;
+}
+
+/**
+ * Fetch active (unacknowledged, non-expired) alerts
+ */
+export async function getActiveAlerts(): Promise<ActiveAlertsResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/alerts/active`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to fetch alerts: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Acknowledge an alert by ID
+ */
+export async function acknowledgeAlert(
+  alertId: string
+): Promise<AlertAcknowledgeResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/alerts/${encodeURIComponent(alertId)}/acknowledge`,
+    {
+      method: "PATCH",
+      credentials: "include",
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to acknowledge alert: ${response.status}`
+    );
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- **Predictive Alert Engine**: Calculates glucose trajectory at 20/30/45-minute horizons using linear projection from current trend rate
- **Threshold Crossing Detection**: Checks current and predicted values against user-configured thresholds (urgent low, low warning, high warning, urgent high)
- **IoB-Based Severity Escalation**: Escalates LOW alert severity when Insulin on Board exceeds 80% of the user's IoB warning threshold (WARNING -> URGENT -> EMERGENCY)
- **Alert Deduplication**: 30-minute window prevents duplicate alerts of the same type; acknowledged alerts no longer block new alerts
- **Alert Expiration**: Alerts auto-expire after 60 minutes
- **Background Scheduler**: Runs alert evaluation every 5 minutes for all users with active Dexcom or Tandem integrations
- **Frontend Active Alerts**: Real-time display with severity-colored cards, 60-second polling, and acknowledge functionality
- **36 tests**: Trajectory calculation, severity determination, threshold crossings, IoB thresholds, deduplication, endpoint auth/validation, and full pipeline happy path

### New Files
| File | Purpose |
|------|---------|
| `apps/api/src/models/alert.py` | Alert model with AlertType/AlertSeverity enums |
| `apps/api/src/schemas/alert.py` | Pydantic response schemas |
| `apps/api/src/services/predictive_alerts.py` | Core engine: trajectory, thresholds, IoB, dedup, persistence |
| `apps/api/src/routers/alerts.py` | GET /api/alerts/active, PATCH /api/alerts/{id}/acknowledge |
| `apps/api/migrations/versions/016_create_alerts.py` | Alerts table with PostgreSQL ENUMs and indexes |
| `apps/api/tests/test_predictive_alerts.py` | 36 tests covering all engine components |

### Modified Files
| File | Change |
|------|--------|
| `apps/api/src/config.py` | Added `alert_check_interval_minutes` and `alert_check_enabled` settings |
| `apps/api/src/main.py` | Registered alerts router |
| `apps/api/src/models/__init__.py` | Exported Alert, AlertSeverity, AlertType |
| `apps/api/src/models/user.py` | Added `alerts` relationship |
| `apps/api/src/services/scheduler.py` | Added `check_alerts_all_users` job (Dexcom + Tandem) |
| `apps/web/src/lib/api.ts` | Added PredictiveAlert types and API client functions |
| `apps/web/src/app/dashboard/alerts/page.tsx` | Active alerts display with severity cards and acknowledge |

## Test plan
- [x] 36 unit tests pass (trajectory, severity, thresholds, IoB, dedup, endpoints, happy path)
- [x] Full suite: 426 passed, 1 skipped
- [x] Ruff lint and format clean
- [x] Next.js ESLint clean
- [x] Playwright visual verification of alerts page and dashboard
- [x] Adversarial code review completed with 6 fixes applied and re-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)