### PR TITLE
feat: add caregiver account creation & linking (Story 8.1)

### DIFF
--- a/apps/api/migrations/versions/022_create_caregiver_invitations.py
+++ b/apps/api/migrations/versions/022_create_caregiver_invitations.py
@@ -1,0 +1,106 @@
+"""Story 8.1: Create caregiver_invitations table.
+
+Revision ID: 022_caregiver_invitations
+Revises: 021_caregiver_links
+Create Date: 2026-02-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "022_caregiver_invitations"
+down_revision = "021_caregiver_links"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "caregiver_invitations",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "patient_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "token",
+            sa.String(64),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column(
+            "status",
+            sa.String(16),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column(
+            "expires_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "accepted_by",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "accepted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_index(
+        "ix_caregiver_invitations_patient_id",
+        "caregiver_invitations",
+        ["patient_id"],
+    )
+    op.create_index(
+        "ix_caregiver_invitations_token",
+        "caregiver_invitations",
+        ["token"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_caregiver_invitations_status",
+        "caregiver_invitations",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_caregiver_invitations_status",
+        table_name="caregiver_invitations",
+    )
+    op.drop_index(
+        "ix_caregiver_invitations_token",
+        table_name="caregiver_invitations",
+    )
+    op.drop_index(
+        "ix_caregiver_invitations_patient_id",
+        table_name="caregiver_invitations",
+    )
+    op.drop_table("caregiver_invitations")

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -15,6 +15,7 @@ from src.routers import (
     alerts,
     auth,
     briefs,
+    caregivers,
     correction_analysis,
     disclaimer,
     emergency_contacts,
@@ -101,6 +102,7 @@ app.include_router(alerts.router)
 app.include_router(emergency_contacts.router)
 app.include_router(escalation.router)
 app.include_router(telegram.router)
+app.include_router(caregivers.router)
 
 
 @app.get("/")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -3,6 +3,7 @@ from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProvide
 from src.models.alert import Alert, AlertSeverity, AlertType
 from src.models.alert_threshold import AlertThreshold
 from src.models.base import Base, TimestampMixin
+from src.models.caregiver_invitation import CaregiverInvitation, InvitationStatus
 from src.models.caregiver_link import CaregiverLink
 from src.models.correction_analysis import CorrectionAnalysis
 from src.models.daily_brief import DailyBrief
@@ -37,8 +38,10 @@ __all__ = [
     "AlertThreshold",
     "AlertType",
     "Base",
+    "CaregiverInvitation",
     "CaregiverLink",
     "ContactPriority",
+    "InvitationStatus",
     "CorrectionAnalysis",
     "TimestampMixin",
     "DailyBrief",

--- a/apps/api/src/models/caregiver_invitation.py
+++ b/apps/api/src/models/caregiver_invitation.py
@@ -1,0 +1,106 @@
+"""Story 8.1: Caregiver invitation model.
+
+Token-based invitations for linking caregivers to patients.
+A diabetic user creates an invitation with a unique token;
+the caregiver visits the invite URL, registers (or links), and
+the invitation is marked as accepted.
+"""
+
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+INVITATION_EXPIRY_DAYS = 7
+TOKEN_BYTES = 32
+
+
+class InvitationStatus(str, Enum):
+    """Lifecycle status of a caregiver invitation."""
+
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    EXPIRED = "expired"
+    REVOKED = "revoked"
+
+
+def _generate_token() -> str:
+    return secrets.token_urlsafe(TOKEN_BYTES)
+
+
+def _default_expiry() -> datetime:
+    return datetime.now(UTC) + timedelta(days=INVITATION_EXPIRY_DAYS)
+
+
+class CaregiverInvitation(Base, TimestampMixin):
+    """Invitation for a caregiver to link with a patient.
+
+    The patient (diabetic user) creates the invitation, which generates
+    a unique token. The caregiver visits the invite URL, registers or
+    links their existing account, and the invitation status moves to
+    ACCEPTED.
+    """
+
+    __tablename__ = "caregiver_invitations"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    patient_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    token: Mapped[str] = mapped_column(
+        String(64),
+        unique=True,
+        nullable=False,
+        default=_generate_token,
+        index=True,
+    )
+
+    status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default=InvitationStatus.PENDING.value,
+    )
+
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=_default_expiry,
+    )
+
+    accepted_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        default=None,
+    )
+
+    accepted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+
+    # Relationships
+    patient = relationship("User", foreign_keys=[patient_id])
+    acceptor = relationship("User", foreign_keys=[accepted_by])
+
+    def __repr__(self) -> str:
+        return (
+            f"<CaregiverInvitation(id={self.id}, "
+            f"patient={self.patient_id}, status={self.status})>"
+        )

--- a/apps/api/src/routers/caregivers.py
+++ b/apps/api/src/routers/caregivers.py
@@ -1,0 +1,251 @@
+"""Story 8.1: Caregiver invitation and linking router.
+
+Endpoints for creating/managing invitations (diabetic users) and
+accepting invitations (unauthenticated caregivers).
+"""
+
+import os
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import CurrentUser, require_caregiver, require_diabetic
+from src.core.security import hash_password
+from src.database import get_db
+from src.models.user import User
+from src.schemas.caregiver import (
+    AcceptInvitationRequest,
+    AcceptInvitationResponse,
+    InvitationCreateResponse,
+    InvitationDetailResponse,
+    InvitationListItem,
+    InvitationListResponse,
+    LinkedPatientResponse,
+    LinkedPatientsListResponse,
+)
+from src.services.caregiver import (
+    accept_invitation,
+    create_invitation,
+    get_invitation_by_token,
+    get_linked_patients,
+    list_invitations,
+    revoke_invitation,
+)
+
+router = APIRouter(prefix="/api/caregivers", tags=["caregivers"])
+
+# Frontend base URL for building invite links
+FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL", "")
+
+
+def _mask_email(email: str) -> str:
+    """Mask an email address for display to unauthenticated users.
+
+    Example: 'patient@example.com' → 'p*****t@example.com'
+    """
+    local, _, domain = email.partition("@")
+    if not domain:
+        return "***"
+    if len(local) <= 2:
+        masked_local = local[0] + "*" * max(len(local) - 1, 1)
+    else:
+        masked_local = local[0] + "*" * (len(local) - 2) + local[-1]
+    return f"{masked_local}@{domain}"
+
+
+def _build_invite_url(request: Request, token: str) -> str:
+    """Build the frontend invite URL from the current request."""
+    if FRONTEND_BASE_URL:
+        return f"{FRONTEND_BASE_URL.rstrip('/')}/invite/{token}"
+    # Fallback: derive from request base URL
+    base = str(request.base_url).rstrip("/")
+    return f"{base}/invite/{token}"
+
+
+@router.post(
+    "/invitations",
+    response_model=InvitationCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_diabetic)],
+)
+async def create_caregiver_invitation(
+    request: Request,
+    current_user: CurrentUser,
+    db: AsyncSession = Depends(get_db),
+) -> InvitationCreateResponse:
+    """Create a new caregiver invitation.
+
+    Generates a unique token that can be shared with a caregiver.
+    Maximum 10 pending invitations per patient.
+    """
+    try:
+        invitation = await create_invitation(db, current_user.id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    return InvitationCreateResponse(
+        id=invitation.id,
+        token=invitation.token,
+        expires_at=invitation.expires_at,
+        invite_url=_build_invite_url(request, invitation.token),
+    )
+
+
+@router.get(
+    "/invitations",
+    response_model=InvitationListResponse,
+    dependencies=[Depends(require_diabetic)],
+)
+async def list_caregiver_invitations(
+    current_user: CurrentUser,
+    db: AsyncSession = Depends(get_db),
+) -> InvitationListResponse:
+    """List all caregiver invitations for the current patient."""
+    invitations = await list_invitations(db, current_user.id)
+
+    # Batch-resolve accepted_by emails to avoid N+1 queries
+    acceptor_ids = [inv.accepted_by for inv in invitations if inv.accepted_by]
+    email_map: dict[uuid.UUID, str] = {}
+    if acceptor_ids:
+        result = await db.execute(
+            select(User.id, User.email).where(User.id.in_(acceptor_ids))
+        )
+        email_map = {row.id: row.email for row in result.all()}
+
+    items = [
+        InvitationListItem(
+            id=inv.id,
+            status=inv.status,
+            created_at=inv.created_at,
+            expires_at=inv.expires_at,
+            accepted_by_email=email_map.get(inv.accepted_by)
+            if inv.accepted_by
+            else None,
+        )
+        for inv in invitations
+    ]
+
+    return InvitationListResponse(invitations=items, count=len(items))
+
+
+@router.delete(
+    "/invitations/{invitation_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_diabetic)],
+)
+async def revoke_caregiver_invitation(
+    invitation_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Revoke a pending caregiver invitation."""
+    try:
+        result = await revoke_invitation(db, current_user.id, invitation_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invitation not found",
+        )
+
+
+@router.get(
+    "/invitations/{token}/details",
+    response_model=InvitationDetailResponse,
+)
+async def get_invitation_details(
+    token: str = Path(..., min_length=20, max_length=64),
+    db: AsyncSession = Depends(get_db),
+) -> InvitationDetailResponse:
+    """Get public invitation details for the acceptance page.
+
+    No authentication required — the token acts as authorization.
+    Patient email is masked for privacy.
+    """
+    invitation = await get_invitation_by_token(db, token)
+
+    if invitation is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invitation not found",
+        )
+
+    # Resolve patient email (masked for privacy on public endpoint)
+    result = await db.execute(
+        select(User.email).where(User.id == invitation.patient_id)
+    )
+    raw_email = result.scalar_one_or_none() or "Unknown"
+    masked = _mask_email(raw_email)
+
+    return InvitationDetailResponse(
+        patient_email=masked,
+        status=invitation.status,
+        expires_at=invitation.expires_at,
+    )
+
+
+@router.post(
+    "/accept",
+    response_model=AcceptInvitationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def accept_caregiver_invitation(
+    data: AcceptInvitationRequest,
+    db: AsyncSession = Depends(get_db),
+) -> AcceptInvitationResponse:
+    """Accept a caregiver invitation.
+
+    Creates a new CAREGIVER account (or links existing caregiver)
+    and establishes the caregiver-patient link.
+    No authentication required — the token acts as authorization.
+    """
+    hashed_pw = hash_password(data.password)
+
+    try:
+        caregiver, _invitation = await accept_invitation(
+            db, data.token, data.email, hashed_pw
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return AcceptInvitationResponse(
+        message="Invitation accepted successfully",
+        user_id=caregiver.id,
+    )
+
+
+@router.get(
+    "/patients",
+    response_model=LinkedPatientsListResponse,
+    dependencies=[Depends(require_caregiver)],
+)
+async def list_linked_patients(
+    current_user: CurrentUser,
+    db: AsyncSession = Depends(get_db),
+) -> LinkedPatientsListResponse:
+    """List all patients linked to the current caregiver."""
+    links = await get_linked_patients(db, current_user.id)
+
+    patients = [
+        LinkedPatientResponse(
+            patient_id=link.patient_id,
+            patient_email=link.patient.email if link.patient else "Unknown",
+            linked_at=link.created_at,
+        )
+        for link in links
+    ]
+
+    return LinkedPatientsListResponse(patients=patients, count=len(patients))

--- a/apps/api/src/schemas/caregiver.py
+++ b/apps/api/src/schemas/caregiver.py
@@ -1,0 +1,91 @@
+"""Story 8.1: Caregiver invitation and linking schemas."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+
+class InvitationCreateResponse(BaseModel):
+    """Response after creating a caregiver invitation."""
+
+    id: uuid.UUID
+    token: str
+    expires_at: datetime
+    invite_url: str
+
+
+class InvitationListItem(BaseModel):
+    """Single invitation in a list response."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    status: str
+    created_at: datetime
+    expires_at: datetime
+    accepted_by_email: str | None = None
+
+
+class InvitationListResponse(BaseModel):
+    """List of caregiver invitations."""
+
+    invitations: list[InvitationListItem]
+    count: int
+
+
+class InvitationDetailResponse(BaseModel):
+    """Public invitation details (for acceptance page, no auth)."""
+
+    patient_email: str
+    status: str
+    expires_at: datetime
+
+
+class AcceptInvitationRequest(BaseModel):
+    """Request to accept a caregiver invitation."""
+
+    token: str = Field(..., min_length=1, max_length=64)
+    email: EmailStr
+    password: str = Field(
+        ...,
+        min_length=8,
+        max_length=128,
+        description="Password (min 8 chars, uppercase, lowercase, number)",
+    )
+
+    @field_validator("password")
+    @classmethod
+    def validate_password_strength(cls, v: str) -> str:
+        """Validate password meets strength requirements."""
+        import re
+
+        if not re.search(r"[a-z]", v):
+            raise ValueError("Password must include uppercase, lowercase, and number")
+        if not re.search(r"[A-Z]", v):
+            raise ValueError("Password must include uppercase, lowercase, and number")
+        if not re.search(r"\d", v):
+            raise ValueError("Password must include uppercase, lowercase, and number")
+        return v
+
+
+class AcceptInvitationResponse(BaseModel):
+    """Response after accepting an invitation."""
+
+    message: str
+    user_id: uuid.UUID
+
+
+class LinkedPatientResponse(BaseModel):
+    """A patient linked to a caregiver."""
+
+    patient_id: uuid.UUID
+    patient_email: str
+    linked_at: datetime
+
+
+class LinkedPatientsListResponse(BaseModel):
+    """List of linked patients for a caregiver."""
+
+    patients: list[LinkedPatientResponse]
+    count: int

--- a/apps/api/src/services/caregiver.py
+++ b/apps/api/src/services/caregiver.py
@@ -1,0 +1,374 @@
+"""Story 8.1: Caregiver invitation and linking service.
+
+Handles invitation creation, acceptance, and caregiver-patient linking.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.caregiver_invitation import (
+    CaregiverInvitation,
+    InvitationStatus,
+)
+from src.models.caregiver_link import CaregiverLink
+from src.models.user import User, UserRole
+
+logger = get_logger(__name__)
+
+MAX_PENDING_INVITATIONS_PER_PATIENT = 10
+MAX_PATIENTS_PER_CAREGIVER = 5
+
+
+async def create_invitation(
+    db: AsyncSession,
+    patient_id: uuid.UUID,
+) -> CaregiverInvitation:
+    """Create a new caregiver invitation.
+
+    Args:
+        db: Database session.
+        patient_id: The diabetic user creating the invitation.
+
+    Returns:
+        The created CaregiverInvitation.
+
+    Raises:
+        ValueError: If the patient already has too many pending invitations.
+    """
+    # Check pending invitation count (with lock to prevent races)
+    result = await db.execute(
+        select(func.count())
+        .select_from(CaregiverInvitation)
+        .where(
+            and_(
+                CaregiverInvitation.patient_id == patient_id,
+                CaregiverInvitation.status == InvitationStatus.PENDING.value,
+            )
+        )
+        .with_for_update()
+    )
+    pending_count = result.scalar_one()
+
+    if pending_count >= MAX_PENDING_INVITATIONS_PER_PATIENT:
+        msg = (
+            f"Maximum of {MAX_PENDING_INVITATIONS_PER_PATIENT} "
+            f"pending invitations allowed"
+        )
+        raise ValueError(msg)
+
+    from src.models.caregiver_invitation import _default_expiry, _generate_token
+
+    invitation = CaregiverInvitation(
+        patient_id=patient_id,
+        token=_generate_token(),
+        expires_at=_default_expiry(),
+        status=InvitationStatus.PENDING.value,
+    )
+    db.add(invitation)
+    await db.commit()
+    await db.refresh(invitation)
+
+    logger.info(
+        "Created caregiver invitation",
+        patient_id=str(patient_id),
+        invitation_id=str(invitation.id),
+    )
+
+    return invitation
+
+
+async def list_invitations(
+    db: AsyncSession,
+    patient_id: uuid.UUID,
+) -> list[CaregiverInvitation]:
+    """List all invitations for a patient, newest first.
+
+    Also auto-expires stale PENDING invitations before returning.
+    """
+    await _expire_stale_invitations_for_patient(db, patient_id)
+
+    result = await db.execute(
+        select(CaregiverInvitation)
+        .where(CaregiverInvitation.patient_id == patient_id)
+        .order_by(CaregiverInvitation.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def revoke_invitation(
+    db: AsyncSession,
+    patient_id: uuid.UUID,
+    invitation_id: uuid.UUID,
+) -> CaregiverInvitation | None:
+    """Revoke a pending invitation.
+
+    Args:
+        db: Database session.
+        patient_id: Owner patient ID (for authorization).
+        invitation_id: The invitation to revoke.
+
+    Returns:
+        Updated invitation, or None if not found / not owned.
+
+    Raises:
+        ValueError: If the invitation is not in PENDING status.
+    """
+    result = await db.execute(
+        select(CaregiverInvitation).where(
+            and_(
+                CaregiverInvitation.id == invitation_id,
+                CaregiverInvitation.patient_id == patient_id,
+            )
+        )
+    )
+    invitation = result.scalar_one_or_none()
+
+    if invitation is None:
+        return None
+
+    if invitation.status != InvitationStatus.PENDING.value:
+        msg = f"Cannot revoke invitation with status '{invitation.status}'"
+        raise ValueError(msg)
+
+    invitation.status = InvitationStatus.REVOKED.value
+    await db.commit()
+    await db.refresh(invitation)
+
+    logger.info(
+        "Revoked caregiver invitation",
+        invitation_id=str(invitation_id),
+        patient_id=str(patient_id),
+    )
+
+    return invitation
+
+
+async def get_invitation_by_token(
+    db: AsyncSession,
+    token: str,
+) -> CaregiverInvitation | None:
+    """Look up an invitation by token.
+
+    Returns None if token not found, expired, or revoked.
+    Auto-expires stale PENDING invitations.
+    """
+    result = await db.execute(
+        select(CaregiverInvitation).where(CaregiverInvitation.token == token)
+    )
+    invitation = result.scalar_one_or_none()
+
+    if invitation is None:
+        return None
+
+    # Auto-expire if past expiry
+    if (
+        invitation.status == InvitationStatus.PENDING.value
+        and invitation.expires_at < datetime.now(UTC)
+    ):
+        invitation.status = InvitationStatus.EXPIRED.value
+        await db.commit()
+        await db.refresh(invitation)
+
+    return invitation
+
+
+async def accept_invitation(
+    db: AsyncSession,
+    token: str,
+    email: str,
+    hashed_password: str,
+) -> tuple[User, CaregiverInvitation]:
+    """Accept an invitation: register or link the caregiver.
+
+    If the email belongs to an existing CAREGIVER user, creates a new
+    CaregiverLink. If the email is new, creates a CAREGIVER user and
+    then creates the link.
+
+    Args:
+        db: Database session.
+        token: Invitation token.
+        email: Caregiver's email.
+        hashed_password: Pre-hashed password for new user creation.
+
+    Returns:
+        Tuple of (caregiver User, updated CaregiverInvitation).
+
+    Raises:
+        ValueError: If token is invalid/expired/revoked, if email belongs
+            to a non-caregiver user, or if caregiver has too many patients.
+    """
+    # Look up invitation with lock
+    result = await db.execute(
+        select(CaregiverInvitation)
+        .where(CaregiverInvitation.token == token)
+        .with_for_update()
+    )
+    invitation = result.scalar_one_or_none()
+
+    if invitation is None:
+        raise ValueError("Invalid invitation token")
+
+    # Auto-expire if past expiry
+    if (
+        invitation.status == InvitationStatus.PENDING.value
+        and invitation.expires_at < datetime.now(UTC)
+    ):
+        invitation.status = InvitationStatus.EXPIRED.value
+        await db.commit()
+        raise ValueError("This invitation has expired")
+
+    if invitation.status != InvitationStatus.PENDING.value:
+        raise ValueError(
+            f"This invitation is no longer valid (status: {invitation.status})"
+        )
+
+    # Prevent self-linking: caregiver email must not belong to the patient
+    email_lower = email.lower()
+    result = await db.execute(select(User).where(User.email == email_lower))
+    existing_user = result.scalar_one_or_none()
+
+    if existing_user is not None:
+        if existing_user.id == invitation.patient_id:
+            raise ValueError("You cannot accept your own invitation")
+        if existing_user.role == UserRole.CAREGIVER:
+            caregiver = existing_user
+        else:
+            raise ValueError(
+                "An account with this email already exists with a different role"
+            )
+    else:
+        # Create new CAREGIVER user
+        caregiver = User(
+            email=email_lower,
+            hashed_password=hashed_password,
+            role=UserRole.CAREGIVER,
+            is_active=True,
+            email_verified=False,
+            disclaimer_acknowledged=False,
+        )
+        db.add(caregiver)
+        await db.flush()  # Get caregiver.id
+
+    # Check max patients per caregiver
+    link_count_result = await db.execute(
+        select(func.count())
+        .select_from(CaregiverLink)
+        .where(CaregiverLink.caregiver_id == caregiver.id)
+    )
+    link_count = link_count_result.scalar_one()
+
+    if link_count >= MAX_PATIENTS_PER_CAREGIVER:
+        await db.rollback()
+        raise ValueError(
+            f"Caregiver already linked to maximum of "
+            f"{MAX_PATIENTS_PER_CAREGIVER} patients"
+        )
+
+    # Create the CaregiverLink
+    link = CaregiverLink(
+        caregiver_id=caregiver.id,
+        patient_id=invitation.patient_id,
+    )
+    db.add(link)
+
+    # Mark invitation as accepted
+    now = datetime.now(UTC)
+    invitation.status = InvitationStatus.ACCEPTED.value
+    invitation.accepted_by = caregiver.id
+    invitation.accepted_at = now
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise ValueError("This caregiver is already linked to this patient")
+
+    await db.refresh(caregiver)
+    await db.refresh(invitation)
+
+    logger.info(
+        "Caregiver invitation accepted",
+        invitation_id=str(invitation.id),
+        caregiver_id=str(caregiver.id),
+        patient_id=str(invitation.patient_id),
+    )
+
+    return caregiver, invitation
+
+
+async def get_linked_patients(
+    db: AsyncSession,
+    caregiver_id: uuid.UUID,
+) -> list[CaregiverLink]:
+    """Get all patients linked to a caregiver.
+
+    Eagerly loads the patient relationship.
+    """
+    from sqlalchemy.orm import selectinload
+
+    result = await db.execute(
+        select(CaregiverLink)
+        .where(CaregiverLink.caregiver_id == caregiver_id)
+        .options(selectinload(CaregiverLink.patient))
+        .order_by(CaregiverLink.created_at)
+    )
+    return list(result.scalars().all())
+
+
+async def _expire_stale_invitations_for_patient(
+    db: AsyncSession,
+    patient_id: uuid.UUID,
+) -> int:
+    """Expire PENDING invitations past their expiry for a specific patient.
+
+    Returns the number of invitations expired.
+    """
+    now = datetime.now(UTC)
+    result = await db.execute(
+        select(CaregiverInvitation).where(
+            and_(
+                CaregiverInvitation.patient_id == patient_id,
+                CaregiverInvitation.status == InvitationStatus.PENDING.value,
+                CaregiverInvitation.expires_at < now,
+            )
+        )
+    )
+    stale = list(result.scalars().all())
+
+    for inv in stale:
+        inv.status = InvitationStatus.EXPIRED.value
+
+    if stale:
+        await db.commit()
+
+    return len(stale)
+
+
+async def expire_stale_invitations(db: AsyncSession) -> int:
+    """Bulk expire all PENDING invitations past their expiry.
+
+    Returns the number of invitations expired.
+    """
+    now = datetime.now(UTC)
+    result = await db.execute(
+        select(CaregiverInvitation).where(
+            and_(
+                CaregiverInvitation.status == InvitationStatus.PENDING.value,
+                CaregiverInvitation.expires_at < now,
+            )
+        )
+    )
+    stale = list(result.scalars().all())
+
+    for inv in stale:
+        inv.status = InvitationStatus.EXPIRED.value
+
+    if stale:
+        await db.commit()
+
+    return len(stale)

--- a/apps/api/tests/test_caregiver_invitations.py
+++ b/apps/api/tests/test_caregiver_invitations.py
@@ -1,0 +1,614 @@
+"""Story 8.1: Tests for caregiver invitation and linking."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models.caregiver_invitation import (
+    INVITATION_EXPIRY_DAYS,
+    CaregiverInvitation,
+    InvitationStatus,
+)
+from src.models.caregiver_link import CaregiverLink
+from src.models.user import User, UserRole
+from src.services.caregiver import (
+    MAX_PATIENTS_PER_CAREGIVER,
+    MAX_PENDING_INVITATIONS_PER_PATIENT,
+    accept_invitation,
+    create_invitation,
+    expire_stale_invitations,
+    get_invitation_by_token,
+    get_linked_patients,
+    list_invitations,
+    revoke_invitation,
+)
+
+# ── Helpers ──
+
+
+def make_invitation(
+    status: str = InvitationStatus.PENDING.value,
+    token: str = "test-token-abc",
+    patient_id: uuid.UUID | None = None,
+    expires_at: datetime | None = None,
+) -> MagicMock:
+    """Create a mock CaregiverInvitation."""
+    inv = MagicMock(spec=CaregiverInvitation)
+    inv.id = uuid.uuid4()
+    inv.patient_id = patient_id or uuid.uuid4()
+    inv.token = token
+    inv.status = status
+    inv.expires_at = expires_at or (datetime.now(UTC) + timedelta(days=7))
+    inv.accepted_by = None
+    inv.accepted_at = None
+    inv.created_at = datetime.now(UTC)
+    inv.updated_at = datetime.now(UTC)
+    return inv
+
+
+def make_user(
+    role: UserRole = UserRole.DIABETIC,
+    email: str = "patient@example.com",
+) -> MagicMock:
+    """Create a mock User."""
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.email = email
+    user.role = role
+    return user
+
+
+# ── TestCaregiverInvitationModel ──
+
+
+class TestCaregiverInvitationModel:
+    """Tests for CaregiverInvitation model attributes."""
+
+    def test_tablename(self):
+        assert CaregiverInvitation.__tablename__ == "caregiver_invitations"
+
+    def test_repr(self):
+        patient_id = uuid.uuid4()
+        inv = CaregiverInvitation(patient_id=patient_id)
+        repr_str = repr(inv)
+        assert "CaregiverInvitation" in repr_str
+        assert str(patient_id) in repr_str
+
+    def test_invitation_status_values(self):
+        assert InvitationStatus.PENDING.value == "pending"
+        assert InvitationStatus.ACCEPTED.value == "accepted"
+        assert InvitationStatus.EXPIRED.value == "expired"
+        assert InvitationStatus.REVOKED.value == "revoked"
+
+    def test_expiry_default(self):
+        """Default expiry is INVITATION_EXPIRY_DAYS (7) days from now."""
+        assert INVITATION_EXPIRY_DAYS == 7
+
+
+# ── TestCreateInvitation ──
+
+
+class TestCreateInvitation:
+    """Tests for create_invitation."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Creates invitation and commits to DB."""
+        db = AsyncMock()
+
+        # Mock pending count query
+        mock_count_result = MagicMock()
+        mock_count_result.scalar_one.return_value = 0
+        db.execute.return_value = mock_count_result
+
+        invitation = await create_invitation(db, uuid.uuid4())
+
+        db.add.assert_called_once()
+        db.commit.assert_called_once()
+        db.refresh.assert_called_once()
+        assert invitation is not None
+
+    @pytest.mark.asyncio
+    async def test_max_pending_limit(self):
+        """Raises ValueError when max pending invitations reached."""
+        db = AsyncMock()
+
+        mock_count_result = MagicMock()
+        mock_count_result.scalar_one.return_value = MAX_PENDING_INVITATIONS_PER_PATIENT
+        db.execute.return_value = mock_count_result
+
+        with pytest.raises(ValueError, match="pending invitations"):
+            await create_invitation(db, uuid.uuid4())
+
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_token_is_generated(self):
+        """Created invitation has a token."""
+        db = AsyncMock()
+
+        mock_count_result = MagicMock()
+        mock_count_result.scalar_one.return_value = 0
+        db.execute.return_value = mock_count_result
+
+        await create_invitation(db, uuid.uuid4())
+
+        added = db.add.call_args[0][0]
+        assert added.token is not None
+        assert len(added.token) > 20
+
+    @pytest.mark.asyncio
+    async def test_expiry_is_7_days(self):
+        """Created invitation expires in ~7 days."""
+        db = AsyncMock()
+
+        mock_count_result = MagicMock()
+        mock_count_result.scalar_one.return_value = 0
+        db.execute.return_value = mock_count_result
+
+        await create_invitation(db, uuid.uuid4())
+
+        added = db.add.call_args[0][0]
+        now = datetime.now(UTC)
+        delta = added.expires_at - now
+        assert 6.9 < delta.total_seconds() / 86400 < 7.1
+
+
+# ── TestListInvitations ──
+
+
+class TestListInvitations:
+    """Tests for list_invitations."""
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.caregiver._expire_stale_invitations_for_patient",
+        new_callable=AsyncMock,
+    )
+    async def test_returns_invitations(self, mock_expire):
+        """Returns all invitations for the patient."""
+        inv1 = make_invitation()
+        inv2 = make_invitation(status=InvitationStatus.ACCEPTED.value)
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [inv1, inv2]
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await list_invitations(db, uuid.uuid4())
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.caregiver._expire_stale_invitations_for_patient",
+        new_callable=AsyncMock,
+    )
+    async def test_empty_list(self, mock_expire):
+        """Returns empty list when no invitations exist."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await list_invitations(db, uuid.uuid4())
+        assert result == []
+
+
+# ── TestRevokeInvitation ──
+
+
+class TestRevokeInvitation:
+    """Tests for revoke_invitation."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Revokes a pending invitation."""
+        inv = make_invitation()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = inv
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await revoke_invitation(db, inv.patient_id, inv.id)
+
+        assert inv.status == InvitationStatus.REVOKED.value
+        db.commit.assert_called_once()
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_not_found(self):
+        """Returns None when invitation not found."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await revoke_invitation(db, uuid.uuid4(), uuid.uuid4())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_already_accepted(self):
+        """Raises ValueError when invitation is not pending."""
+        inv = make_invitation(status=InvitationStatus.ACCEPTED.value)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = inv
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        with pytest.raises(ValueError, match="Cannot revoke"):
+            await revoke_invitation(db, inv.patient_id, inv.id)
+
+
+# ── TestGetInvitationByToken ──
+
+
+class TestGetInvitationByToken:
+    """Tests for get_invitation_by_token."""
+
+    @pytest.mark.asyncio
+    async def test_valid_token(self):
+        """Returns invitation for a valid token."""
+        inv = make_invitation()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = inv
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_invitation_by_token(db, "test-token-abc")
+        assert result is inv
+
+    @pytest.mark.asyncio
+    async def test_expired_auto_marks(self):
+        """Auto-marks expired PENDING invitations."""
+        inv = make_invitation(
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = inv
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_invitation_by_token(db, "test-token-abc")
+        assert result.status == InvitationStatus.EXPIRED.value
+        db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_not_found(self):
+        """Returns None for unknown token."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_invitation_by_token(db, "bogus")
+        assert result is None
+
+
+# ── TestAcceptInvitation ──
+
+
+class TestAcceptInvitation:
+    """Tests for accept_invitation."""
+
+    @pytest.mark.asyncio
+    async def test_new_user_created_as_caregiver(self):
+        """Creates a new CAREGIVER user when email is new."""
+        patient_id = uuid.uuid4()
+        inv = make_invitation(patient_id=patient_id)
+
+        # First execute: invitation lookup (with_for_update)
+        mock_inv_result = MagicMock()
+        mock_inv_result.scalar_one_or_none.return_value = inv
+
+        # Second execute: user lookup (email)
+        mock_user_result = MagicMock()
+        mock_user_result.scalar_one_or_none.return_value = None
+
+        # Third execute: link count
+        mock_count_result = MagicMock()
+        mock_count_result.scalar_one.return_value = 0
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            mock_inv_result,
+            mock_user_result,
+            mock_count_result,
+        ]
+
+        caregiver, returned_inv = await accept_invitation(
+            db, "test-token-abc", "carer@example.com", "hashed_pw"
+        )
+
+        # Should have added 2 objects: User + CaregiverLink
+        assert db.add.call_count == 2
+        added_objects = [call[0][0] for call in db.add.call_args_list]
+
+        new_user = next((o for o in added_objects if isinstance(o, User)), None)
+        new_link = next(
+            (o for o in added_objects if isinstance(o, CaregiverLink)), None
+        )
+
+        assert new_user is not None
+        assert new_user.role == UserRole.CAREGIVER
+        assert new_user.email == "carer@example.com"
+
+        assert new_link is not None
+        assert new_link.patient_id == patient_id
+
+        assert inv.status == InvitationStatus.ACCEPTED.value
+        assert inv.accepted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_existing_caregiver_linked(self):
+        """Links existing CAREGIVER user to a new patient."""
+        patient_id = uuid.uuid4()
+        inv = make_invitation(patient_id=patient_id)
+        existing_caregiver = make_user(
+            role=UserRole.CAREGIVER, email="carer@example.com"
+        )
+
+        mock_inv_result = MagicMock()
+        mock_inv_result.scalar_one_or_none.return_value = inv
+
+        mock_user_result = MagicMock()
+        mock_user_result.scalar_one_or_none.return_value = existing_caregiver
+
+        mock_count_result = MagicMock()
+        mock_count_result.scalar_one.return_value = 1
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            mock_inv_result,
+            mock_user_result,
+            mock_count_result,
+        ]
+
+        caregiver, returned_inv = await accept_invitation(
+            db, "test-token-abc", "carer@example.com", "hashed_pw"
+        )
+
+        # Should only add CaregiverLink, not a new User
+        assert db.add.call_count == 1
+        added = db.add.call_args[0][0]
+        assert isinstance(added, CaregiverLink)
+
+    @pytest.mark.asyncio
+    async def test_self_link_prevented(self):
+        """Raises ValueError when patient tries to accept own invitation."""
+        patient_id = uuid.uuid4()
+        inv = make_invitation(patient_id=patient_id)
+        # The patient themselves tries to accept
+        patient_user = make_user(role=UserRole.DIABETIC, email="patient@example.com")
+        patient_user.id = patient_id
+
+        mock_inv_result = MagicMock()
+        mock_inv_result.scalar_one_or_none.return_value = inv
+
+        mock_user_result = MagicMock()
+        mock_user_result.scalar_one_or_none.return_value = patient_user
+
+        db = AsyncMock()
+        db.execute.side_effect = [mock_inv_result, mock_user_result]
+
+        with pytest.raises(ValueError, match="cannot accept your own"):
+            await accept_invitation(
+                db, "test-token-abc", "patient@example.com", "hashed_pw"
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_caregiver_email_rejected(self):
+        """Raises ValueError when email belongs to a DIABETIC user."""
+        inv = make_invitation()
+        existing_diabetic = make_user(
+            role=UserRole.DIABETIC, email="patient@example.com"
+        )
+
+        mock_inv_result = MagicMock()
+        mock_inv_result.scalar_one_or_none.return_value = inv
+
+        mock_user_result = MagicMock()
+        mock_user_result.scalar_one_or_none.return_value = existing_diabetic
+
+        db = AsyncMock()
+        db.execute.side_effect = [mock_inv_result, mock_user_result]
+
+        with pytest.raises(ValueError, match="different role"):
+            await accept_invitation(
+                db, "test-token-abc", "patient@example.com", "hashed_pw"
+            )
+
+    @pytest.mark.asyncio
+    async def test_max_patients_enforced_with_rollback(self):
+        """Raises ValueError and rolls back when caregiver has too many patients."""
+        inv = make_invitation()
+
+        mock_inv_result = MagicMock()
+        mock_inv_result.scalar_one_or_none.return_value = inv
+
+        # No existing user — new user path (will create then rollback)
+        mock_user_result = MagicMock()
+        mock_user_result.scalar_one_or_none.return_value = None
+
+        mock_count_result = MagicMock()
+        mock_count_result.scalar_one.return_value = MAX_PATIENTS_PER_CAREGIVER
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            mock_inv_result,
+            mock_user_result,
+            mock_count_result,
+        ]
+
+        with pytest.raises(ValueError, match="maximum"):
+            await accept_invitation(
+                db, "test-token-abc", "carer@example.com", "hashed_pw"
+            )
+
+        # Verify rollback was called to prevent orphaned user
+        db.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_expired_token_rejected(self):
+        """Raises ValueError for expired token."""
+        inv = make_invitation(
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+
+        mock_inv_result = MagicMock()
+        mock_inv_result.scalar_one_or_none.return_value = inv
+
+        db = AsyncMock()
+        db.execute.return_value = mock_inv_result
+
+        with pytest.raises(ValueError, match="expired"):
+            await accept_invitation(
+                db, "test-token-abc", "carer@example.com", "hashed_pw"
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_rejected(self):
+        """Raises ValueError for unknown token."""
+        mock_inv_result = MagicMock()
+        mock_inv_result.scalar_one_or_none.return_value = None
+
+        db = AsyncMock()
+        db.execute.return_value = mock_inv_result
+
+        with pytest.raises(ValueError, match="Invalid"):
+            await accept_invitation(db, "bogus-token", "carer@example.com", "hashed_pw")
+
+    @pytest.mark.asyncio
+    async def test_already_accepted_rejected(self):
+        """Raises ValueError for already-accepted invitation."""
+        inv = make_invitation(status=InvitationStatus.ACCEPTED.value)
+
+        mock_inv_result = MagicMock()
+        mock_inv_result.scalar_one_or_none.return_value = inv
+
+        db = AsyncMock()
+        db.execute.return_value = mock_inv_result
+
+        with pytest.raises(ValueError, match="no longer valid"):
+            await accept_invitation(
+                db, "test-token-abc", "carer@example.com", "hashed_pw"
+            )
+
+
+# ── TestGetLinkedPatients ──
+
+
+class TestGetLinkedPatients:
+    """Tests for get_linked_patients."""
+
+    @pytest.mark.asyncio
+    async def test_returns_linked_patients(self):
+        """Returns CaregiverLinks for a caregiver."""
+        link = MagicMock(spec=CaregiverLink)
+        link.patient_id = uuid.uuid4()
+        link.created_at = datetime.now(UTC)
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [link]
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_linked_patients(db, uuid.uuid4())
+        assert len(result) == 1
+        assert result[0] is link
+
+    @pytest.mark.asyncio
+    async def test_empty_when_no_links(self):
+        """Returns empty list when caregiver has no links."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_linked_patients(db, uuid.uuid4())
+        assert result == []
+
+
+# ── TestExpireStaleInvitations ──
+
+
+class TestExpireStaleInvitations:
+    """Tests for expire_stale_invitations."""
+
+    @pytest.mark.asyncio
+    async def test_expires_old_pending(self):
+        """Marks stale PENDING invitations as EXPIRED."""
+        inv = make_invitation(
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [inv]
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        count = await expire_stale_invitations(db)
+        assert count == 1
+        assert inv.status == InvitationStatus.EXPIRED.value
+        db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_non_pending(self):
+        """Doesn't expire non-PENDING invitations."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        count = await expire_stale_invitations(db)
+        assert count == 0
+        db.commit.assert_not_called()
+
+
+# ── TestMaskEmail ──
+
+
+class TestMaskEmail:
+    """Tests for _mask_email helper."""
+
+    def test_normal_email(self):
+        from src.routers.caregivers import _mask_email
+
+        assert _mask_email("patient@example.com") == "p*****t@example.com"
+
+    def test_short_local_part(self):
+        from src.routers.caregivers import _mask_email
+
+        assert _mask_email("ab@example.com") == "a*@example.com"
+
+    def test_single_char_local(self):
+        from src.routers.caregivers import _mask_email
+
+        assert _mask_email("a@example.com") == "a*@example.com"
+
+    def test_no_domain(self):
+        from src.routers.caregivers import _mask_email
+
+        assert _mask_email("nodomain") == "***"
+
+    def test_unknown(self):
+        from src.routers.caregivers import _mask_email
+
+        assert _mask_email("Unknown") == "***"

--- a/apps/web/src/app/dashboard/settings/caregivers/page.tsx
+++ b/apps/web/src/app/dashboard/settings/caregivers/page.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+/**
+ * Story 8.1: Caregiver Invitation Management
+ *
+ * Allows diabetic users to create, view, and revoke caregiver invitations.
+ * Each invitation generates a shareable link that caregivers use to register.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  UserPlus,
+  Plus,
+  Loader2,
+  AlertTriangle,
+  Check,
+  Copy,
+  X,
+  ArrowLeft,
+  Clock,
+  CheckCircle,
+  XCircle,
+} from "lucide-react";
+import clsx from "clsx";
+import {
+  listCaregiverInvitations,
+  createCaregiverInvitation,
+  revokeCaregiverInvitation,
+  type CaregiverInvitationListItem,
+} from "@/lib/api";
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; className: string; icon: typeof Clock }
+> = {
+  pending: {
+    label: "Pending",
+    className: "bg-yellow-500/20 text-yellow-400",
+    icon: Clock,
+  },
+  accepted: {
+    label: "Accepted",
+    className: "bg-green-500/20 text-green-400",
+    icon: CheckCircle,
+  },
+  expired: {
+    label: "Expired",
+    className: "bg-slate-700 text-slate-400",
+    icon: XCircle,
+  },
+  revoked: {
+    label: "Revoked",
+    className: "bg-red-500/20 text-red-400",
+    icon: X,
+  },
+};
+
+export default function CaregiversPage() {
+  const [invitations, setInvitations] = useState<
+    CaregiverInvitationListItem[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
+  const [newInviteUrl, setNewInviteUrl] = useState<string | null>(null);
+
+  const fetchInvitations = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await listCaregiverInvitations();
+      setInvitations(data.invitations);
+    } catch (err) {
+      if (!(err instanceof Error && err.message.includes("401"))) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load invitations"
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchInvitations();
+  }, [fetchInvitations]);
+
+  const handleCreate = async () => {
+    setIsCreating(true);
+    setError(null);
+    setSuccess(null);
+    setNewInviteUrl(null);
+
+    try {
+      const invitation = await createCaregiverInvitation();
+      setNewInviteUrl(invitation.invite_url);
+      setSuccess("Invitation created! Share the link below with your caregiver.");
+      await fetchInvitations();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create invitation"
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleRevoke = async (id: string) => {
+    if (
+      !window.confirm(
+        "Revoke this invitation? The caregiver will no longer be able to use this link."
+      )
+    ) {
+      return;
+    }
+
+    setRevokingId(id);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      await revokeCaregiverInvitation(id);
+      setSuccess("Invitation revoked");
+      await fetchInvitations();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to revoke invitation"
+      );
+    } finally {
+      setRevokingId(null);
+    }
+  };
+
+  const handleCopy = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedUrl(url);
+      setTimeout(() => setCopiedUrl(null), 2000);
+    } catch {
+      setError("Failed to copy to clipboard");
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
+
+  const pendingCount = invitations.filter((i) => i.status === "pending").length;
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <a
+          href="/dashboard/settings"
+          className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Settings
+        </a>
+        <h1 className="text-2xl font-bold">Caregiver Access</h1>
+        <p className="text-slate-400">
+          Invite caregivers to monitor your glucose data via Telegram
+        </p>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div
+          className="bg-red-500/10 rounded-xl p-4 border border-red-500/20"
+          role="alert"
+        >
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Success state */}
+      {success && (
+        <div
+          className="bg-green-500/10 rounded-xl p-4 border border-green-500/20"
+          role="status"
+        >
+          <div className="flex items-center gap-2">
+            <Check className="h-4 w-4 text-green-400 shrink-0" />
+            <p className="text-sm text-green-400">{success}</p>
+          </div>
+        </div>
+      )}
+
+      {/* New invite URL */}
+      {newInviteUrl && (
+        <div className="bg-blue-500/10 rounded-xl p-4 border border-blue-500/20">
+          <p className="text-sm text-blue-400 mb-2">
+            Share this link with your caregiver:
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 bg-slate-800 rounded px-3 py-2 text-sm text-slate-200 overflow-x-auto">
+              {newInviteUrl}
+            </code>
+            <button
+              type="button"
+              onClick={() => handleCopy(newInviteUrl)}
+              className="shrink-0 p-2 rounded-lg bg-blue-600 text-white hover:bg-blue-500 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              aria-label="Copy invite link"
+            >
+              {copiedUrl === newInviteUrl ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+          <p className="text-xs text-slate-500 mt-2">
+            This link expires in 7 days. The caregiver will create an account
+            using this link.
+          </p>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div
+          className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+          role="status"
+          aria-label="Loading invitations"
+        >
+          <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+          <p className="text-slate-400">Loading invitations...</p>
+        </div>
+      )}
+
+      {/* Invitations list */}
+      {!isLoading && (
+        <div className="bg-slate-900 rounded-xl border border-slate-800 p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 bg-blue-500/10 rounded-lg">
+              <UserPlus className="h-5 w-5 text-blue-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Invitations</h2>
+              <p className="text-xs text-slate-500">
+                {pendingCount} pending,{" "}
+                {invitations.filter((i) => i.status === "accepted").length}{" "}
+                accepted
+              </p>
+            </div>
+          </div>
+
+          {invitations.length === 0 && (
+            <div className="text-center py-8">
+              <UserPlus className="h-10 w-10 text-slate-600 mx-auto mb-3" />
+              <p className="text-slate-400 mb-1">No invitations yet</p>
+              <p className="text-xs text-slate-500">
+                Create an invitation to give a caregiver access to your
+                glucose data
+              </p>
+            </div>
+          )}
+
+          {invitations.length > 0 && (
+            <div className="space-y-3 mb-4">
+              {invitations.map((inv) => {
+                const config = STATUS_CONFIG[inv.status] || STATUS_CONFIG.pending;
+                const StatusIcon = config.icon;
+                return (
+                  <div
+                    key={inv.id}
+                    className="flex items-center justify-between bg-slate-800/50 rounded-lg p-4 border border-slate-700/50"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <StatusIcon className="h-4 w-4 shrink-0" />
+                        <span
+                          className={clsx(
+                            "text-xs px-2 py-0.5 rounded-full",
+                            config.className
+                          )}
+                        >
+                          {config.label}
+                        </span>
+                      </div>
+                      <div className="text-xs text-slate-500 mt-1">
+                        Created {formatDate(inv.created_at)} &middot; Expires{" "}
+                        {formatDate(inv.expires_at)}
+                      </div>
+                      {inv.accepted_by_email && (
+                        <div className="text-xs text-green-400 mt-1">
+                          Accepted by {inv.accepted_by_email}
+                        </div>
+                      )}
+                    </div>
+                    {inv.status === "pending" && (
+                      <button
+                        type="button"
+                        onClick={() => handleRevoke(inv.id)}
+                        disabled={revokingId === inv.id}
+                        className="shrink-0 ml-3 p-2 rounded-lg text-slate-400 hover:text-red-400 hover:bg-red-500/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50"
+                        aria-label="Revoke invitation"
+                      >
+                        {revokingId === inv.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <X className="h-4 w-4" />
+                        )}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Create button */}
+          {pendingCount < 10 && (
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={isCreating}
+              className={clsx(
+                "flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium",
+                "bg-blue-600 text-white hover:bg-blue-500",
+                "transition-colors",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                "disabled:opacity-50 disabled:cursor-not-allowed"
+              )}
+            >
+              {isCreating ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              {isCreating ? "Creating..." : "Create Invitation"}
+            </button>
+          )}
+
+          {pendingCount >= 10 && (
+            <p className="text-xs text-slate-500">
+              Maximum of 10 pending invitations reached
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Info card */}
+      <div className="bg-slate-900/50 rounded-xl p-4 border border-slate-800">
+        <h3 className="text-sm font-medium text-slate-300 mb-2">
+          How it works
+        </h3>
+        <ol className="text-xs text-slate-500 space-y-1 list-decimal list-inside">
+          <li>Create an invitation to generate a unique link</li>
+          <li>Share the link with your caregiver</li>
+          <li>They create an account using the link</li>
+          <li>
+            Once linked, they can check your glucose via Telegram bot
+          </li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -6,7 +6,7 @@
  */
 
 import Link from "next/link";
-import { Settings, User, Bell, Database, Link2, Users, MessageCircle } from "lucide-react";
+import { Settings, User, Bell, Database, Link2, Users, MessageCircle, UserPlus } from "lucide-react";
 
 const settingsSections = [
   {
@@ -32,6 +32,12 @@ const settingsSections = [
     description: "Manage contacts for alert escalation via Telegram",
     icon: Users,
     href: "/dashboard/settings/emergency-contacts",
+  },
+  {
+    title: "Caregivers",
+    description: "Invite caregivers to monitor your glucose data",
+    icon: UserPlus,
+    href: "/dashboard/settings/caregivers",
   },
   {
     title: "Telegram",

--- a/apps/web/src/app/invite/[token]/page.tsx
+++ b/apps/web/src/app/invite/[token]/page.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+/**
+ * Story 8.1: Caregiver Invitation Acceptance Page
+ *
+ * Public page (no auth required) where caregivers create an account
+ * and accept a patient's invitation to link.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  UserPlus,
+  Loader2,
+  AlertTriangle,
+  CheckCircle,
+  XCircle,
+  Clock,
+  Eye,
+  EyeOff,
+} from "lucide-react";
+import clsx from "clsx";
+import {
+  getInvitationDetails,
+  acceptCaregiverInvitation,
+  type InvitationDetail,
+} from "@/lib/api";
+
+export default function InviteAcceptPage() {
+  const params = useParams();
+  const router = useRouter();
+  const token = params.token as string;
+
+  const [invitation, setInvitation] = useState<InvitationDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Form state
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const fetchDetails = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await getInvitationDetails(token);
+      setInvitation(data);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to load invitation details"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchDetails();
+  }, [fetchDetails]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+
+    if (password !== confirmPassword) {
+      setFormError("Passwords do not match");
+      return;
+    }
+
+    if (password.length < 8) {
+      setFormError("Password must be at least 8 characters");
+      return;
+    }
+
+    if (!/[a-z]/.test(password) || !/[A-Z]/.test(password) || !/\d/.test(password)) {
+      setFormError(
+        "Password must include uppercase, lowercase, and a number"
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await acceptCaregiverInvitation(token, email, password);
+      setSuccess(true);
+      // Redirect to login after 3 seconds
+      setTimeout(() => {
+        router.push("/");
+      }, 3000);
+    } catch (err) {
+      setFormError(
+        err instanceof Error ? err.message : "Failed to accept invitation"
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-slate-950 flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+          <p className="text-slate-400">Loading invitation...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state (invalid/not found token)
+  if (error || !invitation) {
+    return (
+      <div className="min-h-screen bg-slate-950 flex items-center justify-center p-4">
+        <div className="max-w-md w-full bg-slate-900 rounded-xl border border-slate-800 p-8 text-center">
+          <XCircle className="h-12 w-12 text-red-400 mx-auto mb-4" />
+          <h1 className="text-xl font-bold text-slate-200 mb-2">
+            Invalid Invitation
+          </h1>
+          <p className="text-slate-400 text-sm">
+            {error || "This invitation link is invalid or has expired."}
+          </p>
+          <Link
+            href="/"
+            className="inline-block mt-6 px-4 py-2 bg-slate-800 text-slate-300 rounded-lg text-sm hover:bg-slate-700 transition-colors"
+          >
+            Go to Home
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Expired or revoked
+  if (invitation.status !== "pending") {
+    return (
+      <div className="min-h-screen bg-slate-950 flex items-center justify-center p-4">
+        <div className="max-w-md w-full bg-slate-900 rounded-xl border border-slate-800 p-8 text-center">
+          {invitation.status === "accepted" ? (
+            <>
+              <CheckCircle className="h-12 w-12 text-green-400 mx-auto mb-4" />
+              <h1 className="text-xl font-bold text-slate-200 mb-2">
+                Already Accepted
+              </h1>
+              <p className="text-slate-400 text-sm">
+                This invitation has already been accepted. You can log in to
+                your account.
+              </p>
+            </>
+          ) : (
+            <>
+              <Clock className="h-12 w-12 text-slate-500 mx-auto mb-4" />
+              <h1 className="text-xl font-bold text-slate-200 mb-2">
+                Invitation{" "}
+                {invitation.status === "expired" ? "Expired" : "Revoked"}
+              </h1>
+              <p className="text-slate-400 text-sm">
+                This invitation is no longer valid. Please ask{" "}
+                {invitation.patient_email} to send a new invitation.
+              </p>
+            </>
+          )}
+          <Link
+            href="/"
+            className="inline-block mt-6 px-4 py-2 bg-slate-800 text-slate-300 rounded-lg text-sm hover:bg-slate-700 transition-colors"
+          >
+            Go to Home
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Success state
+  if (success) {
+    return (
+      <div className="min-h-screen bg-slate-950 flex items-center justify-center p-4">
+        <div className="max-w-md w-full bg-slate-900 rounded-xl border border-slate-800 p-8 text-center">
+          <CheckCircle className="h-12 w-12 text-green-400 mx-auto mb-4" />
+          <h1 className="text-xl font-bold text-slate-200 mb-2">
+            Account Created!
+          </h1>
+          <p className="text-slate-400 text-sm mb-4">
+            Your caregiver account has been created and linked to{" "}
+            {invitation.patient_email}. You can now monitor their glucose data
+            via the Telegram bot.
+          </p>
+          <p className="text-xs text-slate-500">
+            Redirecting to login...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Pending — show registration form
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center p-4">
+      <div className="max-w-md w-full bg-slate-900 rounded-xl border border-slate-800 p-8">
+        <div className="text-center mb-6">
+          <UserPlus className="h-12 w-12 text-blue-400 mx-auto mb-4" />
+          <h1 className="text-xl font-bold text-slate-200 mb-2">
+            Caregiver Invitation
+          </h1>
+          <p className="text-slate-400 text-sm">
+            <span className="text-blue-400">{invitation.patient_email}</span>{" "}
+            has invited you to be their caregiver on GlycemicGPT.
+          </p>
+          <p className="text-xs text-slate-500 mt-2">
+            Expires {new Date(invitation.expires_at).toLocaleDateString()}
+          </p>
+        </div>
+
+        {formError && (
+          <div
+            className="bg-red-500/10 rounded-lg p-3 border border-red-500/20 mb-4"
+            role="alert"
+          >
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />
+              <p className="text-sm text-red-400">{formError}</p>
+            </div>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-slate-300 mb-1"
+            >
+              Email Address
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className={clsx(
+                "w-full rounded-lg border px-3 py-2 text-sm",
+                "bg-slate-800 border-slate-700 text-slate-200",
+                "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                "placeholder:text-slate-500"
+              )}
+              placeholder="your@email.com"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-slate-300 mb-1"
+            >
+              Password
+            </label>
+            <div className="relative">
+              <input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                required
+                minLength={8}
+                maxLength={128}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className={clsx(
+                  "w-full rounded-lg border px-3 py-2 pr-10 text-sm",
+                  "bg-slate-800 border-slate-700 text-slate-200",
+                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                  "placeholder:text-slate-500"
+                )}
+                placeholder="Min 8 chars, upper, lower, number"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-slate-400 hover:text-slate-200"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="confirm-password"
+              className="block text-sm font-medium text-slate-300 mb-1"
+            >
+              Confirm Password
+            </label>
+            <input
+              id="confirm-password"
+              type={showPassword ? "text" : "password"}
+              required
+              minLength={8}
+              maxLength={128}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className={clsx(
+                "w-full rounded-lg border px-3 py-2 text-sm",
+                "bg-slate-800 border-slate-700 text-slate-200",
+                "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                "placeholder:text-slate-500"
+              )}
+              placeholder="Confirm your password"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className={clsx(
+              "w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium",
+              "bg-blue-600 text-white hover:bg-blue-500",
+              "transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+              "disabled:opacity-50 disabled:cursor-not-allowed"
+            )}
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Creating Account...
+              </>
+            ) : (
+              <>
+                <UserPlus className="h-4 w-4" />
+                Create Account & Accept
+              </>
+            )}
+          </button>
+        </form>
+
+        <p className="text-xs text-slate-500 text-center mt-4">
+          Already have a caregiver account?{" "}
+          <Link href="/" className="text-blue-400 hover:text-blue-300">
+            Log in
+          </Link>{" "}
+          first, then visit this link again.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -708,3 +708,167 @@ export async function getAlertEscalationTimeline(
 
   return response.json();
 }
+
+/**
+ * Caregiver Invitation API types (Story 8.1)
+ */
+export interface CaregiverInvitation {
+  id: string;
+  token: string;
+  expires_at: string;
+  invite_url: string;
+}
+
+export interface CaregiverInvitationListItem {
+  id: string;
+  status: string;
+  created_at: string;
+  expires_at: string;
+  accepted_by_email: string | null;
+}
+
+export interface CaregiverInvitationListResponse {
+  invitations: CaregiverInvitationListItem[];
+  count: number;
+}
+
+export interface InvitationDetail {
+  patient_email: string;
+  status: string;
+  expires_at: string;
+}
+
+export interface AcceptInvitationResponse {
+  message: string;
+  user_id: string;
+}
+
+export interface LinkedPatient {
+  patient_id: string;
+  patient_email: string;
+  linked_at: string;
+}
+
+export interface LinkedPatientsListResponse {
+  patients: LinkedPatient[];
+  count: number;
+}
+
+/**
+ * Create a new caregiver invitation
+ */
+export async function createCaregiverInvitation(): Promise<CaregiverInvitation> {
+  const response = await fetch(`${API_BASE_URL}/api/caregivers/invitations`, {
+    method: "POST",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to create invitation: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * List all caregiver invitations for the current patient
+ */
+export async function listCaregiverInvitations(): Promise<CaregiverInvitationListResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/caregivers/invitations`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to list invitations: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Revoke a pending caregiver invitation
+ */
+export async function revokeCaregiverInvitation(id: string): Promise<void> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/caregivers/invitations/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+      credentials: "include",
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to revoke invitation: ${response.status}`
+    );
+  }
+}
+
+/**
+ * Get public invitation details (no auth required)
+ */
+export async function getInvitationDetails(
+  token: string
+): Promise<InvitationDetail> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/caregivers/invitations/${encodeURIComponent(token)}/details`
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to fetch invitation details: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Accept a caregiver invitation (no auth required)
+ */
+export async function acceptCaregiverInvitation(
+  token: string,
+  email: string,
+  password: string
+): Promise<AcceptInvitationResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/caregivers/accept`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token, email, password }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to accept invitation: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * List linked patients for the current caregiver
+ */
+export async function listLinkedPatients(): Promise<LinkedPatientsListResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/caregivers/patients`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to list linked patients: ${response.status}`
+    );
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary

- Implement token-based invitation flow for linking caregivers to diabetic patients
- Patients create invitations with unique URL-safe tokens (7-day expiry, max 10 pending)
- Caregivers visit invite URL, register (or link existing account), and get auto-linked
- New `CaregiverInvitation` model with full lifecycle tracking (pending/accepted/expired/revoked)

## What's New

### Backend (FastAPI)
- **Model + Migration**: `CaregiverInvitation` with token, status, expiry, and FK relationships
- **6 API endpoints**: Create/list/revoke invitations (auth), public token details, accept invitation, list linked patients
- **Service layer**: Invitation CRUD, caregiver registration, auto-expiry, race condition safety (`SELECT FOR UPDATE`)
- **Security fixes** (from adversarial review):
  - Patient email masked on public endpoint (`p*****t@example.com`)
  - Self-link prevention (patient cannot accept own invitation)
  - Orphaned user rollback on max-patients failure
  - Token path parameter length validation (min 20, max 64)
  - N+1 query fix: batch user lookups for accepted invitations
  - Configurable `FRONTEND_BASE_URL` env var (replaces naive port replacement)

### Frontend (Next.js)
- **Caregiver settings page** (`/dashboard/settings/caregivers`): Create invitations, copy invite URL, revoke, status badges
- **Public invite page** (`/invite/[token]`): Registration form with password validation, handles all invitation states
- **Settings page**: New Caregivers card between Emergency Contacts and Telegram
- **API client**: 6 functions + 7 TypeScript interfaces

### Tests
- **33 tests** covering model, service, router logic, and security edge cases
- Self-link prevention, rollback verification, email masking, expiry auto-marking
- Full suite: **784 passed**, 1 skipped

## Adversarial Review

Two rounds of adversarial review completed. All CRITICAL/HIGH/MEDIUM findings addressed:
| Severity | Finding | Resolution |
|----------|---------|------------|
| CRITICAL | Patient email disclosure | Masked with _mask_email() |
| CRITICAL | Self-linking possible | ID comparison check added |
| HIGH | Orphaned user on max-patients | db.rollback() before raise |
| MEDIUM | Fragile invite URL | FRONTEND_BASE_URL env var |
| MEDIUM | N+1 query | Batch IN query |
| MEDIUM | Path ambiguity | Path(min_length=20, max_length=64) |

## Test plan

- [x] uv run pytest tests/test_caregiver_invitations.py -x -q - 33 passed
- [x] uv run pytest tests/ -q - 784 passed, 1 skipped
- [x] uv run ruff check and uv run ruff format --check - clean
- [x] npx next lint - no warnings or errors
- [x] Playwright MCP: settings page shows Caregivers card
- [x] Playwright MCP: caregivers page renders empty state
- [x] Playwright MCP: invite page shows error state (API not running)
- [x] Playwright MCP: dashboard, alerts - no regressions
- [x] Adversarial review (2 rounds) - all findings resolved

Generated with [Claude Code](https://claude.com/claude-code)