### PR TITLE
feat: add emergency contact configuration (Story 6.5)

### DIFF
--- a/apps/api/migrations/versions/017_create_emergency_contacts.py
+++ b/apps/api/migrations/versions/017_create_emergency_contacts.py
@@ -1,0 +1,77 @@
+"""Story 6.5: Create emergency_contacts table.
+
+Revision ID: 017_emergency_contacts
+Revises: 016_alerts
+Create Date: 2026-02-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "017_emergency_contacts"
+down_revision = "016_alerts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create enum type using raw SQL to avoid checkfirst issues with asyncpg
+    op.execute(sa.text(
+        "DO $$ BEGIN "
+        "CREATE TYPE contactpriority AS ENUM ('primary', 'secondary'); "
+        "EXCEPTION WHEN duplicate_object THEN NULL; "
+        "END $$"
+    ))
+
+    op.create_table(
+        "emergency_contacts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("telegram_username", sa.String(100), nullable=False),
+        sa.Column(
+            "priority",
+            postgresql.ENUM(name="contactpriority", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    # Index for querying contacts by user
+    op.create_index(
+        "ix_emergency_contacts_user_id",
+        "emergency_contacts",
+        ["user_id"],
+    )
+
+    # Unique constraint: one telegram username per user
+    op.create_unique_constraint(
+        "uq_emergency_contacts_user_telegram",
+        "emergency_contacts",
+        ["user_id", "telegram_username"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_emergency_contacts_user_telegram", "emergency_contacts")
+    op.drop_index("ix_emergency_contacts_user_id")
+    op.drop_table("emergency_contacts")
+    op.execute("DROP TYPE IF EXISTS contactpriority")

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -17,6 +17,7 @@ from src.routers import (
     briefs,
     correction_analysis,
     disclaimer,
+    emergency_contacts,
     glucose_stream,
     health,
     insights,
@@ -95,6 +96,7 @@ app.include_router(safety.router)
 app.include_router(insights.router)
 app.include_router(settings_router.router)
 app.include_router(alerts.router)
+app.include_router(emergency_contacts.router)
 
 
 @app.get("/")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -6,6 +6,7 @@ from src.models.base import Base, TimestampMixin
 from src.models.correction_analysis import CorrectionAnalysis
 from src.models.daily_brief import DailyBrief
 from src.models.disclaimer import DisclaimerAcknowledgment
+from src.models.emergency_contact import ContactPriority, EmergencyContact
 from src.models.glucose import GlucoseReading, TrendDirection
 from src.models.integration import (
     IntegrationCredential,
@@ -27,10 +28,12 @@ __all__ = [
     "AlertThreshold",
     "AlertType",
     "Base",
+    "ContactPriority",
     "CorrectionAnalysis",
     "TimestampMixin",
     "DailyBrief",
     "DisclaimerAcknowledgment",
+    "EmergencyContact",
     "MealAnalysis",
     "GlucoseReading",
     "TrendDirection",

--- a/apps/api/src/models/emergency_contact.py
+++ b/apps/api/src/models/emergency_contact.py
@@ -1,0 +1,80 @@
+"""Story 6.5: Emergency contact model.
+
+Stores emergency contacts for alert escalation. Each user can have
+up to 3 contacts with primary/secondary priority levels.
+"""
+
+import enum
+import uuid
+
+from sqlalchemy import Enum, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class ContactPriority(str, enum.Enum):
+    """Priority level for emergency contacts."""
+
+    PRIMARY = "primary"
+    SECONDARY = "secondary"
+
+
+class EmergencyContact(Base, TimestampMixin):
+    """Emergency contact for alert escalation.
+
+    Each contact has a name, Telegram username, priority level,
+    and position for ordering within the same priority.
+    """
+
+    __tablename__ = "emergency_contacts"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    name: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+    )
+
+    telegram_username: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+    )
+
+    priority: Mapped[ContactPriority] = mapped_column(
+        Enum(
+            ContactPriority,
+            name="contactpriority",
+            create_type=False,
+            values_callable=lambda e: [member.value for member in e],
+        ),
+        nullable=False,
+    )
+
+    position: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+    )
+
+    # Relationship to user
+    user = relationship("User", back_populates="emergency_contacts")
+
+    def __repr__(self) -> str:
+        return (
+            f"<EmergencyContact(name={self.name!r}, "
+            f"telegram=@{self.telegram_username}, "
+            f"priority={self.priority.value})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -140,6 +140,11 @@ class User(Base, TimestampMixin):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    emergency_contacts = relationship(
+        "EmergencyContact",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/routers/emergency_contacts.py
+++ b/apps/api/src/routers/emergency_contacts.py
@@ -1,0 +1,109 @@
+"""Story 6.5: Emergency contacts router.
+
+CRUD endpoints for managing emergency contacts used in alert escalation.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import get_current_user
+from src.database import get_db
+from src.models.user import User
+from src.schemas.emergency_contact import (
+    EmergencyContactCreate,
+    EmergencyContactListResponse,
+    EmergencyContactResponse,
+    EmergencyContactUpdate,
+)
+from src.services.emergency_contact import (
+    create_contact,
+    delete_contact,
+    list_contacts,
+    update_contact,
+)
+
+router = APIRouter(
+    prefix="/api/settings/emergency-contacts",
+    tags=["emergency-contacts"],
+)
+
+
+@router.get("", response_model=EmergencyContactListResponse)
+async def get_contacts(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EmergencyContactListResponse:
+    """List all emergency contacts for the current user."""
+    contacts = await list_contacts(user.id, db)
+    return EmergencyContactListResponse(
+        contacts=[EmergencyContactResponse.model_validate(c) for c in contacts],
+        count=len(contacts),
+    )
+
+
+@router.post(
+    "",
+    response_model=EmergencyContactResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_contact(
+    data: EmergencyContactCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EmergencyContactResponse:
+    """Create a new emergency contact.
+
+    Maximum 3 contacts per user. Returns 409 if the telegram
+    username is already registered for this user.
+    """
+    try:
+        contact = await create_contact(user.id, data, db)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    return EmergencyContactResponse.model_validate(contact)
+
+
+@router.patch("/{contact_id}", response_model=EmergencyContactResponse)
+async def edit_contact(
+    contact_id: uuid.UUID,
+    data: EmergencyContactUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EmergencyContactResponse:
+    """Update an existing emergency contact."""
+    try:
+        contact = await update_contact(user.id, contact_id, data, db)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    if contact is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Emergency contact not found",
+        )
+
+    return EmergencyContactResponse.model_validate(contact)
+
+
+@router.delete("/{contact_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_contact(
+    contact_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete an emergency contact."""
+    deleted = await delete_contact(user.id, contact_id, db)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Emergency contact not found",
+        )

--- a/apps/api/src/schemas/emergency_contact.py
+++ b/apps/api/src/schemas/emergency_contact.py
@@ -1,0 +1,119 @@
+"""Story 6.5: Emergency contact schemas."""
+
+import re
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+from src.models.emergency_contact import ContactPriority
+
+TELEGRAM_USERNAME_RE = re.compile(r"^[a-zA-Z0-9_]{5,32}$")
+
+
+class EmergencyContactCreate(BaseModel):
+    """Request schema for creating an emergency contact."""
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Contact name (1-100 characters).",
+    )
+    telegram_username: str = Field(
+        ...,
+        min_length=5,
+        max_length=32,
+        description="Telegram username (5-32 alphanumeric/underscore, @ prefix stripped).",
+    )
+    priority: ContactPriority = Field(
+        ...,
+        description="Contact priority: primary or secondary.",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            msg = "Name cannot be empty or whitespace only"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("telegram_username")
+    @classmethod
+    def validate_telegram_username(cls, v: str) -> str:
+        # Strip leading @ if provided
+        v = v.lstrip("@").strip()
+        if not TELEGRAM_USERNAME_RE.match(v):
+            msg = (
+                "Telegram username must be 5-32 characters, "
+                "alphanumeric or underscores only"
+            )
+            raise ValueError(msg)
+        return v
+
+
+class EmergencyContactUpdate(BaseModel):
+    """Request schema for updating an emergency contact. All fields optional."""
+
+    name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=100,
+        description="Contact name (1-100 characters).",
+    )
+    telegram_username: str | None = Field(
+        default=None,
+        min_length=5,
+        max_length=32,
+        description="Telegram username (5-32 alphanumeric/underscore, @ prefix stripped).",
+    )
+    priority: ContactPriority | None = Field(
+        default=None,
+        description="Contact priority: primary or secondary.",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, v: str | None) -> str | None:
+        if v is not None:
+            v = v.strip()
+            if not v:
+                msg = "Name cannot be empty or whitespace only"
+                raise ValueError(msg)
+        return v
+
+    @field_validator("telegram_username")
+    @classmethod
+    def validate_telegram_username(cls, v: str | None) -> str | None:
+        if v is not None:
+            v = v.lstrip("@").strip()
+            if not TELEGRAM_USERNAME_RE.match(v):
+                msg = (
+                    "Telegram username must be 5-32 characters, "
+                    "alphanumeric or underscores only"
+                )
+                raise ValueError(msg)
+        return v
+
+
+class EmergencyContactResponse(BaseModel):
+    """Response schema for a single emergency contact."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    name: str
+    telegram_username: str
+    priority: ContactPriority
+    position: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class EmergencyContactListResponse(BaseModel):
+    """Response schema for listing emergency contacts."""
+
+    contacts: list[EmergencyContactResponse]
+    count: int

--- a/apps/api/src/services/emergency_contact.py
+++ b/apps/api/src/services/emergency_contact.py
@@ -1,0 +1,165 @@
+"""Story 6.5: Emergency contact service.
+
+CRUD operations for emergency contacts with a per-user limit of 3.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.emergency_contact import EmergencyContact
+from src.schemas.emergency_contact import (
+    EmergencyContactCreate,
+    EmergencyContactUpdate,
+)
+
+logger = get_logger(__name__)
+
+MAX_CONTACTS_PER_USER = 3
+
+
+async def list_contacts(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> list[EmergencyContact]:
+    """List all emergency contacts for a user, ordered by priority then position."""
+    result = await db.execute(
+        select(EmergencyContact)
+        .where(EmergencyContact.user_id == user_id)
+        .order_by(EmergencyContact.priority, EmergencyContact.position)
+    )
+    return list(result.scalars().all())
+
+
+async def get_contact(
+    user_id: uuid.UUID,
+    contact_id: uuid.UUID,
+    db: AsyncSession,
+) -> EmergencyContact | None:
+    """Get a single emergency contact, scoped to the user."""
+    result = await db.execute(
+        select(EmergencyContact).where(
+            EmergencyContact.id == contact_id,
+            EmergencyContact.user_id == user_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def create_contact(
+    user_id: uuid.UUID,
+    data: EmergencyContactCreate,
+    db: AsyncSession,
+) -> EmergencyContact:
+    """Create a new emergency contact.
+
+    Uses SELECT FOR UPDATE to prevent race conditions on the contact limit.
+
+    Raises:
+        ValueError: If the user already has MAX_CONTACTS_PER_USER contacts.
+        ValueError: If the telegram username already exists for this user.
+    """
+    # Lock existing rows to prevent concurrent inserts bypassing the limit
+    result = await db.execute(
+        select(EmergencyContact)
+        .where(EmergencyContact.user_id == user_id)
+        .with_for_update()
+    )
+    existing = list(result.scalars().all())
+
+    if len(existing) >= MAX_CONTACTS_PER_USER:
+        msg = f"Maximum of {MAX_CONTACTS_PER_USER} emergency contacts allowed"
+        raise ValueError(msg)
+
+    # Use max position + 1 to avoid gaps/collisions after deletes
+    position = max((c.position for c in existing), default=-1) + 1
+
+    contact = EmergencyContact(
+        user_id=user_id,
+        name=data.name,
+        telegram_username=data.telegram_username,
+        priority=data.priority,
+        position=position,
+    )
+    db.add(contact)
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        msg = "A contact with this Telegram username already exists for this user"
+        raise ValueError(msg)  # noqa: B904
+
+    await db.refresh(contact)
+
+    logger.info(
+        "Created emergency contact",
+        user_id=str(user_id),
+        contact_id=str(contact.id),
+        telegram=data.telegram_username,
+    )
+
+    return contact
+
+
+async def update_contact(
+    user_id: uuid.UUID,
+    contact_id: uuid.UUID,
+    updates: EmergencyContactUpdate,
+    db: AsyncSession,
+) -> EmergencyContact | None:
+    """Update an emergency contact. Returns None if not found.
+
+    Raises:
+        ValueError: If updating telegram_username to a duplicate.
+    """
+    contact = await get_contact(user_id, contact_id, db)
+    if contact is None:
+        return None
+
+    update_data = updates.model_dump(exclude_none=True)
+    for field, value in update_data.items():
+        setattr(contact, field, value)
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        msg = "A contact with this Telegram username already exists for this user"
+        raise ValueError(msg)  # noqa: B904
+
+    await db.refresh(contact)
+
+    logger.info(
+        "Updated emergency contact",
+        user_id=str(user_id),
+        contact_id=str(contact_id),
+        fields=list(update_data.keys()),
+    )
+
+    return contact
+
+
+async def delete_contact(
+    user_id: uuid.UUID,
+    contact_id: uuid.UUID,
+    db: AsyncSession,
+) -> bool:
+    """Delete an emergency contact. Returns True if deleted, False if not found."""
+    contact = await get_contact(user_id, contact_id, db)
+    if contact is None:
+        return False
+
+    await db.delete(contact)
+    await db.commit()
+
+    logger.info(
+        "Deleted emergency contact",
+        user_id=str(user_id),
+        contact_id=str(contact_id),
+    )
+
+    return True

--- a/apps/api/tests/test_emergency_contacts.py
+++ b/apps/api/tests/test_emergency_contacts.py
@@ -1,0 +1,567 @@
+"""Story 6.5: Tests for emergency contact schemas, service, and endpoints."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from src.config import settings
+from src.models.emergency_contact import ContactPriority
+from src.schemas.emergency_contact import (
+    EmergencyContactCreate,
+    EmergencyContactUpdate,
+)
+from src.services.emergency_contact import (
+    MAX_CONTACTS_PER_USER,
+    create_contact,
+    delete_contact,
+    get_contact,
+    list_contacts,
+)
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("ec")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+# ── Schema validation tests ──
+
+
+class TestEmergencyContactCreate:
+    """Tests for EmergencyContactCreate schema validation."""
+
+    def test_valid_create(self):
+        data = EmergencyContactCreate(
+            name="Mom",
+            telegram_username="mom_user",
+            priority=ContactPriority.PRIMARY,
+        )
+        assert data.name == "Mom"
+        assert data.telegram_username == "mom_user"
+        assert data.priority == ContactPriority.PRIMARY
+
+    def test_strips_at_prefix(self):
+        data = EmergencyContactCreate(
+            name="Mom",
+            telegram_username="@mom_user",
+            priority=ContactPriority.PRIMARY,
+        )
+        assert data.telegram_username == "mom_user"
+
+    def test_strips_name_whitespace(self):
+        data = EmergencyContactCreate(
+            name="  Mom  ",
+            telegram_username="mom_user",
+            priority=ContactPriority.PRIMARY,
+        )
+        assert data.name == "Mom"
+
+    def test_name_too_long(self):
+        with pytest.raises(ValidationError, match="String should have at most 100"):
+            EmergencyContactCreate(
+                name="x" * 101,
+                telegram_username="mom_user",
+                priority=ContactPriority.PRIMARY,
+            )
+
+    def test_name_empty(self):
+        with pytest.raises(ValidationError):
+            EmergencyContactCreate(
+                name="",
+                telegram_username="mom_user",
+                priority=ContactPriority.PRIMARY,
+            )
+
+    def test_name_whitespace_only(self):
+        with pytest.raises(ValidationError, match="empty or whitespace"):
+            EmergencyContactCreate(
+                name="   ",
+                telegram_username="mom_user",
+                priority=ContactPriority.PRIMARY,
+            )
+
+    def test_telegram_username_too_short(self):
+        with pytest.raises(ValidationError):
+            EmergencyContactCreate(
+                name="Mom",
+                telegram_username="abc",
+                priority=ContactPriority.PRIMARY,
+            )
+
+    def test_telegram_username_invalid_chars(self):
+        with pytest.raises(ValidationError, match="alphanumeric"):
+            EmergencyContactCreate(
+                name="Mom",
+                telegram_username="bad-user!",
+                priority=ContactPriority.PRIMARY,
+            )
+
+    def test_telegram_username_too_long(self):
+        with pytest.raises(ValidationError):
+            EmergencyContactCreate(
+                name="Mom",
+                telegram_username="a" * 33,
+                priority=ContactPriority.PRIMARY,
+            )
+
+    def test_valid_secondary_priority(self):
+        data = EmergencyContactCreate(
+            name="Brother",
+            telegram_username="bro_user",
+            priority=ContactPriority.SECONDARY,
+        )
+        assert data.priority == ContactPriority.SECONDARY
+
+    def test_invalid_priority(self):
+        with pytest.raises(ValidationError):
+            EmergencyContactCreate(
+                name="Mom",
+                telegram_username="mom_user",
+                priority="invalid",
+            )
+
+
+class TestEmergencyContactUpdate:
+    """Tests for EmergencyContactUpdate schema validation."""
+
+    def test_all_none_is_valid(self):
+        update = EmergencyContactUpdate()
+        assert update.name is None
+        assert update.telegram_username is None
+        assert update.priority is None
+
+    def test_partial_update_name(self):
+        update = EmergencyContactUpdate(name="Dad")
+        assert update.name == "Dad"
+        assert update.telegram_username is None
+
+    def test_partial_update_telegram(self):
+        update = EmergencyContactUpdate(telegram_username="@new_user")
+        assert update.telegram_username == "new_user"
+
+    def test_invalid_telegram_format(self):
+        with pytest.raises(ValidationError, match="alphanumeric"):
+            EmergencyContactUpdate(telegram_username="bad user!")
+
+
+# ── Service tests ──
+
+
+class TestListContacts:
+    """Tests for list_contacts service function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(self):
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        contacts = await list_contacts(uuid.uuid4(), mock_db)
+        assert contacts == []
+
+    @pytest.mark.asyncio
+    async def test_returns_contacts(self):
+        c1 = MagicMock()
+        c2 = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [c1, c2]
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        contacts = await list_contacts(uuid.uuid4(), mock_db)
+        assert len(contacts) == 2
+
+
+class TestCreateContact:
+    """Tests for create_contact service function."""
+
+    @pytest.mark.asyncio
+    async def test_create_success(self):
+        user_id = uuid.uuid4()
+        data = EmergencyContactCreate(
+            name="Mom",
+            telegram_username="mom_user",
+            priority=ContactPriority.PRIMARY,
+        )
+
+        # Mock list returning empty (under limit)
+        mock_list_result = MagicMock()
+        mock_list_result.scalars.return_value.all.return_value = []
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_list_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        contact = await create_contact(user_id, data, mock_db)
+        assert contact.name == "Mom"
+        assert contact.telegram_username == "mom_user"
+        assert contact.position == 0
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_at_limit_raises(self):
+        user_id = uuid.uuid4()
+        data = EmergencyContactCreate(
+            name="Fourth",
+            telegram_username="fourth_user",
+            priority=ContactPriority.SECONDARY,
+        )
+
+        # Mock list returning MAX contacts
+        existing = [MagicMock() for _ in range(MAX_CONTACTS_PER_USER)]
+        mock_list_result = MagicMock()
+        mock_list_result.scalars.return_value.all.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_list_result
+
+        with pytest.raises(ValueError, match="Maximum of 3"):
+            await create_contact(user_id, data, mock_db)
+
+
+class TestGetContact:
+    """Tests for get_contact service function."""
+
+    @pytest.mark.asyncio
+    async def test_not_found(self):
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await get_contact(uuid.uuid4(), uuid.uuid4(), mock_db)
+        assert result is None
+
+
+class TestDeleteContact:
+    """Tests for delete_contact service function."""
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found(self):
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await delete_contact(uuid.uuid4(), uuid.uuid4(), mock_db)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self):
+        existing = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+        mock_db.delete = AsyncMock()
+        mock_db.commit = AsyncMock()
+
+        result = await delete_contact(uuid.uuid4(), uuid.uuid4(), mock_db)
+        assert result is True
+        mock_db.delete.assert_called_once_with(existing)
+        mock_db.commit.assert_called_once()
+
+
+# ── Endpoint tests ──
+
+
+class TestGetEmergencyContactsEndpoint:
+    """Tests for GET /api/settings/emergency-contacts."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.get("/api/settings/emergency-contacts")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authenticated_returns_empty_list(self, client):
+        cookie = await register_and_login(client)
+        response = await client.get(
+            "/api/settings/emergency-contacts",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["contacts"] == []
+        assert data["count"] == 0
+
+
+class TestPostEmergencyContactEndpoint:
+    """Tests for POST /api/settings/emergency-contacts."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.post(
+            "/api/settings/emergency-contacts",
+            json={
+                "name": "Mom",
+                "telegram_username": "mom_user",
+                "priority": "primary",
+            },
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_create_contact(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.post(
+            "/api/settings/emergency-contacts",
+            json={
+                "name": "Mom",
+                "telegram_username": "@mom_user",
+                "priority": "primary",
+            },
+            cookies=cookies,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Mom"
+        assert data["telegram_username"] == "mom_user"
+        assert data["priority"] == "primary"
+        assert data["position"] == 0
+        assert "id" in data
+        assert "created_at" in data
+
+    @pytest.mark.asyncio
+    async def test_duplicate_telegram_returns_409(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        contact = {
+            "name": "Mom",
+            "telegram_username": "mom_user",
+            "priority": "primary",
+        }
+
+        # First create succeeds
+        r1 = await client.post(
+            "/api/settings/emergency-contacts", json=contact, cookies=cookies
+        )
+        assert r1.status_code == 201
+
+        # Second create with same telegram should fail
+        r2 = await client.post(
+            "/api/settings/emergency-contacts",
+            json={**contact, "name": "Mother"},
+            cookies=cookies,
+        )
+        assert r2.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_max_contacts_returns_409(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        for i in range(MAX_CONTACTS_PER_USER):
+            r = await client.post(
+                "/api/settings/emergency-contacts",
+                json={
+                    "name": f"Contact {i}",
+                    "telegram_username": f"user_{i}_{uuid.uuid4().hex[:6]}",
+                    "priority": "primary",
+                },
+                cookies=cookies,
+            )
+            assert r.status_code == 201
+
+        # Fourth contact should fail
+        r = await client.post(
+            "/api/settings/emergency-contacts",
+            json={
+                "name": "Overflow",
+                "telegram_username": "overflow_user",
+                "priority": "secondary",
+            },
+            cookies=cookies,
+        )
+        assert r.status_code == 409
+        assert "Maximum" in r.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_telegram_returns_422(self, client):
+        cookie = await register_and_login(client)
+        response = await client.post(
+            "/api/settings/emergency-contacts",
+            json={
+                "name": "Mom",
+                "telegram_username": "ab",
+                "priority": "primary",
+            },
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 422
+
+
+class TestPatchEmergencyContactEndpoint:
+    """Tests for PATCH /api/settings/emergency-contacts/{id}."""
+
+    @pytest.mark.asyncio
+    async def test_update_contact(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        # Create contact
+        r = await client.post(
+            "/api/settings/emergency-contacts",
+            json={
+                "name": "Mom",
+                "telegram_username": "mom_user",
+                "priority": "primary",
+            },
+            cookies=cookies,
+        )
+        contact_id = r.json()["id"]
+
+        # Update name
+        r2 = await client.patch(
+            f"/api/settings/emergency-contacts/{contact_id}",
+            json={"name": "Mother"},
+            cookies=cookies,
+        )
+        assert r2.status_code == 200
+        assert r2.json()["name"] == "Mother"
+        assert r2.json()["telegram_username"] == "mom_user"
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_404(self, client):
+        cookie = await register_and_login(client)
+        fake_id = str(uuid.uuid4())
+        response = await client.patch(
+            f"/api/settings/emergency-contacts/{fake_id}",
+            json={"name": "Nobody"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_owner_isolation(self, client):
+        """User A cannot update User B's contact."""
+        cookie_a = await register_and_login(client)
+        cookie_b = await register_and_login(client)
+
+        # User A creates contact
+        r = await client.post(
+            "/api/settings/emergency-contacts",
+            json={
+                "name": "Mom",
+                "telegram_username": "mom_user",
+                "priority": "primary",
+            },
+            cookies={settings.jwt_cookie_name: cookie_a},
+        )
+        contact_id = r.json()["id"]
+
+        # User B tries to update it
+        r2 = await client.patch(
+            f"/api/settings/emergency-contacts/{contact_id}",
+            json={"name": "Hacked"},
+            cookies={settings.jwt_cookie_name: cookie_b},
+        )
+        assert r2.status_code == 404
+
+
+class TestDeleteEmergencyContactEndpoint:
+    """Tests for DELETE /api/settings/emergency-contacts/{id}."""
+
+    @pytest.mark.asyncio
+    async def test_delete_contact(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        # Create contact
+        r = await client.post(
+            "/api/settings/emergency-contacts",
+            json={
+                "name": "Mom",
+                "telegram_username": "mom_user",
+                "priority": "primary",
+            },
+            cookies=cookies,
+        )
+        contact_id = r.json()["id"]
+
+        # Delete it
+        r2 = await client.delete(
+            f"/api/settings/emergency-contacts/{contact_id}",
+            cookies=cookies,
+        )
+        assert r2.status_code == 204
+
+        # Verify it's gone
+        r3 = await client.get(
+            "/api/settings/emergency-contacts",
+            cookies=cookies,
+        )
+        assert r3.json()["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_404(self, client):
+        cookie = await register_and_login(client)
+        fake_id = str(uuid.uuid4())
+        response = await client.delete(
+            f"/api/settings/emergency-contacts/{fake_id}",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_owner_isolation(self, client):
+        """User A cannot delete User B's contact."""
+        cookie_a = await register_and_login(client)
+        cookie_b = await register_and_login(client)
+
+        # User A creates contact
+        r = await client.post(
+            "/api/settings/emergency-contacts",
+            json={
+                "name": "Mom",
+                "telegram_username": "mom_user",
+                "priority": "primary",
+            },
+            cookies={settings.jwt_cookie_name: cookie_a},
+        )
+        contact_id = r.json()["id"]
+
+        # User B tries to delete it
+        r2 = await client.delete(
+            f"/api/settings/emergency-contacts/{contact_id}",
+            cookies={settings.jwt_cookie_name: cookie_b},
+        )
+        assert r2.status_code == 404
+
+        # Verify it still exists for User A
+        r3 = await client.get(
+            "/api/settings/emergency-contacts",
+            cookies={settings.jwt_cookie_name: cookie_a},
+        )
+        assert r3.json()["count"] == 1

--- a/apps/web/src/app/dashboard/settings/emergency-contacts/page.tsx
+++ b/apps/web/src/app/dashboard/settings/emergency-contacts/page.tsx
@@ -1,0 +1,480 @@
+"use client";
+
+/**
+ * Story 6.5: Emergency Contact Configuration
+ *
+ * CRUD page for managing emergency contacts used in alert escalation.
+ * Max 3 contacts per user, each with name, Telegram username, and priority.
+ *
+ * Accessibility: labeled inputs, aria-describedby, focus-visible rings.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Users,
+  Plus,
+  Loader2,
+  AlertTriangle,
+  Check,
+  Trash2,
+  Pencil,
+  ArrowLeft,
+  X,
+} from "lucide-react";
+import clsx from "clsx";
+import {
+  getEmergencyContacts,
+  createEmergencyContact,
+  updateEmergencyContact,
+  deleteEmergencyContact,
+  type EmergencyContact,
+} from "@/lib/api";
+
+const MAX_CONTACTS = 3;
+
+interface ContactFormData {
+  name: string;
+  telegram_username: string;
+  priority: "primary" | "secondary";
+}
+
+const EMPTY_FORM: ContactFormData = {
+  name: "",
+  telegram_username: "",
+  priority: "primary",
+};
+
+export default function EmergencyContactsPage() {
+  const [contacts, setContacts] = useState<EmergencyContact[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // Form state
+  const [formData, setFormData] = useState<ContactFormData>({ ...EMPTY_FORM });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const fetchContacts = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await getEmergencyContacts();
+      setContacts(data.contacts);
+    } catch (err) {
+      if (!(err instanceof Error && err.message.includes("401"))) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load emergency contacts"
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchContacts();
+  }, [fetchContacts]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      if (editingId) {
+        await updateEmergencyContact(editingId, {
+          name: formData.name,
+          telegram_username: formData.telegram_username,
+          priority: formData.priority,
+        });
+        setSuccess("Contact updated successfully");
+      } else {
+        await createEmergencyContact(formData);
+        setSuccess("Contact added successfully");
+      }
+
+      setFormData({ ...EMPTY_FORM });
+      setEditingId(null);
+      setShowForm(false);
+      await fetchContacts();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to save contact"
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleEdit = (contact: EmergencyContact) => {
+    setFormData({
+      name: contact.name,
+      telegram_username: contact.telegram_username,
+      priority: contact.priority,
+    });
+    setEditingId(contact.id);
+    setShowForm(true);
+    setError(null);
+    setSuccess(null);
+  };
+
+  const handleDelete = async (contactId: string) => {
+    if (!window.confirm("Remove this emergency contact? This cannot be undone.")) {
+      return;
+    }
+
+    setDeletingId(contactId);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      await deleteEmergencyContact(contactId);
+      setSuccess("Contact removed");
+      await fetchContacts();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to delete contact"
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleCancel = () => {
+    setFormData({ ...EMPTY_FORM });
+    setEditingId(null);
+    setShowForm(false);
+    setError(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <a
+          href="/dashboard/settings"
+          className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Settings
+        </a>
+        <h1 className="text-2xl font-bold">Emergency Contacts</h1>
+        <p className="text-slate-400">
+          Manage contacts for automatic alert escalation via Telegram
+        </p>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div
+          className="bg-red-500/10 rounded-xl p-4 border border-red-500/20"
+          role="alert"
+        >
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Success state */}
+      {success && (
+        <div
+          className="bg-green-500/10 rounded-xl p-4 border border-green-500/20"
+          role="status"
+        >
+          <div className="flex items-center gap-2">
+            <Check className="h-4 w-4 text-green-400 shrink-0" />
+            <p className="text-sm text-green-400">{success}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div
+          className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+          role="status"
+          aria-label="Loading emergency contacts"
+        >
+          <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+          <p className="text-slate-400">Loading contacts...</p>
+        </div>
+      )}
+
+      {/* Contact list */}
+      {!isLoading && (
+        <div className="bg-slate-900 rounded-xl border border-slate-800 p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 bg-blue-500/10 rounded-lg">
+              <Users className="h-5 w-5 text-blue-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Contacts</h2>
+              <p className="text-xs text-slate-500">
+                {contacts.length} of {MAX_CONTACTS} contacts configured
+              </p>
+            </div>
+          </div>
+
+          {contacts.length === 0 && !showForm && (
+            <div className="text-center py-8">
+              <Users className="h-10 w-10 text-slate-600 mx-auto mb-3" />
+              <p className="text-slate-400 mb-1">No emergency contacts yet</p>
+              <p className="text-xs text-slate-500">
+                Add contacts who can be notified when you&apos;re unresponsive
+                to alerts
+              </p>
+            </div>
+          )}
+
+          {contacts.length > 0 && (
+            <div className="space-y-3 mb-4">
+              {contacts.map((contact) => (
+                <div
+                  key={contact.id}
+                  className="flex items-center justify-between bg-slate-800/50 rounded-lg p-4 border border-slate-700/50"
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-slate-200 truncate">
+                        {contact.name}
+                      </span>
+                      <span
+                        className={clsx(
+                          "text-xs px-2 py-0.5 rounded-full",
+                          contact.priority === "primary"
+                            ? "bg-blue-500/20 text-blue-400"
+                            : "bg-slate-700 text-slate-400"
+                        )}
+                      >
+                        {contact.priority}
+                      </span>
+                    </div>
+                    <span className="text-xs text-slate-500">
+                      @{contact.telegram_username}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0 ml-3">
+                    <button
+                      type="button"
+                      onClick={() => handleEdit(contact)}
+                      className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      aria-label={`Edit ${contact.name}`}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(contact.id)}
+                      disabled={deletingId === contact.id}
+                      className="p-2 rounded-lg text-slate-400 hover:text-red-400 hover:bg-red-500/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50"
+                      aria-label={`Delete ${contact.name}`}
+                    >
+                      {deletingId === contact.id ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Add button */}
+          {!showForm && contacts.length < MAX_CONTACTS && (
+            <button
+              type="button"
+              onClick={() => {
+                setShowForm(true);
+                setError(null);
+                setSuccess(null);
+              }}
+              className={clsx(
+                "flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium",
+                "bg-blue-600 text-white hover:bg-blue-500",
+                "transition-colors",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              )}
+            >
+              <Plus className="h-4 w-4" />
+              Add Contact
+            </button>
+          )}
+
+          {!showForm && contacts.length >= MAX_CONTACTS && (
+            <p className="text-xs text-slate-500">
+              Maximum of {MAX_CONTACTS} contacts reached
+            </p>
+          )}
+
+          {/* Add/Edit form */}
+          {showForm && (
+            <form onSubmit={handleSubmit} className="space-y-4 mt-4">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-medium text-slate-300">
+                  {editingId ? "Edit Contact" : "Add Contact"}
+                </h3>
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="p-1 rounded text-slate-400 hover:text-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label="Cancel"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="contact-name"
+                  className="block text-sm font-medium text-slate-300 mb-1"
+                >
+                  Name
+                </label>
+                <input
+                  id="contact-name"
+                  type="text"
+                  required
+                  maxLength={100}
+                  value={formData.name}
+                  onChange={(e) =>
+                    setFormData({ ...formData, name: e.target.value })
+                  }
+                  className={clsx(
+                    "w-full rounded-lg border px-3 py-2 text-sm",
+                    "bg-slate-800 border-slate-700 text-slate-200",
+                    "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                    "placeholder:text-slate-500"
+                  )}
+                  placeholder="e.g. Mom"
+                  aria-describedby="name-hint"
+                />
+                <p id="name-hint" className="text-xs text-slate-500 mt-1">
+                  Name of the emergency contact
+                </p>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="contact-telegram"
+                  className="block text-sm font-medium text-slate-300 mb-1"
+                >
+                  Telegram Username
+                </label>
+                <div className="flex items-center gap-2">
+                  <span className="text-slate-400 text-sm">@</span>
+                  <input
+                    id="contact-telegram"
+                    type="text"
+                    required
+                    minLength={5}
+                    maxLength={32}
+                    value={formData.telegram_username}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        telegram_username: e.target.value,
+                      })
+                    }
+                    className={clsx(
+                      "w-full rounded-lg border px-3 py-2 text-sm",
+                      "bg-slate-800 border-slate-700 text-slate-200",
+                      "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                      "placeholder:text-slate-500"
+                    )}
+                    placeholder="username"
+                    aria-describedby="telegram-hint"
+                  />
+                </div>
+                <p id="telegram-hint" className="text-xs text-slate-500 mt-1">
+                  5-32 characters, letters, numbers, and underscores
+                </p>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="contact-priority"
+                  className="block text-sm font-medium text-slate-300 mb-1"
+                >
+                  Priority
+                </label>
+                <select
+                  id="contact-priority"
+                  value={formData.priority}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      priority: e.target.value as "primary" | "secondary",
+                    })
+                  }
+                  className={clsx(
+                    "w-full rounded-lg border px-3 py-2 text-sm",
+                    "bg-slate-800 border-slate-700 text-slate-200",
+                    "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  )}
+                  aria-describedby="priority-hint"
+                >
+                  <option value="primary">Primary</option>
+                  <option value="secondary">Secondary</option>
+                </select>
+                <p id="priority-hint" className="text-xs text-slate-500 mt-1">
+                  Primary contacts are notified first during escalation
+                </p>
+              </div>
+
+              <div className="flex items-center gap-3 pt-2">
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className={clsx(
+                    "flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium",
+                    "bg-blue-600 text-white hover:bg-blue-500",
+                    "transition-colors",
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                    "disabled:opacity-50 disabled:cursor-not-allowed"
+                  )}
+                >
+                  {isSubmitting ? (
+                    <Loader2
+                      className="h-4 w-4 animate-spin"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <Check className="h-4 w-4" aria-hidden="true" />
+                  )}
+                  {isSubmitting
+                    ? "Saving..."
+                    : editingId
+                      ? "Update Contact"
+                      : "Add Contact"}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  disabled={isSubmitting}
+                  className={clsx(
+                    "px-4 py-2 rounded-lg text-sm font-medium",
+                    "bg-slate-800 text-slate-300 hover:bg-slate-700",
+                    "transition-colors",
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500",
+                    "disabled:opacity-50 disabled:cursor-not-allowed"
+                  )}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -5,7 +5,7 @@
  * Placeholder page for settings - will be expanded in Epic 9.
  */
 
-import { Settings, User, Bell, Database, Link2 } from "lucide-react";
+import { Settings, User, Bell, Database, Link2, Users } from "lucide-react";
 
 const settingsSections = [
   {
@@ -25,6 +25,12 @@ const settingsSections = [
     description: "Configure alert thresholds and escalation",
     icon: Bell,
     href: "/dashboard/settings/alerts",
+  },
+  {
+    title: "Emergency Contacts",
+    description: "Manage contacts for alert escalation via Telegram",
+    icon: Users,
+    href: "/dashboard/settings/emergency-contacts",
   },
   {
     title: "Data",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -368,3 +368,127 @@ export async function acknowledgeAlert(
 
   return response.json();
 }
+
+/**
+ * Emergency Contact API types (Story 6.5)
+ */
+export interface EmergencyContact {
+  id: string;
+  name: string;
+  telegram_username: string;
+  priority: "primary" | "secondary";
+  position: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EmergencyContactListResponse {
+  contacts: EmergencyContact[];
+  count: number;
+}
+
+export interface EmergencyContactCreate {
+  name: string;
+  telegram_username: string;
+  priority: "primary" | "secondary";
+}
+
+export interface EmergencyContactUpdate {
+  name?: string;
+  telegram_username?: string;
+  priority?: "primary" | "secondary";
+}
+
+/**
+ * Fetch all emergency contacts
+ */
+export async function getEmergencyContacts(): Promise<EmergencyContactListResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/emergency-contacts`,
+    { credentials: "include" }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to fetch emergency contacts: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Create a new emergency contact
+ */
+export async function createEmergencyContact(
+  data: EmergencyContactCreate
+): Promise<EmergencyContact> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/emergency-contacts`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(data),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to create emergency contact: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Update an existing emergency contact
+ */
+export async function updateEmergencyContact(
+  contactId: string,
+  data: EmergencyContactUpdate
+): Promise<EmergencyContact> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/emergency-contacts/${encodeURIComponent(contactId)}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(data),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to update emergency contact: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Delete an emergency contact
+ */
+export async function deleteEmergencyContact(
+  contactId: string
+): Promise<void> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/emergency-contacts/${encodeURIComponent(contactId)}`,
+    {
+      method: "DELETE",
+      credentials: "include",
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to delete emergency contact: ${response.status}`
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Full CRUD for emergency contacts (name, Telegram username, priority) used in alert escalation
- Backend: Alembic migration, SQLAlchemy model, Pydantic schemas with Telegram username validation, service layer with `SELECT FOR UPDATE` race-condition protection, max 3 contacts per user, unique constraint on (user_id, telegram_username)
- Frontend: Emergency Contacts card on settings page, dedicated CRUD page with add/edit form, delete confirmation dialog, empty/loading/error states
- 35 tests covering schema validation, service logic, and endpoint integration (owner isolation, duplicate detection, limit enforcement)

## Test plan
- [x] `uv run ruff check && uv run ruff format --check` — backend lint clean
- [x] `uv run pytest tests/ -x -q` — 465 passed, 1 skipped
- [x] `npx next lint` — frontend lint clean
- [x] Playwright MCP: `/dashboard` renders correctly
- [x] Playwright MCP: `/dashboard/settings` shows Emergency Contacts card
- [x] Playwright MCP: `/dashboard/settings/emergency-contacts` renders page with form
- [x] Adversarial review: 5 findings fixed (race condition, whitespace bypass, error message leak, delete confirmation, position collision)
- [x] Re-review confirmed all fixes correct, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)