### PR TITLE
feat(web): add AlertCard component with acknowledgment (Story 6.4)

### DIFF
--- a/apps/web/src/app/dashboard/alerts/page.tsx
+++ b/apps/web/src/app/dashboard/alerts/page.tsx
@@ -22,11 +22,6 @@ import {
   Loader2,
   AlertTriangle,
   Check,
-  CheckCircle,
-  Clock,
-  TrendingDown,
-  TrendingUp,
-  Syringe,
   Volume2,
   BellRing,
 } from "lucide-react";
@@ -41,6 +36,7 @@ import {
 } from "@/lib/api";
 import { useAlertNotifications } from "@/providers";
 import { requestNotificationPermission } from "@/lib/browser-notifications";
+import { AlertCard } from "@/components/dashboard/alert-card";
 
 const DEFAULTS = {
   low_warning: 70,
@@ -113,52 +109,6 @@ const THRESHOLD_FIELDS: ThresholdFieldConfig[] = [
     color: "text-purple-400",
   },
 ];
-
-const SEVERITY_CONFIG: Record<
-  string,
-  { bg: string; border: string; text: string; icon: string }
-> = {
-  emergency: {
-    bg: "bg-red-500/15",
-    border: "border-red-500/30",
-    text: "text-red-400",
-    icon: "text-red-400",
-  },
-  urgent: {
-    bg: "bg-red-500/10",
-    border: "border-red-500/20",
-    text: "text-red-400",
-    icon: "text-red-400",
-  },
-  warning: {
-    bg: "bg-amber-500/10",
-    border: "border-amber-500/20",
-    text: "text-amber-400",
-    icon: "text-amber-400",
-  },
-  info: {
-    bg: "bg-blue-500/10",
-    border: "border-blue-500/20",
-    text: "text-blue-400",
-    icon: "text-blue-400",
-  },
-};
-
-function getAlertIcon(alertType: string) {
-  if (alertType.includes("low")) return TrendingDown;
-  if (alertType.includes("high")) return TrendingUp;
-  if (alertType === "iob_warning") return Syringe;
-  return AlertTriangle;
-}
-
-function formatTimeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  return `${hours}h ago`;
-}
 
 export default function AlertsPage() {
   const [formValues, setFormValues] = useState<AlertThresholdUpdate>({});
@@ -544,85 +494,15 @@ export default function AlertsPage() {
         )}
 
         {!alertsLoading && activeAlerts.length > 0 && (
-          <div className="space-y-3" role="list" aria-label="Active alerts">
-            {activeAlerts.map((alert) => {
-              const config = SEVERITY_CONFIG[alert.severity] ?? SEVERITY_CONFIG.info;
-              const Icon = getAlertIcon(alert.alert_type);
-              return (
-                <div
-                  key={alert.id}
-                  className={clsx(
-                    "rounded-lg p-4 border",
-                    config.bg,
-                    config.border
-                  )}
-                  role="listitem"
-                >
-                  <div className="flex items-start gap-3">
-                    <Icon
-                      className={clsx("h-5 w-5 mt-0.5 shrink-0", config.icon)}
-                      aria-hidden="true"
-                    />
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span
-                          className={clsx(
-                            "text-xs font-medium uppercase tracking-wider",
-                            config.text
-                          )}
-                        >
-                          {alert.severity}
-                        </span>
-                        {alert.source === "predictive" && (
-                          <span className="text-xs text-slate-500">
-                            Predicted
-                          </span>
-                        )}
-                      </div>
-                      <p className={clsx("text-sm", config.text)}>
-                        {alert.message}
-                      </p>
-                      <div className="flex items-center gap-3 mt-2 text-xs text-slate-500">
-                        <span className="flex items-center gap-1">
-                          <Clock className="h-3 w-3" aria-hidden="true" />
-                          {formatTimeAgo(alert.created_at)}
-                        </span>
-                        {alert.iob_value != null && (
-                          <span>IoB: {alert.iob_value.toFixed(1)}u</span>
-                        )}
-                        {alert.prediction_minutes != null && (
-                          <span>
-                            {alert.prediction_minutes}min prediction
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    <button
-                      onClick={() => handleAcknowledge(alert.id)}
-                      disabled={acknowledgingId === alert.id}
-                      className={clsx(
-                        "flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium",
-                        "bg-slate-800/50 text-slate-300 hover:bg-slate-700",
-                        "transition-colors shrink-0",
-                        "focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500",
-                        "disabled:opacity-50 disabled:cursor-not-allowed"
-                      )}
-                      aria-label={`Acknowledge ${alert.alert_type.replace("_", " ")} alert`}
-                    >
-                      {acknowledgingId === alert.id ? (
-                        <Loader2
-                          className="h-3 w-3 animate-spin"
-                          aria-hidden="true"
-                        />
-                      ) : (
-                        <CheckCircle className="h-3 w-3" aria-hidden="true" />
-                      )}
-                      Acknowledge
-                    </button>
-                  </div>
-                </div>
-              );
-            })}
+          <div className="space-y-3">
+            {activeAlerts.map((alert) => (
+              <AlertCard
+                key={alert.id}
+                alert={alert}
+                onAcknowledge={handleAcknowledge}
+                isAcknowledging={acknowledgingId === alert.id}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/apps/web/src/components/dashboard/alert-card.tsx
+++ b/apps/web/src/components/dashboard/alert-card.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+/**
+ * Story 6.4: AlertCard Component with Acknowledgment.
+ *
+ * Displays a predictive alert with severity styling, glucose values,
+ * prediction details, countdown timer, and a large acknowledge button
+ * (56px min-height for hypoglycemia fine motor control).
+ *
+ * Accessibility: role="alert", aria-labels, focus-visible rings, 56px touch target.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { CheckCircle, Clock, Loader2 } from "lucide-react";
+import clsx from "clsx";
+import type { PredictiveAlert } from "@/lib/api";
+import {
+  SEVERITY_CONFIG,
+  getAlertIcon,
+  formatAlertTitle,
+  formatTimeAgo,
+  formatCountdown,
+} from "@/lib/alert-utils";
+
+export interface AlertCardProps {
+  alert: PredictiveAlert;
+  onAcknowledge: (alertId: string) => Promise<void>;
+  isAcknowledging?: boolean;
+}
+
+export function AlertCard({
+  alert,
+  onAcknowledge,
+  isAcknowledging = false,
+}: AlertCardProps) {
+  const config = SEVERITY_CONFIG[alert.severity] ?? SEVERITY_CONFIG.info;
+  const Icon = getAlertIcon(alert.alert_type);
+  const title = formatAlertTitle(alert.alert_type);
+
+  // Countdown timer
+  const [countdown, setCountdown] = useState<string | null>(() =>
+    formatCountdown(alert.expires_at)
+  );
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      const remaining = formatCountdown(alert.expires_at);
+      setCountdown(remaining);
+      if (remaining === null && intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    }, 1000);
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [alert.expires_at]);
+
+  const isExpired = countdown === null;
+
+  return (
+    <div
+      className={clsx(
+        "rounded-xl border p-5 transition-all",
+        config.bg,
+        config.border,
+        config.animation
+      )}
+      role="alert"
+      aria-label={`${alert.severity} alert: ${title}`}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-3">
+        <Icon
+          className={clsx("h-5 w-5 shrink-0", config.icon)}
+          aria-hidden="true"
+        />
+        <span
+          className={clsx(
+            "text-xs font-semibold uppercase tracking-wider",
+            config.text
+          )}
+        >
+          {alert.severity}
+        </span>
+        <span className="text-sm font-medium text-slate-200">{title}</span>
+        {alert.source === "predictive" && (
+          <span className="ml-auto text-xs text-slate-500">Predicted</span>
+        )}
+      </div>
+
+      {/* Glucose values */}
+      <div className="flex items-baseline gap-4 mb-3">
+        <div>
+          <span className={clsx("text-2xl font-bold", config.text)}>
+            {alert.current_value}
+          </span>
+          <span className="text-sm text-slate-400 ml-1">mg/dL</span>
+        </div>
+        {alert.predicted_value != null && alert.prediction_minutes != null && (
+          <div className="text-sm text-slate-400">
+            <span className="mr-1">&rarr;</span>
+            <span className={clsx("font-medium", config.text)}>
+              {alert.predicted_value}
+            </span>
+            <span className="ml-1">
+              mg/dL in {alert.prediction_minutes}min
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Message / Recommended action */}
+      <p className={clsx("text-sm mb-3", config.text)}>{alert.message}</p>
+
+      {/* Metadata */}
+      <div className="flex items-center gap-4 mb-4 text-xs text-slate-500">
+        <span className="flex items-center gap-1">
+          <Clock className="h-3 w-3" aria-hidden="true" />
+          {formatTimeAgo(alert.created_at)}
+        </span>
+        {alert.iob_value != null && (
+          <span>IoB: {alert.iob_value.toFixed(1)}u</span>
+        )}
+        {alert.trend_rate != null && (
+          <span>
+            {alert.trend_rate > 0 ? "+" : ""}
+            {alert.trend_rate.toFixed(1)} mg/dL/min
+          </span>
+        )}
+      </div>
+
+      {/* Countdown timer */}
+      {!isExpired && (
+        <div
+          className="flex items-center gap-2 mb-4 text-xs text-slate-400"
+          aria-hidden="true"
+        >
+          <Clock className="h-3 w-3" aria-hidden="true" />
+          <span>Expires in {countdown}</span>
+        </div>
+      )}
+      {isExpired && (
+        <div className="flex items-center gap-2 mb-4 text-xs text-slate-500">
+          <Clock className="h-3 w-3" aria-hidden="true" />
+          <span>Expired</span>
+        </div>
+      )}
+
+      {/* Acknowledge button - 56px min height for hypoglycemia fine motor control */}
+      <button
+        type="button"
+        onClick={() => onAcknowledge(alert.id)}
+        disabled={isAcknowledging || isExpired}
+        className={clsx(
+          "flex items-center justify-center gap-2 w-full rounded-lg",
+          "min-h-[56px] px-4 py-3 text-base font-semibold",
+          "transition-colors",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+          "disabled:opacity-50 disabled:cursor-not-allowed",
+          isExpired
+            ? "bg-slate-800/30 text-slate-500"
+            : "bg-slate-800/50 text-slate-200 hover:bg-slate-700"
+        )}
+        aria-label={`Acknowledge ${alert.alert_type.replace(/_/g, " ")} alert`}
+      >
+        {isAcknowledging ? (
+          <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+        ) : (
+          <CheckCircle className="h-5 w-5" aria-hidden="true" />
+        )}
+        {isAcknowledging ? "Acknowledging..." : "Acknowledge"}
+      </button>
+    </div>
+  );
+}
+

--- a/apps/web/src/components/dashboard/alert-toast.tsx
+++ b/apps/web/src/components/dashboard/alert-toast.tsx
@@ -11,9 +11,10 @@
  */
 
 import { useEffect, useRef, useState, useCallback } from "react";
-import { X, TrendingDown, TrendingUp, Syringe, AlertTriangle } from "lucide-react";
+import { X } from "lucide-react";
 import clsx from "clsx";
 import type { AlertEventData } from "@/hooks/use-glucose-stream";
+import { getAlertIcon } from "@/lib/alert-utils";
 
 const TOAST_CONFIG: Record<
   string,
@@ -54,13 +55,6 @@ const TOAST_CONFIG: Record<
     animation: "",
   },
 };
-
-function getAlertIcon(alertType: string) {
-  if (alertType.includes("low")) return TrendingDown;
-  if (alertType.includes("high")) return TrendingUp;
-  if (alertType === "iob_warning") return Syringe;
-  return AlertTriangle;
-}
 
 export interface AlertToastProps {
   alert: AlertEventData;

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -51,3 +51,5 @@ export {
   type AIInsightCardProps,
   type InsightData,
 } from "./ai-insight-card";
+
+export { AlertCard, type AlertCardProps } from "./alert-card";

--- a/apps/web/src/lib/alert-utils.ts
+++ b/apps/web/src/lib/alert-utils.ts
@@ -1,0 +1,94 @@
+/**
+ * Story 6.4: Shared alert utilities.
+ *
+ * Consolidates severity config, icon mapping, and time formatting
+ * used by AlertCard, AlertToast, and the alerts page.
+ */
+
+import {
+  TrendingDown,
+  TrendingUp,
+  Syringe,
+  AlertTriangle,
+  type LucideIcon,
+} from "lucide-react";
+
+/** Visual config per alert severity level */
+export const SEVERITY_CONFIG: Record<
+  string,
+  { bg: string; border: string; text: string; icon: string; animation: string }
+> = {
+  emergency: {
+    bg: "bg-red-500/15",
+    border: "border-red-500/30",
+    text: "text-red-400",
+    icon: "text-red-400",
+    animation: "animate-pulse-fast",
+  },
+  urgent: {
+    bg: "bg-orange-500/10",
+    border: "border-orange-500/20",
+    text: "text-orange-400",
+    icon: "text-orange-400",
+    animation: "animate-pulse-slow",
+  },
+  warning: {
+    bg: "bg-amber-500/10",
+    border: "border-amber-500/20",
+    text: "text-amber-400",
+    icon: "text-amber-400",
+    animation: "",
+  },
+  info: {
+    bg: "bg-blue-500/10",
+    border: "border-blue-500/20",
+    text: "text-blue-400",
+    icon: "text-blue-400",
+    animation: "",
+  },
+};
+
+/** Map alert_type string to a lucide-react icon component */
+export function getAlertIcon(alertType: string): LucideIcon {
+  if (alertType.includes("low")) return TrendingDown;
+  if (alertType.includes("high")) return TrendingUp;
+  if (alertType === "iob_warning") return Syringe;
+  return AlertTriangle;
+}
+
+/** Format a date string as relative time (e.g., "5m ago") */
+export function formatTimeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  if (diff < 0) return "just now";
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+/** Format expires_at as countdown string "M:SS", or null if expired */
+export function formatCountdown(expiresAt: string): string | null {
+  const remaining = new Date(expiresAt).getTime() - Date.now();
+  if (remaining <= 0) return null;
+  const totalSeconds = Math.floor(remaining / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+const ALERT_TYPE_LABELS: Record<string, string> = {
+  low_urgent: "Urgent Low Glucose",
+  low_warning: "Low Glucose Warning",
+  high_warning: "High Glucose Warning",
+  high_urgent: "Urgent High Glucose",
+  iob_warning: "Insulin on Board Warning",
+};
+
+/** Convert alert_type to human-readable title */
+export function formatAlertTitle(alertType: string): string {
+  return (
+    ALERT_TYPE_LABELS[alertType] ??
+    alertType.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+}


### PR DESCRIPTION
## Summary
- Create reusable `AlertCard` component with severity-based styling, countdown timer, and 56px acknowledge button (hypoglycemia fine motor control)
- Extract shared `alert-utils.ts` module consolidating `SEVERITY_CONFIG`, `getAlertIcon`, `formatTimeAgo`, `formatCountdown`, and `formatAlertTitle`
- Refactor alerts page to use `AlertCard`, removing ~120 lines of duplicated inline rendering
- Deduplicate `AlertToast` icon helper to import from shared utilities

## New Files
| File | Purpose |
|------|---------|
| `apps/web/src/lib/alert-utils.ts` | Shared severity config, icon mapping, time formatting |
| `apps/web/src/components/dashboard/alert-card.tsx` | AlertCard component with countdown timer and 56px button |

## Modified Files
| File | Change |
|------|--------|
| `apps/web/src/components/dashboard/index.ts` | Added AlertCard barrel export |
| `apps/web/src/app/dashboard/alerts/page.tsx` | Replaced inline alert rendering with AlertCard |
| `apps/web/src/components/dashboard/alert-toast.tsx` | Replaced local getAlertIcon with shared import |

## Adversarial Review
11 findings (1 HIGH, 3 MEDIUM, 5 LOW, 1 INFO). 4 bugs fixed:
- Guard `formatTimeAgo` against future dates (clock skew)
- Remove dual export pattern (named-only, matching codebase conventions)
- Use `aria-hidden` on countdown timer to prevent screen reader noise
- Add `type="button"` on acknowledge button for defensive coding

## Test plan
- [x] `npx next lint` — clean
- [x] `uv run pytest tests/` — 430 passed, 1 skipped
- [x] Playwright MCP: `/dashboard/alerts` renders with all sections (thresholds, alerts, preferences)
- [x] Playwright MCP: `/dashboard` core functionality intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)