### PR TITLE
feat: add caregiver data access permission management (Story 8.2)

### DIFF
--- a/apps/api/migrations/versions/023_add_caregiver_permissions.py
+++ b/apps/api/migrations/versions/023_add_caregiver_permissions.py
@@ -1,0 +1,70 @@
+"""Story 8.2: Add permission columns to caregiver_links table.
+
+Revision ID: 023_caregiver_permissions
+Revises: 022_caregiver_invitations
+Create Date: 2026-02-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "023_caregiver_permissions"
+down_revision = "022_caregiver_invitations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "caregiver_links",
+        sa.Column(
+            "can_view_glucose",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "caregiver_links",
+        sa.Column(
+            "can_view_history",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "caregiver_links",
+        sa.Column(
+            "can_view_iob",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "caregiver_links",
+        sa.Column(
+            "can_view_ai_suggestions",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "caregiver_links",
+        sa.Column(
+            "can_receive_alerts",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("caregiver_links", "can_receive_alerts")
+    op.drop_column("caregiver_links", "can_view_ai_suggestions")
+    op.drop_column("caregiver_links", "can_view_iob")
+    op.drop_column("caregiver_links", "can_view_history")
+    op.drop_column("caregiver_links", "can_view_glucose")

--- a/apps/api/src/models/caregiver_link.py
+++ b/apps/api/src/models/caregiver_link.py
@@ -46,6 +46,13 @@ class CaregiverLink(Base, TimestampMixin):
         index=True,
     )
 
+    # Permission flags (Story 8.2)
+    can_view_glucose: Mapped[bool] = mapped_column(default=True)
+    can_view_history: Mapped[bool] = mapped_column(default=True)
+    can_view_iob: Mapped[bool] = mapped_column(default=True)
+    can_view_ai_suggestions: Mapped[bool] = mapped_column(default=False)
+    can_receive_alerts: Mapped[bool] = mapped_column(default=True)
+
     # Relationships
     caregiver = relationship("User", foreign_keys=[caregiver_id])
     patient = relationship("User", foreign_keys=[patient_id])

--- a/apps/api/src/schemas/caregiver_permissions.py
+++ b/apps/api/src/schemas/caregiver_permissions.py
@@ -1,0 +1,55 @@
+"""Story 8.2: Caregiver permission schemas."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CaregiverPermissions(BaseModel):
+    """The 5 per-caregiver permission flags."""
+
+    can_view_glucose: bool = True
+    can_view_history: bool = True
+    can_view_iob: bool = True
+    can_view_ai_suggestions: bool = False
+    can_receive_alerts: bool = True
+
+
+class LinkedCaregiverItem(BaseModel):
+    """A caregiver linked to the current patient, with permissions."""
+
+    link_id: uuid.UUID
+    caregiver_id: uuid.UUID
+    caregiver_email: str
+    linked_at: datetime
+    permissions: CaregiverPermissions
+
+
+class LinkedCaregiversResponse(BaseModel):
+    """List of linked caregivers for a diabetic user."""
+
+    caregivers: list[LinkedCaregiverItem]
+    count: int
+
+
+class PermissionsUpdateRequest(BaseModel):
+    """Partial update of caregiver permissions.
+
+    Only provided fields are updated; omitted fields remain unchanged.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    can_view_glucose: bool | None = None
+    can_view_history: bool | None = None
+    can_view_iob: bool | None = None
+    can_view_ai_suggestions: bool | None = None
+    can_receive_alerts: bool | None = None
+
+
+class PermissionsUpdateResponse(BaseModel):
+    """Response after updating permissions."""
+
+    link_id: uuid.UUID
+    permissions: CaregiverPermissions

--- a/apps/api/tests/test_caregiver_permissions.py
+++ b/apps/api/tests/test_caregiver_permissions.py
@@ -1,0 +1,413 @@
+"""Story 8.2: Tests for caregiver data access permissions."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.caregiver_link import CaregiverLink
+from src.models.user import User, UserRole
+from src.services.caregiver import (
+    PERMISSION_FIELDS,
+    check_caregiver_permission,
+    get_link_permissions,
+    get_linked_caregivers,
+    update_link_permissions,
+)
+
+# ── Helpers ──
+
+
+def make_link(
+    patient_id: uuid.UUID | None = None,
+    caregiver_id: uuid.UUID | None = None,
+    **overrides: bool,
+) -> MagicMock:
+    """Create a mock CaregiverLink with permission defaults."""
+    link = MagicMock(spec=CaregiverLink)
+    link.id = uuid.uuid4()
+    link.patient_id = patient_id or uuid.uuid4()
+    link.caregiver_id = caregiver_id or uuid.uuid4()
+    link.created_at = datetime.now(UTC)
+    link.updated_at = datetime.now(UTC)
+    # Permission defaults
+    link.can_view_glucose = overrides.get("can_view_glucose", True)
+    link.can_view_history = overrides.get("can_view_history", True)
+    link.can_view_iob = overrides.get("can_view_iob", True)
+    link.can_view_ai_suggestions = overrides.get("can_view_ai_suggestions", False)
+    link.can_receive_alerts = overrides.get("can_receive_alerts", True)
+    # Mock caregiver relationship
+    caregiver = MagicMock(spec=User)
+    caregiver.id = link.caregiver_id
+    caregiver.email = "caregiver@example.com"
+    caregiver.role = UserRole.CAREGIVER
+    link.caregiver = caregiver
+    return link
+
+
+# ── TestCaregiverLinkPermissionDefaults ──
+
+
+class TestCaregiverLinkPermissionDefaults:
+    """Tests for CaregiverLink permission column defaults."""
+
+    def test_permission_fields_defined(self):
+        """All 5 permission fields are in the constant set."""
+        expected = {
+            "can_view_glucose",
+            "can_view_history",
+            "can_view_iob",
+            "can_view_ai_suggestions",
+            "can_receive_alerts",
+        }
+        assert expected == PERMISSION_FIELDS
+
+    def test_model_has_permission_columns(self):
+        """CaregiverLink model has all permission columns."""
+        link = CaregiverLink(
+            patient_id=uuid.uuid4(),
+            caregiver_id=uuid.uuid4(),
+        )
+        # These should not raise
+        assert hasattr(link, "can_view_glucose")
+        assert hasattr(link, "can_view_history")
+        assert hasattr(link, "can_view_iob")
+        assert hasattr(link, "can_view_ai_suggestions")
+        assert hasattr(link, "can_receive_alerts")
+
+
+# ── TestGetLinkedCaregivers ──
+
+
+class TestGetLinkedCaregivers:
+    """Tests for get_linked_caregivers service function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_linked_caregivers(self):
+        """Returns CaregiverLinks for a patient."""
+        link = make_link()
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [link]
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_linked_caregivers(db, link.patient_id)
+        assert len(result) == 1
+        assert result[0] is link
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(self):
+        """Returns empty list when no caregivers linked."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_linked_caregivers(db, uuid.uuid4())
+        assert result == []
+
+
+# ── TestGetLinkPermissions ──
+
+
+class TestGetLinkPermissions:
+    """Tests for get_link_permissions service function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_link(self):
+        """Returns the CaregiverLink when found and owned."""
+        patient_id = uuid.uuid4()
+        link = make_link(patient_id=patient_id)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = link
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_link_permissions(db, patient_id, link.id)
+        assert result is link
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self):
+        """Returns None for non-existent link."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await get_link_permissions(db, uuid.uuid4(), uuid.uuid4())
+        assert result is None
+
+
+# ── TestUpdateLinkPermissions ──
+
+
+class TestUpdateLinkPermissions:
+    """Tests for update_link_permissions service function."""
+
+    @pytest.mark.asyncio
+    async def test_full_update(self):
+        """Updates all permission fields."""
+        patient_id = uuid.uuid4()
+        link = make_link(patient_id=patient_id)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = link
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await update_link_permissions(
+            db,
+            patient_id,
+            link.id,
+            can_view_glucose=False,
+            can_view_history=False,
+            can_view_iob=False,
+            can_view_ai_suggestions=True,
+            can_receive_alerts=False,
+        )
+
+        assert result is link
+        assert link.can_view_glucose is False
+        assert link.can_view_ai_suggestions is True
+        db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_partial_update(self):
+        """Only updates provided fields."""
+        patient_id = uuid.uuid4()
+        link = make_link(patient_id=patient_id)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = link
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await update_link_permissions(
+            db,
+            patient_id,
+            link.id,
+            can_view_ai_suggestions=True,
+        )
+
+        assert result is link
+        assert link.can_view_ai_suggestions is True
+        # Other fields should remain at their default values
+        db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_op_skips_commit(self):
+        """Skips commit when no valid fields provided."""
+        patient_id = uuid.uuid4()
+        link = make_link(patient_id=patient_id)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = link
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await update_link_permissions(
+            db,
+            patient_id,
+            link.id,
+            invalid_field=True,
+        )
+
+        assert result is link
+        db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_none(self):
+        """Returns None when link not found."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await update_link_permissions(
+            db,
+            uuid.uuid4(),
+            uuid.uuid4(),
+            can_view_glucose=False,
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ignores_none_values(self):
+        """Ignores fields set to None (from exclude_unset)."""
+        patient_id = uuid.uuid4()
+        link = make_link(patient_id=patient_id)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = link
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await update_link_permissions(
+            db,
+            patient_id,
+            link.id,
+            can_view_glucose=None,
+            can_view_ai_suggestions=True,
+        )
+
+        assert result is link
+        # Only can_view_ai_suggestions should trigger commit
+        db.commit.assert_called_once()
+
+
+# ── TestCheckCaregiverPermission ──
+
+
+class TestCheckCaregiverPermission:
+    """Tests for check_caregiver_permission service function."""
+
+    @pytest.mark.asyncio
+    async def test_permission_granted(self):
+        """Returns True when permission is enabled."""
+        link = make_link(can_view_glucose=True)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = link
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await check_caregiver_permission(
+            db, link.caregiver_id, link.patient_id, "can_view_glucose"
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_permission_denied(self):
+        """Returns False when permission is disabled."""
+        link = make_link(can_view_ai_suggestions=False)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = link
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await check_caregiver_permission(
+            db, link.caregiver_id, link.patient_id, "can_view_ai_suggestions"
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_no_link_returns_false(self):
+        """Returns False when no CaregiverLink exists."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        result = await check_caregiver_permission(
+            db, uuid.uuid4(), uuid.uuid4(), "can_view_glucose"
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_permission_returns_false(self):
+        """Returns False for unknown permission field names."""
+        db = AsyncMock()
+
+        result = await check_caregiver_permission(
+            db, uuid.uuid4(), uuid.uuid4(), "can_do_something_invalid"
+        )
+        assert result is False
+        # Should not even query the database
+        db.execute.assert_not_called()
+
+
+# ── TestPermissionSchemaValidation ──
+
+
+class TestPermissionSchemaValidation:
+    """Tests for permission schemas."""
+
+    def test_update_request_allows_partial(self):
+        """PermissionsUpdateRequest allows omitting fields."""
+        from src.schemas.caregiver_permissions import PermissionsUpdateRequest
+
+        data = PermissionsUpdateRequest(can_view_glucose=False)
+        dumped = data.model_dump(exclude_unset=True)
+        assert dumped == {"can_view_glucose": False}
+
+    def test_permissions_response_has_all_fields(self):
+        """CaregiverPermissions includes all 5 fields with defaults."""
+        from src.schemas.caregiver_permissions import CaregiverPermissions
+
+        perms = CaregiverPermissions()
+        assert perms.can_view_glucose is True
+        assert perms.can_view_history is True
+        assert perms.can_view_iob is True
+        assert perms.can_view_ai_suggestions is False
+        assert perms.can_receive_alerts is True
+
+    def test_update_request_rejects_extra_fields(self):
+        """PermissionsUpdateRequest rejects unknown fields."""
+        from pydantic import ValidationError
+
+        from src.schemas.caregiver_permissions import PermissionsUpdateRequest
+
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            PermissionsUpdateRequest(can_view_glucose=False, is_admin=True)
+
+
+# ── TestPermissionEndpointRBAC ──
+
+
+class TestPermissionEndpointRBAC:
+    """Integration tests verifying RBAC on permission endpoints.
+
+    These tests ensure unauthenticated users get 401 on all three
+    permission endpoints (GET /linked, GET /linked/{id}/permissions,
+    PATCH /linked/{id}/permissions).
+    """
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_cannot_list_linked(self, client):
+        """Unauthenticated requests to GET /linked return 401."""
+        response = await client.get("/api/caregivers/linked")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_cannot_get_permissions(self, client):
+        """Unauthenticated requests to GET /linked/{id}/permissions return 401."""
+        fake_id = str(uuid.uuid4())
+        response = await client.get(f"/api/caregivers/linked/{fake_id}/permissions")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_cannot_update_permissions(self, client):
+        """Unauthenticated requests to PATCH /linked/{id}/permissions return 401."""
+        fake_id = str(uuid.uuid4())
+        response = await client.patch(
+            f"/api/caregivers/linked/{fake_id}/permissions",
+            json={"can_view_glucose": False},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_patch_invalid_uuid_still_401(self, client):
+        """Auth check fires before path validation — invalid UUID still 401."""
+        response = await client.patch(
+            "/api/caregivers/linked/not-a-uuid/permissions",
+            json={"can_view_glucose": False},
+        )
+        # Auth middleware rejects before FastAPI validates path params
+        assert response.status_code == 401

--- a/apps/web/src/app/dashboard/settings/caregivers/[linkId]/permissions/page.tsx
+++ b/apps/web/src/app/dashboard/settings/caregivers/[linkId]/permissions/page.tsx
@@ -1,0 +1,387 @@
+"use client";
+
+/**
+ * Story 8.2: Caregiver Permission Management
+ *
+ * Allows diabetic users to configure per-caregiver data access permissions.
+ * Toggle switches control what data each caregiver can see.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import {
+  Shield,
+  Loader2,
+  AlertTriangle,
+  Check,
+  ArrowLeft,
+  Activity,
+  BarChart3,
+  Syringe,
+  Brain,
+  Bell,
+} from "lucide-react";
+import clsx from "clsx";
+import {
+  getCaregiverPermissions,
+  updateCaregiverPermissions,
+  listLinkedCaregivers,
+  type CaregiverPermissions,
+} from "@/lib/api";
+
+interface PermissionToggle {
+  key: keyof CaregiverPermissions;
+  label: string;
+  description: string;
+  icon: typeof Activity;
+  defaultValue: boolean;
+}
+
+const PERMISSION_TOGGLES: PermissionToggle[] = [
+  {
+    key: "can_view_glucose",
+    label: "View current glucose",
+    description: "See real-time glucose readings and trend",
+    icon: Activity,
+    defaultValue: true,
+  },
+  {
+    key: "can_view_history",
+    label: "View glucose history",
+    description: "See historical glucose charts and data",
+    icon: BarChart3,
+    defaultValue: true,
+  },
+  {
+    key: "can_view_iob",
+    label: "View IoB/CoB data",
+    description: "See insulin on board and carb data",
+    icon: Syringe,
+    defaultValue: true,
+  },
+  {
+    key: "can_view_ai_suggestions",
+    label: "View AI suggestions",
+    description: "See AI-generated analysis and recommendations",
+    icon: Brain,
+    defaultValue: false,
+  },
+  {
+    key: "can_receive_alerts",
+    label: "Receive emergency alerts",
+    description: "Get notified during glucose emergencies",
+    icon: Bell,
+    defaultValue: true,
+  },
+];
+
+export default function CaregiverPermissionsPage() {
+  const params = useParams();
+  const linkId = params.linkId as string;
+
+  const [permissions, setPermissions] = useState<CaregiverPermissions | null>(
+    null
+  );
+  const [caregiverEmail, setCaregiverEmail] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [originalPermissions, setOriginalPermissions] =
+    useState<CaregiverPermissions | null>(null);
+
+  const fetchPermissions = useCallback(async () => {
+    try {
+      setError(null);
+      const [permData, caregiversData] = await Promise.all([
+        getCaregiverPermissions(linkId),
+        listLinkedCaregivers(),
+      ]);
+      setPermissions(permData.permissions);
+      setOriginalPermissions(permData.permissions);
+
+      // Find the caregiver email from the linked caregivers list
+      const caregiver = caregiversData.caregivers.find(
+        (cg) => cg.link_id === linkId
+      );
+      if (caregiver) {
+        setCaregiverEmail(caregiver.caregiver_email);
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to load permissions"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [linkId]);
+
+  useEffect(() => {
+    fetchPermissions();
+  }, [fetchPermissions]);
+
+  const handleToggle = (key: keyof CaregiverPermissions) => {
+    if (!permissions || isSaving) return;
+
+    const updated = { ...permissions, [key]: !permissions[key] };
+    setPermissions(updated);
+    setSuccess(null);
+
+    // Check if there are unsaved changes
+    if (originalPermissions) {
+      const changed = Object.keys(updated).some(
+        (k) =>
+          updated[k as keyof CaregiverPermissions] !==
+          originalPermissions[k as keyof CaregiverPermissions]
+      );
+      setHasChanges(changed);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!permissions || !originalPermissions) return;
+
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    // Only send changed fields
+    const changes: Partial<CaregiverPermissions> = {};
+    for (const key of Object.keys(permissions) as (keyof CaregiverPermissions)[]) {
+      if (permissions[key] !== originalPermissions[key]) {
+        changes[key] = permissions[key];
+      }
+    }
+
+    try {
+      const result = await updateCaregiverPermissions(linkId, changes);
+      setPermissions(result.permissions);
+      setOriginalPermissions(result.permissions);
+      setHasChanges(false);
+      setSuccess("Permissions updated successfully");
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to update permissions"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <Link
+            href="/dashboard/settings/caregivers"
+            className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Caregivers
+          </Link>
+          <h1 className="text-2xl font-bold">Caregiver Permissions</h1>
+        </div>
+        <div
+          className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+          role="status"
+          aria-label="Loading permissions"
+        >
+          <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+          <p className="text-slate-400">Loading permissions...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !permissions) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <Link
+            href="/dashboard/settings/caregivers"
+            className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Caregivers
+          </Link>
+          <h1 className="text-2xl font-bold">Caregiver Permissions</h1>
+        </div>
+        <div
+          className="bg-red-500/10 rounded-xl p-6 border border-red-500/20 text-center"
+          role="alert"
+        >
+          <AlertTriangle className="h-8 w-8 text-red-400 mx-auto mb-3" />
+          <p className="text-red-400">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <Link
+          href="/dashboard/settings/caregivers"
+          className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Caregivers
+        </Link>
+        <h1 className="text-2xl font-bold">Caregiver Permissions</h1>
+        {caregiverEmail && (
+          <p className="text-slate-400">
+            Configure data access for{" "}
+            <span className="text-blue-400">{caregiverEmail}</span>
+          </p>
+        )}
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div
+          className="bg-red-500/10 rounded-xl p-4 border border-red-500/20"
+          role="alert"
+        >
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Success state */}
+      {success && (
+        <div
+          className="bg-green-500/10 rounded-xl p-4 border border-green-500/20"
+          role="status"
+        >
+          <div className="flex items-center gap-2">
+            <Check className="h-4 w-4 text-green-400 shrink-0" />
+            <p className="text-sm text-green-400">{success}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Permission toggles */}
+      {permissions && (
+        <div className="bg-slate-900 rounded-xl border border-slate-800 p-6">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="p-2 bg-blue-500/10 rounded-lg">
+              <Shield className="h-5 w-5 text-blue-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Data Access</h2>
+              <p className="text-xs text-slate-500">
+                Control what this caregiver can see and receive
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            {PERMISSION_TOGGLES.map((toggle) => {
+              const Icon = toggle.icon;
+              const isEnabled = permissions[toggle.key];
+
+              return (
+                <div
+                  key={toggle.key}
+                  className={clsx(
+                    "flex items-center justify-between py-3 px-2 rounded-lg hover:bg-slate-800/50 transition-colors",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900",
+                    isSaving
+                      ? "opacity-50 cursor-not-allowed"
+                      : "cursor-pointer"
+                  )}
+                  onClick={() => handleToggle(toggle.key)}
+                  role="switch"
+                  aria-checked={isEnabled}
+                  aria-label={toggle.label}
+                  aria-disabled={isSaving}
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleToggle(toggle.key);
+                    }
+                  }}
+                >
+                  <div className="flex items-center gap-3">
+                    <Icon
+                      className={clsx(
+                        "h-4 w-4 shrink-0",
+                        isEnabled ? "text-blue-400" : "text-slate-600"
+                      )}
+                    />
+                    <div>
+                      <p className="text-sm font-medium text-slate-200">
+                        {toggle.label}
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        {toggle.description}
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className={clsx(
+                      "relative w-10 h-5 rounded-full transition-colors shrink-0 ml-4",
+                      isEnabled ? "bg-blue-600" : "bg-slate-700"
+                    )}
+                  >
+                    <div
+                      className={clsx(
+                        "absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform",
+                        isEnabled ? "translate-x-5" : "translate-x-0.5"
+                      )}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Save button */}
+          <div className="mt-6 flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!hasChanges || isSaving}
+              className={clsx(
+                "flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium",
+                "bg-blue-600 text-white hover:bg-blue-500",
+                "transition-colors",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                "disabled:opacity-50 disabled:cursor-not-allowed"
+              )}
+            >
+              {isSaving ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+              {isSaving ? "Saving..." : "Save Changes"}
+            </button>
+            {hasChanges && (
+              <p className="text-xs text-slate-500">You have unsaved changes</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Info card */}
+      <div className="bg-slate-900/50 rounded-xl p-4 border border-slate-800">
+        <p className="text-xs text-slate-500">
+          Changes take effect immediately after saving. Caregivers will only
+          see data that you have enabled. Emergency alert permissions control
+          whether this caregiver receives escalation notifications.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -872,3 +872,98 @@ export async function listLinkedPatients(): Promise<LinkedPatientsListResponse> 
 
   return response.json();
 }
+
+/**
+ * Caregiver Permissions API types (Story 8.2)
+ */
+export interface CaregiverPermissions {
+  can_view_glucose: boolean;
+  can_view_history: boolean;
+  can_view_iob: boolean;
+  can_view_ai_suggestions: boolean;
+  can_receive_alerts: boolean;
+}
+
+export interface LinkedCaregiverItem {
+  link_id: string;
+  caregiver_id: string;
+  caregiver_email: string;
+  linked_at: string;
+  permissions: CaregiverPermissions;
+}
+
+export interface LinkedCaregiversResponse {
+  caregivers: LinkedCaregiverItem[];
+  count: number;
+}
+
+export interface PermissionsUpdateResponse {
+  link_id: string;
+  permissions: CaregiverPermissions;
+}
+
+/**
+ * List all caregivers linked to the current patient, with permissions
+ */
+export async function listLinkedCaregivers(): Promise<LinkedCaregiversResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/caregivers/linked`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to list linked caregivers: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Get permissions for a specific caregiver link
+ */
+export async function getCaregiverPermissions(
+  linkId: string
+): Promise<PermissionsUpdateResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/caregivers/linked/${encodeURIComponent(linkId)}/permissions`,
+    { credentials: "include" }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to fetch caregiver permissions: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Update permissions for a specific caregiver link
+ */
+export async function updateCaregiverPermissions(
+  linkId: string,
+  permissions: Partial<CaregiverPermissions>
+): Promise<PermissionsUpdateResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/caregivers/linked/${encodeURIComponent(linkId)}/permissions`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(permissions),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to update caregiver permissions: ${response.status}`
+    );
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary

- Add 5 per-caregiver permission boolean columns to `CaregiverLink` model (migration 023)
- New Pydantic schemas for permission CRUD (`CaregiverPermissions`, `PermissionsUpdateRequest`, etc.)
- 4 new service functions: `get_linked_caregivers`, `get_link_permissions`, `update_link_permissions`, `check_caregiver_permission`
- 3 new REST endpoints: `GET /api/caregivers/linked`, `GET/PATCH /api/caregivers/linked/{id}/permissions`
- Extended caregivers settings page with "Linked Caregivers" section
- New per-caregiver permissions page with 5 toggle switches and save button
- Permission enforcement in data-access paths deferred to stories 8.3-8.6

## Acceptance Criteria

- [x] Diabetic users can configure per-caregiver permissions:
  - View current glucose (default: on)
  - View glucose history (default: on)
  - View IoB/CoB (default: on)
  - View AI suggestions (default: off)
  - Receive emergency alerts (default: on)
- [x] Changes take effect immediately
- [x] Patient-only configuration (require_diabetic on all endpoints)

## Test plan

- [x] 22 unit + integration tests pass (`test_caregiver_permissions.py`)
- [x] 806 total backend tests pass, 1 skipped
- [x] Ruff lint + format clean
- [x] Next.js ESLint clean
- [x] Playwright MCP visual checks: dashboard, alerts, settings, caregivers page, permissions page
- [x] Adversarial review (16 findings) → fixes applied → re-review confirmed all clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)