### PR TITLE
feat: add settings export capability (Story 9.5)

### DIFF
--- a/_bmad-output/PROGRESS.md
+++ b/_bmad-output/PROGRESS.md
@@ -14,9 +14,9 @@
 | 6 | Intelligent Alerting & Escalation | 7/7 | **Complete** |
 | 7 | Telegram Bot Integration | 6/6 | **Complete** |
 | 8 | Caregiver Access & Support | 6/6 | **Complete** |
-| 9 | Settings & Data Management | 4/5 | In Progress |
+| 9 | Settings & Data Management | 5/5 | **Complete** |
 
-**Overall Progress:** 51/54 stories complete (94%)
+**Overall Progress:** 52/54 stories complete (96%)
 
 ---
 
@@ -147,15 +147,15 @@
 
 ## Epic 9: Settings & Data Management
 
-**Status:** In Progress (4/5)
+**Status:** Complete (5/5)
 
 | Story | Title | Status | PR |
 |-------|-------|--------|----|
 | 9.1 | Target Glucose Range Configuration | Done | #90 |
 | 9.2 | Daily Brief Delivery Configuration | Done | #92 |
 | 9.3 | Data Retention Settings | Done | #94 |
-| 9.4 | Data Purge Capability | Done | PR pending |
-| 9.5 | Settings Export | Pending | |
+| 9.4 | Data Purge Capability | Done | #96 |
+| 9.5 | Settings Export | Done | PR pending |
 
 ---
 
@@ -204,10 +204,11 @@ All 6 stories completed:
 - [x] Story 8.5: Multi-Patient Dashboard
 - [x] Story 8.6: Caregiver Read-Only Enforcement
 
-**Epic 9: Settings & Data Management** - IN PROGRESS
+**Epic 9: Settings & Data Management** - COMPLETE
 
+All 5 stories completed:
 - [x] Story 9.1: Target Glucose Range Configuration
 - [x] Story 9.2: Daily Brief Delivery Configuration
 - [x] Story 9.3: Data Retention Settings
 - [x] Story 9.4: Data Purge Capability
-- [ ] Story 9.5: Settings Export
+- [x] Story 9.5: Settings Export

--- a/apps/api/src/schemas/settings_export.py
+++ b/apps/api/src/schemas/settings_export.py
@@ -1,0 +1,31 @@
+"""Story 9.5: Settings export schemas."""
+
+import enum
+
+from pydantic import BaseModel, Field
+
+
+class ExportType(str, enum.Enum):
+    """Export type options."""
+
+    SETTINGS_ONLY = "settings_only"
+    ALL_DATA = "all_data"
+
+
+class SettingsExportRequest(BaseModel):
+    """Request schema for settings export."""
+
+    export_type: ExportType = Field(
+        ...,
+        description="Type of export: 'settings_only' or 'all_data'.",
+    )
+
+
+class SettingsExportResponse(BaseModel):
+    """Response schema wrapping the full export payload.
+
+    The export_data field contains the structured JSON export
+    with metadata, settings, and optionally all user data.
+    """
+
+    export_data: dict

--- a/apps/api/src/services/settings_export.py
+++ b/apps/api/src/services/settings_export.py
@@ -1,0 +1,414 @@
+"""Story 9.5: Settings export service.
+
+Collects user settings and optionally all user data into a
+structured JSON export suitable for backup or portability.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.ai_provider import AIProviderConfig
+from src.models.alert import Alert
+from src.models.alert_threshold import AlertThreshold
+from src.models.brief_delivery_config import BriefDeliveryConfig
+from src.models.correction_analysis import CorrectionAnalysis
+from src.models.daily_brief import DailyBrief
+from src.models.data_retention_config import DataRetentionConfig
+from src.models.emergency_contact import EmergencyContact
+from src.models.escalation_config import EscalationConfig
+from src.models.glucose import GlucoseReading
+from src.models.integration import IntegrationCredential
+from src.models.meal_analysis import MealAnalysis
+from src.models.pump_data import PumpEvent
+from src.models.safety_log import SafetyLog
+from src.models.suggestion_response import SuggestionResponse
+from src.models.target_glucose_range import TargetGlucoseRange
+
+logger = get_logger(__name__)
+
+# Maximum records per category to prevent memory exhaustion on large datasets.
+MAX_EXPORT_RECORDS_PER_CATEGORY = 100_000
+
+
+async def _export_settings(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> dict:
+    """Collect all user settings into a dict.
+
+    Queries each settings table and returns defaults-compatible
+    values when a row does not yet exist.
+    """
+    settings: dict = {}
+
+    # Target glucose range
+    result = await db.execute(
+        select(TargetGlucoseRange).where(TargetGlucoseRange.user_id == user_id)
+    )
+    tgr = result.scalar_one_or_none()
+    settings["target_glucose_range"] = (
+        {
+            "low_target": tgr.low_target,
+            "high_target": tgr.high_target,
+        }
+        if tgr
+        else {"low_target": 70.0, "high_target": 180.0}
+    )
+
+    # Alert thresholds
+    result = await db.execute(
+        select(AlertThreshold).where(AlertThreshold.user_id == user_id)
+    )
+    at = result.scalar_one_or_none()
+    settings["alert_thresholds"] = (
+        {
+            "low_warning": at.low_warning,
+            "urgent_low": at.urgent_low,
+            "high_warning": at.high_warning,
+            "urgent_high": at.urgent_high,
+            "iob_warning": at.iob_warning,
+        }
+        if at
+        else {
+            "low_warning": 70.0,
+            "urgent_low": 55.0,
+            "high_warning": 180.0,
+            "urgent_high": 250.0,
+            "iob_warning": 3.0,
+        }
+    )
+
+    # Escalation config
+    result = await db.execute(
+        select(EscalationConfig).where(EscalationConfig.user_id == user_id)
+    )
+    ec = result.scalar_one_or_none()
+    settings["escalation_config"] = (
+        {
+            "reminder_delay_minutes": ec.reminder_delay_minutes,
+            "primary_contact_delay_minutes": ec.primary_contact_delay_minutes,
+            "all_contacts_delay_minutes": ec.all_contacts_delay_minutes,
+        }
+        if ec
+        else {
+            "reminder_delay_minutes": 5,
+            "primary_contact_delay_minutes": 10,
+            "all_contacts_delay_minutes": 20,
+        }
+    )
+
+    # Brief delivery config
+    result = await db.execute(
+        select(BriefDeliveryConfig).where(BriefDeliveryConfig.user_id == user_id)
+    )
+    bdc = result.scalar_one_or_none()
+    settings["brief_delivery"] = (
+        {
+            "enabled": bdc.enabled,
+            "delivery_time": bdc.delivery_time.isoformat(),
+            "timezone": bdc.timezone,
+            "channel": bdc.channel.value,
+        }
+        if bdc
+        else {
+            "enabled": True,
+            "delivery_time": "07:00:00",
+            "timezone": "UTC",
+            "channel": "both",
+        }
+    )
+
+    # Data retention config
+    result = await db.execute(
+        select(DataRetentionConfig).where(DataRetentionConfig.user_id == user_id)
+    )
+    drc = result.scalar_one_or_none()
+    settings["data_retention"] = (
+        {
+            "glucose_retention_days": drc.glucose_retention_days,
+            "analysis_retention_days": drc.analysis_retention_days,
+            "audit_retention_days": drc.audit_retention_days,
+        }
+        if drc
+        else {
+            "glucose_retention_days": 365,
+            "analysis_retention_days": 365,
+            "audit_retention_days": 730,
+        }
+    )
+
+    # AI provider config (no API key!)
+    result = await db.execute(
+        select(AIProviderConfig).where(AIProviderConfig.user_id == user_id)
+    )
+    apc = result.scalar_one_or_none()
+    settings["ai_provider"] = (
+        {
+            "provider_type": apc.provider_type.value,
+            "model_name": apc.model_name,
+            "status": apc.status.value,
+        }
+        if apc
+        else None
+    )
+
+    # Integrations (no credentials!)
+    result = await db.execute(
+        select(IntegrationCredential).where(IntegrationCredential.user_id == user_id)
+    )
+    integrations = result.scalars().all()
+    settings["integrations"] = [
+        {
+            "integration_type": ic.integration_type.value,
+            "status": ic.status.value,
+            "region": ic.region,
+            "last_sync_at": ic.last_sync_at.isoformat() if ic.last_sync_at else None,
+        }
+        for ic in integrations
+    ]
+
+    # Emergency contacts
+    result = await db.execute(
+        select(EmergencyContact)
+        .where(EmergencyContact.user_id == user_id)
+        .order_by(EmergencyContact.position)
+    )
+    contacts = result.scalars().all()
+    settings["emergency_contacts"] = [
+        {
+            "name": c.name,
+            "telegram_username": c.telegram_username,
+            "priority": c.priority.value,
+            "position": c.position,
+        }
+        for c in contacts
+    ]
+
+    return settings
+
+
+async def _export_all_data(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> dict:
+    """Collect all user data records into a dict.
+
+    Includes glucose readings, pump events, AI analysis results,
+    and audit records.  Each category is capped at
+    MAX_EXPORT_RECORDS_PER_CATEGORY to prevent memory exhaustion.
+    """
+    data: dict = {}
+    limit = MAX_EXPORT_RECORDS_PER_CATEGORY
+
+    # Glucose readings
+    result = await db.execute(
+        select(GlucoseReading)
+        .where(GlucoseReading.user_id == user_id)
+        .order_by(GlucoseReading.reading_timestamp)
+        .limit(limit)
+    )
+    readings = result.scalars().all()
+    data["glucose_readings"] = [
+        {
+            "value": r.value,
+            "reading_timestamp": r.reading_timestamp.isoformat(),
+            "trend": r.trend.value,
+            "trend_rate": r.trend_rate,
+            "source": r.source,
+        }
+        for r in readings
+    ]
+
+    # Pump events
+    result = await db.execute(
+        select(PumpEvent)
+        .where(PumpEvent.user_id == user_id)
+        .order_by(PumpEvent.event_timestamp)
+        .limit(limit)
+    )
+    events = result.scalars().all()
+    data["pump_events"] = [
+        {
+            "event_type": e.event_type.value,
+            "event_timestamp": e.event_timestamp.isoformat(),
+            "value": e.value,
+            "duration_minutes": e.duration_minutes,
+            "source": e.source,
+        }
+        for e in events
+    ]
+
+    # Daily briefs
+    result = await db.execute(
+        select(DailyBrief)
+        .where(DailyBrief.user_id == user_id)
+        .order_by(DailyBrief.period_start)
+        .limit(limit)
+    )
+    briefs = result.scalars().all()
+    data["daily_briefs"] = [
+        {
+            "period_start": b.period_start.isoformat(),
+            "period_end": b.period_end.isoformat(),
+            "ai_summary": b.ai_summary,
+            "time_in_range_pct": b.time_in_range_pct,
+            "average_glucose": b.average_glucose,
+            "readings_count": b.readings_count,
+            "created_at": b.created_at.isoformat(),
+        }
+        for b in briefs
+    ]
+
+    # Meal analyses
+    result = await db.execute(
+        select(MealAnalysis)
+        .where(MealAnalysis.user_id == user_id)
+        .order_by(MealAnalysis.period_start)
+        .limit(limit)
+    )
+    meals = result.scalars().all()
+    data["meal_analyses"] = [
+        {
+            "period_start": m.period_start.isoformat(),
+            "period_end": m.period_end.isoformat(),
+            "ai_analysis": m.ai_analysis,
+            "total_boluses": m.total_boluses,
+            "total_spikes": m.total_spikes,
+            "avg_post_meal_peak": m.avg_post_meal_peak,
+            "created_at": m.created_at.isoformat(),
+        }
+        for m in meals
+    ]
+
+    # Correction analyses
+    result = await db.execute(
+        select(CorrectionAnalysis)
+        .where(CorrectionAnalysis.user_id == user_id)
+        .order_by(CorrectionAnalysis.period_start)
+        .limit(limit)
+    )
+    corrections = result.scalars().all()
+    data["correction_analyses"] = [
+        {
+            "period_start": c.period_start.isoformat(),
+            "period_end": c.period_end.isoformat(),
+            "ai_analysis": c.ai_analysis,
+            "total_corrections": c.total_corrections,
+            "under_corrections": c.under_corrections,
+            "over_corrections": c.over_corrections,
+            "avg_observed_isf": c.avg_observed_isf,
+            "created_at": c.created_at.isoformat(),
+        }
+        for c in corrections
+    ]
+
+    # Suggestion responses
+    result = await db.execute(
+        select(SuggestionResponse)
+        .where(SuggestionResponse.user_id == user_id)
+        .order_by(SuggestionResponse.created_at)
+        .limit(limit)
+    )
+    responses = result.scalars().all()
+    data["suggestion_responses"] = [
+        {
+            "analysis_type": sr.analysis_type,
+            "response": sr.response,
+            "reason": sr.reason,
+            "created_at": sr.created_at.isoformat(),
+        }
+        for sr in responses
+    ]
+
+    # Safety logs
+    result = await db.execute(
+        select(SafetyLog)
+        .where(SafetyLog.user_id == user_id)
+        .order_by(SafetyLog.created_at)
+        .limit(limit)
+    )
+    logs = result.scalars().all()
+    data["safety_logs"] = [
+        {
+            "analysis_type": sl.analysis_type,
+            "status": sl.status,
+            "has_dangerous_content": sl.has_dangerous_content,
+            "created_at": sl.created_at.isoformat(),
+        }
+        for sl in logs
+    ]
+
+    # Alerts
+    result = await db.execute(
+        select(Alert)
+        .where(Alert.user_id == user_id)
+        .order_by(Alert.created_at)
+        .limit(limit)
+    )
+    alerts = result.scalars().all()
+    data["alerts"] = [
+        {
+            "alert_type": a.alert_type.value,
+            "severity": a.severity.value,
+            "message": a.message,
+            "acknowledged": a.acknowledged,
+            "created_at": a.created_at.isoformat(),
+        }
+        for a in alerts
+    ]
+
+    return data
+
+
+def _record_counts_from_data(data: dict) -> dict[str, int]:
+    """Derive record counts from already-loaded data lists."""
+    return {key: len(records) for key, records in data.items()}
+
+
+async def export_user_data(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+    *,
+    include_data: bool = False,
+) -> dict:
+    """Build a complete export payload for the user.
+
+    Args:
+        user_id: User's UUID.
+        db: Database session.
+        include_data: When True, include all historical data
+            (glucose, pump, analysis, audit records).
+
+    Returns:
+        Structured dict ready for JSON serialization.
+    """
+    logger.info(
+        "Settings export initiated",
+        user_id=str(user_id),
+        include_data=include_data,
+    )
+
+    export: dict = {
+        "metadata": {
+            "export_date": datetime.now(UTC).isoformat(),
+            "export_type": "all_data" if include_data else "settings_only",
+            "version": "1.0",
+        },
+        "settings": await _export_settings(user_id, db),
+    }
+
+    if include_data:
+        export["data"] = await _export_all_data(user_id, db)
+        export["metadata"]["record_counts"] = _record_counts_from_data(export["data"])
+
+    logger.info(
+        "Settings export completed",
+        user_id=str(user_id),
+        include_data=include_data,
+    )
+
+    return export

--- a/apps/api/tests/test_caregiver_read_only.py
+++ b/apps/api/tests/test_caregiver_read_only.py
@@ -491,3 +491,21 @@ class TestRouterDependenciesIncludeRoleCheck:
         )
         role_checker = deps[0].dependency
         assert UserRole.CAREGIVER not in role_checker.allowed_roles
+
+    # ── Story 9.5: Settings export ──
+
+    def test_settings_export_has_require_diabetic(self):
+        """POST /api/settings/export has require_diabetic_or_admin."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(router, "/api/settings/export", "POST")
+        dep_classes = [type(d.dependency) for d in deps]
+        assert RoleChecker in dep_classes
+
+    def test_settings_export_role_blocks_caregiver(self):
+        """Settings export role check blocks CAREGIVER."""
+        from src.routers.settings import router
+
+        deps = self._get_route_dependencies(router, "/api/settings/export", "POST")
+        role_checker = deps[0].dependency
+        assert UserRole.CAREGIVER not in role_checker.allowed_roles

--- a/apps/api/tests/test_settings_export.py
+++ b/apps/api/tests/test_settings_export.py
@@ -1,0 +1,306 @@
+"""Story 9.5: Tests for settings export capability.
+
+Tests cover:
+- Schema validation (ExportType, request, response)
+- Service layer (export_user_data)
+- API endpoint (POST /api/settings/export)
+- Structural auth verification
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from src.config import settings
+from src.schemas.settings_export import (
+    ExportType,
+    SettingsExportRequest,
+    SettingsExportResponse,
+)
+
+
+def unique_email(prefix: str = "export") -> str:
+    """Generate a unique email for testing."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def register_and_login(client) -> str:
+    """Register a new user and return the session cookie value."""
+    email = unique_email()
+    password = "SecurePass123"
+
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+# ── Schema tests ──
+
+
+class TestSettingsExportSchemas:
+    """Tests for settings export schema validation."""
+
+    def test_valid_settings_only_request(self):
+        req = SettingsExportRequest(export_type=ExportType.SETTINGS_ONLY)
+        assert req.export_type == ExportType.SETTINGS_ONLY
+
+    def test_valid_all_data_request(self):
+        req = SettingsExportRequest(export_type=ExportType.ALL_DATA)
+        assert req.export_type == ExportType.ALL_DATA
+
+    def test_invalid_export_type(self):
+        with pytest.raises(ValidationError):
+            SettingsExportRequest(export_type="invalid")
+
+    def test_missing_export_type(self):
+        with pytest.raises(ValidationError):
+            SettingsExportRequest()
+
+    def test_response_schema(self):
+        resp = SettingsExportResponse(export_data={"metadata": {}, "settings": {}})
+        assert "metadata" in resp.export_data
+
+
+# ── Service tests ──
+
+
+class TestExportUserData:
+    """Tests for export_user_data service function."""
+
+    @pytest.mark.asyncio
+    async def test_settings_only_export_structure(self):
+        """Verify settings-only export has correct top-level keys."""
+        from src.services.settings_export import export_user_data
+
+        user_id = uuid.uuid4()
+        db = AsyncMock()
+
+        # Mock all queries to return None/empty
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.all.return_value = []
+        db.execute.return_value = mock_result
+
+        result = await export_user_data(user_id, db, include_data=False)
+
+        assert "metadata" in result
+        assert "settings" in result
+        assert "data" not in result
+        assert result["metadata"]["export_type"] == "settings_only"
+        assert result["metadata"]["version"] == "1.0"
+
+    @pytest.mark.asyncio
+    async def test_all_data_export_structure(self):
+        """Verify all-data export includes data and record_counts."""
+        from src.services.settings_export import export_user_data
+
+        user_id = uuid.uuid4()
+        db = AsyncMock()
+
+        # Mock queries
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.all.return_value = []
+        db.execute.return_value = mock_result
+
+        result = await export_user_data(user_id, db, include_data=True)
+
+        assert "metadata" in result
+        assert "settings" in result
+        assert "data" in result
+        assert result["metadata"]["export_type"] == "all_data"
+        assert "record_counts" in result["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_settings_export_contains_all_categories(self):
+        """Verify settings export includes all expected configuration categories."""
+        from src.services.settings_export import export_user_data
+
+        user_id = uuid.uuid4()
+        db = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.all.return_value = []
+        db.execute.return_value = mock_result
+
+        result = await export_user_data(user_id, db, include_data=False)
+
+        settings_data = result["settings"]
+        assert "target_glucose_range" in settings_data
+        assert "alert_thresholds" in settings_data
+        assert "escalation_config" in settings_data
+        assert "brief_delivery" in settings_data
+        assert "data_retention" in settings_data
+        assert "ai_provider" in settings_data
+        assert "integrations" in settings_data
+        assert "emergency_contacts" in settings_data
+
+    @pytest.mark.asyncio
+    async def test_defaults_when_no_config_exists(self):
+        """Verify default values are returned when no settings are configured."""
+        from src.services.settings_export import export_user_data
+
+        user_id = uuid.uuid4()
+        db = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.all.return_value = []
+        db.execute.return_value = mock_result
+
+        result = await export_user_data(user_id, db, include_data=False)
+
+        tgr = result["settings"]["target_glucose_range"]
+        assert tgr["low_target"] == 70.0
+        assert tgr["high_target"] == 180.0
+
+        at = result["settings"]["alert_thresholds"]
+        assert at["urgent_low"] == 55.0
+        assert at["urgent_high"] == 250.0
+
+        assert result["settings"]["ai_provider"] is None
+        assert result["settings"]["integrations"] == []
+
+
+# ── Endpoint tests ──
+
+
+class TestExportEndpoint:
+    """Tests for POST /api/settings/export."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client):
+        response = await client.post(
+            "/api/settings/export",
+            json={"export_type": "settings_only"},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_export_type_returns_422(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.post(
+            "/api/settings/export",
+            json={"export_type": "invalid_type"},
+            cookies=cookies,
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_missing_body_returns_422(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.post(
+            "/api/settings/export",
+            json={},
+            cookies=cookies,
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_settings_only_export(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.post(
+            "/api/settings/export",
+            json={"export_type": "settings_only"},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "export_data" in data
+        export = data["export_data"]
+        assert export["metadata"]["export_type"] == "settings_only"
+        assert "settings" in export
+        assert "data" not in export
+
+    @pytest.mark.asyncio
+    async def test_all_data_export(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.post(
+            "/api/settings/export",
+            json={"export_type": "all_data"},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        export = data["export_data"]
+        assert export["metadata"]["export_type"] == "all_data"
+        assert "settings" in export
+        assert "data" in export
+        assert "record_counts" in export["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_export_does_not_include_credentials(self, client):
+        """Verify no API keys or passwords appear in the export."""
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.post(
+            "/api/settings/export",
+            json={"export_type": "settings_only"},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        export_str = str(response.json())
+        assert "encrypted_api_key" not in export_str
+        assert "encrypted_username" not in export_str
+        assert "encrypted_password" not in export_str
+
+    @pytest.mark.asyncio
+    async def test_export_metadata_has_date_and_version(self, client):
+        cookie = await register_and_login(client)
+        cookies = {settings.jwt_cookie_name: cookie}
+
+        response = await client.post(
+            "/api/settings/export",
+            json={"export_type": "settings_only"},
+            cookies=cookies,
+        )
+        assert response.status_code == 200
+        metadata = response.json()["export_data"]["metadata"]
+        assert "export_date" in metadata
+        assert metadata["version"] == "1.0"
+
+
+# ── Structural tests ──
+
+
+class TestExportEndpointStructure:
+    """Verify the export endpoint has correct auth dependencies."""
+
+    def test_export_endpoint_has_role_checker(self):
+        """POST /api/settings/export must have RoleChecker."""
+        from src.core.auth import RoleChecker
+        from src.routers.settings import router
+
+        export_routes = [
+            r
+            for r in router.routes
+            if hasattr(r, "path")
+            and r.path == "/api/settings/export"
+            and hasattr(r, "methods")
+            and "POST" in r.methods
+        ]
+        assert len(export_routes) == 1
+
+        route = export_routes[0]
+        dep_classes = [type(d.dependency) for d in route.dependencies]
+        assert RoleChecker in dep_classes

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1350,6 +1350,33 @@ export async function purgeUserData(
 }
 
 /**
+ * Settings export (Story 9.5)
+ */
+export interface SettingsExportResponse {
+  export_data: Record<string, unknown>;
+}
+
+export async function exportSettings(
+  exportType: "settings_only" | "all_data"
+): Promise<SettingsExportResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/settings/export`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ export_type: exportType }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to export settings: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
  * Caregiver AI Chat (Story 8.4)
  */
 export interface CaregiverChatResponse {


### PR DESCRIPTION
## Summary
- Add POST `/api/settings/export` endpoint with two export modes: `settings_only` (all configuration without credentials) and `all_data` (settings plus glucose readings, pump events, AI analysis, and audit records)
- Per-category record limit of 100K prevents memory exhaustion on large datasets
- Frontend adds Export Data section to Data settings page with radio buttons for export type and JSON download trigger
- 17 new backend tests covering schema validation, service layer, API endpoint, and structural auth verification

## Changes

### Backend
- **New**: `apps/api/src/schemas/settings_export.py` -- ExportType enum, request/response schemas
- **New**: `apps/api/src/services/settings_export.py` -- Export service with settings collection, data export (capped at 100K per category), and record count derivation
- **New**: `apps/api/tests/test_settings_export.py` -- 17 tests (schema, service, endpoint, structural)
- **Modified**: `apps/api/src/routers/settings.py` -- Added export endpoint with `require_diabetic_or_admin` dependency
- **Modified**: `apps/api/tests/test_caregiver_read_only.py` -- Added 2 structural tests for Story 9.5

### Frontend
- **Modified**: `apps/web/src/app/dashboard/settings/data/page.tsx` -- Added Export Data section with radio buttons and download button
- **Modified**: `apps/web/src/lib/api.ts` -- Added `exportSettings` API function

## Security
- Credentials (API keys, passwords, usernames) are never included in exports via allowlist pattern
- `require_diabetic_or_admin` blocks caregiver access to export endpoint
- Per-category record limit prevents memory exhaustion

## Test plan
- [ ] Backend: 17 Story 9.5 tests pass (`pytest tests/test_settings_export.py`)
- [ ] Backend: Full suite passes (995 tests)
- [ ] Frontend: Lint passes (`next lint`)
- [ ] Visual: Data settings page shows Export Data section with radio buttons and Download Export button
- [ ] Visual: Dashboard and Settings pages render without regressions