### PR TITLE
feat: add daily brief delivery configuration (Story 9.2)

### DIFF
--- a/_bmad-output/PROGRESS.md
+++ b/_bmad-output/PROGRESS.md
@@ -1,6 +1,6 @@
 # GlycemicGPT Implementation Progress
 
-> Last Updated: 2026-02-09
+> Last Updated: 2026-02-10
 
 ## Summary
 
@@ -14,9 +14,9 @@
 | 6 | Intelligent Alerting & Escalation | 7/7 | **Complete** |
 | 7 | Telegram Bot Integration | 6/6 | **Complete** |
 | 8 | Caregiver Access & Support | 6/6 | **Complete** |
-| 9 | Settings & Data Management | 1/5 | In Progress |
+| 9 | Settings & Data Management | 2/5 | In Progress |
 
-**Overall Progress:** 48/54 stories complete (89%)
+**Overall Progress:** 49/54 stories complete (91%)
 
 ---
 
@@ -147,12 +147,12 @@
 
 ## Epic 9: Settings & Data Management
 
-**Status:** In Progress (1/5)
+**Status:** In Progress (2/5)
 
 | Story | Title | Status | PR |
 |-------|-------|--------|----|
-| 9.1 | Target Glucose Range Configuration | Done | PR pending |
-| 9.2 | Daily Brief Delivery Configuration | Pending | |
+| 9.1 | Target Glucose Range Configuration | Done | #90 |
+| 9.2 | Daily Brief Delivery Configuration | Done | PR pending |
 | 9.3 | Data Retention Settings | Pending | |
 | 9.4 | Data Purge Capability | Pending | |
 | 9.5 | Settings Export | Pending | |
@@ -207,7 +207,7 @@ All 6 stories completed:
 **Epic 9: Settings & Data Management** - IN PROGRESS
 
 - [x] Story 9.1: Target Glucose Range Configuration
-- [ ] Story 9.2: Daily Brief Delivery Configuration
+- [x] Story 9.2: Daily Brief Delivery Configuration
 - [ ] Story 9.3: Data Retention Settings
 - [ ] Story 9.4: Data Purge Capability
 - [ ] Story 9.5: Settings Export

--- a/apps/api/migrations/versions/025_create_brief_delivery_configs.py
+++ b/apps/api/migrations/versions/025_create_brief_delivery_configs.py
@@ -1,0 +1,76 @@
+"""Story 9.2: Create brief_delivery_configs table.
+
+Revision ID: 025_brief_delivery_configs
+Revises: 024_target_glucose_ranges
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "025_brief_delivery_configs"
+down_revision = "024_target_glucose_ranges"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    delivery_channel_enum = sa.Enum(
+        "web_only", "telegram", "both", name="deliverychannel"
+    )
+
+    op.create_table(
+        "brief_delivery_configs",
+        sa.Column(
+            "id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("enabled", sa.Boolean, nullable=False, server_default="true"),
+        sa.Column(
+            "delivery_time", sa.Time, nullable=False, server_default="07:00:00"
+        ),
+        sa.Column(
+            "timezone",
+            sa.String(64),
+            nullable=False,
+            server_default="UTC",
+        ),
+        sa.Column(
+            "channel",
+            delivery_channel_enum,
+            nullable=False,
+            server_default="both",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_index(
+        "ix_brief_delivery_configs_user_id",
+        "brief_delivery_configs",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_brief_delivery_configs_user_id")
+    op.drop_table("brief_delivery_configs")
+    op.execute("DROP TYPE IF EXISTS deliverychannel")

--- a/apps/api/src/models/brief_delivery_config.py
+++ b/apps/api/src/models/brief_delivery_config.py
@@ -1,0 +1,89 @@
+"""Story 9.2: Brief delivery configuration model.
+
+Stores user preferences for daily brief delivery (time, timezone, channel).
+"""
+
+import datetime
+import enum
+import uuid
+
+from sqlalchemy import Boolean, Enum, ForeignKey, String, Time
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+# Default delivery time: 07:00
+DEFAULT_DELIVERY_TIME = datetime.time(7, 0)
+DEFAULT_TIMEZONE = "UTC"
+
+
+class DeliveryChannel(str, enum.Enum):
+    """Channels through which daily briefs can be delivered."""
+
+    WEB_ONLY = "web_only"
+    TELEGRAM = "telegram"
+    BOTH = "both"
+
+
+class BriefDeliveryConfig(Base, TimestampMixin):
+    """User-specific daily brief delivery configuration.
+
+    One-to-one with User. Stores when and how
+    the user receives their daily briefs.
+    """
+
+    __tablename__ = "brief_delivery_configs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+    )
+
+    delivery_time: Mapped[datetime.time] = mapped_column(
+        Time,
+        nullable=False,
+        default=DEFAULT_DELIVERY_TIME,
+    )
+
+    timezone: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        default=DEFAULT_TIMEZONE,
+    )
+
+    channel: Mapped[DeliveryChannel] = mapped_column(
+        Enum(
+            DeliveryChannel,
+            name="deliverychannel",
+            create_type=False,
+            values_callable=lambda e: [member.value for member in e],
+        ),
+        nullable=False,
+        default=DeliveryChannel.BOTH,
+    )
+
+    user = relationship("User", back_populates="brief_delivery_config")
+
+    def __repr__(self) -> str:
+        ch = self.channel.value if self.channel else "None"
+        return (
+            f"<BriefDeliveryConfig(user_id={self.user_id}, "
+            f"time={self.delivery_time}, tz={self.timezone}, "
+            f"channel={ch})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -109,6 +109,12 @@ class User(Base, TimestampMixin):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    brief_delivery_config = relationship(
+        "BriefDeliveryConfig",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
     meal_analyses = relationship(
         "MealAnalysis",
         back_populates="user",

--- a/apps/api/src/schemas/brief_delivery_config.py
+++ b/apps/api/src/schemas/brief_delivery_config.py
@@ -1,0 +1,63 @@
+"""Story 9.2: Brief delivery configuration schemas."""
+
+import uuid
+from datetime import datetime, time
+
+from pydantic import BaseModel, Field, field_validator
+
+from src.models.brief_delivery_config import DeliveryChannel
+
+
+class BriefDeliveryConfigResponse(BaseModel):
+    """Response schema for brief delivery configuration."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    enabled: bool
+    delivery_time: time
+    timezone: str
+    channel: DeliveryChannel
+    updated_at: datetime
+
+
+class BriefDeliveryConfigUpdate(BaseModel):
+    """Request schema for updating brief delivery configuration.
+
+    All fields are optional -- only provided fields are updated.
+    """
+
+    enabled: bool | None = None
+    delivery_time: time | None = Field(
+        default=None,
+        description="Delivery time in HH:MM format (e.g. 07:00).",
+    )
+    timezone: str | None = Field(
+        default=None,
+        max_length=64,
+        description="IANA timezone (e.g. 'America/New_York').",
+    )
+    channel: DeliveryChannel | None = None
+
+    @field_validator("timezone")
+    @classmethod
+    def validate_timezone(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        import zoneinfo
+
+        try:
+            zoneinfo.ZoneInfo(v)
+        except (KeyError, zoneinfo.ZoneInfoNotFoundError):
+            msg = f"Invalid timezone: {v}"
+            raise ValueError(msg)
+        return v
+
+
+class BriefDeliveryConfigDefaults(BaseModel):
+    """Default brief delivery configuration values for reference."""
+
+    enabled: bool = True
+    delivery_time: time = time(7, 0)
+    timezone: str = "UTC"
+    channel: DeliveryChannel = DeliveryChannel.BOTH

--- a/apps/api/src/services/brief_delivery_config.py
+++ b/apps/api/src/services/brief_delivery_config.py
@@ -1,0 +1,93 @@
+"""Story 9.2: Brief delivery configuration service.
+
+Manages user brief delivery preferences with get-or-create pattern.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.brief_delivery_config import BriefDeliveryConfig
+from src.schemas.brief_delivery_config import BriefDeliveryConfigUpdate
+
+logger = get_logger(__name__)
+
+
+async def get_or_create_config(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> BriefDeliveryConfig:
+    """Get the user's brief delivery config, creating defaults if none exist.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+
+    Returns:
+        The user's BriefDeliveryConfig record.
+    """
+    result = await db.execute(
+        select(BriefDeliveryConfig).where(BriefDeliveryConfig.user_id == user_id)
+    )
+    config = result.scalar_one_or_none()
+
+    if config is None:
+        config = BriefDeliveryConfig(user_id=user_id)
+        db.add(config)
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            result = await db.execute(
+                select(BriefDeliveryConfig).where(
+                    BriefDeliveryConfig.user_id == user_id
+                )
+            )
+            config = result.scalar_one()
+            return config
+        await db.refresh(config)
+
+        logger.info(
+            "Created default brief delivery config",
+            user_id=str(user_id),
+        )
+
+    return config
+
+
+async def update_config(
+    user_id: uuid.UUID,
+    updates: BriefDeliveryConfigUpdate,
+    db: AsyncSession,
+) -> BriefDeliveryConfig:
+    """Update the user's brief delivery configuration.
+
+    Only fields provided in the request are updated.
+
+    Args:
+        user_id: User's UUID.
+        updates: Partial update with new config values.
+        db: Database session.
+
+    Returns:
+        The updated BriefDeliveryConfig record.
+    """
+    config = await get_or_create_config(user_id, db)
+
+    update_data = updates.model_dump(exclude_none=True)
+    for field, value in update_data.items():
+        setattr(config, field, value)
+
+    await db.commit()
+    await db.refresh(config)
+
+    logger.info(
+        "Updated brief delivery config",
+        user_id=str(user_id),
+        fields=list(update_data.keys()),
+    )
+
+    return config

--- a/apps/api/tests/test_brief_delivery_config.py
+++ b/apps/api/tests/test_brief_delivery_config.py
@@ -1,0 +1,367 @@
+"""Story 9.2: Tests for brief delivery configuration service and settings router."""
+
+import uuid
+from datetime import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from src.config import settings
+from src.schemas.brief_delivery_config import (
+    BriefDeliveryConfigDefaults,
+    BriefDeliveryConfigUpdate,
+    DeliveryChannel,
+)
+from src.services.brief_delivery_config import (
+    get_or_create_config,
+    update_config,
+)
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("brief_delivery")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+# ── Schema validation tests ──
+
+
+class TestBriefDeliveryConfigUpdate:
+    """Tests for BriefDeliveryConfigUpdate schema validation."""
+
+    def test_all_none_is_valid(self):
+        update = BriefDeliveryConfigUpdate()
+        assert update.enabled is None
+        assert update.delivery_time is None
+        assert update.timezone is None
+        assert update.channel is None
+
+    def test_partial_update_enabled(self):
+        update = BriefDeliveryConfigUpdate(enabled=False)
+        assert update.enabled is False
+
+    def test_partial_update_delivery_time(self):
+        update = BriefDeliveryConfigUpdate(delivery_time=time(8, 30))
+        assert update.delivery_time == time(8, 30)
+
+    def test_partial_update_timezone(self):
+        update = BriefDeliveryConfigUpdate(timezone="America/New_York")
+        assert update.timezone == "America/New_York"
+
+    def test_partial_update_channel(self):
+        update = BriefDeliveryConfigUpdate(channel=DeliveryChannel.TELEGRAM)
+        assert update.channel == DeliveryChannel.TELEGRAM
+
+    def test_invalid_timezone_fails(self):
+        with pytest.raises(ValidationError, match="Invalid timezone"):
+            BriefDeliveryConfigUpdate(timezone="Not/A/Timezone")
+
+    def test_valid_timezone_passes(self):
+        update = BriefDeliveryConfigUpdate(timezone="Europe/London")
+        assert update.timezone == "Europe/London"
+
+    def test_all_channels_valid(self):
+        for ch in DeliveryChannel:
+            update = BriefDeliveryConfigUpdate(channel=ch)
+            assert update.channel == ch
+
+
+class TestBriefDeliveryConfigDefaults:
+    """Tests for BriefDeliveryConfigDefaults schema."""
+
+    def test_default_values(self):
+        defaults = BriefDeliveryConfigDefaults()
+        assert defaults.enabled is True
+        assert defaults.delivery_time == time(7, 0)
+        assert defaults.timezone == "UTC"
+        assert defaults.channel == DeliveryChannel.BOTH
+
+
+# ── Service tests ──
+
+
+class TestGetOrCreateConfig:
+    """Tests for get_or_create_config service function."""
+
+    @pytest.mark.asyncio
+    async def test_creates_defaults_when_none_exist(self):
+        """Should create a new BriefDeliveryConfig with defaults."""
+        user_id = uuid.uuid4()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock(return_value=None)
+
+        result = await get_or_create_config(user_id, mock_db)
+
+        assert result.user_id == user_id
+        mock_db.add.assert_called_once_with(result)
+        mock_db.commit.assert_called_once()
+        mock_db.refresh.assert_called_once_with(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_when_found(self):
+        """Should return existing record without creating."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await get_or_create_config(user_id, mock_db)
+
+        assert result == existing
+        mock_db.add.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+
+class TestUpdateConfig:
+    """Tests for update_config service function."""
+
+    @pytest.mark.asyncio
+    async def test_partial_update_enabled(self):
+        """Should only update enabled."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = BriefDeliveryConfigUpdate(enabled=False)
+        result = await update_config(user_id, updates, mock_db)
+
+        assert result.enabled is False
+        mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_partial_update_channel(self):
+        """Should only update channel."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = BriefDeliveryConfigUpdate(channel=DeliveryChannel.WEB_ONLY)
+        result = await update_config(user_id, updates, mock_db)
+
+        assert result.channel == DeliveryChannel.WEB_ONLY
+        mock_db.commit.assert_called_once()
+
+
+# ── Endpoint tests ──
+
+
+class TestGetBriefDeliveryConfigEndpoint:
+    """Tests for GET /api/settings/brief-delivery."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.get("/api/settings/brief-delivery")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authenticated_returns_defaults(self, client):
+        cookie = await register_and_login(client)
+        response = await client.get(
+            "/api/settings/brief-delivery",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is True
+        assert data["delivery_time"] == "07:00:00"
+        assert data["timezone"] == "UTC"
+        assert data["channel"] == "both"
+        assert "id" in data
+        assert "updated_at" in data
+
+    @pytest.mark.asyncio
+    async def test_idempotent_get_or_create(self, client):
+        """Calling GET twice should return the same record."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        r1 = await client.get("/api/settings/brief-delivery", cookies=cookies)
+        r2 = await client.get("/api/settings/brief-delivery", cookies=cookies)
+
+        assert r1.json()["id"] == r2.json()["id"]
+
+
+class TestPatchBriefDeliveryConfigEndpoint:
+    """Tests for PATCH /api/settings/brief-delivery."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.patch(
+            "/api/settings/brief-delivery",
+            json={"enabled": False},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_timezone_returns_422(self, client):
+        cookie = await register_and_login(client)
+        response = await client.patch(
+            "/api/settings/brief-delivery",
+            json={"timezone": "Not/A/Timezone"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_update_enabled(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/brief-delivery",
+            json={"enabled": False},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_update_delivery_time(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/brief-delivery",
+            json={"delivery_time": "08:30:00"},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        assert response.json()["delivery_time"] == "08:30:00"
+
+    @pytest.mark.asyncio
+    async def test_update_timezone(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/brief-delivery",
+            json={"timezone": "America/New_York"},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        assert response.json()["timezone"] == "America/New_York"
+
+    @pytest.mark.asyncio
+    async def test_update_channel(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/brief-delivery",
+            json={"channel": "telegram"},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        assert response.json()["channel"] == "telegram"
+
+    @pytest.mark.asyncio
+    async def test_update_all_fields(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/brief-delivery",
+            json={
+                "enabled": False,
+                "delivery_time": "22:00:00",
+                "timezone": "Europe/London",
+                "channel": "web_only",
+            },
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is False
+        assert data["delivery_time"] == "22:00:00"
+        assert data["timezone"] == "Europe/London"
+        assert data["channel"] == "web_only"
+
+    @pytest.mark.asyncio
+    async def test_persists_across_requests(self, client):
+        """Updated values should persist when fetched again."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        await client.patch(
+            "/api/settings/brief-delivery",
+            json={"timezone": "Asia/Tokyo"},
+            cookies=cookies,
+        )
+
+        response = await client.get(
+            "/api/settings/brief-delivery",
+            cookies=cookies,
+        )
+        assert response.json()["timezone"] == "Asia/Tokyo"
+
+    @pytest.mark.asyncio
+    async def test_empty_body_returns_200(self, client):
+        """Empty PATCH body should succeed without modifying anything."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/brief-delivery",
+            json={},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is True
+        assert data["timezone"] == "UTC"
+
+
+class TestGetBriefDeliveryDefaultsEndpoint:
+    """Tests for GET /api/settings/brief-delivery/defaults."""
+
+    @pytest.mark.asyncio
+    async def test_returns_defaults_without_auth(self, client):
+        response = await client.get("/api/settings/brief-delivery/defaults")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is True
+        assert data["delivery_time"] == "07:00:00"
+        assert data["timezone"] == "UTC"
+        assert data["channel"] == "both"

--- a/apps/api/tests/test_caregiver_read_only.py
+++ b/apps/api/tests/test_caregiver_read_only.py
@@ -176,6 +176,90 @@ class TestRouterDependenciesIncludeRoleCheck:
         dep_classes = [type(d.dependency) for d in deps]
         assert RoleChecker in dep_classes
 
+    # ── Target Glucose Range (Story 9.1) ──
+
+    def test_settings_get_target_glucose_range_has_require_diabetic(self):
+        """GET /api/settings/target-glucose-range has require_diabetic."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/target-glucose-range", "GET"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker in dep_classes
+
+    def test_settings_patch_target_glucose_range_has_require_diabetic(self):
+        """PATCH /api/settings/target-glucose-range has require_diabetic."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/target-glucose-range", "PATCH"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker in dep_classes
+
+    def test_target_glucose_range_defaults_no_role_check(self):
+        """GET /api/settings/target-glucose-range/defaults has no role check."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/target-glucose-range/defaults", "GET"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker not in dep_classes
+
+    def test_target_glucose_range_role_blocks_caregiver(self):
+        """Target glucose range role check blocks CAREGIVER."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/target-glucose-range", "GET"
+        )
+        role_checker = deps[0].dependency
+        assert UserRole.CAREGIVER not in role_checker.allowed_roles
+
+    # ── Brief Delivery (Story 9.2) ──
+
+    def test_settings_get_brief_delivery_has_require_diabetic(self):
+        """GET /api/settings/brief-delivery has require_diabetic."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/brief-delivery", "GET"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker in dep_classes
+
+    def test_settings_patch_brief_delivery_has_require_diabetic(self):
+        """PATCH /api/settings/brief-delivery has require_diabetic."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/brief-delivery", "PATCH"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker in dep_classes
+
+    def test_brief_delivery_defaults_no_role_check(self):
+        """GET /api/settings/brief-delivery/defaults has no role check."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/brief-delivery/defaults", "GET"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker not in dep_classes
+
+    def test_brief_delivery_role_blocks_caregiver(self):
+        """Brief delivery role check blocks CAREGIVER."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/brief-delivery", "GET"
+        )
+        role_checker = deps[0].dependency
+        assert UserRole.CAREGIVER not in role_checker.allowed_roles
+
     # ── Emergency Contacts ──
 
     def test_emergency_contacts_get_has_require_diabetic(self):

--- a/apps/web/src/app/dashboard/settings/brief-delivery/page.tsx
+++ b/apps/web/src/app/dashboard/settings/brief-delivery/page.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+/**
+ * Story 9.2: Brief Delivery Configuration
+ *
+ * Allows users to configure when and how they receive daily briefs.
+ * Settings include delivery time, timezone, delivery channel, and enable/disable toggle.
+ */
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  Clock,
+  Loader2,
+  AlertTriangle,
+  Check,
+  ArrowLeft,
+  RotateCcw,
+} from "lucide-react";
+import Link from "next/link";
+import clsx from "clsx";
+import {
+  getBriefDeliveryConfig,
+  updateBriefDeliveryConfig,
+  type BriefDeliveryConfigResponse,
+} from "@/lib/api";
+
+const DEFAULTS = {
+  enabled: true,
+  delivery_time: "07:00:00",
+  timezone: "UTC",
+  channel: "both" as const,
+};
+
+const CHANNEL_OPTIONS = [
+  { value: "both", label: "Web + Telegram" },
+  { value: "web_only", label: "Web Only" },
+  { value: "telegram", label: "Telegram Only" },
+] as const;
+
+const COMMON_TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Anchorage",
+  "Pacific/Honolulu",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Asia/Tokyo",
+  "Asia/Shanghai",
+  "Australia/Sydney",
+];
+
+export default function BriefDeliveryPage() {
+  const [config, setConfig] = useState<BriefDeliveryConfigResponse | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Form state
+  const [enabled, setEnabled] = useState(true);
+  const [deliveryTime, setDeliveryTime] = useState("07:00");
+  const [timezone, setTimezone] = useState("UTC");
+  const [channel, setChannel] = useState<"web_only" | "telegram" | "both">(
+    "both"
+  );
+
+  // Build timezone options, including saved timezone if not in common list
+  const timezoneOptions = useMemo(() => {
+    if (timezone && !COMMON_TIMEZONES.includes(timezone)) {
+      return [...COMMON_TIMEZONES, timezone].sort();
+    }
+    return COMMON_TIMEZONES;
+  }, [timezone]);
+
+  // Auto-clear success message after 5 seconds
+  useEffect(() => {
+    if (!success) return;
+    const timer = setTimeout(() => setSuccess(null), 5000);
+    return () => clearTimeout(timer);
+  }, [success]);
+
+  const fetchConfig = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await getBriefDeliveryConfig();
+      setConfig(data);
+      setEnabled(data.enabled);
+      // delivery_time comes as "HH:MM:SS", we need "HH:MM" for <input type="time">
+      setDeliveryTime(data.delivery_time.slice(0, 5));
+      setTimezone(data.timezone);
+      setChannel(data.channel);
+    } catch (err) {
+      if (!(err instanceof Error && err.message.includes("401"))) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load brief delivery configuration"
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      // Only send fields that actually changed
+      const payload: Record<string, unknown> = {};
+      if (config && enabled !== config.enabled) payload.enabled = enabled;
+      if (config && deliveryTime + ":00" !== config.delivery_time)
+        payload.delivery_time = deliveryTime + ":00";
+      if (config && timezone !== config.timezone) payload.timezone = timezone;
+      if (config && channel !== config.channel) payload.channel = channel;
+
+      const updated = await updateBriefDeliveryConfig(
+        payload as Parameters<typeof updateBriefDeliveryConfig>[0]
+      );
+      setConfig(updated);
+      setSuccess("Brief delivery configuration updated successfully");
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to update brief delivery configuration"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const updated = await updateBriefDeliveryConfig({
+        enabled: DEFAULTS.enabled,
+        delivery_time: DEFAULTS.delivery_time,
+        timezone: DEFAULTS.timezone,
+        channel: DEFAULTS.channel,
+      });
+      setConfig(updated);
+      setEnabled(DEFAULTS.enabled);
+      setDeliveryTime(DEFAULTS.delivery_time.slice(0, 5));
+      setTimezone(DEFAULTS.timezone);
+      setChannel(DEFAULTS.channel);
+      setSuccess("Brief delivery configuration reset to defaults");
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to reset brief delivery configuration"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const hasChanges =
+    config &&
+    (enabled !== config.enabled ||
+      deliveryTime + ":00" !== config.delivery_time ||
+      timezone !== config.timezone ||
+      channel !== config.channel);
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <Link
+          href="/dashboard/settings"
+          className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Settings
+        </Link>
+        <h1 className="text-2xl font-bold">Daily Brief Delivery</h1>
+        <p className="text-slate-400">
+          Configure when and how you receive your daily glucose briefs
+        </p>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div
+          className="bg-red-500/10 rounded-xl p-4 border border-red-500/20"
+          role="alert"
+        >
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Success state */}
+      {success && (
+        <div
+          className="bg-green-500/10 rounded-xl p-4 border border-green-500/20"
+          role="status"
+        >
+          <div className="flex items-center gap-2">
+            <Check className="h-4 w-4 text-green-400 shrink-0" />
+            <p className="text-sm text-green-400">{success}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div
+          className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+          role="status"
+          aria-label="Loading brief delivery configuration"
+        >
+          <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+          <p className="text-slate-400">Loading delivery configuration...</p>
+        </div>
+      )}
+
+      {/* Configuration form */}
+      {!isLoading && (
+        <div className="bg-slate-900 rounded-xl border border-slate-800 p-6">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="p-2 bg-blue-500/10 rounded-lg">
+              <Clock className="h-5 w-5 text-blue-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Delivery Settings</h2>
+              <p className="text-xs text-slate-500">
+                Control your daily brief schedule and delivery channel
+              </p>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* Enable/Disable toggle */}
+            <div className="flex items-center justify-between">
+              <div>
+                <label
+                  htmlFor="enabled"
+                  className="text-sm font-medium text-slate-300"
+                >
+                  Enable Daily Briefs
+                </label>
+                <p className="text-xs text-slate-500">
+                  Receive automated daily glucose analysis
+                </p>
+              </div>
+              <button
+                id="enabled"
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                onClick={() => setEnabled(!enabled)}
+                disabled={isSaving}
+                className={clsx(
+                  "relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent",
+                  "transition-colors duration-200 ease-in-out",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                  "disabled:opacity-50 disabled:cursor-not-allowed",
+                  enabled ? "bg-blue-600" : "bg-slate-700"
+                )}
+              >
+                <span
+                  className={clsx(
+                    "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow",
+                    "transform transition duration-200 ease-in-out",
+                    enabled ? "translate-x-5" : "translate-x-0"
+                  )}
+                />
+              </button>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {/* Delivery time */}
+              <div>
+                <label
+                  htmlFor="delivery-time"
+                  className="block text-sm font-medium text-slate-300 mb-1"
+                >
+                  Delivery Time
+                </label>
+                <input
+                  id="delivery-time"
+                  type="time"
+                  value={deliveryTime}
+                  onChange={(e) => setDeliveryTime(e.target.value)}
+                  disabled={isSaving}
+                  className={clsx(
+                    "w-full rounded-lg border px-3 py-2 text-sm",
+                    "bg-slate-800 border-slate-700 text-slate-200",
+                    "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                    "disabled:opacity-50 disabled:cursor-not-allowed"
+                  )}
+                  aria-describedby="delivery-time-hint"
+                />
+                <p
+                  id="delivery-time-hint"
+                  className="text-xs text-slate-500 mt-1"
+                >
+                  Default: 07:00 AM
+                </p>
+              </div>
+
+              {/* Timezone */}
+              <div>
+                <label
+                  htmlFor="timezone"
+                  className="block text-sm font-medium text-slate-300 mb-1"
+                >
+                  Timezone
+                </label>
+                <select
+                  id="timezone"
+                  value={timezone}
+                  onChange={(e) => setTimezone(e.target.value)}
+                  disabled={isSaving}
+                  className={clsx(
+                    "w-full rounded-lg border px-3 py-2 text-sm",
+                    "bg-slate-800 border-slate-700 text-slate-200",
+                    "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                    "disabled:opacity-50 disabled:cursor-not-allowed"
+                  )}
+                  aria-describedby="timezone-hint"
+                >
+                  {timezoneOptions.map((tz) => (
+                    <option key={tz} value={tz}>
+                      {tz.replace(/_/g, " ")}
+                    </option>
+                  ))}
+                </select>
+                <p id="timezone-hint" className="text-xs text-slate-500 mt-1">
+                  Default: UTC
+                </p>
+              </div>
+            </div>
+
+            {/* Channel selection */}
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-2">
+                Delivery Channel
+              </label>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                {CHANNEL_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    aria-pressed={channel === opt.value}
+                    onClick={() => setChannel(opt.value)}
+                    disabled={isSaving}
+                    className={clsx(
+                      "px-4 py-3 rounded-lg border text-sm font-medium text-center",
+                      "transition-colors",
+                      "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                      "disabled:opacity-50 disabled:cursor-not-allowed",
+                      channel === opt.value
+                        ? "bg-blue-600/20 border-blue-500 text-blue-400"
+                        : "bg-slate-800 border-slate-700 text-slate-400 hover:border-slate-600"
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-slate-500 mt-1">
+                Default: Web + Telegram
+              </p>
+            </div>
+
+            {/* Preview */}
+            {!isLoading && (
+              <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
+                <p className="text-xs text-slate-500 mb-2">Preview</p>
+                <p className="text-lg font-semibold text-blue-400">
+                  {enabled ? "Enabled" : "Disabled"} &middot; {deliveryTime}{" "}
+                  {timezone.replace(/_/g, " ")} &middot;{" "}
+                  {CHANNEL_OPTIONS.find((o) => o.value === channel)?.label}
+                </p>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-3 pt-2">
+              <button
+                type="submit"
+                disabled={isSaving || !hasChanges}
+                className={clsx(
+                  "flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium",
+                  "bg-blue-600 text-white hover:bg-blue-500",
+                  "transition-colors",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+              >
+                {isSaving ? (
+                  <Loader2
+                    className="h-4 w-4 animate-spin"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Check className="h-4 w-4" aria-hidden="true" />
+                )}
+                {isSaving ? "Saving..." : "Save Changes"}
+              </button>
+
+              <button
+                type="button"
+                onClick={handleReset}
+                disabled={
+                  isSaving ||
+                  !config ||
+                  (config.enabled === DEFAULTS.enabled &&
+                    config.delivery_time === DEFAULTS.delivery_time &&
+                    config.timezone === DEFAULTS.timezone &&
+                    config.channel === DEFAULTS.channel)
+                }
+                className={clsx(
+                  "flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium",
+                  "bg-slate-800 text-slate-300 hover:bg-slate-700",
+                  "transition-colors",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+              >
+                <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                Reset to Defaults
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Info card */}
+      <div className="bg-slate-900/50 rounded-xl p-4 border border-slate-800">
+        <p className="text-xs text-slate-500">
+          Daily briefs provide an AI-generated summary of your glucose data from
+          the previous 24 hours. They are delivered at the scheduled time in your
+          selected timezone. Telegram delivery requires a linked Telegram account.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -8,7 +8,7 @@
  */
 
 import Link from "next/link";
-import { Settings, User, Bell, Database, Link2, Users, MessageCircle, UserPlus, Target } from "lucide-react";
+import { Settings, User, Bell, Database, Link2, Users, MessageCircle, UserPlus, Target, Clock } from "lucide-react";
 import { useUserContext } from "@/providers";
 
 interface SettingsSection {
@@ -38,6 +38,12 @@ const settingsSections: SettingsSection[] = [
     description: "Set your target glucose range for dashboard and AI analysis",
     icon: Target,
     href: "/dashboard/settings/glucose-range",
+  },
+  {
+    title: "Daily Briefs",
+    description: "Configure delivery time, timezone, and channel for daily briefs",
+    icon: Clock,
+    href: "/dashboard/settings/brief-delivery",
   },
   {
     title: "Alerts",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1149,6 +1149,78 @@ export async function updateTargetGlucoseRange(
 }
 
 /**
+ * Brief Delivery Config API types (Story 9.2)
+ */
+export interface BriefDeliveryConfigResponse {
+  id: string;
+  enabled: boolean;
+  delivery_time: string;
+  timezone: string;
+  channel: "web_only" | "telegram" | "both";
+  updated_at: string;
+}
+
+export interface BriefDeliveryConfigUpdate {
+  enabled?: boolean;
+  delivery_time?: string;
+  timezone?: string;
+  channel?: "web_only" | "telegram" | "both";
+}
+
+export interface BriefDeliveryConfigDefaults {
+  enabled: boolean;
+  delivery_time: string;
+  timezone: string;
+  channel: "web_only" | "telegram" | "both";
+}
+
+/**
+ * Fetch current brief delivery configuration
+ */
+export async function getBriefDeliveryConfig(): Promise<BriefDeliveryConfigResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/brief-delivery`,
+    { credentials: "include" }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to fetch brief delivery config: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Update brief delivery configuration
+ */
+export async function updateBriefDeliveryConfig(
+  updates: BriefDeliveryConfigUpdate
+): Promise<BriefDeliveryConfigResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/brief-delivery`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(updates),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail ||
+        `Failed to update brief delivery config: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
  * Caregiver AI Chat (Story 8.4)
  */
 export interface CaregiverChatResponse {


### PR DESCRIPTION
## Summary

- Add user-configurable daily brief delivery settings (time, timezone, channel, enable/disable)
- New BriefDeliveryConfig model, schemas, service, and migration (025)
- GET/PATCH /api/settings/brief-delivery endpoints with role-based access control
- New frontend settings page with toggle, time picker, timezone dropdown, channel buttons, and live preview
- 26 backend tests + 8 caregiver read-only structural tests for Stories 9.1 and 9.2

## Changes

### Backend
- `apps/api/src/models/brief_delivery_config.py` - SQLAlchemy model with DeliveryChannel enum
- `apps/api/src/schemas/brief_delivery_config.py` - Pydantic schemas with IANA timezone validation
- `apps/api/src/services/brief_delivery_config.py` - Get-or-create + partial update service
- `apps/api/migrations/versions/025_create_brief_delivery_configs.py` - Database migration
- `apps/api/src/routers/settings.py` - 3 new endpoints (GET/PATCH brief-delivery, GET defaults)
- `apps/api/src/models/user.py` - Added brief_delivery_config relationship
- `apps/api/tests/test_brief_delivery_config.py` - 26 tests (schema, service, endpoints)
- `apps/api/tests/test_caregiver_read_only.py` - 8 structural tests for 9.1 + 9.2 endpoints

### Frontend
- `apps/web/src/app/dashboard/settings/brief-delivery/page.tsx` - New settings page
- `apps/web/src/app/dashboard/settings/page.tsx` - Added Daily Briefs card
- `apps/web/src/lib/api.ts` - Brief delivery API types and functions

## Test plan
- [x] Backend: 927 passed, 1 skipped (ruff clean)
- [x] Frontend: 328 passed, 13 suites (ESLint clean)
- [x] Playwright MCP visual verification of brief-delivery page, settings hub, dashboard, briefs, alerts
- [x] Adversarial review completed with all findings addressed
- [x] Re-review confirmed all fixes