### PR TITLE
feat(web): add multi-patient card grid for caregiver dashboard (Story 8.5)

### DIFF
--- a/_bmad-output/PROGRESS.md
+++ b/_bmad-output/PROGRESS.md
@@ -1,0 +1,204 @@
+# GlycemicGPT Implementation Progress
+
+> Last Updated: 2026-02-09
+
+## Summary
+
+| Epic | Title | Stories | Status |
+|------|-------|---------|--------|
+| 1 | Foundation & Safety Compliance | 5/5 | Complete |
+| 2 | User Authentication & Account Management | 4/4 | Complete |
+| 3 | Data Source Connection | 7/7 | Complete |
+| 4 | Real-Time Glucose Dashboard | 6/6 | **Complete** |
+| 5 | AI-Powered Analysis & Recommendations | 8/8 | **Complete** |
+| 6 | Intelligent Alerting & Escalation | 7/7 | **Complete** |
+| 7 | Telegram Bot Integration | 6/6 | **Complete** |
+| 8 | Caregiver Access & Support | 5/6 | In Progress |
+| 9 | Settings & Data Management | 0/5 | Not Started |
+
+**Overall Progress:** 46/54 stories complete (85%)
+
+---
+
+## Epic 1: Foundation & Safety Compliance
+
+**Status:** Complete
+**Retrospective:** [epic-1-retrospective.md](implementation-artifacts/epic-1-retrospective.md)
+
+| Story | Title | Status | PR |
+|-------|-------|--------|-----|
+| 1.1 | Project Scaffolding & Docker Setup | Done | Initial commit |
+| 1.2 | Database Migrations & Health Endpoint | Done | Initial commit |
+| 1.3 | First-Run Safety Disclaimer | Done | Initial commit |
+| 1.4 | Kubernetes Deployment Manifests | Done | Initial commit |
+| 1.5 | Structured Logging & Backup Configuration | Done | Initial commit |
+
+---
+
+## Epic 2: User Authentication & Account Management
+
+**Status:** Complete
+**Retrospective:** [epic-2-retrospective.md](implementation-artifacts/epic-2-retrospective.md)
+
+| Story | Title | Status | PR |
+|-------|-------|--------|-----|
+| 2.1 | User Registration | Done | Initial commit |
+| 2.2 | User Login & Session Management | Done | Initial commit |
+| 2.3 | User Logout | Done | Initial commit |
+| 2.4 | Role-Based Access Control | Done | Initial commit |
+
+---
+
+## Epic 3: Data Source Connection
+
+**Status:** Complete
+**Retrospective:** Pending
+
+| Story | Title | Status | PR |
+|-------|-------|--------|-----|
+| 3.1 | Dexcom Credential Configuration | Done | Initial commit |
+| 3.2 | Dexcom CGM Data Ingestion | Done | Initial commit |
+| 3.3 | Tandem Credential Configuration | Done | Initial commit |
+| 3.4 | Tandem Pump Data Ingestion | Done | Initial commit |
+| 3.5 | Control-IQ Activity Parsing | Done | Initial commit |
+| 3.6 | Data Freshness Display | Done | Initial commit |
+| 3.7 | IoB Projection Engine | Done | [#1](https://github.com/jlengelbrecht/GlycemicGPT/pull/1) |
+
+---
+
+## Epic 4: Real-Time Glucose Dashboard
+
+**Status:** Complete
+**Retrospective:** Pending
+
+| Story | Title | Status | PR |
+|-------|-------|--------|-----|
+| 4.1 | Dashboard Layout & Navigation | Done | [#3](https://github.com/jlengelbrecht/GlycemicGPT/pull/3) |
+| 4.2 | GlucoseHero Component | Done | [#20](https://github.com/jlengelbrecht/GlycemicGPT/pull/20) |
+| 4.3 | TrendArrow Component | Done | [#22](https://github.com/jlengelbrecht/GlycemicGPT/pull/22) |
+| 4.4 | TimeInRangeBar Component | Done | [#24](https://github.com/jlengelbrecht/GlycemicGPT/pull/24) |
+| 4.5 | Real-Time Updates via SSE | Done | [#26](https://github.com/jlengelbrecht/GlycemicGPT/pull/26) |
+| 4.6 | Dashboard Accessibility | Done | Pending |
+
+---
+
+## Epic 5: AI-Powered Analysis & Recommendations
+
+**Status:** Complete
+
+| Story | Title | Status | PR |
+|-------|-------|--------|----|
+| 5.1 | AI Provider Configuration | Done | [#30](https://github.com/jlengelbrecht/GlycemicGPT/pull/30) |
+| 5.2 | BYOAI Abstraction Layer | Done | [#32](https://github.com/jlengelbrecht/GlycemicGPT/pull/32) |
+| 5.3 | Daily Brief Generation | Done | [#34](https://github.com/jlengelbrecht/GlycemicGPT/pull/34) |
+| 5.4 | Pattern Recognition & Carb Ratio Suggestions | Done | [#36](https://github.com/jlengelbrecht/GlycemicGPT/pull/36) |
+| 5.5 | Correction Factor Suggestions | Done | [#38](https://github.com/jlengelbrecht/GlycemicGPT/pull/38) |
+| 5.6 | Pre-Validation Safety Layer | Done | [#40](https://github.com/jlengelbrecht/GlycemicGPT/pull/40) |
+| 5.7 | AIInsightCard Component | Done | [#44](https://github.com/jlengelbrecht/GlycemicGPT/pull/44) |
+| 5.8 | AI Reasoning Display & Audit Logging | Done | [#46](https://github.com/jlengelbrecht/GlycemicGPT/pull/46) |
+
+---
+
+## Epic 6: Intelligent Alerting & Escalation
+
+**Status:** Complete
+
+| Story | Title | Status | PR |
+|-------|-------|--------|----|
+| 6.1 | Alert Threshold Configuration | Done | [#48](https://github.com/jlengelbrecht/GlycemicGPT/pull/48) |
+| 6.2 | Predictive Alert Engine | Done | [#50](https://github.com/jlengelbrecht/GlycemicGPT/pull/50) |
+| 6.3 | Tiered Alert Delivery | Done | [#52](https://github.com/jlengelbrecht/GlycemicGPT/pull/52) |
+| 6.4 | AlertCard Component with Acknowledgment | Done | [#54](https://github.com/jlengelbrecht/GlycemicGPT/pull/54) |
+| 6.5 | Emergency Contact Configuration | Done | [#56](https://github.com/jlengelbrecht/GlycemicGPT/pull/56) |
+| 6.6 | Escalation Timing Configuration | Done | [#58](https://github.com/jlengelbrecht/GlycemicGPT/pull/58) |
+| 6.7 | Automatic Escalation to Caregivers | Done | [#60](https://github.com/jlengelbrecht/GlycemicGPT/pull/60) |
+
+---
+
+## Epic 7: Telegram Bot Integration
+
+**Status:** Complete
+
+| Story | Title | Status | PR |
+|-------|-------|--------|----|
+| 7.1 | Telegram Bot Setup & Configuration | Done | [#62](https://github.com/jlengelbrecht/GlycemicGPT/pull/62) |
+| 7.2 | Alert Delivery via Telegram | Done | [#64](https://github.com/jlengelbrecht/GlycemicGPT/pull/64) |
+| 7.3 | Daily Brief via Telegram | Done | [#66](https://github.com/jlengelbrecht/GlycemicGPT/pull/66) |
+| 7.4 | Telegram Command Handlers | Done | [#68](https://github.com/jlengelbrecht/GlycemicGPT/pull/68) |
+| 7.5 | AI Chat via Telegram | Done | [#75](https://github.com/jlengelbrecht/GlycemicGPT/pull/75) |
+| 7.6 | Caregiver Telegram Access | Done | [#77](https://github.com/jlengelbrecht/GlycemicGPT/pull/77) |
+
+---
+
+## Epic 8: Caregiver Access & Support
+
+**Status:** In Progress
+
+| Story | Title | Status | PR |
+|-------|-------|--------|----|
+| 8.1 | Caregiver Account Creation & Linking | Done | #78 |
+| 8.2 | Caregiver Data Access Configuration | Done | #80 |
+| 8.3 | Caregiver Dashboard View | Done | #82 |
+| 8.4 | Caregiver AI Queries | Done | #84 |
+| 8.5 | Multi-Patient Dashboard | Done | PR pending |
+| 8.6 | Caregiver Read-Only Enforcement | Pending |
+
+---
+
+## Epic 9: Settings & Data Management
+
+**Status:** Not Started
+
+| Story | Title | Status |
+|-------|-------|--------|
+| 9.1 | Target Glucose Range Configuration | Pending |
+| 9.2 | Daily Brief Delivery Configuration | Pending |
+| 9.3 | Data Retention Settings | Pending |
+| 9.4 | Data Purge Capability | Pending |
+| 9.5 | Settings Export | Pending |
+
+---
+
+## Release History
+
+| Version | Date | Notable Features |
+|---------|------|------------------|
+| 0.1.9 | 2026-02-08 | Real-time SSE updates (Story 4.5) |
+| 0.1.8 | 2026-02-08 | TimeInRangeBar component (Story 4.4) |
+| 0.1.7 | 2026-02-08 | TrendArrow component (Story 4.3) |
+| 0.1.6 | 2026-02-07 | GlucoseHero component (Story 4.2) |
+| 0.1.1 | 2026-02-07 | Foundation, Auth, Data Sources, Dashboard Layout |
+
+---
+
+## Current Sprint Focus
+
+**Epic 6: Intelligent Alerting & Escalation** - COMPLETE
+
+All 7 stories completed:
+- [x] Story 6.1: Alert Threshold Configuration
+- [x] Story 6.2: Predictive Alert Engine
+- [x] Story 6.3: Tiered Alert Delivery
+- [x] Story 6.4: AlertCard Component with Acknowledgment
+- [x] Story 6.5: Emergency Contact Configuration
+- [x] Story 6.6: Escalation Timing Configuration
+- [x] Story 6.7: Automatic Escalation to Caregivers
+
+**Epic 7: Telegram Bot Integration** - COMPLETE
+
+All 6 stories completed:
+- [x] Story 7.1: Telegram Bot Setup & Configuration
+- [x] Story 7.2: Alert Delivery via Telegram
+- [x] Story 7.3: Daily Brief via Telegram
+- [x] Story 7.4: Telegram Command Handlers
+- [x] Story 7.5: AI Chat via Telegram
+- [x] Story 7.6: Caregiver Telegram Access
+
+**Epic 8: Caregiver Access & Support** - IN PROGRESS
+
+- [x] Story 8.1: Caregiver Account Creation & Linking
+- [x] Story 8.2: Caregiver Data Access Configuration
+- [x] Story 8.3: Caregiver Dashboard View
+- [x] Story 8.4: Caregiver AI Queries
+- [x] Story 8.5: Multi-Patient Dashboard
+- [ ] Story 8.6: Caregiver Read-Only Enforcement

--- a/apps/web/src/app/dashboard/caregiver/page.tsx
+++ b/apps/web/src/app/dashboard/caregiver/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 /**
- * Story 8.3: Caregiver Dashboard View
+ * Stories 8.3 & 8.5: Caregiver Dashboard View
  *
- * Read-only dashboard for caregivers to view their linked patient's
- * glucose status. Data is filtered by permissions set by the patient.
+ * Read-only dashboard for caregivers to view their linked patients'
+ * glucose status. Data is filtered by permissions set by each patient.
+ *
+ * Story 8.5: Multi-patient card grid with drill-down detail view.
+ * When multiple patients are linked, shows a summary card for each.
+ * Tapping a card reveals the full detail view (glucose, IoB, AI chat).
  * Auto-refreshes every 60 seconds via REST polling.
  */
 
@@ -12,6 +16,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import {
   Activity,
+  ChevronLeft,
   Clock,
   Syringe,
   Loader2,
@@ -57,6 +62,22 @@ function getGlucoseColor(value: number): string {
   return "text-red-400";
 }
 
+/**
+ * Status dot color based on glucose value for patient overview cards.
+ * Green = in range (70-180), Yellow = warning (55-69/181-250 or stale),
+ * Red = critical (<55 or >250), Slate = no data available or not permitted.
+ */
+function getStatusDotColor(status: CaregiverPatientStatus | null): string {
+  if (!status?.glucose || !status.permissions.can_view_glucose) {
+    return "bg-slate-500"; // No data or no permission — grey indicates unavailable
+  }
+  if (status.glucose.is_stale) return "bg-yellow-400";
+  const v = status.glucose.value;
+  if (v < 55 || v > 250) return "bg-red-400";
+  if (v < 70 || v > 180) return "bg-yellow-400";
+  return "bg-green-400";
+}
+
 export default function CaregiverDashboardPage() {
   const router = useRouter();
   const { user, isLoading: isUserLoading } = useUserContext();
@@ -70,12 +91,22 @@ export default function CaregiverDashboardPage() {
   const [error, setError] = useState<string | null>(null);
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
 
+  // Story 8.5: Multi-patient overview state
+  const [patientStatuses, setPatientStatuses] = useState<
+    Map<string, CaregiverPatientStatus>
+  >(new Map());
+  const [isLoadingStatuses, setIsLoadingStatuses] = useState(false);
+
   // Story 8.4: AI chat state
   const [chatMessage, setChatMessage] = useState("");
   const [chatResponse, setChatResponse] =
     useState<CaregiverChatResponse | null>(null);
   const [isChatLoading, setIsChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
+
+  // Whether we're in multi-patient mode (show grid overview)
+  const isMultiPatient = patients.length > 1;
+  const showOverview = isMultiPatient && !selectedPatientId;
 
   // Redirect non-caregivers away from this page
   useEffect(() => {
@@ -90,7 +121,9 @@ export default function CaregiverDashboardPage() {
       try {
         const data = await listLinkedPatients();
         setPatients(data.patients);
-        if (data.patients.length > 0) {
+        // Single patient: auto-select for direct detail view
+        // Multiple patients: stay on overview (selectedPatientId stays null)
+        if (data.patients.length === 1) {
           setSelectedPatientId(data.patients[0].patient_id);
         }
       } catch (err) {
@@ -104,7 +137,49 @@ export default function CaregiverDashboardPage() {
     loadPatients();
   }, []);
 
-  // Fetch patient status
+  // Story 8.5: Fetch all patient statuses in parallel for overview cards
+  const fetchAllStatuses = useCallback(
+    async (showRefreshing = false) => {
+      if (patients.length <= 1) return;
+
+      if (showRefreshing) setIsRefreshing(true);
+      setIsLoadingStatuses(true);
+
+      const results = await Promise.allSettled(
+        patients.map((p) => getCaregiverPatientStatus(p.patient_id))
+      );
+
+      // Merge: keep previous successful data for patients whose fetch failed
+      setPatientStatuses((prev) => {
+        const merged = new Map(prev);
+        let failCount = 0;
+        results.forEach((result, idx) => {
+          if (result.status === "fulfilled") {
+            merged.set(patients[idx].patient_id, result.value);
+          } else {
+            failCount++;
+          }
+        });
+        if (failCount > 0 && failCount < patients.length) {
+          setError(
+            `Failed to refresh ${failCount} of ${patients.length} patients`
+          );
+        } else if (failCount === patients.length) {
+          setError("Failed to fetch patient statuses");
+        } else {
+          setError(null);
+        }
+        return merged;
+      });
+
+      setLastRefresh(new Date());
+      setIsLoadingStatuses(false);
+      setIsRefreshing(false);
+    },
+    [patients]
+  );
+
+  // Fetch single patient status (for detail view)
   const fetchStatus = useCallback(
     async (showRefreshing = false) => {
       if (!selectedPatientId) return;
@@ -162,23 +237,50 @@ export default function CaregiverDashboardPage() {
     }
   }, [selectedPatientId, fetchStatus]);
 
+  // Fetch all statuses when patients load (for multi-patient overview)
+  useEffect(() => {
+    if (patients.length > 1) {
+      fetchAllStatuses();
+    }
+  }, [patients, fetchAllStatuses]);
+
   // Auto-refresh every 60 seconds
   useEffect(() => {
-    if (!selectedPatientId) return;
+    if (patients.length === 0) return;
 
     const interval = setInterval(() => {
-      fetchStatus();
+      if (selectedPatientId) {
+        fetchStatus();
+      } else if (patients.length > 1) {
+        fetchAllStatuses();
+      }
     }, REFRESH_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [selectedPatientId, fetchStatus]);
+  }, [patients, selectedPatientId, fetchStatus, fetchAllStatuses]);
+
+  // Handle selecting a patient from the overview grid
+  const handleSelectPatient = (patientId: string) => {
+    setSelectedPatientId(patientId);
+  };
+
+  // Handle going back to overview
+  const handleBackToOverview = () => {
+    setSelectedPatientId(null);
+    setStatus(null);
+    setChatMessage("");
+    setChatResponse(null);
+    setChatError(null);
+    // Refresh overview data (may be stale after time in detail view)
+    fetchAllStatuses();
+  };
 
   if (isLoading) {
     return (
       <main id="main-content" className="space-y-6">
         <div>
           <h1 className="text-2xl font-bold">Caregiver Dashboard</h1>
-          <p className="text-slate-400">Monitor your patient&apos;s glucose</p>
+          <p className="text-slate-400">Loading patient data</p>
         </div>
         <div
           className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
@@ -216,10 +318,33 @@ export default function CaregiverDashboardPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">Caregiver Dashboard</h1>
-          <p className="text-slate-400">
-            Monitor your patient&apos;s glucose
-          </p>
+          {showOverview ? (
+            <>
+              <h1 className="text-2xl font-bold">Caregiver Dashboard</h1>
+              <p className="text-slate-400">
+                Monitoring {patients.length} patients
+              </p>
+            </>
+          ) : (
+            <div className="flex items-center gap-3">
+              {isMultiPatient && (
+                <button
+                  type="button"
+                  onClick={handleBackToOverview}
+                  className="p-1.5 rounded-lg text-slate-400 hover:text-white hover:bg-slate-800 transition-colors"
+                  aria-label="Back to all patients"
+                >
+                  <ChevronLeft className="h-5 w-5" />
+                </button>
+              )}
+              <div>
+                <h1 className="text-2xl font-bold">Caregiver Dashboard</h1>
+                <p className="text-slate-400">
+                  Monitor your patient&apos;s glucose
+                </p>
+              </div>
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <span className="text-xs px-2 py-1 rounded-full bg-blue-500/10 text-blue-400 border border-blue-500/20">
@@ -228,7 +353,11 @@ export default function CaregiverDashboardPage() {
           </span>
           <button
             type="button"
-            onClick={() => fetchStatus(true)}
+            onClick={() =>
+              showOverview
+                ? fetchAllStatuses(true)
+                : fetchStatus(true)
+            }
             disabled={isRefreshing}
             className="p-2 rounded-lg text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-50"
             aria-label="Refresh data"
@@ -253,32 +382,132 @@ export default function CaregiverDashboardPage() {
         </div>
       )}
 
-      {/* Patient selector (if multiple patients) */}
-      {patients.length > 1 && (
-        <div className="bg-slate-900 rounded-xl p-4 border border-slate-800">
-          <label
-            htmlFor="patient-select"
-            className="text-sm font-medium text-slate-300 mb-2 block"
-          >
-            Select patient
-          </label>
-          <select
-            id="patient-select"
-            value={selectedPatientId || ""}
-            onChange={(e) => setSelectedPatientId(e.target.value)}
-            className="w-full bg-slate-800 text-slate-200 rounded-lg px-3 py-2 text-sm border border-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            {patients.map((p) => (
-              <option key={p.patient_id} value={p.patient_id}>
-                {p.patient_email}
-              </option>
-            ))}
-          </select>
+      {/* Story 8.5: Multi-patient card grid (overview mode) */}
+      {showOverview && (
+        <>
+          {isLoadingStatuses && patientStatuses.size === 0 ? (
+            <div
+              className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+              role="status"
+              aria-label="Loading patient statuses"
+            >
+              <Loader2 className="h-6 w-6 text-blue-400 animate-spin mx-auto mb-2" />
+              <p className="text-sm text-slate-400">
+                Loading patient statuses...
+              </p>
+            </div>
+          ) : (
+            <div
+              className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+              aria-live="polite"
+              aria-atomic="false"
+            >
+              {patients.map((patient) => {
+                const ps = patientStatuses.get(patient.patient_id) || null;
+                const dotColor = getStatusDotColor(ps);
+                const g =
+                  ps?.permissions.can_view_glucose && ps?.glucose
+                    ? ps.glucose
+                    : null;
+
+                return (
+                  <button
+                    key={patient.patient_id}
+                    type="button"
+                    onClick={() => handleSelectPatient(patient.patient_id)}
+                    className="bg-slate-900 rounded-xl p-5 border border-slate-800 text-left hover:border-blue-500/40 hover:bg-slate-900/80 transition-all cursor-pointer group"
+                    aria-label={`View details for ${patient.patient_email}`}
+                  >
+                    {/* Patient name + status dot */}
+                    <div className="flex items-center gap-2 mb-3">
+                      <span
+                        className={clsx(
+                          "h-2.5 w-2.5 rounded-full shrink-0",
+                          dotColor
+                        )}
+                        aria-hidden="true"
+                      />
+                      <span className="text-sm font-medium text-slate-200 truncate">
+                        {patient.patient_email}
+                      </span>
+                    </div>
+
+                    {/* Glucose value + trend */}
+                    {g ? (
+                      <div className="space-y-1">
+                        <div className="flex items-baseline gap-2">
+                          <span
+                            className={clsx(
+                              "text-3xl font-bold",
+                              getGlucoseColor(g.value)
+                            )}
+                          >
+                            {g.value}
+                          </span>
+                          <span className="text-sm text-slate-400">mg/dL</span>
+                          <span className="text-lg">
+                            {getTrendArrow(g.trend)}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-1 text-xs text-slate-500">
+                          <Clock className="h-3 w-3" />
+                          <span>
+                            {g.minutes_ago < 1
+                              ? "Just now"
+                              : `${g.minutes_ago}m ago`}
+                          </span>
+                          {g.is_stale && (
+                            <span className="text-yellow-400 ml-1">
+                              Stale
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ) : ps?.permissions.can_view_glucose === false ? (
+                      <div className="flex items-center gap-1.5 text-slate-500">
+                        <Lock className="h-3.5 w-3.5" />
+                        <span className="text-xs">Not permitted</span>
+                      </div>
+                    ) : (
+                      <p className="text-xs text-slate-500">No data</p>
+                    )}
+
+                    {/* Tap hint */}
+                    <p className="text-xs text-slate-600 mt-3 group-hover:text-slate-400 transition-colors">
+                      Tap to view details
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {lastRefresh && (
+            <p className="text-xs text-slate-500 text-center">
+              Last updated{" "}
+              {lastRefresh.toLocaleTimeString(undefined, {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </p>
+          )}
+        </>
+      )}
+
+      {/* Detail view loading spinner (drill-down transition) */}
+      {!showOverview && !status && selectedPatientId && (
+        <div
+          className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+          role="status"
+          aria-label="Loading patient details"
+        >
+          <Loader2 className="h-6 w-6 text-blue-400 animate-spin mx-auto mb-2" />
+          <p className="text-sm text-slate-400">Loading patient details...</p>
         </div>
       )}
 
-      {/* Patient status display */}
-      {status && (
+      {/* Patient detail view (single patient or drill-down from grid) */}
+      {!showOverview && status && (
         <>
           {/* Patient info bar */}
           <div className="flex items-center gap-2 text-sm text-slate-400">


### PR DESCRIPTION
## Summary

- Converts the caregiver dashboard from a single-patient dropdown to a **card grid overview** with drill-down detail view
- When multiple patients are linked, caregivers see a summary card for each showing: glucose value (color-coded), trend arrow, status dot (green/yellow/red/slate), and last-updated timestamp
- Tapping a card reveals the full detail view (glucose, IoB, AI chat); back button returns to overview
- Single patient linked: auto-selects to detail view (preserves existing UX)

### Key implementation details

- **Frontend-only change** — no backend modifications needed
- Parallel fetch via `Promise.allSettled()` with graceful partial failure handling (preserves previous data on transient errors)
- Responsive grid layout: 1 column (mobile), 2 columns (sm), 3 columns (lg)
- `aria-live` region on grid for screen reader auto-refresh announcements
- Loading spinner for drill-down transitions
- Auto-refresh only fires for the active view mode (overview OR detail, not both)

## Test plan

- [x] Frontend lint passes (`npx next lint`)
- [x] Frontend tests pass (328 tests)
- [x] Backend tests pass (14 caregiver tests)
- [x] Adversarial review completed (10 findings)
- [x] All 10 findings fixed and verified via re-review
- [x] Playwright MCP visual verification: `/dashboard`, `/dashboard/caregiver`, `/dashboard/briefs`, `/dashboard/alerts`, `/dashboard/settings` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)