### PR TITLE
fix: enable Save Changes button when API is unavailable (Story 10.1)

### DIFF
--- a/apps/web/src/app/dashboard/settings/brief-delivery/page.tsx
+++ b/apps/web/src/app/dashboard/settings/brief-delivery/page.tsx
@@ -103,6 +103,13 @@ export default function BriefDeliveryPage() {
             : "Failed to load brief delivery configuration"
         );
       }
+      // Use defaults as baseline so the form is still functional
+      setConfig({
+        enabled: DEFAULTS.enabled,
+        delivery_time: DEFAULTS.delivery_time,
+        timezone: DEFAULTS.timezone,
+        channel: DEFAULTS.channel,
+      } as BriefDeliveryConfigResponse);
     } finally {
       setIsLoading(false);
     }

--- a/apps/web/src/app/dashboard/settings/data/page.tsx
+++ b/apps/web/src/app/dashboard/settings/data/page.tsx
@@ -105,6 +105,12 @@ export default function DataRetentionPage() {
             : "Failed to load data retention configuration"
         );
       }
+      // Use defaults as baseline so the form is still functional
+      setConfig({
+        glucose_retention_days: DEFAULTS.glucose_retention_days,
+        analysis_retention_days: DEFAULTS.analysis_retention_days,
+        audit_retention_days: DEFAULTS.audit_retention_days,
+      } as DataRetentionConfigResponse);
     } finally {
       setIsLoading(false);
     }

--- a/apps/web/src/app/dashboard/settings/glucose-range/page.tsx
+++ b/apps/web/src/app/dashboard/settings/glucose-range/page.tsx
@@ -17,6 +17,7 @@ import {
   ArrowLeft,
   RotateCcw,
 } from "lucide-react";
+import Link from "next/link";
 import clsx from "clsx";
 import {
   getTargetGlucoseRange,
@@ -52,6 +53,11 @@ export default function GlucoseRangePage() {
             : "Failed to load target glucose range"
         );
       }
+      // Use defaults as baseline so the form is still functional
+      setRange({
+        low_target: DEFAULTS.low_target,
+        high_target: DEFAULTS.high_target,
+      } as TargetGlucoseRangeResponse);
     } finally {
       setIsLoading(false);
     }
@@ -60,6 +66,13 @@ export default function GlucoseRangePage() {
   useEffect(() => {
     fetchRange();
   }, [fetchRange]);
+
+  // Auto-clear success message after 5 seconds
+  useEffect(() => {
+    if (!success) return;
+    const timer = setTimeout(() => setSuccess(null), 5000);
+    return () => clearTimeout(timer);
+  }, [success]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -140,13 +153,13 @@ export default function GlucoseRangePage() {
     <div className="space-y-6">
       {/* Page header */}
       <div>
-        <a
+        <Link
           href="/dashboard/settings"
           className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
         >
           <ArrowLeft className="h-4 w-4" />
           Back to Settings
-        </a>
+        </Link>
         <h1 className="text-2xl font-bold">Target Glucose Range</h1>
         <p className="text-slate-400">
           Set your personal target range for dashboard display and AI analysis


### PR DESCRIPTION
## Summary

- Fix Save Changes button being permanently disabled on all settings pages when the backend API is unavailable
- Root cause: dirty-state comparison (`hasChanges`) required a non-null config object from a successful API fetch; when the fetch failed, config stayed `null` and `hasChanges` was always falsy
- Fix: set config state to default values in the catch block of each page's fetch function, so `hasChanges` can detect when form values differ from defaults
- Also fixed glucose-range page to use Next.js `<Link>` (instead of raw `<a>`) for back navigation and added auto-clear for success messages (consistency with other settings pages)

## Affected Pages

- `/dashboard/settings/glucose-range` 
- `/dashboard/settings/brief-delivery`
- `/dashboard/settings/data`

## Test plan

- [x] Frontend lint passes (no warnings or errors)
- [x] Playwright MCP: glucose-range page loads with defaults when API unavailable, Save enables after changing value
- [x] Playwright MCP: brief-delivery page loads with defaults when API unavailable, Save enables after changing timezone
- [x] Playwright MCP: data page loads with defaults when API unavailable, Save enables after changing retention period
- [x] Playwright MCP: main dashboard still renders correctly
- [x] Playwright MCP: settings index page renders all cards
- [x] Adversarial review completed with no critical/high findings