### PR TITLE
feat: add data retention settings (Story 9.3)

### DIFF
--- a/_bmad-output/PROGRESS.md
+++ b/_bmad-output/PROGRESS.md
@@ -14,9 +14,9 @@
 | 6 | Intelligent Alerting & Escalation | 7/7 | **Complete** |
 | 7 | Telegram Bot Integration | 6/6 | **Complete** |
 | 8 | Caregiver Access & Support | 6/6 | **Complete** |
-| 9 | Settings & Data Management | 2/5 | In Progress |
+| 9 | Settings & Data Management | 3/5 | In Progress |
 
-**Overall Progress:** 49/54 stories complete (91%)
+**Overall Progress:** 50/54 stories complete (93%)
 
 ---
 
@@ -147,13 +147,13 @@
 
 ## Epic 9: Settings & Data Management
 
-**Status:** In Progress (2/5)
+**Status:** In Progress (3/5)
 
 | Story | Title | Status | PR |
 |-------|-------|--------|----|
 | 9.1 | Target Glucose Range Configuration | Done | #90 |
-| 9.2 | Daily Brief Delivery Configuration | Done | PR pending |
-| 9.3 | Data Retention Settings | Pending | |
+| 9.2 | Daily Brief Delivery Configuration | Done | #92 |
+| 9.3 | Data Retention Settings | Done | PR pending |
 | 9.4 | Data Purge Capability | Pending | |
 | 9.5 | Settings Export | Pending | |
 
@@ -208,6 +208,6 @@ All 6 stories completed:
 
 - [x] Story 9.1: Target Glucose Range Configuration
 - [x] Story 9.2: Daily Brief Delivery Configuration
-- [ ] Story 9.3: Data Retention Settings
+- [x] Story 9.3: Data Retention Settings
 - [ ] Story 9.4: Data Purge Capability
 - [ ] Story 9.5: Settings Export

--- a/apps/api/migrations/versions/026_create_data_retention_configs.py
+++ b/apps/api/migrations/versions/026_create_data_retention_configs.py
@@ -1,0 +1,73 @@
+"""Story 9.3: Create data_retention_configs table.
+
+Revision ID: 026_data_retention_configs
+Revises: 025_brief_delivery_configs
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "026_data_retention_configs"
+down_revision = "025_brief_delivery_configs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "data_retention_configs",
+        sa.Column(
+            "id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column(
+            "glucose_retention_days",
+            sa.Integer,
+            nullable=False,
+            server_default="365",
+        ),
+        sa.Column(
+            "analysis_retention_days",
+            sa.Integer,
+            nullable=False,
+            server_default="365",
+        ),
+        sa.Column(
+            "audit_retention_days",
+            sa.Integer,
+            nullable=False,
+            server_default="730",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_index(
+        "ix_data_retention_configs_user_id",
+        "data_retention_configs",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_data_retention_configs_user_id")
+    op.drop_table("data_retention_configs")

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -63,6 +63,10 @@ class Settings(BaseSettings):
     escalation_check_interval_minutes: int = 1  # Check every 1 minute
     escalation_check_enabled: bool = True  # Enable/disable automatic escalation
 
+    # Data Retention (Story 9.3)
+    data_retention_enabled: bool = True
+    data_retention_check_interval_hours: int = 24  # Run daily
+
     # Telegram Bot (Story 7.1)
     telegram_bot_token: str = ""
     telegram_polling_enabled: bool = True

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -3,10 +3,12 @@ from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProvide
 from src.models.alert import Alert, AlertSeverity, AlertType
 from src.models.alert_threshold import AlertThreshold
 from src.models.base import Base, TimestampMixin
+from src.models.brief_delivery_config import BriefDeliveryConfig
 from src.models.caregiver_invitation import CaregiverInvitation, InvitationStatus
 from src.models.caregiver_link import CaregiverLink
 from src.models.correction_analysis import CorrectionAnalysis
 from src.models.daily_brief import DailyBrief
+from src.models.data_retention_config import DataRetentionConfig
 from src.models.disclaimer import DisclaimerAcknowledgment
 from src.models.emergency_contact import ContactPriority, EmergencyContact
 from src.models.escalation_config import EscalationConfig
@@ -25,6 +27,7 @@ from src.models.meal_analysis import MealAnalysis
 from src.models.pump_data import PumpEvent, PumpEventType
 from src.models.safety_log import SafetyLog
 from src.models.suggestion_response import SuggestionResponse
+from src.models.target_glucose_range import TargetGlucoseRange
 from src.models.telegram_link import TelegramLink
 from src.models.telegram_verification import TelegramVerificationCode
 from src.models.user import User, UserRole
@@ -38,31 +41,34 @@ __all__ = [
     "AlertThreshold",
     "AlertType",
     "Base",
+    "BriefDeliveryConfig",
     "CaregiverInvitation",
     "CaregiverLink",
     "ContactPriority",
-    "InvitationStatus",
     "CorrectionAnalysis",
-    "TimestampMixin",
     "DailyBrief",
+    "DataRetentionConfig",
     "DisclaimerAcknowledgment",
     "EmergencyContact",
     "EscalationConfig",
     "EscalationEvent",
     "EscalationTier",
-    "NotificationStatus",
-    "MealAnalysis",
     "GlucoseReading",
-    "TrendDirection",
+    "InvitationStatus",
     "IntegrationCredential",
     "IntegrationStatus",
     "IntegrationType",
+    "MealAnalysis",
+    "NotificationStatus",
     "PumpEvent",
     "PumpEventType",
     "SafetyLog",
     "SuggestionResponse",
+    "TargetGlucoseRange",
     "TelegramLink",
     "TelegramVerificationCode",
+    "TimestampMixin",
+    "TrendDirection",
     "User",
     "UserRole",
 ]

--- a/apps/api/src/models/data_retention_config.py
+++ b/apps/api/src/models/data_retention_config.py
@@ -1,0 +1,75 @@
+"""Story 9.3: Data retention configuration model.
+
+Stores user-configured data retention periods for glucose data,
+AI analysis results, and audit logs.
+"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Integer
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+# Default retention periods in days
+DEFAULT_GLUCOSE_RETENTION_DAYS = 365  # 1 year
+DEFAULT_ANALYSIS_RETENTION_DAYS = 365  # 1 year
+DEFAULT_AUDIT_RETENTION_DAYS = 730  # 2 years
+
+
+class DataRetentionConfig(Base, TimestampMixin):
+    """User-specific data retention configuration.
+
+    One-to-one with User. Controls how long different categories of data
+    are retained before being eligible for automatic cleanup.
+
+    Categories:
+        - glucose: GlucoseReading, PumpEvent records
+        - analysis: DailyBrief, MealAnalysis, CorrectionAnalysis, SuggestionResponse
+        - audit: SafetyLog, Alert, EscalationEvent
+    """
+
+    __tablename__ = "data_retention_configs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    glucose_retention_days: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=DEFAULT_GLUCOSE_RETENTION_DAYS,
+    )
+
+    analysis_retention_days: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=DEFAULT_ANALYSIS_RETENTION_DAYS,
+    )
+
+    audit_retention_days: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=DEFAULT_AUDIT_RETENTION_DAYS,
+    )
+
+    user = relationship("User", back_populates="data_retention_config")
+
+    def __repr__(self) -> str:
+        return (
+            f"<DataRetentionConfig(user_id={self.user_id}, "
+            f"glucose={self.glucose_retention_days}d, "
+            f"analysis={self.analysis_retention_days}d, "
+            f"audit={self.audit_retention_days}d)>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -186,6 +186,12 @@ class User(Base, TimestampMixin):
         cascade="all, delete-orphan",
         uselist=False,
     )
+    data_retention_config = relationship(
+        "DataRetentionConfig",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
 
     def __repr__(self) -> str:
         return f"<User {self.email} ({self.role.value})>"

--- a/apps/api/src/schemas/data_retention_config.py
+++ b/apps/api/src/schemas/data_retention_config.py
@@ -1,0 +1,69 @@
+"""Story 9.3: Data retention configuration schemas."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from src.models.data_retention_config import (
+    DEFAULT_ANALYSIS_RETENTION_DAYS,
+    DEFAULT_AUDIT_RETENTION_DAYS,
+    DEFAULT_GLUCOSE_RETENTION_DAYS,
+)
+
+
+class DataRetentionConfigResponse(BaseModel):
+    """Response schema for data retention configuration."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    glucose_retention_days: int
+    analysis_retention_days: int
+    audit_retention_days: int
+    updated_at: datetime
+
+
+class DataRetentionConfigUpdate(BaseModel):
+    """Request schema for updating data retention configuration.
+
+    All fields are optional -- only provided fields are updated.
+    Minimum retention is 30 days; maximum is 3650 days (10 years).
+    """
+
+    glucose_retention_days: int | None = Field(
+        default=None,
+        ge=30,
+        le=3650,
+        description="Glucose data retention in days (30-3650).",
+    )
+    analysis_retention_days: int | None = Field(
+        default=None,
+        ge=30,
+        le=3650,
+        description="AI analysis retention in days (30-3650).",
+    )
+    audit_retention_days: int | None = Field(
+        default=None,
+        ge=30,
+        le=3650,
+        description="Audit log retention in days (30-3650).",
+    )
+
+
+class DataRetentionConfigDefaults(BaseModel):
+    """Default data retention configuration values for reference."""
+
+    glucose_retention_days: int = DEFAULT_GLUCOSE_RETENTION_DAYS
+    analysis_retention_days: int = DEFAULT_ANALYSIS_RETENTION_DAYS
+    audit_retention_days: int = DEFAULT_AUDIT_RETENTION_DAYS
+
+
+class StorageUsageResponse(BaseModel):
+    """Response schema for storage usage record counts."""
+
+    glucose_records: int
+    pump_records: int
+    analysis_records: int
+    audit_records: int
+    total_records: int

--- a/apps/api/src/services/data_retention_config.py
+++ b/apps/api/src/services/data_retention_config.py
@@ -1,0 +1,288 @@
+"""Story 9.3: Data retention configuration service.
+
+Manages user data retention settings with get-or-create pattern,
+and provides the background enforcement job that prunes expired data.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.alert import Alert
+from src.models.correction_analysis import CorrectionAnalysis
+from src.models.daily_brief import DailyBrief
+from src.models.data_retention_config import DataRetentionConfig
+from src.models.escalation_event import EscalationEvent
+from src.models.glucose import GlucoseReading
+from src.models.meal_analysis import MealAnalysis
+from src.models.pump_data import PumpEvent
+from src.models.safety_log import SafetyLog
+from src.models.suggestion_response import SuggestionResponse
+from src.schemas.data_retention_config import DataRetentionConfigUpdate
+
+logger = get_logger(__name__)
+
+
+async def get_or_create_config(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> DataRetentionConfig:
+    """Get the user's data retention config, creating defaults if none exist.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+
+    Returns:
+        The user's DataRetentionConfig record.
+    """
+    result = await db.execute(
+        select(DataRetentionConfig).where(DataRetentionConfig.user_id == user_id)
+    )
+    config = result.scalar_one_or_none()
+
+    if config is None:
+        config = DataRetentionConfig(user_id=user_id)
+        db.add(config)
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            result = await db.execute(
+                select(DataRetentionConfig).where(
+                    DataRetentionConfig.user_id == user_id
+                )
+            )
+            config = result.scalar_one()
+            return config
+        await db.refresh(config)
+
+        logger.info(
+            "Created default data retention config",
+            user_id=str(user_id),
+        )
+
+    return config
+
+
+async def update_config(
+    user_id: uuid.UUID,
+    updates: DataRetentionConfigUpdate,
+    db: AsyncSession,
+) -> DataRetentionConfig:
+    """Update the user's data retention configuration.
+
+    Only fields provided in the request are updated.
+
+    Args:
+        user_id: User's UUID.
+        updates: Partial update with new retention values.
+        db: Database session.
+
+    Returns:
+        The updated DataRetentionConfig record.
+    """
+    config = await get_or_create_config(user_id, db)
+
+    update_data = updates.model_dump(exclude_none=True)
+    for field, value in update_data.items():
+        setattr(config, field, value)
+
+    await db.commit()
+    await db.refresh(config)
+
+    logger.info(
+        "Updated data retention config",
+        user_id=str(user_id),
+        fields=list(update_data.keys()),
+    )
+
+    return config
+
+
+async def get_storage_usage(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> dict[str, int]:
+    """Get the count of records in each data category for a user.
+
+    Returns a dict with record counts for display purposes.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+
+    Returns:
+        Dict with keys: glucose_records, pump_records, analysis_records,
+        audit_records, total_records.
+    """
+    glucose_count = (
+        await db.execute(select(func.count()).where(GlucoseReading.user_id == user_id))
+    ).scalar_one()
+
+    pump_count = (
+        await db.execute(select(func.count()).where(PumpEvent.user_id == user_id))
+    ).scalar_one()
+
+    brief_count = (
+        await db.execute(select(func.count()).where(DailyBrief.user_id == user_id))
+    ).scalar_one()
+
+    meal_count = (
+        await db.execute(select(func.count()).where(MealAnalysis.user_id == user_id))
+    ).scalar_one()
+
+    correction_count = (
+        await db.execute(
+            select(func.count()).where(CorrectionAnalysis.user_id == user_id)
+        )
+    ).scalar_one()
+
+    suggestion_count = (
+        await db.execute(
+            select(func.count()).where(SuggestionResponse.user_id == user_id)
+        )
+    ).scalar_one()
+
+    safety_count = (
+        await db.execute(select(func.count()).where(SafetyLog.user_id == user_id))
+    ).scalar_one()
+
+    alert_count = (
+        await db.execute(select(func.count()).where(Alert.user_id == user_id))
+    ).scalar_one()
+
+    escalation_count = (
+        await db.execute(select(func.count()).where(EscalationEvent.user_id == user_id))
+    ).scalar_one()
+
+    analysis_total = brief_count + meal_count + correction_count + suggestion_count
+    audit_total = safety_count + alert_count + escalation_count
+    glucose_total = glucose_count + pump_count
+
+    return {
+        "glucose_records": glucose_count,
+        "pump_records": pump_count,
+        "analysis_records": analysis_total,
+        "audit_records": audit_total,
+        "total_records": glucose_total + analysis_total + audit_total,
+    }
+
+
+async def enforce_retention_for_user(
+    user_id: uuid.UUID,
+    config: DataRetentionConfig,
+    db: AsyncSession,
+) -> dict[str, int]:
+    """Delete records older than the configured retention period for a user.
+
+    Args:
+        user_id: User's UUID.
+        config: The user's data retention configuration.
+        db: Database session.
+
+    Returns:
+        Dict with count of deleted records per category.
+    """
+    now = datetime.now(UTC)
+    deleted = {}
+
+    # Glucose data: GlucoseReading and PumpEvent
+    glucose_cutoff = now - timedelta(days=config.glucose_retention_days)
+
+    result = await db.execute(
+        delete(GlucoseReading).where(
+            GlucoseReading.user_id == user_id,
+            GlucoseReading.reading_timestamp < glucose_cutoff,
+        )
+    )
+    deleted["glucose_readings"] = result.rowcount
+
+    result = await db.execute(
+        delete(PumpEvent).where(
+            PumpEvent.user_id == user_id,
+            PumpEvent.event_timestamp < glucose_cutoff,
+        )
+    )
+    deleted["pump_events"] = result.rowcount
+
+    # Analysis data: DailyBrief, MealAnalysis, CorrectionAnalysis, SuggestionResponse
+    analysis_cutoff = now - timedelta(days=config.analysis_retention_days)
+
+    result = await db.execute(
+        delete(DailyBrief).where(
+            DailyBrief.user_id == user_id,
+            DailyBrief.created_at < analysis_cutoff,
+        )
+    )
+    deleted["daily_briefs"] = result.rowcount
+
+    result = await db.execute(
+        delete(MealAnalysis).where(
+            MealAnalysis.user_id == user_id,
+            MealAnalysis.created_at < analysis_cutoff,
+        )
+    )
+    deleted["meal_analyses"] = result.rowcount
+
+    result = await db.execute(
+        delete(CorrectionAnalysis).where(
+            CorrectionAnalysis.user_id == user_id,
+            CorrectionAnalysis.created_at < analysis_cutoff,
+        )
+    )
+    deleted["correction_analyses"] = result.rowcount
+
+    result = await db.execute(
+        delete(SuggestionResponse).where(
+            SuggestionResponse.user_id == user_id,
+            SuggestionResponse.created_at < analysis_cutoff,
+        )
+    )
+    deleted["suggestion_responses"] = result.rowcount
+
+    # Audit data: SafetyLog, EscalationEvent, Alert
+    # EscalationEvent must be deleted before Alert due to FK cascade
+    # (escalation_events.alert_id -> alerts.id ON DELETE CASCADE)
+    audit_cutoff = now - timedelta(days=config.audit_retention_days)
+
+    result = await db.execute(
+        delete(SafetyLog).where(
+            SafetyLog.user_id == user_id,
+            SafetyLog.created_at < audit_cutoff,
+        )
+    )
+    deleted["safety_logs"] = result.rowcount
+
+    result = await db.execute(
+        delete(EscalationEvent).where(
+            EscalationEvent.user_id == user_id,
+            EscalationEvent.created_at < audit_cutoff,
+        )
+    )
+    deleted["escalation_events"] = result.rowcount
+
+    result = await db.execute(
+        delete(Alert).where(
+            Alert.user_id == user_id,
+            Alert.created_at < audit_cutoff,
+        )
+    )
+    deleted["alerts"] = result.rowcount
+
+    await db.commit()
+
+    total = sum(deleted.values())
+    if total > 0:
+        logger.info(
+            "Enforced data retention policy",
+            user_id=str(user_id),
+            deleted=deleted,
+            total_deleted=total,
+        )
+
+    return deleted

--- a/apps/api/tests/test_caregiver_read_only.py
+++ b/apps/api/tests/test_caregiver_read_only.py
@@ -417,3 +417,55 @@ class TestRouterDependenciesIncludeRoleCheck:
         deps = self._get_route_dependencies(router, "/api/ai/insights", "GET")
         role_checker = deps[0].dependency
         assert UserRole.CAREGIVER not in role_checker.allowed_roles
+
+    # ── Story 9.3: Data Retention ──
+
+    def test_data_retention_get_has_require_diabetic(self):
+        """GET /api/settings/data-retention has require_diabetic_or_admin."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/data-retention", "GET"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker in dep_classes
+
+    def test_data_retention_patch_has_require_diabetic(self):
+        """PATCH /api/settings/data-retention has require_diabetic_or_admin."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/data-retention", "PATCH"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker in dep_classes
+
+    def test_data_retention_usage_has_require_diabetic(self):
+        """GET /api/settings/data-retention/usage has require_diabetic_or_admin."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/data-retention/usage", "GET"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker in dep_classes
+
+    def test_data_retention_defaults_no_role_check(self):
+        """GET /api/settings/data-retention/defaults has no role check."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/data-retention/defaults", "GET"
+        )
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker not in dep_classes
+
+    def test_data_retention_role_blocks_caregiver(self):
+        """Data retention role check blocks CAREGIVER."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(
+            router, "/api/settings/data-retention", "GET"
+        )
+        role_checker = deps[0].dependency
+        assert UserRole.CAREGIVER not in role_checker.allowed_roles

--- a/apps/api/tests/test_data_retention_config.py
+++ b/apps/api/tests/test_data_retention_config.py
@@ -1,0 +1,421 @@
+"""Story 9.3: Tests for data retention configuration service and settings router."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from src.config import settings
+from src.models.data_retention_config import (
+    DEFAULT_ANALYSIS_RETENTION_DAYS,
+    DEFAULT_AUDIT_RETENTION_DAYS,
+    DEFAULT_GLUCOSE_RETENTION_DAYS,
+    DataRetentionConfig,
+)
+from src.schemas.data_retention_config import (
+    DataRetentionConfigDefaults,
+    DataRetentionConfigUpdate,
+)
+from src.services.data_retention_config import (
+    enforce_retention_for_user,
+    get_or_create_config,
+    update_config,
+)
+
+
+def unique_email(prefix: str = "test") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email("data_retention")
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+# ── Schema validation tests ──
+
+
+class TestDataRetentionConfigUpdate:
+    """Tests for DataRetentionConfigUpdate schema validation."""
+
+    def test_all_none_is_valid(self):
+        update = DataRetentionConfigUpdate()
+        assert update.glucose_retention_days is None
+        assert update.analysis_retention_days is None
+        assert update.audit_retention_days is None
+
+    def test_partial_update_glucose(self):
+        update = DataRetentionConfigUpdate(glucose_retention_days=90)
+        assert update.glucose_retention_days == 90
+        assert update.analysis_retention_days is None
+
+    def test_partial_update_analysis(self):
+        update = DataRetentionConfigUpdate(analysis_retention_days=180)
+        assert update.analysis_retention_days == 180
+
+    def test_partial_update_audit(self):
+        update = DataRetentionConfigUpdate(audit_retention_days=365)
+        assert update.audit_retention_days == 365
+
+    def test_below_minimum_fails(self):
+        with pytest.raises(ValidationError):
+            DataRetentionConfigUpdate(glucose_retention_days=29)
+
+    def test_above_maximum_fails(self):
+        with pytest.raises(ValidationError):
+            DataRetentionConfigUpdate(glucose_retention_days=3651)
+
+    def test_boundary_minimum_passes(self):
+        update = DataRetentionConfigUpdate(glucose_retention_days=30)
+        assert update.glucose_retention_days == 30
+
+    def test_boundary_maximum_passes(self):
+        update = DataRetentionConfigUpdate(glucose_retention_days=3650)
+        assert update.glucose_retention_days == 3650
+
+    def test_all_fields_valid(self):
+        update = DataRetentionConfigUpdate(
+            glucose_retention_days=90,
+            analysis_retention_days=180,
+            audit_retention_days=365,
+        )
+        assert update.glucose_retention_days == 90
+        assert update.analysis_retention_days == 180
+        assert update.audit_retention_days == 365
+
+
+class TestDataRetentionConfigDefaults:
+    """Tests for DataRetentionConfigDefaults schema."""
+
+    def test_default_values(self):
+        defaults = DataRetentionConfigDefaults()
+        assert defaults.glucose_retention_days == DEFAULT_GLUCOSE_RETENTION_DAYS
+        assert defaults.analysis_retention_days == DEFAULT_ANALYSIS_RETENTION_DAYS
+        assert defaults.audit_retention_days == DEFAULT_AUDIT_RETENTION_DAYS
+
+
+# ── Service tests ──
+
+
+class TestGetOrCreateConfig:
+    """Tests for get_or_create_config service function."""
+
+    @pytest.mark.asyncio
+    async def test_creates_defaults_when_none_exist(self):
+        """Should create a new DataRetentionConfig with defaults."""
+        user_id = uuid.uuid4()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock(return_value=None)
+
+        result = await get_or_create_config(user_id, mock_db)
+
+        assert result.user_id == user_id
+        mock_db.add.assert_called_once_with(result)
+        mock_db.commit.assert_called_once()
+        mock_db.refresh.assert_called_once_with(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_when_found(self):
+        """Should return existing record without creating."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await get_or_create_config(user_id, mock_db)
+
+        assert result == existing
+        mock_db.add.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+
+class TestUpdateConfig:
+    """Tests for update_config service function."""
+
+    @pytest.mark.asyncio
+    async def test_partial_update_glucose(self):
+        """Should only update glucose_retention_days."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+        existing.glucose_retention_days = DEFAULT_GLUCOSE_RETENTION_DAYS
+        existing.analysis_retention_days = DEFAULT_ANALYSIS_RETENTION_DAYS
+        existing.audit_retention_days = DEFAULT_AUDIT_RETENTION_DAYS
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = DataRetentionConfigUpdate(glucose_retention_days=90)
+        result = await update_config(user_id, updates, mock_db)
+
+        assert result.glucose_retention_days == 90
+        mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_update_no_change(self):
+        """Empty update should still commit without errors."""
+        user_id = uuid.uuid4()
+        existing = MagicMock()
+        existing.user_id = user_id
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        updates = DataRetentionConfigUpdate()
+        result = await update_config(user_id, updates, mock_db)
+
+        assert result == existing
+        mock_db.commit.assert_called_once()
+
+
+# ── Enforcement tests ──
+
+
+class TestEnforceRetention:
+    """Tests for enforce_retention_for_user service function."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_expired_records(self):
+        """Should execute delete queries for all categories."""
+        user_id = uuid.uuid4()
+        config = MagicMock(spec=DataRetentionConfig)
+        config.glucose_retention_days = 30
+        config.analysis_retention_days = 30
+        config.audit_retention_days = 30
+
+        mock_result = MagicMock()
+        mock_result.rowcount = 5
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await enforce_retention_for_user(user_id, config, mock_db)
+
+        # 9 delete queries (glucose, pump, daily_brief, meal, correction,
+        # suggestion, safety, alert, escalation)
+        assert mock_db.execute.call_count == 9
+        mock_db.commit.assert_called_once()
+
+        # Each category returned 5 deleted
+        assert result["glucose_readings"] == 5
+        assert result["pump_events"] == 5
+        assert result["daily_briefs"] == 5
+        assert result["alerts"] == 5
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_nothing_expired(self):
+        """Should return zero counts when no records match."""
+        user_id = uuid.uuid4()
+        config = MagicMock(spec=DataRetentionConfig)
+        config.glucose_retention_days = 3650
+        config.analysis_retention_days = 3650
+        config.audit_retention_days = 3650
+
+        mock_result = MagicMock()
+        mock_result.rowcount = 0
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await enforce_retention_for_user(user_id, config, mock_db)
+
+        assert all(v == 0 for v in result.values())
+
+
+# ── Endpoint tests ──
+
+
+class TestGetDataRetentionEndpoint:
+    """Tests for GET /api/settings/data-retention."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.get("/api/settings/data-retention")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authenticated_returns_defaults(self, client):
+        cookie = await register_and_login(client)
+        response = await client.get(
+            "/api/settings/data-retention",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["glucose_retention_days"] == DEFAULT_GLUCOSE_RETENTION_DAYS
+        assert data["analysis_retention_days"] == DEFAULT_ANALYSIS_RETENTION_DAYS
+        assert data["audit_retention_days"] == DEFAULT_AUDIT_RETENTION_DAYS
+        assert "id" in data
+        assert "updated_at" in data
+
+    @pytest.mark.asyncio
+    async def test_idempotent_get_or_create(self, client):
+        """Calling GET twice should return the same record."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        r1 = await client.get("/api/settings/data-retention", cookies=cookies)
+        r2 = await client.get("/api/settings/data-retention", cookies=cookies)
+
+        assert r1.json()["id"] == r2.json()["id"]
+
+
+class TestPatchDataRetentionEndpoint:
+    """Tests for PATCH /api/settings/data-retention."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.patch(
+            "/api/settings/data-retention",
+            json={"glucose_retention_days": 90},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_range_returns_422(self, client):
+        cookie = await register_and_login(client)
+        response = await client.patch(
+            "/api/settings/data-retention",
+            json={"glucose_retention_days": 10},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_valid_partial_update(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/data-retention",
+            json={"glucose_retention_days": 90},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["glucose_retention_days"] == 90
+        assert data["analysis_retention_days"] == DEFAULT_ANALYSIS_RETENTION_DAYS
+
+    @pytest.mark.asyncio
+    async def test_update_all_fields(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/data-retention",
+            json={
+                "glucose_retention_days": 90,
+                "analysis_retention_days": 180,
+                "audit_retention_days": 365,
+            },
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["glucose_retention_days"] == 90
+        assert data["analysis_retention_days"] == 180
+        assert data["audit_retention_days"] == 365
+
+    @pytest.mark.asyncio
+    async def test_persists_across_requests(self, client):
+        """Updated values should persist when fetched again."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        await client.patch(
+            "/api/settings/data-retention",
+            json={"audit_retention_days": 365},
+            cookies=cookies,
+        )
+
+        response = await client.get(
+            "/api/settings/data-retention",
+            cookies=cookies,
+        )
+        assert response.json()["audit_retention_days"] == 365
+
+    @pytest.mark.asyncio
+    async def test_empty_body_returns_200(self, client):
+        """Empty PATCH body should succeed without modifying anything."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.patch(
+            "/api/settings/data-retention",
+            json={},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["glucose_retention_days"] == DEFAULT_GLUCOSE_RETENTION_DAYS
+
+
+class TestGetDataRetentionDefaultsEndpoint:
+    """Tests for GET /api/settings/data-retention/defaults."""
+
+    @pytest.mark.asyncio
+    async def test_returns_defaults_without_auth(self, client):
+        response = await client.get("/api/settings/data-retention/defaults")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["glucose_retention_days"] == DEFAULT_GLUCOSE_RETENTION_DAYS
+        assert data["analysis_retention_days"] == DEFAULT_ANALYSIS_RETENTION_DAYS
+        assert data["audit_retention_days"] == DEFAULT_AUDIT_RETENTION_DAYS
+
+
+class TestGetStorageUsageEndpoint:
+    """Tests for GET /api/settings/data-retention/usage."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.get("/api/settings/data-retention/usage")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authenticated_returns_usage(self, client):
+        cookie = await register_and_login(client)
+        response = await client.get(
+            "/api/settings/data-retention/usage",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "glucose_records" in data
+        assert "pump_records" in data
+        assert "analysis_records" in data
+        assert "audit_records" in data
+        assert "total_records" in data
+        # Fresh user should have zero records
+        assert data["total_records"] == 0

--- a/apps/web/src/app/dashboard/settings/data/page.tsx
+++ b/apps/web/src/app/dashboard/settings/data/page.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+/**
+ * Story 9.3: Data Retention Settings
+ *
+ * Allows users to configure retention periods for glucose data,
+ * AI analysis results, and audit logs. Displays storage usage.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Database,
+  Loader2,
+  AlertTriangle,
+  Check,
+  ArrowLeft,
+  RotateCcw,
+} from "lucide-react";
+import Link from "next/link";
+import clsx from "clsx";
+import {
+  getDataRetentionConfig,
+  updateDataRetentionConfig,
+  getStorageUsage,
+  type DataRetentionConfigResponse,
+  type StorageUsageResponse,
+} from "@/lib/api";
+
+const DEFAULTS = {
+  glucose_retention_days: 365,
+  analysis_retention_days: 365,
+  audit_retention_days: 730,
+};
+
+const RETENTION_OPTIONS = [
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
+  { value: 180, label: "6 months" },
+  { value: 365, label: "1 year" },
+  { value: 730, label: "2 years" },
+  { value: 1825, label: "5 years" },
+  { value: 3650, label: "10 years" },
+];
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+export default function DataRetentionPage() {
+  const [config, setConfig] = useState<DataRetentionConfigResponse | null>(
+    null
+  );
+  const [usage, setUsage] = useState<StorageUsageResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Form state
+  const [glucoseDays, setGlucoseDays] = useState(365);
+  const [analysisDays, setAnalysisDays] = useState(365);
+  const [auditDays, setAuditDays] = useState(730);
+
+  // Auto-clear success message after 5 seconds
+  useEffect(() => {
+    if (!success) return;
+    const timer = setTimeout(() => setSuccess(null), 5000);
+    return () => clearTimeout(timer);
+  }, [success]);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setError(null);
+      const [configData, usageData] = await Promise.all([
+        getDataRetentionConfig(),
+        getStorageUsage(),
+      ]);
+      setConfig(configData);
+      setUsage(usageData);
+      setGlucoseDays(configData.glucose_retention_days);
+      setAnalysisDays(configData.analysis_retention_days);
+      setAuditDays(configData.audit_retention_days);
+    } catch (err) {
+      if (!(err instanceof Error && err.message.includes("401"))) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load data retention configuration"
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Check if any retention period is being reduced (destructive operation)
+  const isReducingRetention =
+    config &&
+    (glucoseDays < config.glucose_retention_days ||
+      analysisDays < config.analysis_retention_days ||
+      auditDays < config.audit_retention_days);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // Warn the user if they are reducing any retention period
+    if (isReducingRetention) {
+      const confirmed = window.confirm(
+        "You are reducing one or more retention periods. " +
+          "Data older than the new retention period will be permanently " +
+          "deleted during the next enforcement cycle. This cannot be undone.\n\n" +
+          "Are you sure you want to continue?"
+      );
+      if (!confirmed) return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      // Only send fields that actually changed
+      const payload: Record<string, unknown> = {};
+      if (config && glucoseDays !== config.glucose_retention_days)
+        payload.glucose_retention_days = glucoseDays;
+      if (config && analysisDays !== config.analysis_retention_days)
+        payload.analysis_retention_days = analysisDays;
+      if (config && auditDays !== config.audit_retention_days)
+        payload.audit_retention_days = auditDays;
+
+      const updated = await updateDataRetentionConfig(
+        payload as Parameters<typeof updateDataRetentionConfig>[0]
+      );
+      setConfig(updated);
+      setSuccess("Data retention configuration updated successfully");
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to update data retention configuration"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    // Resetting to defaults may reduce retention periods — confirm with user
+    if (config) {
+      const wouldReduce =
+        DEFAULTS.glucose_retention_days < config.glucose_retention_days ||
+        DEFAULTS.analysis_retention_days < config.analysis_retention_days ||
+        DEFAULTS.audit_retention_days < config.audit_retention_days;
+
+      if (wouldReduce) {
+        const confirmed = window.confirm(
+          "Resetting to defaults will reduce one or more retention periods. " +
+            "Data older than the default retention period will be permanently " +
+            "deleted during the next enforcement cycle. This cannot be undone.\n\n" +
+            "Are you sure you want to reset to defaults?"
+        );
+        if (!confirmed) return;
+      }
+    }
+
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const updated = await updateDataRetentionConfig({
+        glucose_retention_days: DEFAULTS.glucose_retention_days,
+        analysis_retention_days: DEFAULTS.analysis_retention_days,
+        audit_retention_days: DEFAULTS.audit_retention_days,
+      });
+      setConfig(updated);
+      setGlucoseDays(DEFAULTS.glucose_retention_days);
+      setAnalysisDays(DEFAULTS.analysis_retention_days);
+      setAuditDays(DEFAULTS.audit_retention_days);
+      setSuccess("Data retention configuration reset to defaults");
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to reset data retention configuration"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const hasChanges =
+    config &&
+    (glucoseDays !== config.glucose_retention_days ||
+      analysisDays !== config.analysis_retention_days ||
+      auditDays !== config.audit_retention_days);
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <Link
+          href="/dashboard/settings"
+          className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Settings
+        </Link>
+        <h1 className="text-2xl font-bold">Data Retention</h1>
+        <p className="text-slate-400">
+          Configure how long your data is retained before automatic cleanup
+        </p>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div
+          className="bg-red-500/10 rounded-xl p-4 border border-red-500/20"
+          role="alert"
+        >
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Success state */}
+      {success && (
+        <div
+          className="bg-green-500/10 rounded-xl p-4 border border-green-500/20"
+          role="status"
+        >
+          <div className="flex items-center gap-2">
+            <Check className="h-4 w-4 text-green-400 shrink-0" />
+            <p className="text-sm text-green-400">{success}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div
+          className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+          role="status"
+          aria-label="Loading data retention configuration"
+        >
+          <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+          <p className="text-slate-400">
+            Loading data retention configuration...
+          </p>
+        </div>
+      )}
+
+      {/* Storage usage */}
+      {!isLoading && usage && (
+        <div className="bg-slate-900 rounded-xl border border-slate-800 p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 bg-purple-500/10 rounded-lg">
+              <Database className="h-5 w-5 text-purple-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Storage Usage</h2>
+              <p className="text-xs text-slate-500">
+                Current record counts by category
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div className="bg-slate-800/50 rounded-lg p-3 border border-slate-700/50">
+              <p className="text-xs text-slate-500 mb-1">Glucose Data</p>
+              <p className="text-lg font-semibold text-blue-400">
+                {formatNumber(usage.glucose_records + usage.pump_records)}
+              </p>
+              <p className="text-xs text-slate-600">
+                {formatNumber(usage.glucose_records)} CGM +{" "}
+                {formatNumber(usage.pump_records)} pump
+              </p>
+            </div>
+            <div className="bg-slate-800/50 rounded-lg p-3 border border-slate-700/50">
+              <p className="text-xs text-slate-500 mb-1">AI Analysis</p>
+              <p className="text-lg font-semibold text-green-400">
+                {formatNumber(usage.analysis_records)}
+              </p>
+              <p className="text-xs text-slate-600">
+                briefs, meals, corrections
+              </p>
+            </div>
+            <div className="bg-slate-800/50 rounded-lg p-3 border border-slate-700/50">
+              <p className="text-xs text-slate-500 mb-1">Audit Logs</p>
+              <p className="text-lg font-semibold text-amber-400">
+                {formatNumber(usage.audit_records)}
+              </p>
+              <p className="text-xs text-slate-600">
+                safety, alerts, escalations
+              </p>
+            </div>
+            <div className="bg-slate-800/50 rounded-lg p-3 border border-slate-700/50">
+              <p className="text-xs text-slate-500 mb-1">Total Records</p>
+              <p className="text-lg font-semibold text-white">
+                {formatNumber(usage.total_records)}
+              </p>
+              <p className="text-xs text-slate-600">across all categories</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Configuration form */}
+      {!isLoading && (
+        <div className="bg-slate-900 rounded-xl border border-slate-800 p-6">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="p-2 bg-blue-500/10 rounded-lg">
+              <Database className="h-5 w-5 text-blue-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Retention Periods</h2>
+              <p className="text-xs text-slate-500">
+                Set how long each category of data is kept
+              </p>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* Glucose retention */}
+            <div>
+              <label
+                htmlFor="glucose-retention"
+                className="block text-sm font-medium text-slate-300 mb-1"
+              >
+                Glucose Data Retention
+              </label>
+              <select
+                id="glucose-retention"
+                value={glucoseDays}
+                onChange={(e) => setGlucoseDays(Number(e.target.value))}
+                disabled={isSaving}
+                className={clsx(
+                  "w-full rounded-lg border px-3 py-2 text-sm",
+                  "bg-slate-800 border-slate-700 text-slate-200",
+                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+                aria-describedby="glucose-retention-hint"
+              >
+                {RETENTION_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              <p
+                id="glucose-retention-hint"
+                className="text-xs text-slate-500 mt-1"
+              >
+                CGM readings and pump events. Default: 1 year
+              </p>
+            </div>
+
+            {/* Analysis retention */}
+            <div>
+              <label
+                htmlFor="analysis-retention"
+                className="block text-sm font-medium text-slate-300 mb-1"
+              >
+                AI Analysis Retention
+              </label>
+              <select
+                id="analysis-retention"
+                value={analysisDays}
+                onChange={(e) => setAnalysisDays(Number(e.target.value))}
+                disabled={isSaving}
+                className={clsx(
+                  "w-full rounded-lg border px-3 py-2 text-sm",
+                  "bg-slate-800 border-slate-700 text-slate-200",
+                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+                aria-describedby="analysis-retention-hint"
+              >
+                {RETENTION_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              <p
+                id="analysis-retention-hint"
+                className="text-xs text-slate-500 mt-1"
+              >
+                Daily briefs, meal analyses, correction analyses. Default: 1 year
+              </p>
+            </div>
+
+            {/* Audit retention */}
+            <div>
+              <label
+                htmlFor="audit-retention"
+                className="block text-sm font-medium text-slate-300 mb-1"
+              >
+                Audit Log Retention
+              </label>
+              <select
+                id="audit-retention"
+                value={auditDays}
+                onChange={(e) => setAuditDays(Number(e.target.value))}
+                disabled={isSaving}
+                className={clsx(
+                  "w-full rounded-lg border px-3 py-2 text-sm",
+                  "bg-slate-800 border-slate-700 text-slate-200",
+                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+                aria-describedby="audit-retention-hint"
+              >
+                {RETENTION_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              <p
+                id="audit-retention-hint"
+                className="text-xs text-slate-500 mt-1"
+              >
+                Safety logs, alerts, escalation events. Default: 2 years
+              </p>
+            </div>
+
+            {/* Preview */}
+            {!isLoading && (
+              <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
+                <p className="text-xs text-slate-500 mb-2">Preview</p>
+                <p className="text-lg font-semibold text-blue-400">
+                  Glucose:{" "}
+                  {RETENTION_OPTIONS.find((o) => o.value === glucoseDays)
+                    ?.label ?? `${glucoseDays} days`}{" "}
+                  &middot; Analysis:{" "}
+                  {RETENTION_OPTIONS.find((o) => o.value === analysisDays)
+                    ?.label ?? `${analysisDays} days`}{" "}
+                  &middot; Audit:{" "}
+                  {RETENTION_OPTIONS.find((o) => o.value === auditDays)
+                    ?.label ?? `${auditDays} days`}
+                </p>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-3 pt-2">
+              <button
+                type="submit"
+                disabled={isSaving || !hasChanges}
+                className={clsx(
+                  "flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium",
+                  "bg-blue-600 text-white hover:bg-blue-500",
+                  "transition-colors",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+              >
+                {isSaving ? (
+                  <Loader2
+                    className="h-4 w-4 animate-spin"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Check className="h-4 w-4" aria-hidden="true" />
+                )}
+                {isSaving ? "Saving..." : "Save Changes"}
+              </button>
+
+              <button
+                type="button"
+                onClick={handleReset}
+                disabled={
+                  isSaving ||
+                  !config ||
+                  (config.glucose_retention_days ===
+                    DEFAULTS.glucose_retention_days &&
+                    config.analysis_retention_days ===
+                      DEFAULTS.analysis_retention_days &&
+                    config.audit_retention_days ===
+                      DEFAULTS.audit_retention_days)
+                }
+                className={clsx(
+                  "flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium",
+                  "bg-slate-800 text-slate-300 hover:bg-slate-700",
+                  "transition-colors",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+              >
+                <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                Reset to Defaults
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Info card */}
+      <div className="bg-slate-900/50 rounded-xl p-4 border border-slate-800">
+        <p className="text-xs text-slate-500">
+          Data retention policies are enforced automatically on a daily schedule.
+          Records older than the configured retention period will be permanently
+          deleted. Reducing retention periods will cause older data to be removed
+          during the next enforcement cycle. Minimum retention is 30 days.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1221,6 +1221,102 @@ export async function updateBriefDeliveryConfig(
 }
 
 /**
+ * Data Retention Config API types (Story 9.3)
+ */
+export interface DataRetentionConfigResponse {
+  id: string;
+  glucose_retention_days: number;
+  analysis_retention_days: number;
+  audit_retention_days: number;
+  updated_at: string;
+}
+
+export interface DataRetentionConfigUpdate {
+  glucose_retention_days?: number;
+  analysis_retention_days?: number;
+  audit_retention_days?: number;
+}
+
+export interface DataRetentionConfigDefaults {
+  glucose_retention_days: number;
+  analysis_retention_days: number;
+  audit_retention_days: number;
+}
+
+export interface StorageUsageResponse {
+  glucose_records: number;
+  pump_records: number;
+  analysis_records: number;
+  audit_records: number;
+  total_records: number;
+}
+
+/**
+ * Fetch current data retention configuration
+ */
+export async function getDataRetentionConfig(): Promise<DataRetentionConfigResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/data-retention`,
+    { credentials: "include" }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to fetch data retention config: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Update data retention configuration
+ */
+export async function updateDataRetentionConfig(
+  updates: DataRetentionConfigUpdate
+): Promise<DataRetentionConfigResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/data-retention`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(updates),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail ||
+        `Failed to update data retention config: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch storage usage (record counts)
+ */
+export async function getStorageUsage(): Promise<StorageUsageResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/settings/data-retention/usage`,
+    { credentials: "include" }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to fetch storage usage: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
  * Caregiver AI Chat (Story 8.4)
  */
 export interface CaregiverChatResponse {


### PR DESCRIPTION
## Summary

- Add configurable data retention periods for glucose data (CGM + pump), AI analysis results (briefs, meals, corrections), and audit logs (safety, alerts, escalations)
- Backend: DataRetentionConfig model, GET/PATCH/defaults/usage endpoints under /api/settings/data-retention, StorageUsageResponse Pydantic model, background scheduler job for daily enforcement, migration 026
- Frontend: Data retention settings page with storage usage display, three category dropdowns, confirmation dialog when reducing retention periods, preview bar, reset-to-defaults

## Test plan

- [x] 28 backend tests (schemas, services, endpoints) all passing
- [x] 960 total backend tests passing (no regressions)
- [x] 328 frontend tests passing (no regressions)
- [x] Ruff lint + format clean
- [x] ESLint clean
- [x] Playwright MCP visual verification: settings page, data retention page, dashboard, briefs, alerts
- [x] Adversarial review: 10 initial findings, 7 fixed, 3 accepted as MVP-appropriate
- [x] Adversarial re-review: all fixes verified, no blocking issues found