### PR TITLE
feat: add caregiver AI chat for patient queries (Story 8.4)

### DIFF
--- a/apps/api/src/schemas/caregiver_dashboard.py
+++ b/apps/api/src/schemas/caregiver_dashboard.py
@@ -7,7 +7,7 @@ These endpoints return permission-filtered data to caregivers.
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 from src.schemas.caregiver_permissions import CaregiverPermissions
 
@@ -65,3 +65,35 @@ class CaregiverGlucoseHistoryResponse(BaseModel):
     patient_id: uuid.UUID
     readings: list[CaregiverGlucoseHistoryReading]
     count: int
+
+
+# ── Story 8.4: Caregiver AI chat schemas ──
+
+
+class CaregiverChatRequest(BaseModel):
+    """Request schema for caregiver AI chat."""
+
+    message: str = Field(
+        ...,
+        min_length=1,
+        max_length=2000,
+        description="The caregiver's question about their patient",
+    )
+
+    @field_validator("message", mode="before")
+    @classmethod
+    def strip_message_whitespace(cls, v: str) -> str:
+        """Strip leading/trailing whitespace so blank messages fail min_length."""
+        if isinstance(v, str):
+            return v.strip()
+        return v
+
+
+class CaregiverChatResponse(BaseModel):
+    """Response schema for caregiver AI chat."""
+
+    response: str = Field(..., description="AI-generated response text")
+    disclaimer: str = Field(
+        default="Not medical advice. Consult your healthcare provider.",
+        description="Safety disclaimer",
+    )

--- a/apps/api/tests/test_caregiver_ai_chat.py
+++ b/apps/api/tests/test_caregiver_ai_chat.py
@@ -1,0 +1,314 @@
+"""Story 8.4: Tests for caregiver AI chat endpoint and service."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.models.caregiver_link import CaregiverLink
+from src.models.user import User, UserRole
+from src.schemas.caregiver_dashboard import CaregiverChatRequest, CaregiverChatResponse
+
+# ── Helpers ──
+
+
+def _make_link(
+    patient_id: uuid.UUID | None = None,
+    caregiver_id: uuid.UUID | None = None,
+    can_view_ai_suggestions: bool = True,
+) -> MagicMock:
+    """Create a mock CaregiverLink."""
+    link = MagicMock(spec=CaregiverLink)
+    link.id = uuid.uuid4()
+    link.patient_id = patient_id or uuid.uuid4()
+    link.caregiver_id = caregiver_id or uuid.uuid4()
+    link.can_view_glucose = True
+    link.can_view_history = True
+    link.can_view_iob = True
+    link.can_view_ai_suggestions = can_view_ai_suggestions
+    link.can_receive_alerts = True
+    patient = MagicMock(spec=User)
+    patient.id = link.patient_id
+    patient.email = "patient@example.com"
+    patient.role = UserRole.DIABETIC
+    link.patient = patient
+    return link
+
+
+# ── TestCaregiverChatSchemas ──
+
+
+class TestCaregiverChatSchemas:
+    """Tests for chat request/response schemas."""
+
+    def test_request_validates_min_length(self):
+        """Empty message is rejected."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            CaregiverChatRequest(message="")
+
+    def test_request_validates_max_length(self):
+        """Message exceeding 2000 chars is rejected."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            CaregiverChatRequest(message="x" * 2001)
+
+    def test_request_rejects_whitespace_only(self):
+        """Whitespace-only message is rejected after stripping."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            CaregiverChatRequest(message="   ")
+
+    def test_request_strips_whitespace(self):
+        """Leading/trailing whitespace is stripped from message."""
+        req = CaregiverChatRequest(message="  How is my patient?  ")
+        assert req.message == "How is my patient?"
+
+    def test_request_accepts_valid_message(self):
+        """Valid message is accepted."""
+        req = CaregiverChatRequest(message="How is my patient doing?")
+        assert req.message == "How is my patient doing?"
+
+    def test_response_has_default_disclaimer(self):
+        """Response schema includes default disclaimer."""
+        resp = CaregiverChatResponse(response="test")
+        assert "medical advice" in resp.disclaimer.lower()
+
+    def test_response_custom_disclaimer(self):
+        """Response schema accepts custom disclaimer."""
+        resp = CaregiverChatResponse(response="test", disclaimer="Custom")
+        assert resp.disclaimer == "Custom"
+
+
+# ── TestCaregiverChatEndpoint ──
+
+
+class TestCaregiverChatEndpoint:
+    """Tests for POST /patients/{patient_id}/chat."""
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_chat.handle_caregiver_chat_web",
+        new_callable=AsyncMock,
+    )
+    @patch("src.routers.caregivers._get_caregiver_link", new_callable=AsyncMock)
+    async def test_successful_chat(self, mock_get_link, mock_web_chat):
+        """Returns AI response when permission granted."""
+        from src.routers.caregivers import caregiver_ai_chat
+
+        caregiver_id = uuid.uuid4()
+        patient_id = uuid.uuid4()
+        link = _make_link(caregiver_id=caregiver_id, patient_id=patient_id)
+        mock_get_link.return_value = link
+        mock_web_chat.return_value = "Your patient is at 120 mg/dL and stable."
+
+        mock_user = MagicMock()
+        mock_user.id = caregiver_id
+
+        request = CaregiverChatRequest(message="How is my patient doing?")
+
+        result = await caregiver_ai_chat(
+            patient_id=patient_id,
+            data=request,
+            current_user=mock_user,
+            db=AsyncMock(),
+        )
+
+        assert isinstance(result, CaregiverChatResponse)
+        assert "120 mg/dL" in result.response
+        assert "medical advice" in result.disclaimer.lower()
+        mock_web_chat.assert_called_once()
+        args = mock_web_chat.call_args[0]
+        assert args[2] == patient_id  # patient_id forwarded correctly
+        assert args[3] == "How is my patient doing?"  # message forwarded
+
+    @pytest.mark.asyncio
+    @patch("src.routers.caregivers._get_caregiver_link", new_callable=AsyncMock)
+    async def test_ai_permission_denied_returns_403(self, mock_get_link):
+        """Returns 403 when can_view_ai_suggestions is False."""
+        from src.routers.caregivers import caregiver_ai_chat
+
+        link = _make_link(can_view_ai_suggestions=False)
+        mock_get_link.return_value = link
+
+        mock_user = MagicMock()
+        mock_user.id = uuid.uuid4()
+
+        request = CaregiverChatRequest(message="How is my patient?")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await caregiver_ai_chat(
+                patient_id=uuid.uuid4(),
+                data=request,
+                current_user=mock_user,
+                db=AsyncMock(),
+            )
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    @patch("src.routers.caregivers._get_caregiver_link", new_callable=AsyncMock)
+    async def test_unlinked_patient_returns_404(self, mock_get_link):
+        """Returns 404 for unlinked patient."""
+        from src.routers.caregivers import caregiver_ai_chat
+
+        mock_get_link.side_effect = HTTPException(
+            status_code=404, detail="Patient not linked to your account"
+        )
+
+        mock_user = MagicMock()
+        mock_user.id = uuid.uuid4()
+
+        request = CaregiverChatRequest(message="How is my patient?")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await caregiver_ai_chat(
+                patient_id=uuid.uuid4(),
+                data=request,
+                current_user=mock_user,
+                db=AsyncMock(),
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_chat.handle_caregiver_chat_web",
+        new_callable=AsyncMock,
+    )
+    @patch("src.routers.caregivers._get_caregiver_link", new_callable=AsyncMock)
+    async def test_ai_provider_error_returns_502(self, mock_get_link, mock_web_chat):
+        """Returns 502 when AI provider fails."""
+        from src.routers.caregivers import caregiver_ai_chat
+
+        link = _make_link()
+        mock_get_link.return_value = link
+        mock_web_chat.side_effect = HTTPException(
+            status_code=502,
+            detail="Unable to get a response from the AI provider",
+        )
+
+        mock_user = MagicMock()
+        mock_user.id = uuid.uuid4()
+
+        request = CaregiverChatRequest(message="How is my patient?")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await caregiver_ai_chat(
+                patient_id=uuid.uuid4(),
+                data=request,
+                current_user=mock_user,
+                db=AsyncMock(),
+            )
+
+        assert exc_info.value.status_code == 502
+
+
+# ── TestHandleCaregiverChatWeb ──
+
+
+class TestHandleCaregiverChatWeb:
+    """Tests for the web-optimized caregiver chat service."""
+
+    @pytest.mark.asyncio
+    async def test_returns_plain_text_without_html_escape(self):
+        """Web handler returns raw AI content without HTML escaping."""
+        from src.services.telegram_chat import handle_caregiver_chat_web
+
+        mock_patient = MagicMock(spec=User)
+        mock_patient.id = uuid.uuid4()
+        mock_patient.email = "patient@example.com"
+
+        mock_ai_response = MagicMock()
+        mock_ai_response.content = "Patient is at 120 mg/dL & stable."
+        mock_ai_response.model = "test-model"
+        mock_ai_response.provider.value = "openai"
+        mock_ai_response.usage.input_tokens = 100
+        mock_ai_response.usage.output_tokens = 50
+
+        db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_patient
+        db.execute.return_value = mock_result
+
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = mock_ai_response
+
+        with (
+            patch(
+                "src.services.telegram_chat.get_ai_client",
+                new_callable=AsyncMock,
+                return_value=mock_client,
+            ),
+            patch(
+                "src.services.telegram_chat._build_glucose_context",
+                new_callable=AsyncMock,
+                return_value="Recent glucose data: 120 mg/dL",
+            ),
+        ):
+            result = await handle_caregiver_chat_web(
+                db, uuid.uuid4(), mock_patient.id, "How is my patient?"
+            )
+
+        # Should NOT be HTML-escaped (& should remain as &, not &amp;)
+        assert "&" in result
+        assert "&amp;" not in result
+        # Should NOT have Telegram HTML disclaimer tags
+        assert "<i>" not in result
+
+    @pytest.mark.asyncio
+    async def test_patient_not_found_raises_404(self):
+        """Raises 404 when patient not found."""
+        from src.services.telegram_chat import handle_caregiver_chat_web
+
+        db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        db.execute.return_value = mock_result
+
+        with pytest.raises(HTTPException) as exc_info:
+            await handle_caregiver_chat_web(
+                db, uuid.uuid4(), uuid.uuid4(), "How is my patient?"
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_ai_provider_error_raises_502(self):
+        """Raises 502 when AI provider fails."""
+        from src.services.telegram_chat import handle_caregiver_chat_web
+
+        mock_patient = MagicMock(spec=User)
+        mock_patient.id = uuid.uuid4()
+        mock_patient.email = "patient@example.com"
+
+        db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_patient
+        db.execute.return_value = mock_result
+
+        mock_client = AsyncMock()
+        mock_client.generate.side_effect = RuntimeError("API timeout")
+
+        with (
+            patch(
+                "src.services.telegram_chat.get_ai_client",
+                new_callable=AsyncMock,
+                return_value=mock_client,
+            ),
+            patch(
+                "src.services.telegram_chat._build_glucose_context",
+                new_callable=AsyncMock,
+                return_value="",
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await handle_caregiver_chat_web(
+                db, uuid.uuid4(), mock_patient.id, "How is my patient?"
+            )
+
+        assert exc_info.value.status_code == 502

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1081,3 +1081,35 @@ export async function getCaregiverGlucoseHistory(
 
   return response.json();
 }
+
+/**
+ * Caregiver AI Chat (Story 8.4)
+ */
+export interface CaregiverChatResponse {
+  response: string;
+  disclaimer: string;
+}
+
+export async function sendCaregiverChat(
+  patientId: string,
+  message: string
+): Promise<CaregiverChatResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/caregivers/patients/${encodeURIComponent(patientId)}/chat`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ message }),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to send chat message: ${response.status}`
+    );
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- Add `POST /patients/{patient_id}/chat` endpoint for caregiver AI queries, gated by `can_view_ai_suggestions` permission
- Add `handle_caregiver_chat_web()` service function that returns plain text (no Telegram HTML formatting) with proper HTTP exceptions
- Add AI chat UI section to caregiver dashboard with input field, suggestion chips ("How is my patient doing?", "Should I be worried?"), response display with disclaimer
- Add `CaregiverChatRequest`/`CaregiverChatResponse` Pydantic schemas with whitespace-stripping validator
- Add 14 backend tests covering schemas, endpoint, and service function

## Changes
| File | Change |
|------|--------|
| `apps/api/src/schemas/caregiver_dashboard.py` | Added chat request/response schemas with whitespace validator |
| `apps/api/src/services/telegram_chat.py` | Added `handle_caregiver_chat_web()` — web-optimized variant |
| `apps/api/src/routers/caregivers.py` | Added `POST /patients/{patient_id}/chat` endpoint |
| `apps/api/tests/test_caregiver_ai_chat.py` | 14 tests: schemas, endpoint, service |
| `apps/web/src/lib/api.ts` | Added `sendCaregiverChat()` API client function |
| `apps/web/src/app/dashboard/caregiver/page.tsx` | Added AI chat card with accessibility (aria-live), patient-switch cleanup |

## Security
- Permission enforcement: `can_view_ai_suggestions` checked before AI call
- IDOR protection: `_get_caregiver_link()` validates caregiver-patient relationship
- Input validation: Pydantic `min_length=1, max_length=2000` with whitespace stripping
- XSS safe: React JSX auto-escapes AI response content
- No HTML escaping in web variant (unlike Telegram) since React handles it

## Test plan
- [x] Backend: 840 passed, 1 skipped (14 new tests)
- [x] Frontend: 328 passed
- [x] Ruff lint + format: clean
- [x] Next.js lint: clean
- [x] Playwright MCP: verified `/dashboard`, `/dashboard/caregiver`, `/dashboard/briefs`, `/dashboard/alerts`, `/dashboard/settings` — no regressions
- [x] Adversarial review: 11 findings, 4 actionable fixes applied
- [x] Adversarial re-review: all fixes confirmed correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)