### PR TITLE
feat: add escalation timing configuration (Story 6.6)

### DIFF
--- a/apps/api/migrations/versions/018_create_escalation_configs.py
+++ b/apps/api/migrations/versions/018_create_escalation_configs.py
@@ -1,0 +1,69 @@
+"""Story 6.6: Create escalation_configs table.
+
+Revision ID: 018_escalation_configs
+Revises: 017_emergency_contacts
+Create Date: 2026-02-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "018_escalation_configs"
+down_revision = "017_emergency_contacts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "escalation_configs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column(
+            "reminder_delay_minutes",
+            sa.Integer(),
+            nullable=False,
+            server_default="5",
+        ),
+        sa.Column(
+            "primary_contact_delay_minutes",
+            sa.Integer(),
+            nullable=False,
+            server_default="10",
+        ),
+        sa.Column(
+            "all_contacts_delay_minutes",
+            sa.Integer(),
+            nullable=False,
+            server_default="20",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_escalation_configs_user_id",
+        "escalation_configs",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_escalation_configs_user_id")
+    op.drop_table("escalation_configs")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -7,6 +7,7 @@ from src.models.correction_analysis import CorrectionAnalysis
 from src.models.daily_brief import DailyBrief
 from src.models.disclaimer import DisclaimerAcknowledgment
 from src.models.emergency_contact import ContactPriority, EmergencyContact
+from src.models.escalation_config import EscalationConfig
 from src.models.glucose import GlucoseReading, TrendDirection
 from src.models.integration import (
     IntegrationCredential,
@@ -34,6 +35,7 @@ __all__ = [
     "DailyBrief",
     "DisclaimerAcknowledgment",
     "EmergencyContact",
+    "EscalationConfig",
     "MealAnalysis",
     "GlucoseReading",
     "TrendDirection",

--- a/apps/api/src/models/escalation_config.py
+++ b/apps/api/src/models/escalation_config.py
@@ -1,0 +1,71 @@
+"""Story 6.6: Escalation timing configuration model.
+
+Stores user-configured escalation timing for alert escalation to contacts.
+"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Integer
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class EscalationConfig(Base, TimestampMixin):
+    """User-specific escalation timing configuration.
+
+    One-to-one with User. Stores the delay (in minutes) before each
+    escalation tier triggers:
+    1. Reminder to user
+    2. Alert to primary emergency contact
+    3. Alert to all emergency contacts
+    """
+
+    __tablename__ = "escalation_configs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    # Minutes before a reminder is sent to the user
+    reminder_delay_minutes: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=5,
+    )
+
+    # Minutes before primary emergency contact is alerted
+    primary_contact_delay_minutes: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=10,
+    )
+
+    # Minutes before all emergency contacts are alerted
+    all_contacts_delay_minutes: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=20,
+    )
+
+    # Relationship to user
+    user = relationship("User", back_populates="escalation_config")
+
+    def __repr__(self) -> str:
+        return (
+            f"<EscalationConfig(user_id={self.user_id}, "
+            f"reminder={self.reminder_delay_minutes}m, "
+            f"primary={self.primary_contact_delay_minutes}m, "
+            f"all={self.all_contacts_delay_minutes}m)>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -145,6 +145,12 @@ class User(Base, TimestampMixin):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    escalation_config = relationship(
+        "EscalationConfig",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/schemas/escalation_config.py
+++ b/apps/api/src/schemas/escalation_config.py
@@ -1,0 +1,84 @@
+"""Story 6.6: Escalation timing configuration schemas."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class EscalationConfigResponse(BaseModel):
+    """Response schema for escalation timing configuration."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    reminder_delay_minutes: int
+    primary_contact_delay_minutes: int
+    all_contacts_delay_minutes: int
+    updated_at: datetime
+
+
+class EscalationConfigUpdate(BaseModel):
+    """Request schema for updating escalation timing.
+
+    All fields are optional — only provided fields are updated.
+    Validates that tier ordering is consistent (reminder < primary < all).
+    """
+
+    reminder_delay_minutes: int | None = Field(
+        default=None,
+        ge=2,
+        le=60,
+        description="Minutes before first reminder (2-60).",
+    )
+    primary_contact_delay_minutes: int | None = Field(
+        default=None,
+        ge=2,
+        le=120,
+        description="Minutes before primary contact alert (2-120).",
+    )
+    all_contacts_delay_minutes: int | None = Field(
+        default=None,
+        ge=2,
+        le=240,
+        description="Minutes before all contacts alert (2-240).",
+    )
+
+    @model_validator(mode="after")
+    def validate_tier_ordering(self) -> "EscalationConfigUpdate":
+        """Ensure reminder < primary_contact < all_contacts when both provided."""
+        if (
+            self.reminder_delay_minutes is not None
+            and self.primary_contact_delay_minutes is not None
+            and self.reminder_delay_minutes >= self.primary_contact_delay_minutes
+        ):
+            msg = (
+                "reminder_delay_minutes must be less than primary_contact_delay_minutes"
+            )
+            raise ValueError(msg)
+
+        if (
+            self.primary_contact_delay_minutes is not None
+            and self.all_contacts_delay_minutes is not None
+            and self.primary_contact_delay_minutes >= self.all_contacts_delay_minutes
+        ):
+            msg = "primary_contact_delay_minutes must be less than all_contacts_delay_minutes"
+            raise ValueError(msg)
+
+        if (
+            self.reminder_delay_minutes is not None
+            and self.all_contacts_delay_minutes is not None
+            and self.reminder_delay_minutes >= self.all_contacts_delay_minutes
+        ):
+            msg = "reminder_delay_minutes must be less than all_contacts_delay_minutes"
+            raise ValueError(msg)
+
+        return self
+
+
+class EscalationConfigDefaults(BaseModel):
+    """Default escalation timing values for reference."""
+
+    reminder_delay_minutes: int = 5
+    primary_contact_delay_minutes: int = 10
+    all_contacts_delay_minutes: int = 20

--- a/apps/api/src/services/escalation_config.py
+++ b/apps/api/src/services/escalation_config.py
@@ -1,0 +1,129 @@
+"""Story 6.6: Escalation timing configuration service.
+
+Manages user escalation timing with get-or-create pattern.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.escalation_config import EscalationConfig
+from src.schemas.escalation_config import EscalationConfigUpdate
+
+logger = get_logger(__name__)
+
+
+async def get_or_create_config(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> EscalationConfig:
+    """Get the user's escalation config, creating defaults if none exist.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+
+    Returns:
+        The user's EscalationConfig record.
+    """
+    result = await db.execute(
+        select(EscalationConfig).where(EscalationConfig.user_id == user_id)
+    )
+    config = result.scalar_one_or_none()
+
+    if config is None:
+        config = EscalationConfig(user_id=user_id)
+        db.add(config)
+        try:
+            await db.commit()
+        except IntegrityError:
+            # Concurrent request already created the row — fetch it
+            await db.rollback()
+            result = await db.execute(
+                select(EscalationConfig).where(EscalationConfig.user_id == user_id)
+            )
+            config = result.scalar_one()
+            return config
+        await db.refresh(config)
+
+        logger.info(
+            "Created default escalation config",
+            user_id=str(user_id),
+        )
+
+    return config
+
+
+async def update_config(
+    user_id: uuid.UUID,
+    updates: EscalationConfigUpdate,
+    db: AsyncSession,
+) -> EscalationConfig:
+    """Update the user's escalation timing configuration.
+
+    Only fields provided in the request are updated. Validates
+    tier ordering against both new and existing values.
+
+    Args:
+        user_id: User's UUID.
+        updates: Partial update with new timing values.
+        db: Database session.
+
+    Returns:
+        The updated EscalationConfig record.
+
+    Raises:
+        ValueError: If tier ordering is invalid after merge.
+    """
+    config = await get_or_create_config(user_id, db)
+
+    # Merge new values with existing, keeping existing for unset fields
+    new_reminder = (
+        updates.reminder_delay_minutes
+        if updates.reminder_delay_minutes is not None
+        else config.reminder_delay_minutes
+    )
+    new_primary = (
+        updates.primary_contact_delay_minutes
+        if updates.primary_contact_delay_minutes is not None
+        else config.primary_contact_delay_minutes
+    )
+    new_all = (
+        updates.all_contacts_delay_minutes
+        if updates.all_contacts_delay_minutes is not None
+        else config.all_contacts_delay_minutes
+    )
+
+    # Validate merged ordering
+    if new_reminder >= new_primary:
+        msg = (
+            f"reminder_delay_minutes ({new_reminder}) must be less than "
+            f"primary_contact_delay_minutes ({new_primary})"
+        )
+        raise ValueError(msg)
+
+    if new_primary >= new_all:
+        msg = (
+            f"primary_contact_delay_minutes ({new_primary}) must be less than "
+            f"all_contacts_delay_minutes ({new_all})"
+        )
+        raise ValueError(msg)
+
+    # Apply updates
+    update_data = updates.model_dump(exclude_none=True)
+    for field, value in update_data.items():
+        setattr(config, field, value)
+
+    await db.commit()
+    await db.refresh(config)
+
+    logger.info(
+        "Updated escalation config",
+        user_id=str(user_id),
+        fields=list(update_data.keys()),
+    )
+
+    return config

--- a/apps/api/tests/test_escalation_config.py
+++ b/apps/api/tests/test_escalation_config.py
@@ -1,0 +1,464 @@
+"""Story 6.6: Tests for escalation timing configuration."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+
+from src.config import settings
+from src.schemas.escalation_config import (
+    EscalationConfigDefaults,
+    EscalationConfigUpdate,
+)
+from src.services.escalation_config import get_or_create_config, update_config
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("esc")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+# ── Schema validation tests ──
+
+
+class TestEscalationConfigUpdate:
+    """Tests for EscalationConfigUpdate schema validation."""
+
+    def test_all_none_is_valid(self):
+        update = EscalationConfigUpdate()
+        assert update.reminder_delay_minutes is None
+        assert update.primary_contact_delay_minutes is None
+        assert update.all_contacts_delay_minutes is None
+
+    def test_partial_update_reminder(self):
+        update = EscalationConfigUpdate(reminder_delay_minutes=3)
+        assert update.reminder_delay_minutes == 3
+        assert update.primary_contact_delay_minutes is None
+
+    def test_partial_update_primary(self):
+        update = EscalationConfigUpdate(primary_contact_delay_minutes=15)
+        assert update.primary_contact_delay_minutes == 15
+
+    def test_valid_ordering(self):
+        update = EscalationConfigUpdate(
+            reminder_delay_minutes=3,
+            primary_contact_delay_minutes=8,
+            all_contacts_delay_minutes=15,
+        )
+        assert update.reminder_delay_minutes == 3
+        assert update.all_contacts_delay_minutes == 15
+
+    def test_reminder_ge_primary_fails(self):
+        with pytest.raises(
+            ValidationError,
+            match="reminder_delay_minutes must be less than primary_contact_delay_minutes",
+        ):
+            EscalationConfigUpdate(
+                reminder_delay_minutes=10,
+                primary_contact_delay_minutes=5,
+            )
+
+    def test_reminder_equal_primary_fails(self):
+        with pytest.raises(
+            ValidationError,
+            match="reminder_delay_minutes must be less than primary_contact_delay_minutes",
+        ):
+            EscalationConfigUpdate(
+                reminder_delay_minutes=10,
+                primary_contact_delay_minutes=10,
+            )
+
+    def test_primary_ge_all_contacts_fails(self):
+        with pytest.raises(
+            ValidationError,
+            match="primary_contact_delay_minutes must be less than all_contacts_delay_minutes",
+        ):
+            EscalationConfigUpdate(
+                primary_contact_delay_minutes=25,
+                all_contacts_delay_minutes=20,
+            )
+
+    def test_reminder_ge_all_contacts_fails(self):
+        with pytest.raises(
+            ValidationError,
+            match="reminder_delay_minutes must be less than all_contacts_delay_minutes",
+        ):
+            EscalationConfigUpdate(
+                reminder_delay_minutes=30,
+                all_contacts_delay_minutes=20,
+            )
+
+    def test_below_minimum_fails(self):
+        with pytest.raises(ValidationError):
+            EscalationConfigUpdate(reminder_delay_minutes=1)
+
+    def test_above_maximum_reminder_fails(self):
+        with pytest.raises(ValidationError):
+            EscalationConfigUpdate(reminder_delay_minutes=61)
+
+    def test_above_maximum_primary_fails(self):
+        with pytest.raises(ValidationError):
+            EscalationConfigUpdate(primary_contact_delay_minutes=121)
+
+    def test_above_maximum_all_contacts_fails(self):
+        with pytest.raises(ValidationError):
+            EscalationConfigUpdate(all_contacts_delay_minutes=241)
+
+    def test_minimum_value_accepted(self):
+        update = EscalationConfigUpdate(reminder_delay_minutes=2)
+        assert update.reminder_delay_minutes == 2
+
+    def test_maximum_values_accepted(self):
+        update = EscalationConfigUpdate(
+            reminder_delay_minutes=60,
+            primary_contact_delay_minutes=120,
+            all_contacts_delay_minutes=240,
+        )
+        assert update.reminder_delay_minutes == 60
+        assert update.primary_contact_delay_minutes == 120
+        assert update.all_contacts_delay_minutes == 240
+
+
+class TestEscalationConfigDefaults:
+    """Tests for EscalationConfigDefaults schema."""
+
+    def test_default_values(self):
+        defaults = EscalationConfigDefaults()
+        assert defaults.reminder_delay_minutes == 5
+        assert defaults.primary_contact_delay_minutes == 10
+        assert defaults.all_contacts_delay_minutes == 20
+
+
+# ── Service tests ──
+
+
+class TestGetOrCreateConfig:
+    """Tests for get_or_create_config service function."""
+
+    @pytest.mark.asyncio
+    async def test_creates_defaults_when_none_exist(self):
+        user_id = uuid.uuid4()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock(return_value=None)
+
+        result = await get_or_create_config(user_id, mock_db)
+
+        assert result.user_id == user_id
+        mock_db.add.assert_called_once_with(result)
+        mock_db.commit.assert_called_once()
+        mock_db.refresh.assert_called_once_with(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_when_found(self):
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await get_or_create_config(user_id, mock_db)
+
+        assert result == existing
+        mock_db.add.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_create_integrity_error_fallback(self):
+        """When a concurrent request already created the row, fallback to fetch."""
+        user_id = uuid.uuid4()
+        fetched = MagicMock()
+        fetched.user_id = user_id
+
+        # First execute: no existing row; second execute: returns the row
+        first_result = MagicMock()
+        first_result.scalar_one_or_none.return_value = None
+
+        second_result = MagicMock()
+        second_result.scalar_one.return_value = fetched
+
+        mock_db = AsyncMock()
+        mock_db.execute.side_effect = [first_result, second_result]
+        mock_db.commit = AsyncMock(side_effect=IntegrityError("dup", {}, Exception()))
+        mock_db.rollback = AsyncMock()
+
+        result = await get_or_create_config(user_id, mock_db)
+
+        assert result == fetched
+        mock_db.rollback.assert_called_once()
+        mock_db.refresh.assert_not_called()
+
+
+class TestUpdateConfig:
+    """Tests for update_config service function."""
+
+    @pytest.mark.asyncio
+    async def test_partial_update_applies_fields(self):
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+        existing.reminder_delay_minutes = 5
+        existing.primary_contact_delay_minutes = 10
+        existing.all_contacts_delay_minutes = 20
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = EscalationConfigUpdate(reminder_delay_minutes=3)
+        result = await update_config(user_id, updates, mock_db)
+
+        assert result.reminder_delay_minutes == 3
+        mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ordering_violation_reminder_ge_primary(self):
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+        existing.reminder_delay_minutes = 5
+        existing.primary_contact_delay_minutes = 10
+        existing.all_contacts_delay_minutes = 20
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = EscalationConfigUpdate(reminder_delay_minutes=15)
+
+        with pytest.raises(
+            ValueError,
+            match="reminder_delay_minutes.*must be less than.*primary_contact_delay_minutes",
+        ):
+            await update_config(user_id, updates, mock_db)
+
+    @pytest.mark.asyncio
+    async def test_ordering_violation_primary_ge_all(self):
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+        existing.reminder_delay_minutes = 5
+        existing.primary_contact_delay_minutes = 10
+        existing.all_contacts_delay_minutes = 20
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = EscalationConfigUpdate(primary_contact_delay_minutes=25)
+
+        with pytest.raises(
+            ValueError,
+            match="primary_contact_delay_minutes.*must be less than.*all_contacts_delay_minutes",
+        ):
+            await update_config(user_id, updates, mock_db)
+
+    @pytest.mark.asyncio
+    async def test_single_field_update_succeeds(self):
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+        existing.reminder_delay_minutes = 5
+        existing.primary_contact_delay_minutes = 10
+        existing.all_contacts_delay_minutes = 20
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = EscalationConfigUpdate(all_contacts_delay_minutes=30)
+        result = await update_config(user_id, updates, mock_db)
+
+        assert result.all_contacts_delay_minutes == 30
+        mock_db.commit.assert_called_once()
+
+
+# ── Endpoint tests ──
+
+
+class TestGetEscalationConfigEndpoint:
+    """Tests for GET /api/settings/escalation-config."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.get("/api/settings/escalation-config")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authenticated_returns_defaults(self, client):
+        cookie = await register_and_login(client)
+        response = await client.get(
+            "/api/settings/escalation-config",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reminder_delay_minutes"] == 5
+        assert data["primary_contact_delay_minutes"] == 10
+        assert data["all_contacts_delay_minutes"] == 20
+        assert "id" in data
+        assert "updated_at" in data
+
+    @pytest.mark.asyncio
+    async def test_idempotent_get_or_create(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        r1 = await client.get("/api/settings/escalation-config", cookies=cookies)
+        r2 = await client.get("/api/settings/escalation-config", cookies=cookies)
+
+        assert r1.json()["id"] == r2.json()["id"]
+
+
+class TestPatchEscalationConfigEndpoint:
+    """Tests for PATCH /api/settings/escalation-config."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.patch(
+            "/api/settings/escalation-config",
+            json={"reminder_delay_minutes": 3},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_below_minimum_returns_422(self, client):
+        cookie = await register_and_login(client)
+        response = await client.patch(
+            "/api/settings/escalation-config",
+            json={"reminder_delay_minutes": 1},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_ordering_violation_returns_422(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        # Ensure config exists
+        await client.get("/api/settings/escalation-config", cookies=cookies)
+
+        # Set reminder above default primary_contact (10)
+        response = await client.patch(
+            "/api/settings/escalation-config",
+            json={"reminder_delay_minutes": 15},
+            cookies=cookies,
+        )
+        assert response.status_code == 422
+        assert "reminder_delay_minutes" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_valid_partial_update(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/escalation-config",
+            json={"reminder_delay_minutes": 3},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reminder_delay_minutes"] == 3
+        assert data["primary_contact_delay_minutes"] == 10
+        assert data["all_contacts_delay_minutes"] == 20
+
+    @pytest.mark.asyncio
+    async def test_update_all_fields(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/escalation-config",
+            json={
+                "reminder_delay_minutes": 3,
+                "primary_contact_delay_minutes": 8,
+                "all_contacts_delay_minutes": 15,
+            },
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reminder_delay_minutes"] == 3
+        assert data["primary_contact_delay_minutes"] == 8
+        assert data["all_contacts_delay_minutes"] == 15
+
+    @pytest.mark.asyncio
+    async def test_persists_across_requests(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        await client.patch(
+            "/api/settings/escalation-config",
+            json={"all_contacts_delay_minutes": 30},
+            cookies=cookies,
+        )
+
+        response = await client.get("/api/settings/escalation-config", cookies=cookies)
+        assert response.json()["all_contacts_delay_minutes"] == 30
+
+    @pytest.mark.asyncio
+    async def test_empty_body_returns_200(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/escalation-config",
+            json={},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reminder_delay_minutes"] == 5
+        assert data["primary_contact_delay_minutes"] == 10
+
+
+class TestGetEscalationConfigDefaultsEndpoint:
+    """Tests for GET /api/settings/escalation-config/defaults."""
+
+    @pytest.mark.asyncio
+    async def test_returns_defaults_without_auth(self, client):
+        response = await client.get("/api/settings/escalation-config/defaults")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reminder_delay_minutes"] == 5
+        assert data["primary_contact_delay_minutes"] == 10
+        assert data["all_contacts_delay_minutes"] == 20

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -492,3 +492,67 @@ export async function deleteEmergencyContact(
     );
   }
 }
+
+/**
+ * Escalation Config API types (Story 6.6)
+ */
+export interface EscalationConfigResponse {
+  id: string;
+  reminder_delay_minutes: number;
+  primary_contact_delay_minutes: number;
+  all_contacts_delay_minutes: number;
+  updated_at: string;
+}
+
+export interface EscalationConfigUpdate {
+  reminder_delay_minutes?: number;
+  primary_contact_delay_minutes?: number;
+  all_contacts_delay_minutes?: number;
+}
+
+/**
+ * Fetch escalation timing configuration
+ */
+export async function getEscalationConfig(): Promise<EscalationConfigResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/escalation-config`,
+    { credentials: "include" }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail ||
+        `Failed to fetch escalation config: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Update escalation timing configuration
+ */
+export async function updateEscalationConfig(
+  data: EscalationConfigUpdate
+): Promise<EscalationConfigResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/escalation-config`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(data),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail ||
+        `Failed to update escalation config: ${response.status}`
+    );
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- Add escalation timing configuration allowing users to set delay intervals before alerts escalate to emergency contacts
- Three configurable tiers: First Reminder (2-60 min), Primary Contact (2-120 min), All Contacts (2-240 min)
- Backend: migration, model, schemas with tier ordering validation, service with get-or-create + race condition handling, 3 REST endpoints
- Frontend: Escalation Timing section on alerts page with loading spinner, client-side bounds + ordering validation, save/reset functionality
- 33 backend tests covering schema validation, service logic, IntegrityError fallback, and endpoint behavior

## New Files
- `apps/api/migrations/versions/018_create_escalation_configs.py` — DB migration
- `apps/api/src/models/escalation_config.py` — SQLAlchemy model (one-to-one with User)
- `apps/api/src/schemas/escalation_config.py` — Pydantic schemas with tier ordering validation
- `apps/api/src/services/escalation_config.py` — Service layer with get-or-create pattern
- `apps/api/tests/test_escalation_config.py` — 33 tests (schema, service, endpoints)

## Modified Files
- `apps/api/src/models/user.py` — Added escalation_config relationship
- `apps/api/src/models/__init__.py` — Added EscalationConfig export
- `apps/api/src/routers/settings.py` — Added GET/PATCH/GET-defaults endpoints
- `apps/web/src/lib/api.ts` — Added types and API functions
- `apps/web/src/app/dashboard/alerts/page.tsx` — Added Escalation Timing UI section

## Test plan
- [x] 33 new backend tests pass (498 total, 1 skipped)
- [x] Ruff lint + format clean
- [x] ESLint clean
- [x] Adversarial review completed — 12 findings, 7 fixed
- [x] Subagent re-review confirmed all fixes correct
- [x] Playwright visual: dashboard renders correctly
- [x] Playwright visual: alerts page shows all sections including escalation timing with 3 inputs
- [x] Playwright visual: settings page unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)