### PR TITLE
feat(api): add caregiver Telegram access (Story 7.6)

### DIFF
--- a/apps/api/migrations/versions/021_create_caregiver_links.py
+++ b/apps/api/migrations/versions/021_create_caregiver_links.py
@@ -1,0 +1,78 @@
+"""Story 7.6: Create caregiver_links table.
+
+Revision ID: 021_caregiver_links
+Revises: 020_telegram_links
+Create Date: 2026-02-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "021_caregiver_links"
+down_revision = "020_telegram_links"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "caregiver_links",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "caregiver_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "patient_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "caregiver_id", "patient_id", name="uq_caregiver_patient"
+        ),
+        sa.CheckConstraint(
+            "caregiver_id != patient_id", name="ck_no_self_link"
+        ),
+    )
+
+    op.create_index(
+        "ix_caregiver_links_caregiver_id",
+        "caregiver_links",
+        ["caregiver_id"],
+    )
+    op.create_index(
+        "ix_caregiver_links_patient_id",
+        "caregiver_links",
+        ["patient_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_caregiver_links_patient_id", table_name="caregiver_links"
+    )
+    op.drop_index(
+        "ix_caregiver_links_caregiver_id", table_name="caregiver_links"
+    )
+    op.drop_table("caregiver_links")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -3,6 +3,7 @@ from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProvide
 from src.models.alert import Alert, AlertSeverity, AlertType
 from src.models.alert_threshold import AlertThreshold
 from src.models.base import Base, TimestampMixin
+from src.models.caregiver_link import CaregiverLink
 from src.models.correction_analysis import CorrectionAnalysis
 from src.models.daily_brief import DailyBrief
 from src.models.disclaimer import DisclaimerAcknowledgment
@@ -36,6 +37,7 @@ __all__ = [
     "AlertThreshold",
     "AlertType",
     "Base",
+    "CaregiverLink",
     "ContactPriority",
     "CorrectionAnalysis",
     "TimestampMixin",

--- a/apps/api/src/models/caregiver_link.py
+++ b/apps/api/src/models/caregiver_link.py
@@ -1,0 +1,56 @@
+"""Story 7.6: Caregiver-to-patient link model.
+
+Defines the many-to-many relationship between CAREGIVER and DIABETIC users.
+A caregiver can be linked to multiple patients; a patient can have
+multiple caregivers.
+"""
+
+import uuid
+
+from sqlalchemy import CheckConstraint, ForeignKey, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class CaregiverLink(Base, TimestampMixin):
+    """Links a caregiver user to a patient (diabetic) user.
+
+    Unique constraint on (caregiver_id, patient_id) prevents duplicates.
+    """
+
+    __tablename__ = "caregiver_links"
+    __table_args__ = (
+        UniqueConstraint("caregiver_id", "patient_id", name="uq_caregiver_patient"),
+        CheckConstraint("caregiver_id != patient_id", name="ck_no_self_link"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    caregiver_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    patient_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Relationships
+    caregiver = relationship("User", foreign_keys=[caregiver_id])
+    patient = relationship("User", foreign_keys=[patient_id])
+
+    def __repr__(self) -> str:
+        return (
+            f"<CaregiverLink(caregiver={self.caregiver_id}, patient={self.patient_id})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -162,6 +162,18 @@ class User(Base, TimestampMixin):
         cascade="all, delete-orphan",
         uselist=False,
     )
+    caregiver_links = relationship(
+        "CaregiverLink",
+        foreign_keys="[CaregiverLink.caregiver_id]",
+        cascade="all, delete-orphan",
+        overlaps="caregiver",
+    )
+    patient_links = relationship(
+        "CaregiverLink",
+        foreign_keys="[CaregiverLink.patient_id]",
+        cascade="all, delete-orphan",
+        overlaps="patient",
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/services/telegram_caregiver.py
+++ b/apps/api/src/services/telegram_caregiver.py
@@ -1,0 +1,263 @@
+"""Story 7.6: Caregiver Telegram access.
+
+Handles Telegram commands from CAREGIVER-role users,
+scoping all data access to their linked patients.
+
+Supported interactions:
+  /status      - Check linked patient's current glucose
+  /help        - List available caregiver commands
+  Plain text   - AI chat about patient's glucose data
+
+Blocked commands (read-only access):
+  /acknowledge - Patient-only
+  /brief       - Patient-only
+"""
+
+import html
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.logging_config import get_logger
+from src.models.caregiver_link import CaregiverLink
+
+logger = get_logger(__name__)
+
+# Commands that modify state — blocked for caregivers
+_BLOCKED_COMMANDS = frozenset({"/acknowledge", "/brief"})
+
+
+async def get_linked_patients(
+    db: AsyncSession,
+    caregiver_id: uuid.UUID,
+) -> list[CaregiverLink]:
+    """Return all CaregiverLink rows for this caregiver.
+
+    Eagerly loads the patient relationship for email access.
+
+    Args:
+        db: Database session.
+        caregiver_id: Caregiver's user UUID.
+
+    Returns:
+        List of CaregiverLink objects (may be empty).
+    """
+    result = await db.execute(
+        select(CaregiverLink)
+        .where(CaregiverLink.caregiver_id == caregiver_id)
+        .options(selectinload(CaregiverLink.patient))
+    )
+    return list(result.scalars().all())
+
+
+async def _handle_caregiver_status(
+    db: AsyncSession,
+    links: list[CaregiverLink],
+) -> str:
+    """Build glucose status for the caregiver's linked patient(s).
+
+    If the caregiver has a single patient, shows that patient's
+    full glucose status. If multiple patients, shows a brief
+    summary for each.
+    """
+    # Lazy import to avoid circular dependency
+    from src.services.telegram_commands import _handle_status
+
+    if len(links) == 1:
+        patient = links[0].patient
+        patient_label = html.escape(patient.email)
+        status = await _handle_status(db, links[0].patient_id)
+        return f"\U0001f465 <b>Patient:</b> {patient_label}\n\n{status}"
+
+    # Multiple patients — brief status for each
+    from src.models.glucose import GlucoseReading
+    from src.services.alert_notifier import trend_description
+
+    lines = ["\U0001f465 <b>Linked Patients</b>", ""]
+
+    for link in links:
+        patient = link.patient
+        patient_label = html.escape(patient.email)
+
+        result = await db.execute(
+            select(GlucoseReading)
+            .where(GlucoseReading.user_id == link.patient_id)
+            .order_by(GlucoseReading.reading_timestamp.desc())
+            .limit(1)
+        )
+        reading = result.scalar_one_or_none()
+
+        if reading is None:
+            lines.append(f"\u2022 <b>{patient_label}:</b> No data available")
+        else:
+            trend = trend_description(reading.trend_rate)
+            lines.append(
+                f"\u2022 <b>{patient_label}:</b> {reading.value:.0f} mg/dL ({trend})"
+            )
+
+    return "\n".join(lines)
+
+
+def _handle_caregiver_help() -> str:
+    """Return caregiver-specific help text."""
+    return (
+        "\U0001f4cb <b>Caregiver Commands</b>\n"
+        "\n"
+        "/status \u2013 Check your patient's glucose\n"
+        "/help \u2013 Show this help message\n"
+        "\n"
+        "\U0001f4ac Or type a question about your patient's glucose data.\n"
+        "\n"
+        "\u2139\ufe0f /acknowledge and /brief are not available "
+        "for caregiver accounts."
+    )
+
+
+def _handle_blocked_command() -> str:
+    """Return message for commands blocked for caregivers."""
+    return (
+        "\u26d4 This command is only available for patient accounts.\n"
+        "As a caregiver, you can use /status or ask questions in plain text."
+    )
+
+
+def _handle_no_patients() -> str:
+    """Return message when caregiver has no linked patients."""
+    return (
+        "\u2139\ufe0f No patients linked to your account.\n"
+        "Ask your patient to link you as a caregiver in the "
+        "GlycemicGPT web app."
+    )
+
+
+def _resolve_patient_for_chat(
+    links: list[CaregiverLink],
+    text: str,
+) -> CaregiverLink | None:
+    """Resolve which patient a caregiver chat message is about.
+
+    If single patient, returns that link. If multiple, attempts
+    to match patient email from the message text.
+
+    Args:
+        links: Caregiver's patient links.
+        text: The user's message text.
+
+    Returns:
+        The matching CaregiverLink, or None if ambiguous.
+    """
+    if len(links) == 1:
+        return links[0]
+
+    # Try name matching against patient emails
+    lower_text = text.lower()
+    for link in links:
+        email_prefix = link.patient.email.split("@")[0].lower()
+        if email_prefix in lower_text:
+            return link
+
+    return None
+
+
+async def _handle_caregiver_chat(
+    db: AsyncSession,
+    caregiver_id: uuid.UUID,
+    links: list[CaregiverLink],
+    text: str,
+) -> str:
+    """Route a caregiver's natural language message to AI chat.
+
+    Resolves the target patient and delegates to handle_caregiver_chat
+    in telegram_chat.py.
+    """
+    link = _resolve_patient_for_chat(links, text)
+
+    if link is None:
+        # Multiple patients, couldn't resolve — list them
+        patient_list = ", ".join(
+            html.escape(link_item.patient.email) for link_item in links
+        )
+        return (
+            "\u2139\ufe0f You have multiple linked patients. "
+            "Please mention their name in your message.\n"
+            f"Linked patients: {patient_list}"
+        )
+
+    try:
+        from src.services.telegram_chat import handle_caregiver_chat
+    except ImportError:
+        logger.error("Failed to import telegram_chat module", exc_info=True)
+        return (
+            "\u26a0\ufe0f AI chat is temporarily unavailable. Please try again later."
+        )
+
+    return await handle_caregiver_chat(db, caregiver_id, link.patient_id, text)
+
+
+async def handle_caregiver_command(
+    db: AsyncSession,
+    caregiver_id: uuid.UUID,
+    text: str,
+) -> str:
+    """Route a caregiver's Telegram message to the appropriate handler.
+
+    Always returns a response string. Exceptions are caught and
+    converted to user-friendly error messages.
+
+    Args:
+        db: Database session.
+        caregiver_id: Caregiver's user UUID.
+        text: Raw message text.
+
+    Returns:
+        HTML-formatted response string.
+    """
+    try:
+        return await _route_caregiver_command(db, caregiver_id, text)
+    except Exception:
+        logger.error(
+            "Unexpected error in caregiver command handler",
+            caregiver_id=str(caregiver_id),
+            exc_info=True,
+        )
+        return "\u26a0\ufe0f Something went wrong. Please try again later."
+
+
+async def _route_caregiver_command(
+    db: AsyncSession,
+    caregiver_id: uuid.UUID,
+    text: str,
+) -> str:
+    """Internal caregiver command router (may raise)."""
+    stripped = text.strip()
+    lower = stripped.lower()
+
+    # Check for blocked commands
+    if lower in _BLOCKED_COMMANDS or lower.startswith("/acknowledge_"):
+        return _handle_blocked_command()
+
+    # Help doesn't need DB access
+    if lower == "/help":
+        return _handle_caregiver_help()
+
+    # Get linked patients (needed for remaining handlers)
+    links = await get_linked_patients(db, caregiver_id)
+
+    if lower == "/status":
+        if not links:
+            return _handle_no_patients()
+        return await _handle_caregiver_status(db, links)
+
+    # Unknown /commands
+    if stripped.startswith("/"):
+        return (
+            "\u2753 Unrecognized command.\n"
+            "Send /help to see available caregiver commands."
+        )
+
+    # Plain text — AI chat
+    if not links:
+        return _handle_no_patients()
+    return await _handle_caregiver_chat(db, caregiver_id, links, stripped)

--- a/apps/api/tests/test_caregiver_link.py
+++ b/apps/api/tests/test_caregiver_link.py
@@ -1,0 +1,42 @@
+"""Story 7.6: Tests for CaregiverLink model."""
+
+import uuid
+
+from src.models.caregiver_link import CaregiverLink
+
+
+class TestCaregiverLinkModel:
+    """Tests for the CaregiverLink model."""
+
+    def test_repr(self):
+        caregiver_id = uuid.uuid4()
+        patient_id = uuid.uuid4()
+        link = CaregiverLink(
+            caregiver_id=caregiver_id,
+            patient_id=patient_id,
+        )
+        repr_str = repr(link)
+        assert str(caregiver_id) in repr_str
+        assert str(patient_id) in repr_str
+        assert "CaregiverLink" in repr_str
+
+    def test_tablename(self):
+        assert CaregiverLink.__tablename__ == "caregiver_links"
+
+    def test_unique_constraint_exists(self):
+        """The model has a unique constraint on (caregiver_id, patient_id)."""
+        constraints = CaregiverLink.__table_args__
+        assert any(
+            getattr(c, "name", None) == "uq_caregiver_patient"
+            for c in constraints
+            if hasattr(c, "name")
+        )
+
+    def test_self_link_check_constraint_exists(self):
+        """The model has a check constraint preventing self-linking."""
+        constraints = CaregiverLink.__table_args__
+        assert any(
+            getattr(c, "name", None) == "ck_no_self_link"
+            for c in constraints
+            if hasattr(c, "name")
+        )

--- a/apps/api/tests/test_telegram_caregiver.py
+++ b/apps/api/tests/test_telegram_caregiver.py
@@ -1,0 +1,455 @@
+"""Story 7.6: Tests for caregiver Telegram access."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models.caregiver_link import CaregiverLink
+from src.models.glucose import GlucoseReading, TrendDirection
+from src.models.user import User, UserRole
+from src.services.telegram_caregiver import (
+    _handle_blocked_command,
+    _handle_caregiver_chat,
+    _handle_caregiver_help,
+    _handle_caregiver_status,
+    _handle_no_patients,
+    _resolve_patient_for_chat,
+    get_linked_patients,
+    handle_caregiver_command,
+)
+
+# ── Helpers ──
+
+
+def make_user(
+    role: UserRole = UserRole.DIABETIC,
+    email: str = "patient@example.com",
+) -> MagicMock:
+    """Create a mock User."""
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.email = email
+    user.role = role
+    return user
+
+
+def make_link(
+    caregiver_id: uuid.UUID | None = None,
+    patient: MagicMock | None = None,
+) -> MagicMock:
+    """Create a mock CaregiverLink with patient loaded."""
+    link = MagicMock(spec=CaregiverLink)
+    link.id = uuid.uuid4()
+    link.caregiver_id = caregiver_id or uuid.uuid4()
+    patient = patient or make_user()
+    link.patient_id = patient.id
+    link.patient = patient
+    return link
+
+
+def make_reading(
+    value: int = 120,
+    trend_rate: float = 0.5,
+    minutes_ago: int = 3,
+) -> MagicMock:
+    """Create a mock GlucoseReading."""
+    reading = MagicMock(spec=GlucoseReading)
+    reading.value = value
+    reading.trend_rate = trend_rate
+    reading.trend = TrendDirection.FLAT
+    reading.reading_timestamp = datetime.now(UTC) - timedelta(minutes=minutes_ago)
+    reading.user_id = uuid.uuid4()
+    return reading
+
+
+# ── TestGetLinkedPatients ──
+
+
+class TestGetLinkedPatients:
+    """Tests for get_linked_patients."""
+
+    @pytest.mark.asyncio
+    async def test_one_patient(self):
+        link = make_link()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [link]
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_linked_patients(db, uuid.uuid4())
+        assert len(result) == 1
+        assert result[0] is link
+
+    @pytest.mark.asyncio
+    async def test_multiple_patients(self):
+        links = [make_link(), make_link()]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = links
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_linked_patients(db, uuid.uuid4())
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_patients(self):
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_linked_patients(db, uuid.uuid4())
+        assert result == []
+
+
+# ── TestHandleCaregiverStatus ──
+
+
+class TestHandleCaregiverStatus:
+    """Tests for _handle_caregiver_status."""
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_commands._handle_status", new_callable=AsyncMock)
+    async def test_single_patient_shows_patient_label(self, mock_status):
+        mock_status.return_value = "120 mg/dL"
+        patient = make_user(email="alice@example.com")
+        link = make_link(patient=patient)
+
+        result = await _handle_caregiver_status(AsyncMock(), [link])
+
+        assert "alice@example.com" in result
+        assert "120 mg/dL" in result
+        assert "Patient" in result
+
+    @pytest.mark.asyncio
+    async def test_multiple_patients_lists_all(self):
+        patient1 = make_user(email="alice@example.com")
+        patient2 = make_user(email="bob@example.com")
+        link1 = make_link(patient=patient1)
+        link2 = make_link(patient=patient2)
+
+        # Mock DB for each patient's latest reading
+        reading1 = make_reading(value=110)
+        reading2 = make_reading(value=200)
+
+        db = AsyncMock()
+        mock_result1 = MagicMock()
+        mock_result1.scalar_one_or_none.return_value = reading1
+        mock_result2 = MagicMock()
+        mock_result2.scalar_one_or_none.return_value = reading2
+        db.execute.side_effect = [mock_result1, mock_result2]
+
+        result = await _handle_caregiver_status(db, [link1, link2])
+
+        assert "alice@example.com" in result
+        assert "bob@example.com" in result
+        assert "110 mg/dL" in result
+        assert "200 mg/dL" in result
+        assert "Linked Patients" in result
+
+    @pytest.mark.asyncio
+    async def test_multiple_patients_no_data(self):
+        patient = make_user(email="empty@example.com")
+        link = make_link(patient=patient)
+
+        db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        db.execute.return_value = mock_result
+
+        result = await _handle_caregiver_status(db, [link, make_link()])
+
+        assert "No data available" in result
+
+
+# ── TestHandleCaregiverChat ──
+
+
+class TestHandleCaregiverChat:
+    """Tests for _handle_caregiver_chat."""
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_chat.handle_caregiver_chat",
+        new_callable=AsyncMock,
+    )
+    async def test_single_patient_routes_to_chat(self, mock_chat):
+        mock_chat.return_value = "AI response"
+        caregiver_id = uuid.uuid4()
+        link = make_link(caregiver_id=caregiver_id)
+
+        result = await _handle_caregiver_chat(
+            AsyncMock(), caregiver_id, [link], "How are they?"
+        )
+
+        assert result == "AI response"
+        mock_chat.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_multiple_patients_no_match_lists_patients(self):
+        patient1 = make_user(email="alice@example.com")
+        patient2 = make_user(email="bob@example.com")
+        links = [
+            make_link(patient=patient1),
+            make_link(patient=patient2),
+        ]
+
+        result = await _handle_caregiver_chat(
+            AsyncMock(), uuid.uuid4(), links, "How are they?"
+        )
+
+        assert "multiple linked patients" in result
+        assert "alice@example.com" in result
+        assert "bob@example.com" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_chat.handle_caregiver_chat",
+        new_callable=AsyncMock,
+    )
+    async def test_multiple_patients_name_match(self, mock_chat):
+        mock_chat.return_value = "AI response about Alice"
+        patient1 = make_user(email="alice@example.com")
+        patient2 = make_user(email="bob@example.com")
+        links = [
+            make_link(patient=patient1),
+            make_link(patient=patient2),
+        ]
+
+        result = await _handle_caregiver_chat(
+            AsyncMock(), uuid.uuid4(), links, "How is alice doing?"
+        )
+
+        assert result == "AI response about Alice"
+        # Should have called with alice's patient_id
+        call_args = mock_chat.call_args
+        assert call_args[0][2] == patient1.id
+
+    @pytest.mark.asyncio
+    async def test_import_error_returns_unavailable(self):
+        """ImportError for telegram_chat is caught gracefully."""
+        import builtins
+
+        link = make_link()
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "src.services.telegram_chat":
+                raise ImportError("no module")
+            return original_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=mock_import):
+            result = await _handle_caregiver_chat(
+                AsyncMock(), uuid.uuid4(), [link], "How are they?"
+            )
+        assert "temporarily unavailable" in result
+
+
+# ── TestResolvePatientForChat ──
+
+
+class TestResolvePatientForChat:
+    """Tests for _resolve_patient_for_chat."""
+
+    def test_single_patient_returns_that_link(self):
+        link = make_link()
+        result = _resolve_patient_for_chat([link], "anything")
+        assert result is link
+
+    def test_multiple_no_match_returns_none(self):
+        links = [make_link(), make_link()]
+        result = _resolve_patient_for_chat(links, "no match here")
+        assert result is None
+
+    def test_multiple_email_prefix_match(self):
+        patient = make_user(email="alice@example.com")
+        link1 = make_link(patient=patient)
+        link2 = make_link()
+
+        result = _resolve_patient_for_chat([link1, link2], "How is alice doing?")
+        assert result is link1
+
+    def test_short_prefix_matches_cautiously(self):
+        """Short email prefixes like 'a' can match unintended text."""
+        patient1 = make_user(email="a@example.com")
+        patient2 = make_user(email="bob@example.com")
+        link1 = make_link(patient=patient1)
+        link2 = make_link(patient=patient2)
+
+        # "a" matches in almost any message — this is documented behavior
+        result = _resolve_patient_for_chat([link1, link2], "How is a doing?")
+        assert result is link1
+
+
+# ── TestHandleCaregiverHelp ──
+
+
+class TestHandleCaregiverHelp:
+    """Tests for _handle_caregiver_help."""
+
+    def test_lists_status_and_help(self):
+        result = _handle_caregiver_help()
+        assert "/status" in result
+        assert "/help" in result
+
+    def test_mentions_ai_chat(self):
+        result = _handle_caregiver_help()
+        assert "question" in result.lower()
+
+    def test_notes_blocked_commands(self):
+        result = _handle_caregiver_help()
+        assert "/acknowledge" in result
+        assert "/brief" in result
+        assert "not available" in result
+
+
+# ── TestCaregiverCommandBlocking ──
+
+
+class TestCaregiverCommandBlocking:
+    """Tests for blocked commands."""
+
+    def test_blocked_message_mentions_patient(self):
+        result = _handle_blocked_command()
+        assert "patient accounts" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_caregiver.get_linked_patients",
+        new_callable=AsyncMock,
+    )
+    async def test_acknowledge_blocked(self, mock_links):
+        result = await handle_caregiver_command(
+            AsyncMock(), uuid.uuid4(), "/acknowledge"
+        )
+        assert "patient accounts" in result
+        mock_links.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_caregiver.get_linked_patients",
+        new_callable=AsyncMock,
+    )
+    async def test_brief_blocked(self, mock_links):
+        result = await handle_caregiver_command(AsyncMock(), uuid.uuid4(), "/brief")
+        assert "patient accounts" in result
+        mock_links.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_caregiver.get_linked_patients",
+        new_callable=AsyncMock,
+    )
+    async def test_acknowledge_with_id_blocked(self, mock_links):
+        alert_id = uuid.uuid4()
+        result = await handle_caregiver_command(
+            AsyncMock(), uuid.uuid4(), f"/acknowledge_{alert_id}"
+        )
+        assert "patient accounts" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_caregiver.get_linked_patients",
+        new_callable=AsyncMock,
+    )
+    async def test_status_allowed(self, mock_links):
+        mock_links.return_value = [make_link()]
+
+        with patch(
+            "src.services.telegram_caregiver._handle_caregiver_status",
+            new_callable=AsyncMock,
+        ) as mock_status:
+            mock_status.return_value = "status OK"
+            result = await handle_caregiver_command(
+                AsyncMock(), uuid.uuid4(), "/status"
+            )
+
+        assert result == "status OK"
+
+
+# ── TestHandleCaregiverCommand ──
+
+
+class TestHandleCaregiverCommand:
+    """Integration tests for handle_caregiver_command routing."""
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_caregiver.get_linked_patients",
+        new_callable=AsyncMock,
+    )
+    async def test_no_patients_status(self, mock_links):
+        mock_links.return_value = []
+        result = await handle_caregiver_command(AsyncMock(), uuid.uuid4(), "/status")
+        assert "No patients linked" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_caregiver.get_linked_patients",
+        new_callable=AsyncMock,
+    )
+    async def test_no_patients_plain_text(self, mock_links):
+        mock_links.return_value = []
+        result = await handle_caregiver_command(
+            AsyncMock(), uuid.uuid4(), "how is she?"
+        )
+        assert "No patients linked" in result
+
+    @pytest.mark.asyncio
+    async def test_help_command(self):
+        result = await handle_caregiver_command(AsyncMock(), uuid.uuid4(), "/help")
+        assert "Caregiver Commands" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_caregiver.get_linked_patients",
+        new_callable=AsyncMock,
+    )
+    async def test_unknown_slash_command(self, mock_links):
+        mock_links.return_value = []
+        result = await handle_caregiver_command(AsyncMock(), uuid.uuid4(), "/foobar")
+        assert "Unrecognized command" in result
+
+    @pytest.mark.asyncio
+    async def test_exception_caught(self):
+        """Exceptions are caught and return friendly error."""
+        db = AsyncMock()
+        db.execute.side_effect = RuntimeError("DB error")
+
+        result = await handle_caregiver_command(db, uuid.uuid4(), "/status")
+        assert "Something went wrong" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_caregiver.get_linked_patients",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "src.services.telegram_caregiver._handle_caregiver_chat",
+        new_callable=AsyncMock,
+    )
+    async def test_plain_text_routes_to_chat(self, mock_chat, mock_links):
+        mock_links.return_value = [make_link()]
+        mock_chat.return_value = "AI response"
+
+        result = await handle_caregiver_command(
+            AsyncMock(), uuid.uuid4(), "How is patient doing?"
+        )
+        assert result == "AI response"
+
+
+# ── TestNoPatients ──
+
+
+class TestNoPatients:
+    """Tests for _handle_no_patients."""
+
+    def test_message_content(self):
+        result = _handle_no_patients()
+        assert "No patients linked" in result
+        assert "web app" in result


### PR DESCRIPTION
## Summary

- Add `CaregiverLink` model + migration for linking caregiver and patient accounts
- Enable CAREGIVER-role users to use Telegram bot: `/status`, `/help`, AI chat about patient data
- Block patient-only commands (`/acknowledge`, `/brief`) for caregivers with clear error messages
- Upgrade escalation engine to resolve emergency contact usernames to Telegram chat_ids and deliver real notifications
- Add caregiver AI chat using patient's AI provider config and glucose context
- Support multi-patient caregivers with email prefix matching for patient resolution

## Security Hardening (Adversarial Review)

- `CheckConstraint` preventing self-linking (`caregiver_id != patient_id`)
- Case-insensitive username matching (`func.lower()`) for escalation delivery
- `html.escape()` applied to `user_email` and `alert.message` in `build_escalation_message`

## Test Plan

- [x] 751 tests pass (10 new tests added), 1 skipped
- [x] Ruff lint + format: clean
- [x] Frontend ESLint: clean
- [x] Playwright MCP visual regression: landing page renders correctly
- [x] Adversarial review: 18 findings, 9 fixed, 9 documented as acceptable/deferred
- [x] Re-review: all 9 fixes verified, no new issues

## Files Changed (12 files, +1422/-33)

**New:**
- `apps/api/src/models/caregiver_link.py` — CaregiverLink model
- `apps/api/migrations/versions/021_create_caregiver_links.py` — Migration
- `apps/api/src/services/telegram_caregiver.py` — Caregiver command handlers
- `apps/api/tests/test_caregiver_link.py` — Model tests (4 tests)
- `apps/api/tests/test_telegram_caregiver.py` — Caregiver handler tests (34 tests)

**Modified:**
- `apps/api/src/models/__init__.py` — Register CaregiverLink
- `apps/api/src/models/user.py` — Add caregiver_links/patient_links relationships
- `apps/api/src/services/telegram_commands.py` — Role detection + caregiver routing
- `apps/api/src/services/telegram_chat.py` — handle_caregiver_chat()
- `apps/api/src/services/escalation_engine.py` — Real Telegram delivery + HTML escaping
- `apps/api/tests/test_telegram_commands.py` — Caregiver routing tests (4 new)
- `apps/api/tests/test_escalation_engine.py` — _resolve_contact_chat_id tests (5 new) + db param updates