### PR TITLE
feat: add target glucose range configuration (Story 9.1)

### DIFF
--- a/_bmad-output/PROGRESS.md
+++ b/_bmad-output/PROGRESS.md
@@ -14,9 +14,9 @@
 | 6 | Intelligent Alerting & Escalation | 7/7 | **Complete** |
 | 7 | Telegram Bot Integration | 6/6 | **Complete** |
 | 8 | Caregiver Access & Support | 6/6 | **Complete** |
-| 9 | Settings & Data Management | 0/5 | Not Started |
+| 9 | Settings & Data Management | 1/5 | In Progress |
 
-**Overall Progress:** 47/54 stories complete (87%)
+**Overall Progress:** 48/54 stories complete (89%)
 
 ---
 
@@ -141,21 +141,21 @@
 | 8.3 | Caregiver Dashboard View | Done | #82 |
 | 8.4 | Caregiver AI Queries | Done | #84 |
 | 8.5 | Multi-Patient Dashboard | Done | #86 |
-| 8.6 | Caregiver Read-Only Enforcement | Done | PR pending |
+| 8.6 | Caregiver Read-Only Enforcement | Done | #88 |
 
 ---
 
 ## Epic 9: Settings & Data Management
 
-**Status:** Not Started
+**Status:** In Progress (1/5)
 
-| Story | Title | Status |
-|-------|-------|--------|
-| 9.1 | Target Glucose Range Configuration | Pending |
-| 9.2 | Daily Brief Delivery Configuration | Pending |
-| 9.3 | Data Retention Settings | Pending |
-| 9.4 | Data Purge Capability | Pending |
-| 9.5 | Settings Export | Pending |
+| Story | Title | Status | PR |
+|-------|-------|--------|----|
+| 9.1 | Target Glucose Range Configuration | Done | PR pending |
+| 9.2 | Daily Brief Delivery Configuration | Pending | |
+| 9.3 | Data Retention Settings | Pending | |
+| 9.4 | Data Purge Capability | Pending | |
+| 9.5 | Settings Export | Pending | |
 
 ---
 
@@ -203,3 +203,11 @@ All 6 stories completed:
 - [x] Story 8.4: Caregiver AI Queries
 - [x] Story 8.5: Multi-Patient Dashboard
 - [x] Story 8.6: Caregiver Read-Only Enforcement
+
+**Epic 9: Settings & Data Management** - IN PROGRESS
+
+- [x] Story 9.1: Target Glucose Range Configuration
+- [ ] Story 9.2: Daily Brief Delivery Configuration
+- [ ] Story 9.3: Data Retention Settings
+- [ ] Story 9.4: Data Purge Capability
+- [ ] Story 9.5: Settings Export

--- a/apps/api/migrations/versions/024_create_target_glucose_ranges.py
+++ b/apps/api/migrations/versions/024_create_target_glucose_ranges.py
@@ -1,0 +1,53 @@
+"""Story 9.1: Create target_glucose_ranges table.
+
+Revision ID: 024_target_glucose_ranges
+Revises: 023_add_caregiver_permissions
+Create Date: 2026-02-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "024_target_glucose_ranges"
+down_revision = "023_caregiver_permissions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "target_glucose_ranges",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("low_target", sa.Float(), nullable=False, server_default="70.0"),
+        sa.Column("high_target", sa.Float(), nullable=False, server_default="180.0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_target_glucose_ranges_user_id",
+        "target_glucose_ranges",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_target_glucose_ranges_user_id")
+    op.drop_table("target_glucose_ranges")

--- a/apps/api/src/models/target_glucose_range.py
+++ b/apps/api/src/models/target_glucose_range.py
@@ -1,0 +1,56 @@
+"""Story 9.1: Target glucose range model.
+
+Stores user-configured target glucose range for dashboard display and AI analysis.
+"""
+
+import uuid
+
+from sqlalchemy import Float, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class TargetGlucoseRange(Base, TimestampMixin):
+    """User-specific target glucose range configuration.
+
+    One-to-one with User. Stores the low and high target values
+    used by dashboard displays, reports, and AI suggestions.
+    """
+
+    __tablename__ = "target_glucose_ranges"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    low_target: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=70.0,
+    )
+
+    high_target: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=180.0,
+    )
+
+    user = relationship("User", back_populates="target_glucose_range")
+
+    def __repr__(self) -> str:
+        return (
+            f"<TargetGlucoseRange(user_id={self.user_id}, "
+            f"range={self.low_target}-{self.high_target})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -174,6 +174,12 @@ class User(Base, TimestampMixin):
         cascade="all, delete-orphan",
         overlaps="patient",
     )
+    target_glucose_range = relationship(
+        "TargetGlucoseRange",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/schemas/target_glucose_range.py
+++ b/apps/api/src/schemas/target_glucose_range.py
@@ -1,0 +1,57 @@
+"""Story 9.1: Target glucose range schemas."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class TargetGlucoseRangeResponse(BaseModel):
+    """Response schema for target glucose range."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    low_target: float
+    high_target: float
+    updated_at: datetime
+
+
+class TargetGlucoseRangeUpdate(BaseModel):
+    """Request schema for updating target glucose range.
+
+    Both fields are optional — only provided fields are updated.
+    Validates that low_target < high_target when both are provided.
+    """
+
+    low_target: float | None = Field(
+        default=None,
+        ge=40.0,
+        le=200.0,
+        description="Low target threshold (mg/dL). Range: 40-200.",
+    )
+    high_target: float | None = Field(
+        default=None,
+        ge=80.0,
+        le=400.0,
+        description="High target threshold (mg/dL). Range: 80-400.",
+    )
+
+    @model_validator(mode="after")
+    def validate_target_ordering(self) -> "TargetGlucoseRangeUpdate":
+        """Ensure low_target < high_target when both are provided."""
+        if (
+            self.low_target is not None
+            and self.high_target is not None
+            and self.low_target >= self.high_target
+        ):
+            msg = "low_target must be less than high_target"
+            raise ValueError(msg)
+        return self
+
+
+class TargetGlucoseRangeDefaults(BaseModel):
+    """Default target glucose range values for reference."""
+
+    low_target: float = 70.0
+    high_target: float = 180.0

--- a/apps/api/src/services/target_glucose_range.py
+++ b/apps/api/src/services/target_glucose_range.py
@@ -1,0 +1,116 @@
+"""Story 9.1: Target glucose range service.
+
+Manages user target glucose range configuration with get-or-create pattern.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.target_glucose_range import TargetGlucoseRange
+from src.schemas.target_glucose_range import TargetGlucoseRangeUpdate
+
+logger = get_logger(__name__)
+
+
+async def get_or_create_range(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> TargetGlucoseRange:
+    """Get the user's target glucose range, creating defaults if none exist.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+
+    Returns:
+        The user's TargetGlucoseRange record.
+    """
+    result = await db.execute(
+        select(TargetGlucoseRange).where(TargetGlucoseRange.user_id == user_id)
+    )
+    target_range = result.scalar_one_or_none()
+
+    if target_range is None:
+        target_range = TargetGlucoseRange(user_id=user_id)
+        db.add(target_range)
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            result = await db.execute(
+                select(TargetGlucoseRange).where(TargetGlucoseRange.user_id == user_id)
+            )
+            target_range = result.scalar_one()
+            return target_range
+        await db.refresh(target_range)
+
+        logger.info(
+            "Created default target glucose range",
+            user_id=str(user_id),
+        )
+
+    return target_range
+
+
+async def update_range(
+    user_id: uuid.UUID,
+    updates: TargetGlucoseRangeUpdate,
+    db: AsyncSession,
+) -> TargetGlucoseRange:
+    """Update the user's target glucose range.
+
+    Only fields provided in the request are updated. Validates
+    that low_target < high_target against both new and existing values.
+
+    Args:
+        user_id: User's UUID.
+        updates: Partial update with new target values.
+        db: Database session.
+
+    Returns:
+        The updated TargetGlucoseRange record.
+
+    Raises:
+        ValueError: If target ordering is invalid after merge.
+    """
+    target_range = await get_or_create_range(user_id, db)
+
+    new_low = (
+        updates.low_target
+        if updates.low_target is not None
+        else target_range.low_target
+    )
+    new_high = (
+        updates.high_target
+        if updates.high_target is not None
+        else target_range.high_target
+    )
+
+    if new_low >= new_high:
+        msg = f"low_target ({new_low}) must be less than high_target ({new_high})"
+        logger.warning(
+            "Target glucose range validation failed",
+            user_id=str(user_id),
+            low_target=new_low,
+            high_target=new_high,
+        )
+        raise ValueError(msg)
+
+    update_data = updates.model_dump(exclude_none=True)
+    for field, value in update_data.items():
+        setattr(target_range, field, value)
+
+    await db.commit()
+    await db.refresh(target_range)
+
+    logger.info(
+        "Updated target glucose range",
+        user_id=str(user_id),
+        fields=list(update_data.keys()),
+    )
+
+    return target_range

--- a/apps/api/tests/test_target_glucose_range.py
+++ b/apps/api/tests/test_target_glucose_range.py
@@ -1,0 +1,374 @@
+"""Story 9.1: Tests for target glucose range service and settings router."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from src.config import settings
+from src.schemas.target_glucose_range import (
+    TargetGlucoseRangeDefaults,
+    TargetGlucoseRangeUpdate,
+)
+from src.services.target_glucose_range import get_or_create_range, update_range
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("glucose_range")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+# ── Schema validation tests ──
+
+
+class TestTargetGlucoseRangeUpdate:
+    """Tests for TargetGlucoseRangeUpdate schema validation."""
+
+    def test_all_none_is_valid(self):
+        update = TargetGlucoseRangeUpdate()
+        assert update.low_target is None
+        assert update.high_target is None
+
+    def test_partial_update_low(self):
+        update = TargetGlucoseRangeUpdate(low_target=80.0)
+        assert update.low_target == 80.0
+        assert update.high_target is None
+
+    def test_partial_update_high(self):
+        update = TargetGlucoseRangeUpdate(high_target=200.0)
+        assert update.high_target == 200.0
+        assert update.low_target is None
+
+    def test_low_ge_high_fails(self):
+        with pytest.raises(
+            ValidationError, match="low_target must be less than high_target"
+        ):
+            # Both values within field ranges (40-200, 80-400) but low >= high
+            TargetGlucoseRangeUpdate(low_target=150.0, high_target=100.0)
+
+    def test_low_equal_high_fails(self):
+        with pytest.raises(
+            ValidationError, match="low_target must be less than high_target"
+        ):
+            TargetGlucoseRangeUpdate(low_target=100.0, high_target=100.0)
+
+    def test_valid_ordering_passes(self):
+        update = TargetGlucoseRangeUpdate(low_target=65.0, high_target=200.0)
+        assert update.low_target == 65.0
+        assert update.high_target == 200.0
+
+    def test_low_below_range_fails(self):
+        with pytest.raises(ValidationError):
+            TargetGlucoseRangeUpdate(low_target=30.0)
+
+    def test_low_above_range_fails(self):
+        with pytest.raises(ValidationError):
+            TargetGlucoseRangeUpdate(low_target=210.0)
+
+    def test_high_below_range_fails(self):
+        with pytest.raises(ValidationError):
+            TargetGlucoseRangeUpdate(high_target=70.0)
+
+    def test_high_above_range_fails(self):
+        with pytest.raises(ValidationError):
+            TargetGlucoseRangeUpdate(high_target=410.0)
+
+
+class TestTargetGlucoseRangeDefaults:
+    """Tests for TargetGlucoseRangeDefaults schema."""
+
+    def test_default_values(self):
+        defaults = TargetGlucoseRangeDefaults()
+        assert defaults.low_target == 70.0
+        assert defaults.high_target == 180.0
+
+
+# ── Service tests ──
+
+
+class TestGetOrCreateRange:
+    """Tests for get_or_create_range service function."""
+
+    @pytest.mark.asyncio
+    async def test_creates_defaults_when_none_exist(self):
+        """Should create a new TargetGlucoseRange with defaults."""
+        user_id = uuid.uuid4()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock(return_value=None)
+
+        result = await get_or_create_range(user_id, mock_db)
+
+        assert result.user_id == user_id
+        mock_db.add.assert_called_once_with(result)
+        mock_db.commit.assert_called_once()
+        mock_db.refresh.assert_called_once_with(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_when_found(self):
+        """Should return existing record without creating."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await get_or_create_range(user_id, mock_db)
+
+        assert result == existing
+        mock_db.add.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+
+class TestUpdateRange:
+    """Tests for update_range service function."""
+
+    @pytest.mark.asyncio
+    async def test_partial_update_low_target(self):
+        """Should only update low_target."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+        existing.low_target = 70.0
+        existing.high_target = 180.0
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = TargetGlucoseRangeUpdate(low_target=80.0)
+        result = await update_range(user_id, updates, mock_db)
+
+        assert result.low_target == 80.0
+        mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ordering_violation_low_ge_high(self):
+        """Should raise ValueError when low_target >= high_target after merge."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+        existing.low_target = 70.0
+        existing.high_target = 180.0
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        # Set low_target above existing high_target
+        updates = TargetGlucoseRangeUpdate(low_target=190.0)
+
+        with pytest.raises(
+            ValueError, match="low_target.*must be less than.*high_target"
+        ):
+            await update_range(user_id, updates, mock_db)
+
+    @pytest.mark.asyncio
+    async def test_ordering_violation_equal(self):
+        """Should raise ValueError when low_target == high_target after merge."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+        existing.low_target = 70.0
+        existing.high_target = 180.0
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = TargetGlucoseRangeUpdate(high_target=80.0)
+
+        # After merge: low=70 >= high=80? No. Actually low=70 < high=80 so this passes.
+        # Let's set low to same as new high instead
+        updates = TargetGlucoseRangeUpdate(low_target=180.0)
+
+        with pytest.raises(
+            ValueError, match="low_target.*must be less than.*high_target"
+        ):
+            await update_range(user_id, updates, mock_db)
+
+
+# ── Endpoint tests ──
+
+
+class TestGetTargetGlucoseRangeEndpoint:
+    """Tests for GET /api/settings/target-glucose-range."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.get("/api/settings/target-glucose-range")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authenticated_returns_defaults(self, client):
+        cookie = await register_and_login(client)
+        response = await client.get(
+            "/api/settings/target-glucose-range",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["low_target"] == 70.0
+        assert data["high_target"] == 180.0
+        assert "id" in data
+        assert "updated_at" in data
+
+    @pytest.mark.asyncio
+    async def test_idempotent_get_or_create(self, client):
+        """Calling GET twice should return the same record."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        r1 = await client.get("/api/settings/target-glucose-range", cookies=cookies)
+        r2 = await client.get("/api/settings/target-glucose-range", cookies=cookies)
+
+        assert r1.json()["id"] == r2.json()["id"]
+
+
+class TestPatchTargetGlucoseRangeEndpoint:
+    """Tests for PATCH /api/settings/target-glucose-range."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.patch(
+            "/api/settings/target-glucose-range",
+            json={"low_target": 80.0},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_range_returns_422(self, client):
+        cookie = await register_and_login(client)
+        response = await client.patch(
+            "/api/settings/target-glucose-range",
+            json={"low_target": 30.0},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_ordering_violation_returns_422(self, client):
+        """Setting low_target above existing high_target should fail."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        # Ensure range exists
+        await client.get("/api/settings/target-glucose-range", cookies=cookies)
+
+        response = await client.patch(
+            "/api/settings/target-glucose-range",
+            json={"low_target": 190.0},
+            cookies=cookies,
+        )
+        assert response.status_code == 422
+        assert "low_target" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_valid_partial_update(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/target-glucose-range",
+            json={"low_target": 80.0},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["low_target"] == 80.0
+        assert data["high_target"] == 180.0
+
+    @pytest.mark.asyncio
+    async def test_update_both_fields(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/target-glucose-range",
+            json={"low_target": 65.0, "high_target": 200.0},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["low_target"] == 65.0
+        assert data["high_target"] == 200.0
+
+    @pytest.mark.asyncio
+    async def test_persists_across_requests(self, client):
+        """Updated values should persist when fetched again."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        await client.patch(
+            "/api/settings/target-glucose-range",
+            json={"high_target": 200.0},
+            cookies=cookies,
+        )
+
+        response = await client.get(
+            "/api/settings/target-glucose-range",
+            cookies=cookies,
+        )
+        assert response.json()["high_target"] == 200.0
+
+    @pytest.mark.asyncio
+    async def test_empty_body_returns_200(self, client):
+        """Empty PATCH body should succeed without modifying anything."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/target-glucose-range",
+            json={},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["low_target"] == 70.0
+        assert data["high_target"] == 180.0
+
+
+class TestGetTargetGlucoseRangeDefaultsEndpoint:
+    """Tests for GET /api/settings/target-glucose-range/defaults."""
+
+    @pytest.mark.asyncio
+    async def test_returns_defaults_without_auth(self, client):
+        response = await client.get("/api/settings/target-glucose-range/defaults")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["low_target"] == 70.0
+        assert data["high_target"] == 180.0

--- a/apps/web/src/app/dashboard/settings/glucose-range/page.tsx
+++ b/apps/web/src/app/dashboard/settings/glucose-range/page.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+/**
+ * Story 9.1: Target Glucose Range Configuration
+ *
+ * Allows users to set their personal low and high target glucose values.
+ * Defaults are 70-180 mg/dL (standard diabetes management targets).
+ * These values are used by the dashboard display and AI analysis.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Target,
+  Loader2,
+  AlertTriangle,
+  Check,
+  ArrowLeft,
+  RotateCcw,
+} from "lucide-react";
+import clsx from "clsx";
+import {
+  getTargetGlucoseRange,
+  updateTargetGlucoseRange,
+  type TargetGlucoseRangeResponse,
+} from "@/lib/api";
+
+const DEFAULTS = { low_target: 70, high_target: 180 };
+
+export default function GlucoseRangePage() {
+  const [range, setRange] = useState<TargetGlucoseRangeResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Form state
+  const [lowTarget, setLowTarget] = useState<string>("70");
+  const [highTarget, setHighTarget] = useState<string>("180");
+
+  const fetchRange = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await getTargetGlucoseRange();
+      setRange(data);
+      setLowTarget(String(data.low_target));
+      setHighTarget(String(data.high_target));
+    } catch (err) {
+      if (!(err instanceof Error && err.message.includes("401"))) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load target glucose range"
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRange();
+  }, [fetchRange]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    const low = parseFloat(lowTarget);
+    const high = parseFloat(highTarget);
+
+    if (isNaN(low) || isNaN(high)) {
+      setError("Please enter valid numbers");
+      setIsSaving(false);
+      return;
+    }
+
+    if (low >= high) {
+      setError("Low target must be less than high target");
+      setIsSaving(false);
+      return;
+    }
+
+    try {
+      const updated = await updateTargetGlucoseRange({
+        low_target: low,
+        high_target: high,
+      });
+      setRange(updated);
+      setSuccess("Target glucose range updated successfully");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to update target range"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const updated = await updateTargetGlucoseRange({
+        low_target: DEFAULTS.low_target,
+        high_target: DEFAULTS.high_target,
+      });
+      setRange(updated);
+      setLowTarget(String(DEFAULTS.low_target));
+      setHighTarget(String(DEFAULTS.high_target));
+      setSuccess("Target glucose range reset to defaults");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to reset target range"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const lowNum = parseFloat(lowTarget);
+  const highNum = parseFloat(highTarget);
+  const hasChanges =
+    range &&
+    (parseFloat(lowTarget) !== range.low_target ||
+      parseFloat(highTarget) !== range.high_target);
+  const isValid =
+    !isNaN(lowNum) &&
+    !isNaN(highNum) &&
+    lowNum >= 40 &&
+    lowNum <= 200 &&
+    highNum >= 80 &&
+    highNum <= 400 &&
+    lowNum < highNum;
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <a
+          href="/dashboard/settings"
+          className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Settings
+        </a>
+        <h1 className="text-2xl font-bold">Target Glucose Range</h1>
+        <p className="text-slate-400">
+          Set your personal target range for dashboard display and AI analysis
+        </p>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div
+          className="bg-red-500/10 rounded-xl p-4 border border-red-500/20"
+          role="alert"
+        >
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Success state */}
+      {success && (
+        <div
+          className="bg-green-500/10 rounded-xl p-4 border border-green-500/20"
+          role="status"
+        >
+          <div className="flex items-center gap-2">
+            <Check className="h-4 w-4 text-green-400 shrink-0" />
+            <p className="text-sm text-green-400">{success}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div
+          className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+          role="status"
+          aria-label="Loading target glucose range"
+        >
+          <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+          <p className="text-slate-400">Loading target range...</p>
+        </div>
+      )}
+
+      {/* Configuration form */}
+      {!isLoading && (
+        <div className="bg-slate-900 rounded-xl border border-slate-800 p-6">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="p-2 bg-green-500/10 rounded-lg">
+              <Target className="h-5 w-5 text-green-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Range Settings</h2>
+              <p className="text-xs text-slate-500">
+                Values used by Time in Range calculations and AI suggestions
+              </p>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {/* Low target */}
+              <div>
+                <label
+                  htmlFor="low-target"
+                  className="block text-sm font-medium text-slate-300 mb-1"
+                >
+                  Low Target (mg/dL)
+                </label>
+                <input
+                  id="low-target"
+                  type="number"
+                  min={40}
+                  max={200}
+                  step={1}
+                  value={lowTarget}
+                  onChange={(e) => setLowTarget(e.target.value)}
+                  disabled={isSaving}
+                  className={clsx(
+                    "w-full rounded-lg border px-3 py-2 text-sm",
+                    "bg-slate-800 border-slate-700 text-slate-200",
+                    "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                    "placeholder:text-slate-500",
+                    "disabled:opacity-50 disabled:cursor-not-allowed"
+                  )}
+                  aria-describedby="low-target-hint"
+                />
+                <p id="low-target-hint" className="text-xs text-slate-500 mt-1">
+                  Range: 40-200 mg/dL. Default: 70 mg/dL
+                </p>
+              </div>
+
+              {/* High target */}
+              <div>
+                <label
+                  htmlFor="high-target"
+                  className="block text-sm font-medium text-slate-300 mb-1"
+                >
+                  High Target (mg/dL)
+                </label>
+                <input
+                  id="high-target"
+                  type="number"
+                  min={80}
+                  max={400}
+                  step={1}
+                  value={highTarget}
+                  onChange={(e) => setHighTarget(e.target.value)}
+                  disabled={isSaving}
+                  className={clsx(
+                    "w-full rounded-lg border px-3 py-2 text-sm",
+                    "bg-slate-800 border-slate-700 text-slate-200",
+                    "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                    "placeholder:text-slate-500",
+                    "disabled:opacity-50 disabled:cursor-not-allowed"
+                  )}
+                  aria-describedby="high-target-hint"
+                />
+                <p
+                  id="high-target-hint"
+                  className="text-xs text-slate-500 mt-1"
+                >
+                  Range: 80-400 mg/dL. Default: 180 mg/dL
+                </p>
+              </div>
+            </div>
+
+            {/* Visual preview */}
+            {isValid && (
+              <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
+                <p className="text-xs text-slate-500 mb-2">Preview</p>
+                <p className="text-lg font-semibold text-green-400">
+                  Target: {lowNum}-{highNum} mg/dL
+                </p>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-3 pt-2">
+              <button
+                type="submit"
+                disabled={isSaving || !hasChanges || !isValid}
+                className={clsx(
+                  "flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium",
+                  "bg-blue-600 text-white hover:bg-blue-500",
+                  "transition-colors",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+              >
+                {isSaving ? (
+                  <Loader2
+                    className="h-4 w-4 animate-spin"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Check className="h-4 w-4" aria-hidden="true" />
+                )}
+                {isSaving ? "Saving..." : "Save Changes"}
+              </button>
+
+              <button
+                type="button"
+                onClick={handleReset}
+                disabled={
+                  isSaving ||
+                  (range?.low_target === DEFAULTS.low_target &&
+                    range?.high_target === DEFAULTS.high_target)
+                }
+                className={clsx(
+                  "flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium",
+                  "bg-slate-800 text-slate-300 hover:bg-slate-700",
+                  "transition-colors",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+              >
+                <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                Reset to Defaults
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Info card */}
+      <div className="bg-slate-900/50 rounded-xl p-4 border border-slate-800">
+        <p className="text-xs text-slate-500">
+          Your target glucose range determines what counts as &quot;in range&quot; on the
+          dashboard Time in Range bar and influences AI-generated suggestions.
+          The standard range for most people with diabetes is 70-180 mg/dL.
+          Consult your healthcare provider before changing these values.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -8,7 +8,7 @@
  */
 
 import Link from "next/link";
-import { Settings, User, Bell, Database, Link2, Users, MessageCircle, UserPlus } from "lucide-react";
+import { Settings, User, Bell, Database, Link2, Users, MessageCircle, UserPlus, Target } from "lucide-react";
 import { useUserContext } from "@/providers";
 
 interface SettingsSection {
@@ -32,6 +32,12 @@ const settingsSections: SettingsSection[] = [
     description: "Connect Dexcom, Tandem, and other data sources",
     icon: Link2,
     href: "/dashboard/settings/integrations",
+  },
+  {
+    title: "Glucose Range",
+    description: "Set your target glucose range for dashboard and AI analysis",
+    icon: Target,
+    href: "/dashboard/settings/glucose-range",
   },
   {
     title: "Alerts",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1083,6 +1083,72 @@ export async function getCaregiverGlucoseHistory(
 }
 
 /**
+ * Target Glucose Range API types (Story 9.1)
+ */
+export interface TargetGlucoseRangeResponse {
+  id: string;
+  low_target: number;
+  high_target: number;
+  updated_at: string;
+}
+
+export interface TargetGlucoseRangeUpdate {
+  low_target?: number;
+  high_target?: number;
+}
+
+export interface TargetGlucoseRangeDefaults {
+  low_target: number;
+  high_target: number;
+}
+
+/**
+ * Fetch current target glucose range
+ */
+export async function getTargetGlucoseRange(): Promise<TargetGlucoseRangeResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/target-glucose-range`,
+    { credentials: "include" }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to fetch target glucose range: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Update target glucose range
+ */
+export async function updateTargetGlucoseRange(
+  updates: TargetGlucoseRangeUpdate
+): Promise<TargetGlucoseRangeResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/target-glucose-range`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(updates),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail ||
+        `Failed to update target glucose range: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
  * Caregiver AI Chat (Story 8.4)
  */
 export interface CaregiverChatResponse {


### PR DESCRIPTION
## Summary
- Add user-configurable target glucose range (low/high targets, defaults 70-180 mg/dL)
- New settings page at `/dashboard/settings/glucose-range` with live preview, reset to defaults, and validation
- Dashboard and TimeInRangeBar now fetch and display user's personal target range
- Backend: model, schema, service (get-or-create + partial update), migration, 3 settings endpoints, 27 tests (893 total pass)

## Test plan
- [x] Backend lint clean (ruff check + ruff format)
- [x] 27 new target glucose range tests passing (schema, service, endpoint)
- [x] 893 total backend tests passing (no regressions)
- [x] Frontend lint clean (next lint)
- [x] 328 frontend tests passing (no regressions)
- [x] Playwright MCP: settings page shows new Glucose Range card
- [x] Playwright MCP: glucose range page renders form, preview, actions
- [x] Playwright MCP: dashboard renders with target range in metrics card and TimeInRangeBar
- [x] Playwright MCP: briefs and alerts pages still render correctly
- [x] Adversarial subagent review (20 findings, 1 fixed, rest N/A or consistent with project patterns)
- [x] Re-review approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)