### PR TITLE
feat: add communications settings hub page (Story 12.2)

### DIFF
--- a/apps/web/__tests__/settings/communications.test.tsx
+++ b/apps/web/__tests__/settings/communications.test.tsx
@@ -1,0 +1,295 @@
+/**
+ * Tests for the Communications Settings Hub page.
+ *
+ * Story 12.2: Redesign Communications Settings Hub
+ *
+ * Verifies:
+ * 1. Page renders with correct heading and back link
+ * 2. Telegram channel card shows connected/not connected status
+ * 3. Future channels (Discord, Email) show as "Coming Soon"
+ * 4. Offline banner appears when API is unreachable
+ * 5. Telegram card links to the detailed Telegram settings page
+ */
+
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+});
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const mockGetTelegramStatus = jest.fn();
+
+jest.mock("../../src/lib/api", () => ({
+  __esModule: true,
+  getTelegramStatus: (...args: unknown[]) => mockGetTelegramStatus(...args),
+}));
+
+import CommunicationsPage from "../../src/app/dashboard/settings/communications/page";
+
+describe("Story 12.2: Communications Settings Hub", () => {
+  beforeEach(() => {
+    mockGetTelegramStatus.mockReset();
+  });
+
+  describe("when Telegram is not linked", () => {
+    beforeEach(() => {
+      mockGetTelegramStatus.mockResolvedValue({
+        linked: false,
+        bot_username: "GlycemicGPTBot",
+      });
+    });
+
+    it("renders page heading and description", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: /communications/i, level: 1 })
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(/configure notification channels/i)
+      ).toBeInTheDocument();
+    });
+
+    it("shows Back to Settings link", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        const backLink = screen.getByText(/back to settings/i);
+        expect(backLink.closest("a")).toHaveAttribute(
+          "href",
+          "/dashboard/settings"
+        );
+      });
+    });
+
+    it("shows Telegram channel as Not Connected", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Not Connected")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(/receive alerts and daily briefs via telegram bot/i)
+      ).toBeInTheDocument();
+    });
+
+    it("links Telegram card to telegram settings", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Telegram")).toBeInTheDocument();
+      });
+
+      const telegramLink = screen.getByText("Telegram").closest("a");
+      expect(telegramLink).toHaveAttribute(
+        "href",
+        "/dashboard/settings/telegram"
+      );
+    });
+  });
+
+  describe("when Telegram is linked", () => {
+    beforeEach(() => {
+      mockGetTelegramStatus.mockResolvedValue({
+        linked: true,
+        bot_username: "GlycemicGPTBot",
+        link: {
+          username: "testuser",
+          linked_at: "2026-01-15T12:00:00Z",
+        },
+      });
+    });
+
+    it("shows Telegram channel as Connected", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Connected")).toBeInTheDocument();
+      });
+    });
+
+    it("shows linked username", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Linked as @testuser")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading indicator before API resolves", async () => {
+      let resolve: (v: unknown) => void;
+      mockGetTelegramStatus.mockReturnValue(
+        new Promise((r) => {
+          resolve = r;
+        })
+      );
+
+      render(<CommunicationsPage />);
+
+      expect(
+        screen.getByRole("status", { name: /loading communication channels/i })
+      ).toBeInTheDocument();
+
+      // Resolve the promise to prevent act warnings
+      await act(async () => {
+        resolve!({ linked: false, bot_username: "GlycemicGPTBot" });
+      });
+    });
+  });
+
+  describe("future channels", () => {
+    beforeEach(() => {
+      mockGetTelegramStatus.mockResolvedValue({
+        linked: false,
+        bot_username: "GlycemicGPTBot",
+      });
+    });
+
+    it("shows Discord as coming soon", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Discord")).toBeInTheDocument();
+      });
+
+      const comingSoonBadges = screen.getAllByText("Coming Soon");
+      expect(comingSoonBadges.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("shows Email as coming soon", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Email")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("offline state", () => {
+    beforeEach(() => {
+      mockGetTelegramStatus.mockRejectedValue(
+        new Error("NetworkError: Failed to fetch")
+      );
+    });
+
+    it("shows offline banner when API is unreachable", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/unable to connect to server/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows Retry Connection button", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /retry connection/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("clicking Retry calls getTelegramStatus again", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /retry connection/i })
+        ).toBeInTheDocument();
+      });
+
+      // First call was the initial load
+      expect(mockGetTelegramStatus).toHaveBeenCalledTimes(1);
+
+      // Retry still fails
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /retry connection/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockGetTelegramStatus).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("clears offline banner when retry succeeds", async () => {
+      render(<CommunicationsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/unable to connect to server/i)
+        ).toBeInTheDocument();
+      });
+
+      // Next call succeeds
+      mockGetTelegramStatus.mockResolvedValue({
+        linked: false,
+        bot_username: "GlycemicGPTBot",
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /retry connection/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/unable to connect to server/i)
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("401 error handling", () => {
+    it("does not show offline banner on 401 errors", async () => {
+      mockGetTelegramStatus.mockRejectedValue(
+        new Error("Failed to fetch Telegram status: 401")
+      );
+
+      render(<CommunicationsPage />);
+
+      // Wait for loading to complete
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("status", {
+            name: /loading communication channels/i,
+          })
+        ).not.toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText(/unable to connect to server/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/dashboard/settings/communications/page.tsx
+++ b/apps/web/src/app/dashboard/settings/communications/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+/**
+ * Story 12.2: Communications Settings Hub
+ *
+ * Unified hub for configuring notification channels: Telegram, and future
+ * channels (Discord, Email, etc.). Shows connection status for each channel
+ * and links to detailed configuration pages.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  MessageCircle,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  ChevronRight,
+  Radio,
+  Mail,
+  Hash,
+} from "lucide-react";
+import {
+  getTelegramStatus,
+  type TelegramStatusResponse,
+} from "@/lib/api";
+import { OfflineBanner } from "@/components/ui/offline-banner";
+
+export default function CommunicationsPage() {
+  const [telegramStatus, setTelegramStatus] =
+    useState<TelegramStatusResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isOffline, setIsOffline] = useState(false);
+  const [isRetrying, setIsRetrying] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const data = await getTelegramStatus();
+      setTelegramStatus(data);
+      setIsOffline(false);
+    } catch (err) {
+      if (!(err instanceof Error && err.message.includes("401"))) {
+        setIsOffline(true);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  const telegramLinked = telegramStatus?.linked === true;
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <Link
+          href="/dashboard/settings"
+          className="flex items-center gap-1 text-sm text-slate-400 hover:text-slate-300 mb-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Settings
+        </Link>
+        <h1 className="text-2xl font-bold">Communications</h1>
+        <p className="text-slate-400">
+          Configure notification channels for alerts and daily briefs
+        </p>
+      </div>
+
+      {/* Offline banner */}
+      {isOffline && (
+        <OfflineBanner
+          onRetry={async () => {
+            setIsRetrying(true);
+            await fetchStatus();
+            setIsRetrying(false);
+          }}
+          isRetrying={isRetrying}
+          message="Unable to connect to server. Channel status may be outdated."
+        />
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div
+          className="bg-slate-900 rounded-xl p-12 border border-slate-800 text-center"
+          role="status"
+          aria-label="Loading communication channels"
+        >
+          <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+          <p className="text-slate-400">Loading channels...</p>
+        </div>
+      )}
+
+      {/* Channel cards */}
+      {!isLoading && (
+        <div className="space-y-4">
+          {/* Telegram channel */}
+          <Link
+            href="/dashboard/settings/telegram"
+            className="block bg-slate-900 rounded-xl border border-slate-800 p-6 hover:border-slate-700 transition-colors group"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <div className="p-3 bg-blue-500/10 rounded-lg group-hover:bg-blue-500/20 transition-colors">
+                  <MessageCircle className="h-6 w-6 text-blue-400" />
+                </div>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-lg font-semibold group-hover:text-white transition-colors">
+                      Telegram
+                    </h2>
+                    {telegramLinked ? (
+                      <span className="inline-flex items-center gap-1 bg-green-500/10 text-green-400 text-xs font-medium px-2 py-0.5 rounded-full">
+                        <CheckCircle2 className="h-3 w-3" />
+                        Connected
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 bg-slate-700 text-slate-400 text-xs font-medium px-2 py-0.5 rounded-full">
+                        <XCircle className="h-3 w-3" />
+                        Not Connected
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm text-slate-400 mt-1">
+                    {telegramLinked && telegramStatus?.link?.username
+                      ? `Linked as @${telegramStatus.link.username}`
+                      : "Receive alerts and daily briefs via Telegram bot"}
+                  </p>
+                </div>
+              </div>
+              <ChevronRight className="h-5 w-5 text-slate-600 group-hover:text-slate-400 transition-colors" />
+            </div>
+          </Link>
+
+          {/* Future channels - coming soon */}
+          <div className="bg-slate-900/50 rounded-xl border border-slate-800/50 p-6 opacity-60">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <div className="p-3 bg-slate-800 rounded-lg">
+                  <Hash className="h-6 w-6 text-slate-500" />
+                </div>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-lg font-semibold text-slate-500">
+                      Discord
+                    </h2>
+                    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-slate-800 text-slate-500">
+                      Coming Soon
+                    </span>
+                  </div>
+                  <p className="text-sm text-slate-600 mt-1">
+                    Receive notifications via Discord webhook
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-slate-900/50 rounded-xl border border-slate-800/50 p-6 opacity-60">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <div className="p-3 bg-slate-800 rounded-lg">
+                  <Mail className="h-6 w-6 text-slate-500" />
+                </div>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-lg font-semibold text-slate-500">
+                      Email
+                    </h2>
+                    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-slate-800 text-slate-500">
+                      Coming Soon
+                    </span>
+                  </div>
+                  <p className="text-sm text-slate-600 mt-1">
+                    Receive daily brief summaries via email
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Info card */}
+      <div className="bg-slate-900/50 rounded-xl p-4 border border-slate-800">
+        <div className="flex items-start gap-2">
+          <Radio className="h-4 w-4 text-slate-500 mt-0.5 shrink-0" />
+          <p className="text-xs text-slate-500">
+            Communication channels determine how you receive glucose alerts,
+            daily brief summaries, and caregiver notifications. Configure at
+            least one channel to stay informed about your glucose trends.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -8,7 +8,7 @@
  */
 
 import Link from "next/link";
-import { Settings, User, Bell, Database, Link2, Users, MessageCircle, UserPlus, Target, Clock } from "lucide-react";
+import { Settings, User, Bell, Database, Link2, Users, Radio, UserPlus, Target, Clock } from "lucide-react";
 import { useUserContext } from "@/providers";
 
 interface SettingsSection {
@@ -64,10 +64,10 @@ const settingsSections: SettingsSection[] = [
     href: "/dashboard/settings/caregivers",
   },
   {
-    title: "Telegram",
-    description: "Link your Telegram account for alert notifications",
-    icon: MessageCircle,
-    href: "/dashboard/settings/telegram",
+    title: "Communications",
+    description: "Configure Telegram and other notification channels",
+    icon: Radio,
+    href: "/dashboard/settings/communications",
     caregiverVisible: true,
   },
   {

--- a/apps/web/src/app/dashboard/settings/telegram/page.tsx
+++ b/apps/web/src/app/dashboard/settings/telegram/page.tsx
@@ -200,11 +200,11 @@ export default function TelegramSettingsPage() {
     <div className="space-y-6 max-w-2xl">
       {/* Back link */}
       <Link
-        href="/dashboard/settings"
+        href="/dashboard/settings/communications"
         className="inline-flex items-center gap-2 text-slate-400 hover:text-white transition-colors text-sm"
       >
         <ArrowLeft className="h-4 w-4" />
-        Back to Settings
+        Back to Communications
       </Link>
 
       {/* Page header */}


### PR DESCRIPTION
## Summary

- Adds a new Communications settings hub page at `/dashboard/settings/communications` that aggregates all notification channels
- Telegram card shows live connection status (Connected/Not Connected) and links to the existing detailed Telegram config page
- Discord and Email shown as Coming Soon placeholders with muted styling
- Settings index page renamed from "Telegram" to "Communications" with updated icon and description
- Telegram settings page back link updated to point to Communications hub instead of Settings root
- Offline banner with retry support when API is unreachable; 401 auth errors excluded from offline detection

## Test plan

- [x] 14 new tests in `communications.test.tsx` covering all page states:
  - Page heading, description, and back link
  - Telegram connected/not connected status display
  - Linked username display
  - Loading indicator before API resolves
  - Discord and Email "Coming Soon" badges
  - Offline banner when API is unreachable
  - Retry button click triggers re-fetch
  - Successful retry clears offline banner
  - 401 errors do not trigger offline banner
- [x] Full test suite: 371 tests pass across 16 suites
- [x] Playwright visual verification: settings index, communications hub, telegram back link, main dashboard