### PR TITLE
feat(api): add AI chat via Telegram (Story 7.5)

### DIFF
--- a/apps/api/src/services/telegram_chat.py
+++ b/apps/api/src/services/telegram_chat.py
@@ -1,0 +1,252 @@
+"""Story 7.5: AI chat via Telegram.
+
+Handles natural language messages from Telegram by routing them
+to the user's configured AI provider with recent glucose context.
+Each message is a standalone Q&A (no conversation history).
+"""
+
+import html
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.glucose import GlucoseReading
+from src.models.user import User
+from src.schemas.ai_response import AIMessage
+from src.services.ai_client import get_ai_client
+from src.services.alert_notifier import trend_description
+from src.services.iob_projection import get_iob_projection
+
+logger = get_logger(__name__)
+
+# Telegram message length limit
+TELEGRAM_MAX_LENGTH = 4096
+
+# Safety disclaimer appended to every AI response
+SAFETY_DISCLAIMER = (
+    "\n\n\u26a0\ufe0f <i>Not medical advice. Consult your healthcare provider.</i>"
+)
+
+# How many hours of glucose data to include as context
+CONTEXT_HOURS = 2
+
+# Maximum readings to fetch for context
+CONTEXT_MAX_READINGS = 24
+
+_SYSTEM_PROMPT_PREFIX = """\
+You are a supportive diabetes management assistant integrated with GlycemicGPT. \
+You help users understand their glucose patterns, discuss insulin management, \
+and answer questions about their diabetes care.
+
+Guidelines:
+- Be concise (this is a Telegram chat, keep responses under 300 words)
+- Be supportive and non-judgmental
+- Reference the user's recent glucose data when relevant
+- Do NOT recommend specific insulin dose changes
+- Do NOT recommend specific carb-to-insulin ratios
+- Suggest discussing observations with their endocrinologist
+- Use plain text, avoid markdown (Telegram uses HTML)
+
+"""
+
+# Maximum characters we accept from user input before truncating
+MAX_USER_MESSAGE_LENGTH = 2000
+
+
+async def _build_glucose_context(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> str:
+    """Build a glucose context string from recent readings.
+
+    Fetches the last CONTEXT_HOURS of glucose readings and IoB data,
+    and formats them as a concise summary for the AI system prompt.
+
+    Args:
+        db: Database session.
+        user_id: User's UUID.
+
+    Returns:
+        A formatted string describing recent glucose data, or empty
+        string if no data is available.
+    """
+    cutoff = datetime.now(UTC) - timedelta(hours=CONTEXT_HOURS)
+
+    result = await db.execute(
+        select(GlucoseReading)
+        .where(
+            GlucoseReading.user_id == user_id,
+            GlucoseReading.reading_timestamp >= cutoff,
+        )
+        .order_by(GlucoseReading.reading_timestamp.desc())
+        .limit(CONTEXT_MAX_READINGS)
+    )
+    readings = list(result.scalars().all())
+
+    if not readings:
+        return f"Recent glucose data: No readings available in the last {CONTEXT_HOURS} hours."
+
+    latest = readings[0]
+    values = [r.value for r in readings]
+    min_val = min(values)
+    max_val = max(values)
+    avg_val = sum(values) / len(values)
+    trend = trend_description(latest.trend_rate)
+
+    lines = [
+        f"Recent glucose data (last {CONTEXT_HOURS} hours):",
+        f"- Current: {latest.value} mg/dL ({trend})",
+        f"- Range: {min_val}-{max_val} mg/dL",
+        f"- Average: {avg_val:.0f} mg/dL",
+        f"- Readings: {len(readings)}",
+    ]
+
+    # Add IoB if available
+    iob = await get_iob_projection(db, user_id)
+    if iob is not None:
+        lines.append(f"- Insulin on Board: {iob.projected_iob:.1f} units")
+        if iob.is_stale:
+            lines.append("- (IoB data is stale, >2 hours old)")
+
+    return "\n".join(lines)
+
+
+def _build_system_prompt(glucose_context: str) -> str:
+    """Build the system prompt with glucose context embedded.
+
+    Uses string concatenation instead of str.format() to avoid
+    injection if the glucose context contains brace characters.
+
+    Args:
+        glucose_context: Formatted glucose data string.
+
+    Returns:
+        Complete system prompt for the AI provider.
+    """
+    if glucose_context:
+        return _SYSTEM_PROMPT_PREFIX + glucose_context
+    return _SYSTEM_PROMPT_PREFIX.rstrip()
+
+
+def _truncate_response(text: str) -> str:
+    """Truncate text to fit within Telegram's message length limit.
+
+    Reserves space for the safety disclaimer. If the response
+    exceeds the limit, it is truncated with an ellipsis.
+
+    Args:
+        text: The full response text (before disclaimer).
+
+    Returns:
+        Text truncated to fit within TELEGRAM_MAX_LENGTH with disclaimer.
+    """
+    max_content_length = TELEGRAM_MAX_LENGTH - len(SAFETY_DISCLAIMER)
+    if len(text) <= max_content_length:
+        return text + SAFETY_DISCLAIMER
+    return text[: max_content_length - 3] + "..." + SAFETY_DISCLAIMER
+
+
+async def handle_chat(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    text: str,
+) -> str:
+    """Process a natural language message through the user's AI provider.
+
+    Fetches recent glucose context, builds a system prompt, and
+    generates a response using the user's configured AI provider.
+    Always appends a safety disclaimer.
+
+    Args:
+        db: Database session.
+        user_id: User's UUID.
+        text: The user's message text.
+
+    Returns:
+        HTML-formatted response string with safety disclaimer.
+    """
+    # Fetch User object (needed for get_ai_client)
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+
+    if user is None:
+        logger.error("User not found for AI chat", user_id=str(user_id))
+        return "\u26a0\ufe0f Something went wrong. Please try again later."
+
+    # Get the user's AI client
+    try:
+        ai_client = await get_ai_client(user, db)
+    except HTTPException as exc:
+        if exc.status_code == 404:
+            return (
+                "\u2139\ufe0f No AI provider configured.\n"
+                "Set up your AI provider in the GlycemicGPT web app "
+                "under Settings to use AI chat."
+            )
+        logger.error(
+            "AI provider configuration error",
+            user_id=str(user_id),
+            detail=exc.detail,
+        )
+        return (
+            "\u26a0\ufe0f There is an issue with your AI provider configuration. "
+            "Please check Settings or try again later."
+        )
+
+    # Truncate overly long user messages to limit token usage
+    truncated_text = text[:MAX_USER_MESSAGE_LENGTH]
+
+    # Build context and prompt
+    try:
+        glucose_context = await _build_glucose_context(db, user_id)
+    except Exception:
+        logger.error(
+            "Failed to build glucose context for AI chat",
+            user_id=str(user_id),
+            exc_info=True,
+        )
+        glucose_context = "Recent glucose data: unavailable due to a temporary error."
+    system_prompt = _build_system_prompt(glucose_context)
+
+    # Generate AI response
+    try:
+        ai_response = await ai_client.generate(
+            messages=[AIMessage(role="user", content=truncated_text)],
+            system_prompt=system_prompt,
+            max_tokens=800,
+        )
+    except Exception:
+        logger.error(
+            "AI provider error in Telegram chat",
+            user_id=str(user_id),
+            exc_info=True,
+        )
+        return (
+            "\u26a0\ufe0f Unable to get a response from the AI provider. "
+            "Please check your API key in Settings or try again later."
+        )
+
+    content = ai_response.content.strip()
+    if not content:
+        return (
+            "\u2139\ufe0f The AI returned an empty response. "
+            "Please try rephrasing your question." + SAFETY_DISCLAIMER
+        )
+
+    # Escape any HTML in the AI response to prevent injection
+    safe_content = html.escape(content)
+
+    logger.info(
+        "Telegram AI chat response generated",
+        user_id=str(user_id),
+        model=ai_response.model,
+        provider=ai_response.provider.value,
+        input_tokens=ai_response.usage.input_tokens,
+        output_tokens=ai_response.usage.output_tokens,
+    )
+
+    return _truncate_response(safe_content)

--- a/apps/api/tests/test_telegram_chat.py
+++ b/apps/api/tests/test_telegram_chat.py
@@ -1,0 +1,555 @@
+"""Story 7.5: Tests for AI chat via Telegram."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models.ai_provider import AIProviderType
+from src.models.glucose import GlucoseReading, TrendDirection
+from src.models.user import User
+from src.schemas.ai_response import AIResponse, AIUsage
+from src.services.iob_projection import IoBProjection
+from src.services.telegram_chat import (
+    MAX_USER_MESSAGE_LENGTH,
+    SAFETY_DISCLAIMER,
+    TELEGRAM_MAX_LENGTH,
+    _build_glucose_context,
+    _build_system_prompt,
+    _truncate_response,
+    handle_chat,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+def make_reading(
+    value: int = 120,
+    trend_rate: float = 0.5,
+    minutes_ago: int = 3,
+    trend: TrendDirection = TrendDirection.FLAT,
+    user_id: uuid.UUID | None = None,
+) -> MagicMock:
+    """Create a mock GlucoseReading."""
+    reading = MagicMock(spec=GlucoseReading)
+    reading.value = value
+    reading.trend_rate = trend_rate
+    reading.trend = trend
+    reading.reading_timestamp = datetime.now(UTC) - timedelta(minutes=minutes_ago)
+    reading.user_id = user_id or uuid.uuid4()
+    return reading
+
+
+def make_iob(
+    projected_iob: float = 2.5,
+    is_stale: bool = False,
+) -> IoBProjection:
+    """Create a real IoBProjection dataclass."""
+    now = datetime.now(UTC)
+    return IoBProjection(
+        confirmed_iob=3.0,
+        confirmed_at=now - timedelta(minutes=30),
+        projected_iob=projected_iob,
+        projected_at=now,
+        projected_30min=1.8,
+        projected_60min=0.9,
+        minutes_since_confirmed=30,
+        is_stale=is_stale,
+        stale_warning="IoB data is stale" if is_stale else None,
+    )
+
+
+def make_ai_response(content: str = "AI says hello") -> AIResponse:
+    """Create a mock AIResponse."""
+    return AIResponse(
+        content=content,
+        model="claude-sonnet-4-5-20250929",
+        provider=AIProviderType.CLAUDE,
+        usage=AIUsage(input_tokens=100, output_tokens=50),
+    )
+
+
+def make_user(user_id: uuid.UUID | None = None) -> MagicMock:
+    """Create a mock User."""
+    user = MagicMock(spec=User)
+    user.id = user_id or uuid.uuid4()
+    user.email = "test@example.com"
+    return user
+
+
+# ---------------------------------------------------------------------------
+# _build_glucose_context tests
+# ---------------------------------------------------------------------------
+class TestBuildGlucoseContext:
+    """Tests for _build_glucose_context."""
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat.get_iob_projection", new_callable=AsyncMock)
+    async def test_with_readings_and_iob(self, mock_iob):
+        mock_iob.return_value = make_iob(projected_iob=2.5)
+
+        readings = [
+            make_reading(value=150, trend_rate=-1.5, minutes_ago=0),
+            make_reading(value=140, minutes_ago=5),
+            make_reading(value=130, minutes_ago=10),
+        ]
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = readings
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        context = await _build_glucose_context(db, uuid.uuid4())
+
+        assert "150 mg/dL" in context
+        assert "falling" in context.lower()
+        assert "130-150" in context
+        assert "2.5 units" in context
+        assert "Readings: 3" in context
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat.get_iob_projection", new_callable=AsyncMock)
+    async def test_no_readings(self, mock_iob):
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        context = await _build_glucose_context(db, uuid.uuid4())
+
+        assert "No readings available in the last 2 hours" in context
+        mock_iob.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat.get_iob_projection", new_callable=AsyncMock)
+    async def test_stale_iob_shows_warning(self, mock_iob):
+        mock_iob.return_value = make_iob(is_stale=True)
+
+        readings = [make_reading(value=110)]
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = readings
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        context = await _build_glucose_context(db, uuid.uuid4())
+
+        assert "stale" in context.lower()
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat.get_iob_projection", new_callable=AsyncMock)
+    async def test_no_iob_data(self, mock_iob):
+        mock_iob.return_value = None
+
+        readings = [make_reading(value=95)]
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = readings
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        context = await _build_glucose_context(db, uuid.uuid4())
+
+        assert "95 mg/dL" in context
+        assert "Insulin on Board" not in context
+
+
+# ---------------------------------------------------------------------------
+# _build_system_prompt tests
+# ---------------------------------------------------------------------------
+class TestBuildSystemPrompt:
+    """Tests for _build_system_prompt."""
+
+    def test_includes_glucose_context(self):
+        context = "Current: 120 mg/dL (stable)"
+        prompt = _build_system_prompt(context)
+
+        assert "120 mg/dL" in prompt
+        assert "stable" in prompt
+
+    def test_includes_safety_guidelines(self):
+        prompt = _build_system_prompt("")
+
+        assert "NOT recommend specific insulin dose" in prompt
+        assert "endocrinologist" in prompt
+
+    def test_includes_telegram_instruction(self):
+        prompt = _build_system_prompt("")
+
+        assert "concise" in prompt.lower()
+        assert "Telegram" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _truncate_response tests
+# ---------------------------------------------------------------------------
+class TestTruncateResponse:
+    """Tests for _truncate_response."""
+
+    def test_short_response_gets_disclaimer(self):
+        result = _truncate_response("Hello world")
+
+        assert result.endswith(SAFETY_DISCLAIMER)
+        assert "Hello world" in result
+
+    def test_long_response_truncated_with_ellipsis(self):
+        long_text = "x" * TELEGRAM_MAX_LENGTH
+        result = _truncate_response(long_text)
+
+        assert len(result) <= TELEGRAM_MAX_LENGTH
+        assert "..." in result
+        assert result.endswith(SAFETY_DISCLAIMER)
+
+    def test_exact_limit_not_truncated(self):
+        max_content = TELEGRAM_MAX_LENGTH - len(SAFETY_DISCLAIMER)
+        exact_text = "y" * max_content
+        result = _truncate_response(exact_text)
+
+        assert len(result) == TELEGRAM_MAX_LENGTH
+        assert "..." not in result
+
+
+# ---------------------------------------------------------------------------
+# handle_chat tests
+# ---------------------------------------------------------------------------
+class TestHandleChat:
+    """Tests for handle_chat."""
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_successful_response(self, mock_get_client, mock_context):
+        mock_context.return_value = "Current: 120 mg/dL"
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response(
+            "Your glucose looks stable."
+        )
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "How am I doing?")
+
+        assert "glucose looks stable" in msg
+        assert "Not medical advice" in msg
+        mock_client.generate.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_no_ai_provider_returns_friendly_error(self, mock_get_client):
+        from fastapi import HTTPException
+
+        mock_get_client.side_effect = HTTPException(
+            status_code=404, detail="No AI provider"
+        )
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "Hello")
+
+        assert "No AI provider configured" in msg
+        assert "Settings" in msg
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_ai_error_caught_gracefully(self, mock_get_client, mock_context):
+        mock_context.return_value = ""
+
+        mock_client = AsyncMock()
+        mock_client.generate.side_effect = ConnectionError("API timeout")
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "Why am I high?")
+
+        assert "Unable to get a response" in msg
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_safety_disclaimer_appended(self, mock_get_client, mock_context):
+        mock_context.return_value = ""
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response("Some advice here.")
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "What should I do?")
+
+        assert "Not medical advice" in msg
+        assert msg.endswith(SAFETY_DISCLAIMER)
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_long_response_truncated(self, mock_get_client, mock_context):
+        mock_context.return_value = ""
+
+        long_content = "a" * 5000
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response(long_content)
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "Tell me everything")
+
+        assert len(msg) <= TELEGRAM_MAX_LENGTH
+        assert "..." in msg
+        assert "Not medical advice" in msg
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_empty_response_handled(self, mock_get_client, mock_context):
+        mock_context.return_value = ""
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response("")
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "...")
+
+        assert "empty response" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_user_not_found(self):
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, uuid.uuid4(), "Hello")
+
+        assert "Something went wrong" in msg
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_glucose_context_passed_to_system_prompt(
+        self, mock_get_client, mock_context
+    ):
+        mock_context.return_value = "Current: 180 mg/dL (rising)"
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response("Response")
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        await handle_chat(db, user.id, "What's happening?")
+
+        # Verify the system prompt contains glucose context
+        call_kwargs = mock_client.generate.call_args
+        system_prompt = call_kwargs.kwargs.get(
+            "system_prompt", call_kwargs[1].get("system_prompt", "")
+        )
+        assert "180 mg/dL" in system_prompt
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_html_in_ai_response_is_escaped(self, mock_get_client, mock_context):
+        mock_context.return_value = ""
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response(
+            "<script>alert('xss')</script> advice"
+        )
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "Tell me something")
+
+        assert "<script>" not in msg
+        assert "&lt;script&gt;" in msg
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_whitespace_only_response_treated_as_empty(
+        self, mock_get_client, mock_context
+    ):
+        mock_context.return_value = ""
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response("   \n  ")
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "test")
+
+        assert "empty response" in msg.lower()
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_user_message_passed_to_ai(self, mock_get_client, mock_context):
+        """Finding #8: Verify user's question text reaches the AI provider."""
+        mock_context.return_value = ""
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response("Response")
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        await handle_chat(db, user.id, "Why am I spiking?")
+
+        call_kwargs = mock_client.generate.call_args
+        messages = call_kwargs.kwargs.get(
+            "messages", call_kwargs[1].get("messages", [])
+        )
+        assert len(messages) == 1
+        assert messages[0].content == "Why am I spiking?"
+        assert messages[0].role == "user"
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_long_user_message_truncated(self, mock_get_client, mock_context):
+        """Finding #3: Overly long user messages are truncated before sending to AI."""
+        mock_context.return_value = ""
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response("Response")
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        long_message = "x" * (MAX_USER_MESSAGE_LENGTH + 500)
+        await handle_chat(db, user.id, long_message)
+
+        call_kwargs = mock_client.generate.call_args
+        messages = call_kwargs.kwargs.get(
+            "messages", call_kwargs[1].get("messages", [])
+        )
+        assert len(messages[0].content) == MAX_USER_MESSAGE_LENGTH
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat._build_glucose_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_glucose_context_error_uses_fallback(
+        self, mock_get_client, mock_context
+    ):
+        """Finding #4: DB error in glucose context doesn't crash the handler."""
+        mock_context.side_effect = RuntimeError("DB connection lost")
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response("Still works")
+        mock_get_client.return_value = mock_client
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "How am I doing?")
+
+        assert "Still works" in msg
+        mock_client.generate.assert_called_once()
+        # Verify fallback context was used in the system prompt
+        call_kwargs = mock_client.generate.call_args
+        system_prompt = call_kwargs.kwargs.get(
+            "system_prompt", call_kwargs[1].get("system_prompt", "")
+        )
+        assert "unavailable due to a temporary error" in system_prompt
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_unsupported_provider_returns_config_error(self, mock_get_client):
+        """Finding #5: HTTP 400 (unsupported provider) gets distinct message."""
+        from fastapi import HTTPException
+
+        mock_get_client.side_effect = HTTPException(
+            status_code=400, detail="Unsupported AI provider"
+        )
+
+        user = make_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await handle_chat(db, user.id, "Hello")
+
+        assert "issue with your AI provider configuration" in msg
+        assert "No AI provider configured" not in msg
+
+
+class TestBuildSystemPromptSafety:
+    """Finding #1: Test that braces in glucose context don't break prompt."""
+
+    def test_braces_in_context_are_safe(self):
+        context = "Data: {unknown_key} and more {stuff}"
+        prompt = _build_system_prompt(context)
+
+        assert "{unknown_key}" in prompt
+        assert "{stuff}" in prompt
+
+    def test_empty_context_no_trailing_whitespace(self):
+        """Finding #8: Empty context should not produce trailing newlines."""
+        prompt = _build_system_prompt("")
+        assert not prompt.endswith("\n")


### PR DESCRIPTION
## Summary

- Add AI-powered natural language chat via Telegram for linked users
- Route non-command messages through user's configured AI provider (Claude/OpenAI)
- Inject recent glucose context (last 2 hours of readings + IoB) into system prompt automatically
- Append safety disclaimer to every AI response, enforce 4096-char Telegram limit

## Key design decisions

- Stateless Q&A: no conversation history persistence, each message standalone with glucose context via system prompt
- Separate `telegram_chat.py` service keeps AI chat logic isolated from command routing
- String concatenation for system prompt (avoids format-string injection via brace characters)
- Input length cap (2000 chars) to limit token usage and API costs
- Graceful degradation: no AI provider configured returns friendly setup instructions, DB errors use fallback context
- HTML escaping on all AI output to prevent injection
- Lazy import in `_handle_chat_message()` avoids circular dependencies

## Security

- `html.escape()` on AI response content before sending to Telegram
- Input truncation prevents abuse via oversized messages
- HTTPException status code inspection distinguishes "no provider" (404) from "bad config" (400)
- ImportError in lazy import caught with user-friendly fallback

## Test plan

- [x] 26 new tests in test_telegram_chat.py (context building, system prompt, truncation, handle_chat paths)
- [x] 5 new/updated tests in test_telegram_commands.py (AI chat routing, edge cases, ImportError)
- [x] Full backend suite: 707 passed, 1 skipped
- [x] Ruff lint + format: clean
- [x] Frontend lint: clean
- [x] Playwright MCP visual checks: no regressions on dashboard, alerts, telegram settings
- [x] Two rounds of adversarial review with all findings fixed