### PR TITLE
feat: add graceful offline/disconnected state to all settings pages (Story 12.4)

### DIFF
--- a/apps/web/__tests__/components/ui/offline-banner.test.tsx
+++ b/apps/web/__tests__/components/ui/offline-banner.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for the OfflineBanner component.
+ *
+ * Story 12.4: Graceful Offline/Disconnected State for All Settings
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OfflineBanner } from "../../../src/components/ui/offline-banner";
+
+describe("OfflineBanner", () => {
+  it("renders default message when no custom message provided", () => {
+    const onRetry = jest.fn();
+    render(<OfflineBanner onRetry={onRetry} />);
+
+    expect(
+      screen.getByText("Unable to connect to server. Showing default values.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders custom message when provided", () => {
+    const onRetry = jest.fn();
+    render(
+      <OfflineBanner
+        onRetry={onRetry}
+        message="Unable to connect to server. Profile management is unavailable."
+      />
+    );
+
+    expect(
+      screen.getByText(
+        "Unable to connect to server. Profile management is unavailable."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders Retry Connection button", () => {
+    const onRetry = jest.fn();
+    render(<OfflineBanner onRetry={onRetry} />);
+
+    expect(
+      screen.getByRole("button", { name: /retry connection/i })
+    ).toBeInTheDocument();
+  });
+
+  it("calls onRetry when Retry Connection is clicked", () => {
+    const onRetry = jest.fn();
+    render(<OfflineBanner onRetry={onRetry} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /retry connection/i })
+    );
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows Retrying... text when isRetrying is true", () => {
+    const onRetry = jest.fn();
+    render(<OfflineBanner onRetry={onRetry} isRetrying />);
+
+    expect(screen.getByText("Retrying...")).toBeInTheDocument();
+    expect(screen.queryByText("Retry Connection")).not.toBeInTheDocument();
+  });
+
+  it("disables retry button when isRetrying is true", () => {
+    const onRetry = jest.fn();
+    render(<OfflineBanner onRetry={onRetry} isRetrying />);
+
+    const button = screen.getByRole("button", { name: /retrying/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("has alert role for accessibility", () => {
+    const onRetry = jest.fn();
+    render(<OfflineBanner onRetry={onRetry} />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("uses amber color scheme for warning styling", () => {
+    const onRetry = jest.fn();
+    const { container } = render(<OfflineBanner onRetry={onRetry} />);
+
+    const alertDiv = container.firstElementChild;
+    expect(alertDiv?.className).toContain("amber");
+  });
+});

--- a/apps/web/__tests__/settings/offline-state.test.tsx
+++ b/apps/web/__tests__/settings/offline-state.test.tsx
@@ -1,0 +1,383 @@
+/**
+ * Integration tests for offline/disconnected state across settings pages.
+ *
+ * Story 12.4: Graceful Offline/Disconnected State for All Settings
+ *
+ * Verifies that when the API is unreachable, settings pages:
+ * 1. Show the OfflineBanner with warning message and retry button
+ * 2. Load with sensible default values
+ * 3. Disable the Save Changes button with a tooltip
+ * 4. Disable the Reset to Defaults button
+ * 5. Disable action buttons (create, edit, delete, etc.)
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+});
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Simulate API failure for all requests
+jest.mock("../../src/lib/api", () => {
+  const networkError = new Error("NetworkError: Failed to fetch");
+
+  return {
+    __esModule: true,
+    // Glucose range
+    getTargetGlucoseRange: jest.fn().mockRejectedValue(networkError),
+    updateTargetGlucoseRange: jest.fn().mockRejectedValue(networkError),
+    // Brief delivery
+    getBriefDeliveryConfig: jest.fn().mockRejectedValue(networkError),
+    updateBriefDeliveryConfig: jest.fn().mockRejectedValue(networkError),
+    // Alert thresholds + escalation
+    getAlertThresholds: jest.fn().mockRejectedValue(networkError),
+    updateAlertThresholds: jest.fn().mockRejectedValue(networkError),
+    getEscalationConfig: jest.fn().mockRejectedValue(networkError),
+    updateEscalationConfig: jest.fn().mockRejectedValue(networkError),
+    // Data retention
+    getDataRetentionConfig: jest.fn().mockRejectedValue(networkError),
+    updateDataRetentionConfig: jest.fn().mockRejectedValue(networkError),
+    getStorageUsage: jest.fn().mockRejectedValue(networkError),
+    exportSettings: jest.fn().mockRejectedValue(networkError),
+    purgeUserData: jest.fn().mockRejectedValue(networkError),
+    // Emergency contacts
+    getEmergencyContacts: jest.fn().mockRejectedValue(networkError),
+    createEmergencyContact: jest.fn().mockRejectedValue(networkError),
+    updateEmergencyContact: jest.fn().mockRejectedValue(networkError),
+    deleteEmergencyContact: jest.fn().mockRejectedValue(networkError),
+    // Profile
+    getCurrentUser: jest.fn().mockRejectedValue(networkError),
+    updateProfile: jest.fn().mockRejectedValue(networkError),
+    changePassword: jest.fn().mockRejectedValue(networkError),
+    // Integrations
+    listIntegrations: jest.fn().mockRejectedValue(networkError),
+    connectDexcom: jest.fn().mockRejectedValue(networkError),
+    disconnectDexcom: jest.fn().mockRejectedValue(networkError),
+    connectTandem: jest.fn().mockRejectedValue(networkError),
+    disconnectTandem: jest.fn().mockRejectedValue(networkError),
+    // Telegram
+    getTelegramStatus: jest.fn().mockRejectedValue(networkError),
+    generateTelegramCode: jest.fn().mockRejectedValue(networkError),
+    sendTelegramTestMessage: jest.fn().mockRejectedValue(networkError),
+    unlinkTelegram: jest.fn().mockRejectedValue(networkError),
+    // Caregivers
+    listCaregiverInvitations: jest.fn().mockRejectedValue(networkError),
+    createCaregiverInvitation: jest.fn().mockRejectedValue(networkError),
+    revokeCaregiverInvitation: jest.fn().mockRejectedValue(networkError),
+    listLinkedCaregivers: jest.fn().mockRejectedValue(networkError),
+    unlinkCaregiver: jest.fn().mockRejectedValue(networkError),
+  };
+});
+
+// Import pages after mocks are set up
+import GlucoseRangePage from "../../src/app/dashboard/settings/glucose-range/page";
+import BriefDeliveryPage from "../../src/app/dashboard/settings/brief-delivery/page";
+import AlertSettingsPage from "../../src/app/dashboard/settings/alerts/page";
+import DataRetentionPage from "../../src/app/dashboard/settings/data/page";
+import EmergencyContactsPage from "../../src/app/dashboard/settings/emergency-contacts/page";
+import ProfilePage from "../../src/app/dashboard/settings/profile/page";
+import IntegrationsPage from "../../src/app/dashboard/settings/integrations/page";
+import TelegramPage from "../../src/app/dashboard/settings/telegram/page";
+import CaregiversPage from "../../src/app/dashboard/settings/caregivers/page";
+
+describe("Story 12.4: Offline state across settings pages", () => {
+  describe("Glucose Range Page", () => {
+    it("shows offline banner when API is unreachable", async () => {
+      render(<GlucoseRangePage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to connect to server. Showing default values."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("renders form with default values when offline", async () => {
+      render(<GlucoseRangePage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const lowInput = screen.getByLabelText(
+        /low target/i
+      ) as HTMLInputElement;
+      const highInput = screen.getByLabelText(
+        /high target/i
+      ) as HTMLInputElement;
+
+      expect(lowInput.value).toBe("70");
+      expect(highInput.value).toBe("180");
+    });
+
+    it("shows Retry Connection button when offline", async () => {
+      render(<GlucoseRangePage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /retry connection/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables Save Changes button when offline", async () => {
+      render(<GlucoseRangePage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const saveButton = screen.getByRole("button", {
+        name: /save changes/i,
+      });
+      expect(saveButton).toBeDisabled();
+    });
+  });
+
+  describe("Brief Delivery Page", () => {
+    it("shows offline banner when API is unreachable", async () => {
+      render(<BriefDeliveryPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to connect to server. Showing default values."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables Save Changes button when offline", async () => {
+      render(<BriefDeliveryPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const saveButton = screen.getByRole("button", {
+        name: /save changes/i,
+      });
+      expect(saveButton).toBeDisabled();
+    });
+  });
+
+  describe("Alert Settings Page", () => {
+    it("shows offline banner when API is unreachable", async () => {
+      render(<AlertSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to connect to server. Showing default values."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("renders form with default threshold values when offline", async () => {
+      render(<AlertSettingsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const urgentLow = screen.getByLabelText(
+        /urgent low/i
+      ) as HTMLInputElement;
+      expect(urgentLow.value).toBe("55");
+    });
+
+    it("disables Save Changes button when offline", async () => {
+      render(<AlertSettingsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const saveButton = screen.getByRole("button", {
+        name: /save changes/i,
+      });
+      expect(saveButton).toBeDisabled();
+    });
+  });
+
+  describe("Data Retention Page", () => {
+    it("shows offline banner when API is unreachable", async () => {
+      render(<DataRetentionPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to connect to server. Showing default values."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables Save Changes button when offline", async () => {
+      render(<DataRetentionPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const saveButton = screen.getByRole("button", {
+        name: /save changes/i,
+      });
+      expect(saveButton).toBeDisabled();
+    });
+  });
+
+  describe("Emergency Contacts Page", () => {
+    it("shows offline banner when API is unreachable", async () => {
+      render(<EmergencyContactsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to connect to server. Contact management is unavailable."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables Add Contact button when offline", async () => {
+      render(<EmergencyContactsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const addButton = screen.getByRole("button", {
+        name: /add contact/i,
+      });
+      expect(addButton).toBeDisabled();
+    });
+  });
+
+  describe("Profile Page", () => {
+    it("shows offline banner when API is unreachable", async () => {
+      render(<ProfilePage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to connect to server. Profile management is unavailable."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows Retry Connection button when offline", async () => {
+      render(<ProfilePage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /retry connection/i })
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Integrations Page", () => {
+    it("shows offline banner when API is unreachable", async () => {
+      render(<IntegrationsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to connect to server. Integration management is unavailable."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables Test Connection buttons when offline", async () => {
+      render(<IntegrationsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const connectButtons = screen.getAllByRole("button", {
+        name: /test connection/i,
+      });
+      connectButtons.forEach((btn) => expect(btn).toBeDisabled());
+    });
+  });
+
+  describe("Telegram Page", () => {
+    it("shows offline banner when API is unreachable", async () => {
+      render(<TelegramPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to connect to server. Telegram settings are unavailable."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables Generate Code button when offline", async () => {
+      render(<TelegramPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const generateButton = screen.getByRole("button", {
+        name: /generate verification code/i,
+      });
+      expect(generateButton).toBeDisabled();
+    });
+  });
+
+  describe("Caregivers Page", () => {
+    it("shows offline banner when API is unreachable", async () => {
+      render(<CaregiversPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to connect to server. Caregiver management is unavailable."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables Create Invitation button when offline", async () => {
+      render(<CaregiversPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      const createButton = screen.getByRole("button", {
+        name: /create invitation/i,
+      });
+      expect(createButton).toBeDisabled();
+    });
+  });
+});

--- a/apps/web/src/components/ui/offline-banner.tsx
+++ b/apps/web/src/components/ui/offline-banner.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Story 12.4: Reusable offline/disconnected state banner.
+ *
+ * Shows a clear warning when the API is unavailable, with a retry button.
+ */
+
+import { RefreshCw, WifiOff } from "lucide-react";
+import clsx from "clsx";
+
+export function OfflineBanner({
+  onRetry,
+  isRetrying,
+  message,
+}: {
+  onRetry: () => void;
+  isRetrying?: boolean;
+  message?: string;
+}) {
+  return (
+    <div
+      className="bg-amber-500/10 rounded-xl p-4 border border-amber-500/20"
+      role="alert"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <WifiOff className="h-4 w-4 text-amber-400 shrink-0" />
+          <p className="text-sm text-amber-400">
+            {message ||
+              "Unable to connect to server. Showing default values."}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRetry}
+          disabled={isRetrying}
+          className={clsx(
+            "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium whitespace-nowrap",
+            "bg-amber-500/20 text-amber-400 hover:bg-amber-500/30",
+            "transition-colors",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500",
+            "disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          <RefreshCw
+            className={clsx(
+              "h-3.5 w-3.5",
+              isRetrying && "animate-spin"
+            )}
+            aria-hidden="true"
+          />
+          {isRetrying ? "Retrying..." : "Retry Connection"}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add reusable `OfflineBanner` component with amber warning, WifiOff icon, and Retry Connection button
- All 9 settings pages now gracefully handle API unreachability: show offline banner, load sensible defaults, and disable all action buttons with tooltips
- Pages covered: Glucose Range, Brief Delivery, Alerts, Data Retention, Emergency Contacts, Caregivers, Profile, Integrations, Telegram
- Fix Telegram retry flow with dedicated `isRetrying` state (was broken: `pageState === "loading"` never true after initial load)
- Pass `isOffline` prop to `IntegrationCard` so Dexcom/Tandem buttons disable correctly
- 29 new tests: 21 integration tests across all 9 pages + 8 unit tests for OfflineBanner component

## Test plan

- [x] All 357 tests pass (15 suites, 0 failures)
- [x] TypeScript compiles cleanly
- [x] Playwright MCP visual verification on all 9 settings pages showing offline state
- [x] Dashboard navigation unaffected (no regressions)
- [x] Subagent code review passed (2 rounds: initial review found 5 critical issues, all fixed, re-review confirmed all resolved)