### PR TITLE
feat: add Telegram bot token configuration (Story 12.3)

### DIFF
--- a/_bmad-output/PROGRESS.md
+++ b/_bmad-output/PROGRESS.md
@@ -15,14 +15,14 @@
 | 7 | Telegram Bot Integration | 6/6 | **Complete** |
 | 8 | Caregiver Access & Support | 6/6 | **Complete** |
 | 9 | Settings & Data Management | 5/5 | **Complete** |
-| 10 | Settings Infrastructure Fixes | 2/3 | **In Progress** |
+| 10 | Settings Infrastructure Fixes | 3/3 | **Complete** |
 | 11 | AI Configuration & Chat Interface | 0/3 | **Pending** |
-| 12 | Integration & Communication Config | 0/4 | **Pending** |
+| 12 | Integration & Communication Config | 4/4 | **Complete** |
 | 13 | E2E Testing & Real Data Verification | 0/3 | **Pending** |
 
 **MVP Stories:** 54/54 complete (100%)
-**Post-MVP Fix Stories:** 2/13 complete (15%)
-**Overall Progress:** 56/67 stories complete (84%)
+**Post-MVP Fix Stories:** 7/13 complete (54%)
+**Overall Progress:** 61/67 stories complete (91%)
 
 ---
 
@@ -238,11 +238,11 @@ All 5 stories completed:
 
 ## Post-MVP Fix Epics (from manual testing feedback)
 
-**Epic 10: Settings Infrastructure Fixes** - PENDING
+**Epic 10: Settings Infrastructure Fixes** - COMPLETE
 
 - [x] Story 10.1: Fix Save Changes Button Across All Settings Pages
-- [x] Story 10.2: Create Settings > Profile Page
-- [ ] Story 10.3: Create Settings > Alerts Page
+- [x] Story 10.2: Create Settings > Profile Page - [PR #105](https://github.com/jlengelbrecht/GlycemicGPT/pull/105)
+- [x] Story 10.3: Create Settings > Alerts Page - [PR #107](https://github.com/jlengelbrecht/GlycemicGPT/pull/107)
 
 **Epic 11: AI Configuration & Chat Interface** - PENDING
 
@@ -250,12 +250,12 @@ All 5 stories completed:
 - [ ] Story 11.2: Create Web-Based AI Chat Interface
 - [ ] Story 11.3: Wire Daily Briefs Web Delivery
 
-**Epic 12: Integration & Communication Configuration** - PENDING
+**Epic 12: Integration & Communication Configuration** - COMPLETE
 
-- [ ] Story 12.1: Create Settings > Integrations Page
-- [ ] Story 12.2: Redesign Communications Settings Hub
-- [ ] Story 12.3: Add Telegram Bot Token Configuration
-- [ ] Story 12.4: Graceful Offline/Disconnected State for All Settings
+- [x] Story 12.1: Create Settings > Integrations Page - [PR #109](https://github.com/jlengelbrecht/GlycemicGPT/pull/109)
+- [x] Story 12.2: Redesign Communications Settings Hub - [PR #113](https://github.com/jlengelbrecht/GlycemicGPT/pull/113)
+- [x] Story 12.3: Add Telegram Bot Token Configuration
+- [x] Story 12.4: Graceful Offline/Disconnected State for All Settings - [PR #111](https://github.com/jlengelbrecht/GlycemicGPT/pull/111)
 
 **Epic 13: End-to-End Testing & Real Data Verification** - PENDING
 

--- a/apps/web/__tests__/settings/telegram-bot-config.test.tsx
+++ b/apps/web/__tests__/settings/telegram-bot-config.test.tsx
@@ -1,0 +1,644 @@
+/**
+ * Tests for Telegram Bot Token Configuration (Story 12.3)
+ *
+ * Verifies:
+ * 1. Bot Setup section renders with token input and validate button
+ * 2. Bot configured state shows username and "Configured" badge
+ * 3. Token input has show/hide toggle
+ * 4. Validate Token button is disabled when input is empty or offline
+ * 5. Account linking section is disabled when bot is not configured
+ * 6. "Bot not configured" warning appears when bot is not set up
+ * 7. Remove Bot Token confirmation flow works
+ * 8. Offline state disables all actions
+ */
+
+import {
+  render,
+  screen,
+  waitFor,
+  act,
+  fireEvent,
+} from "@testing-library/react";
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+});
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const mockGetTelegramBotConfig = jest.fn();
+const mockGetTelegramStatus = jest.fn();
+const mockSaveTelegramBotToken = jest.fn();
+const mockRemoveTelegramBotToken = jest.fn();
+const mockGenerateTelegramCode = jest.fn();
+const mockSendTelegramTestMessage = jest.fn();
+const mockUnlinkTelegram = jest.fn();
+
+jest.mock("../../src/lib/api", () => ({
+  __esModule: true,
+  getTelegramBotConfig: (...args: unknown[]) =>
+    mockGetTelegramBotConfig(...args),
+  getTelegramStatus: (...args: unknown[]) => mockGetTelegramStatus(...args),
+  saveTelegramBotToken: (...args: unknown[]) =>
+    mockSaveTelegramBotToken(...args),
+  removeTelegramBotToken: (...args: unknown[]) =>
+    mockRemoveTelegramBotToken(...args),
+  generateTelegramCode: (...args: unknown[]) =>
+    mockGenerateTelegramCode(...args),
+  sendTelegramTestMessage: (...args: unknown[]) =>
+    mockSendTelegramTestMessage(...args),
+  unlinkTelegram: (...args: unknown[]) => mockUnlinkTelegram(...args),
+}));
+
+import TelegramSettingsPage from "../../src/app/dashboard/settings/telegram/page";
+
+describe("Story 12.3: Telegram Bot Token Configuration", () => {
+  beforeEach(() => {
+    mockGetTelegramBotConfig.mockReset();
+    mockGetTelegramStatus.mockReset();
+    mockSaveTelegramBotToken.mockReset();
+    mockRemoveTelegramBotToken.mockReset();
+    mockGenerateTelegramCode.mockReset();
+    mockSendTelegramTestMessage.mockReset();
+    mockUnlinkTelegram.mockReset();
+  });
+
+  describe("when bot is NOT configured", () => {
+    beforeEach(() => {
+      mockGetTelegramBotConfig.mockResolvedValue({
+        configured: false,
+        bot_username: null,
+        configured_at: null,
+      });
+      mockGetTelegramStatus.mockRejectedValue(
+        new Error("Telegram bot is not configured: 503")
+      );
+    });
+
+    it("renders Bot Setup section with instructions", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: /bot setup/i })
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(/a telegram bot token is required/i)
+      ).toBeInTheDocument();
+      // @BotFather appears in both description and instructions
+      const botFatherRefs = screen.getAllByText(/@BotFather/);
+      expect(botFatherRefs.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("shows token input field", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i)
+        ).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i);
+      expect(input).toHaveAttribute("type", "password");
+    });
+
+    it("has show/hide toggle for token input", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i)
+        ).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i);
+      expect(input).toHaveAttribute("type", "password");
+
+      const toggleBtn = screen.getByRole("button", { name: /show token/i });
+      await act(async () => {
+        fireEvent.click(toggleBtn);
+      });
+
+      expect(input).toHaveAttribute("type", "text");
+
+      const hideBtn = screen.getByRole("button", { name: /hide token/i });
+      await act(async () => {
+        fireEvent.click(hideBtn);
+      });
+
+      expect(input).toHaveAttribute("type", "password");
+    });
+
+    it("shows Validate Token button disabled when input is empty", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /validate bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole("button", { name: /validate bot token/i })
+      ).toBeDisabled();
+    });
+
+    it("enables Validate Token button when token is entered", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i)
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i),
+          { target: { value: "123456:ABC-DEF" } }
+        );
+      });
+
+      expect(
+        screen.getByRole("button", { name: /validate bot token/i })
+      ).toBeEnabled();
+    });
+
+    it("shows bot not configured warning", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /telegram bot not configured\. an administrator must set up the bot token first/i
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables account linking Generate Code button", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /generate verification code/i })
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole("button", { name: /generate verification code/i })
+      ).toBeDisabled();
+    });
+  });
+
+  describe("when bot IS configured", () => {
+    beforeEach(() => {
+      mockGetTelegramBotConfig.mockResolvedValue({
+        configured: true,
+        bot_username: "GlycemicGPTBot",
+        configured_at: "2026-01-15T12:00:00Z",
+      });
+      mockGetTelegramStatus.mockResolvedValue({
+        linked: false,
+        bot_username: "GlycemicGPTBot",
+      });
+    });
+
+    it("shows Configured badge", async () => {
+      render(<TelegramSettingsPage />);
+
+      // Wait for the page to load by checking for a known element
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /remove bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Configured")).toBeInTheDocument();
+    });
+
+    it("shows bot username", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /remove bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      // Username appears in both bot config card and account linking instructions
+      const usernameElements = screen.getAllByText("@GlycemicGPTBot");
+      expect(usernameElements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("shows Remove Bot Token button", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /remove bot token/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("does NOT show bot not configured warning", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /remove bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText(/telegram bot not configured/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it("enables Generate Code button for account linking", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /generate verification code/i })
+        ).toBeEnabled();
+      });
+    });
+  });
+
+  describe("validate token flow", () => {
+    beforeEach(() => {
+      mockGetTelegramBotConfig.mockResolvedValue({
+        configured: false,
+        bot_username: null,
+        configured_at: null,
+      });
+      mockGetTelegramStatus.mockRejectedValue(
+        new Error("Telegram bot is not configured: 503")
+      );
+    });
+
+    it("calls saveTelegramBotToken on Validate click", async () => {
+      mockSaveTelegramBotToken.mockResolvedValue({
+        valid: true,
+        bot_username: "MyTestBot",
+      });
+
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i)
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i),
+          { target: { value: "123456:ABC-DEF" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /validate bot token/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockSaveTelegramBotToken).toHaveBeenCalledWith("123456:ABC-DEF");
+      });
+    });
+
+    it("shows success message after valid token", async () => {
+      mockSaveTelegramBotToken.mockResolvedValue({
+        valid: true,
+        bot_username: "MyTestBot",
+      });
+      // After validation, re-fetch status
+      mockGetTelegramStatus
+        .mockRejectedValueOnce(new Error("503"))
+        .mockResolvedValue({
+          linked: false,
+          bot_username: "MyTestBot",
+        });
+
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i)
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i),
+          { target: { value: "123456:ABC-DEF" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /validate bot token/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/bot token validated/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows error message on invalid token", async () => {
+      mockSaveTelegramBotToken.mockRejectedValue(
+        new Error("Invalid bot token")
+      );
+
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i)
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i),
+          { target: { value: "bad-token" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /validate bot token/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Invalid bot token")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("remove bot token flow", () => {
+    beforeEach(() => {
+      mockGetTelegramBotConfig.mockResolvedValue({
+        configured: true,
+        bot_username: "GlycemicGPTBot",
+        configured_at: "2026-01-15T12:00:00Z",
+      });
+      mockGetTelegramStatus.mockResolvedValue({
+        linked: false,
+        bot_username: "GlycemicGPTBot",
+      });
+    });
+
+    it("shows confirmation on Remove Bot Token click", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /remove bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /remove bot token/i })
+        );
+      });
+
+      expect(
+        screen.getByText(/removing the bot token will disable/i)
+      ).toBeInTheDocument();
+      expect(screen.getByText("Yes, Remove")).toBeInTheDocument();
+    });
+
+    it("calls removeTelegramBotToken on confirm", async () => {
+      mockRemoveTelegramBotToken.mockResolvedValue(undefined);
+
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /remove bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /remove bot token/i })
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Yes, Remove"));
+      });
+
+      await waitFor(() => {
+        expect(mockRemoveTelegramBotToken).toHaveBeenCalled();
+      });
+    });
+
+    it("dismisses confirmation on Cancel click", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /remove bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /remove bot token/i })
+        );
+      });
+
+      expect(screen.getByText("Yes, Remove")).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Cancel"));
+      });
+
+      expect(screen.queryByText("Yes, Remove")).not.toBeInTheDocument();
+    });
+
+    it("transitions back to unconfigured state after successful removal", async () => {
+      mockRemoveTelegramBotToken.mockResolvedValue(undefined);
+      // After removal, bot config re-check returns not configured
+      mockGetTelegramStatus.mockRejectedValue(
+        new Error("Telegram bot is not configured: 503")
+      );
+
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /remove bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /remove bot token/i })
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Yes, Remove"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/bot token removed/i)).toBeInTheDocument();
+      });
+
+      // Should now show the token input form (unconfigured state)
+      expect(
+        screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i)
+      ).toBeInTheDocument();
+      // Configured badge should be gone
+      expect(screen.queryByText("Configured")).not.toBeInTheDocument();
+    });
+
+    it("dismisses confirmation and shows error on removal failure", async () => {
+      mockRemoveTelegramBotToken.mockRejectedValue(
+        new Error("Permission denied")
+      );
+
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /remove bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /remove bot token/i })
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Yes, Remove"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Permission denied")).toBeInTheDocument();
+      });
+
+      // Confirmation dialog should be dismissed
+      expect(screen.queryByText("Yes, Remove")).not.toBeInTheDocument();
+      // Should still show configured state (not reverted)
+      expect(screen.getByText("Configured")).toBeInTheDocument();
+    });
+  });
+
+  describe("offline state", () => {
+    beforeEach(() => {
+      mockGetTelegramBotConfig.mockRejectedValue(
+        new Error("NetworkError: Failed to fetch")
+      );
+      mockGetTelegramStatus.mockRejectedValue(
+        new Error("NetworkError: Failed to fetch")
+      );
+    });
+
+    it("shows offline banner", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/unable to connect to server/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables Validate Token button when offline", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /validate bot token/i })
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole("button", { name: /validate bot token/i })
+      ).toBeDisabled();
+    });
+
+    it("disables token input field when offline", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i)
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByPlaceholderText(/ABCdefGhIJKlmNoPQRsTUVwxyz/i)
+      ).toBeDisabled();
+    });
+  });
+
+  describe("page header and navigation", () => {
+    beforeEach(() => {
+      mockGetTelegramBotConfig.mockResolvedValue({
+        configured: false,
+        bot_username: null,
+        configured_at: null,
+      });
+      mockGetTelegramStatus.mockRejectedValue(
+        new Error("Telegram bot is not configured: 503")
+      );
+    });
+
+    it("renders page heading", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: /telegram/i, level: 1 })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows Back to Communications link", async () => {
+      render(<TelegramSettingsPage />);
+
+      await waitFor(() => {
+        const backLink = screen.getByText(/back to communications/i);
+        expect(backLink.closest("a")).toHaveAttribute(
+          "href",
+          "/dashboard/settings/communications"
+        );
+      });
+    });
+  });
+});

--- a/apps/web/src/app/dashboard/settings/telegram/page.tsx
+++ b/apps/web/src/app/dashboard/settings/telegram/page.tsx
@@ -2,7 +2,11 @@
  * Telegram Settings Page
  *
  * Story 7.1: Telegram Bot Setup & Configuration
- * Allows users to link/unlink their Telegram account for alert notifications.
+ * Story 12.3: Add Telegram Bot Token Configuration
+ *
+ * Two-step flow:
+ * 1. Bot Setup (Admin): Configure bot token via @BotFather
+ * 2. Account Linking (User): Link personal Telegram account
  */
 
 "use client";
@@ -11,17 +15,26 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import {
   ArrowLeft,
+  Bot,
   CheckCircle2,
   Copy,
+  Eye,
+  EyeOff,
+  Key,
   Loader2,
   MessageCircle,
   Send,
+  Trash2,
   Unlink,
 } from "lucide-react";
 import {
   generateTelegramCode,
+  getTelegramBotConfig,
   getTelegramStatus,
+  saveTelegramBotToken,
+  removeTelegramBotToken,
   sendTelegramTestMessage,
+  TelegramBotConfigResponse,
   TelegramStatusResponse,
   TelegramVerificationCodeResponse,
   unlinkTelegram,
@@ -44,8 +57,19 @@ export default function TelegramSettingsPage() {
   const [copied, setCopied] = useState(false);
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
 
+  // Bot config state (Story 12.3)
+  const [botConfig, setBotConfig] = useState<TelegramBotConfigResponse | null>(
+    null
+  );
+  const [botToken, setBotToken] = useState("");
+  const [showToken, setShowToken] = useState(false);
+  const [botActionLoading, setBotActionLoading] = useState(false);
+  const [confirmRemoveBot, setConfirmRemoveBot] = useState(false);
+
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const botConfigured = botConfig?.configured === true;
 
   const clearTimers = useCallback(() => {
     if (pollRef.current) {
@@ -55,6 +79,18 @@ export default function TelegramSettingsPage() {
     if (countdownRef.current) {
       clearInterval(countdownRef.current);
       countdownRef.current = null;
+    }
+  }, []);
+
+  const fetchBotConfig = useCallback(async () => {
+    try {
+      const data = await getTelegramBotConfig();
+      setBotConfig(data);
+      return data;
+    } catch {
+      // If bot-config endpoint fails, treat as not configured
+      setBotConfig({ configured: false, bot_username: null, configured_at: null });
+      return null;
     }
   }, []);
 
@@ -71,8 +107,13 @@ export default function TelegramSettingsPage() {
       }
     } catch (err) {
       const is401 = err instanceof Error && err.message.includes("401");
-      if (!is401) {
+      const is503 = err instanceof Error && err.message.includes("503");
+      if (!is401 && !is503) {
         setIsOffline(true);
+      }
+      // 503 means bot not configured - not an offline state
+      if (is503) {
+        setIsOffline(false);
       }
       if (pageState === "loading") {
         setPageState("not_linked");
@@ -82,7 +123,11 @@ export default function TelegramSettingsPage() {
 
   // Initial load
   useEffect(() => {
-    fetchStatus();
+    const init = async () => {
+      await fetchBotConfig();
+      await fetchStatus();
+    };
+    init();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -90,6 +135,62 @@ export default function TelegramSettingsPage() {
   useEffect(() => {
     return () => clearTimers();
   }, [clearTimers]);
+
+  const handleValidateToken = async () => {
+    if (!botToken.trim()) return;
+    setError(null);
+    setSuccess(null);
+    setBotActionLoading(true);
+
+    try {
+      const result = await saveTelegramBotToken(botToken.trim());
+      if (result.valid) {
+        setBotConfig({
+          configured: true,
+          bot_username: result.bot_username,
+          configured_at: new Date().toISOString(),
+        });
+        setBotToken("");
+        setSuccess(
+          `Bot token validated! Connected as @${result.bot_username}`
+        );
+        // Re-fetch status now that bot is configured
+        await fetchStatus();
+      } else {
+        setError("Token validation failed. Please check the token and try again.");
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to validate bot token"
+      );
+    } finally {
+      setBotActionLoading(false);
+    }
+  };
+
+  const handleRemoveBotToken = async () => {
+    setError(null);
+    setSuccess(null);
+    setBotActionLoading(true);
+
+    try {
+      await removeTelegramBotToken();
+      setBotConfig({
+        configured: false,
+        bot_username: null,
+        configured_at: null,
+      });
+      setConfirmRemoveBot(false);
+      setSuccess("Bot token removed.");
+    } catch (err) {
+      setConfirmRemoveBot(false);
+      setError(
+        err instanceof Error ? err.message : "Failed to remove bot token"
+      );
+    } finally {
+      setBotActionLoading(false);
+    }
+  };
 
   const handleGenerateCode = async () => {
     setError(null);
@@ -179,13 +280,10 @@ export default function TelegramSettingsPage() {
   const handleCopyCode = async () => {
     if (!codeData) return;
     try {
-      await navigator.clipboard.writeText(
-        `/start ${codeData.code}`
-      );
+      await navigator.clipboard.writeText(`/start ${codeData.code}`);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Clipboard API not available — show manual copy hint
       setSuccess("Select and copy the command manually.");
     }
   };
@@ -215,7 +313,7 @@ export default function TelegramSettingsPage() {
         <div>
           <h1 className="text-2xl font-bold">Telegram</h1>
           <p className="text-slate-400 text-sm">
-            Link your Telegram account to receive alert notifications
+            Configure bot setup and link your Telegram account
           </p>
         </div>
       </div>
@@ -225,6 +323,7 @@ export default function TelegramSettingsPage() {
         <OfflineBanner
           onRetry={async () => {
             setIsRetrying(true);
+            await fetchBotConfig();
             await fetchStatus();
             setIsRetrying(false);
           }}
@@ -253,6 +352,182 @@ export default function TelegramSettingsPage() {
         </div>
       )}
 
+      {/* ================================================================ */}
+      {/* Step 1: Bot Setup (Admin) - Story 12.3 */}
+      {/* ================================================================ */}
+      <div className="bg-slate-900 rounded-xl p-6 border border-slate-800 space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Bot className="h-5 w-5 text-blue-400" />
+            <h2 className="text-lg font-semibold">Bot Setup</h2>
+          </div>
+          {botConfigured && (
+            <span className="inline-flex items-center gap-1.5 bg-green-500/10 text-green-400 text-xs font-medium px-2.5 py-1 rounded-full">
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              Configured
+            </span>
+          )}
+        </div>
+
+        {botConfigured ? (
+          /* Bot is configured - show status */
+          <div className="space-y-4">
+            <div className="bg-slate-800 rounded-lg p-4 space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-slate-400">Bot Username</span>
+                <span className="text-white font-mono">
+                  @{botConfig.bot_username}
+                </span>
+              </div>
+              {botConfig.configured_at && (
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-slate-400">Configured On</span>
+                  <span className="text-white">
+                    {new Date(botConfig.configured_at).toLocaleDateString()}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {/* Remove bot token */}
+            {!confirmRemoveBot ? (
+              <button
+                onClick={() => setConfirmRemoveBot(true)}
+                disabled={isOffline || botActionLoading}
+                title={
+                  isOffline
+                    ? "Cannot remove token while disconnected"
+                    : undefined
+                }
+                className="w-full text-red-400 hover:text-red-300 disabled:opacity-50 disabled:cursor-not-allowed text-sm transition-colors flex items-center justify-center gap-2 py-2"
+                aria-label="Remove bot token"
+              >
+                <Trash2 className="h-4 w-4" />
+                Remove Bot Token
+              </button>
+            ) : (
+              <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 space-y-3">
+                <p className="text-red-400 text-sm">
+                  Are you sure? Removing the bot token will disable all Telegram
+                  notifications.
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleRemoveBotToken}
+                    disabled={botActionLoading}
+                    className="flex-1 bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-3 py-2 transition-colors"
+                  >
+                    {botActionLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin mx-auto" />
+                    ) : (
+                      "Yes, Remove"
+                    )}
+                  </button>
+                  <button
+                    onClick={() => setConfirmRemoveBot(false)}
+                    className="flex-1 bg-slate-800 hover:bg-slate-700 text-white text-sm font-medium rounded-lg px-3 py-2 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          /* Bot is NOT configured - show setup form */
+          <div className="space-y-4">
+            <p className="text-slate-400 text-sm">
+              A Telegram bot token is required before users can link their
+              accounts. Create a bot via{" "}
+              <span className="text-white font-mono">@BotFather</span> on
+              Telegram to get a token.
+            </p>
+
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium text-slate-300">
+                How to get a bot token:
+              </h3>
+              <ol className="list-decimal list-inside space-y-2 text-sm text-slate-400">
+                <li>
+                  Open Telegram and search for{" "}
+                  <span className="text-white font-mono">@BotFather</span>
+                </li>
+                <li>
+                  Send <span className="font-mono text-white">/newbot</span> and
+                  follow the prompts
+                </li>
+                <li>Copy the bot token provided by BotFather</li>
+                <li>Paste it below and click &quot;Validate Token&quot;</li>
+              </ol>
+            </div>
+
+            {/* Token input */}
+            <div className="space-y-2">
+              <label
+                htmlFor="bot-token"
+                className="block text-sm font-medium text-slate-300"
+              >
+                Bot Token
+              </label>
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <Key className="h-4 w-4 text-slate-500" />
+                </div>
+                <input
+                  id="bot-token"
+                  type={showToken ? "text" : "password"}
+                  value={botToken}
+                  onChange={(e) => setBotToken(e.target.value)}
+                  placeholder="123456789:ABCdefGhIJKlmNoPQRsTUVwxyz"
+                  disabled={isOffline}
+                  className="w-full bg-slate-800 border border-slate-700 rounded-lg pl-10 pr-12 py-3 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 font-mono text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowToken(!showToken)}
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-slate-400 hover:text-white transition-colors"
+                  aria-label={showToken ? "Hide token" : "Show token"}
+                >
+                  {showToken ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {/* Validate button */}
+            <button
+              onClick={handleValidateToken}
+              disabled={
+                !botToken.trim() || botActionLoading || isOffline
+              }
+              title={
+                isOffline
+                  ? "Cannot validate token while disconnected"
+                  : !botToken.trim()
+                    ? "Enter a bot token first"
+                    : undefined
+              }
+              className="w-full bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg px-4 py-3 transition-colors flex items-center justify-center gap-2"
+              aria-label="Validate bot token"
+            >
+              {botActionLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <CheckCircle2 className="h-4 w-4" />
+              )}
+              Validate Token
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* ================================================================ */}
+      {/* Step 2: Account Linking (User) */}
+      {/* ================================================================ */}
+
       {/* Loading state */}
       {pageState === "loading" && (
         <div className="bg-slate-900 rounded-xl p-8 border border-slate-800 flex items-center justify-center">
@@ -260,9 +535,20 @@ export default function TelegramSettingsPage() {
         </div>
       )}
 
+      {/* Bot not configured warning */}
+      {!botConfigured && pageState !== "loading" && (
+        <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg px-4 py-3 text-sm text-amber-400">
+          Telegram bot not configured. An administrator must set up the bot
+          token first before accounts can be linked.
+        </div>
+      )}
+
       {/* Not linked state */}
       {pageState === "not_linked" && (
-        <div className="bg-slate-900 rounded-xl p-6 border border-slate-800 space-y-6">
+        <div
+          className={`bg-slate-900 rounded-xl p-6 border border-slate-800 space-y-6 ${!botConfigured ? "opacity-60 pointer-events-none" : ""}`}
+          aria-disabled={!botConfigured}
+        >
           <div className="space-y-4">
             <h2 className="text-lg font-semibold">
               Connect Your Telegram Account
@@ -283,24 +569,32 @@ export default function TelegramSettingsPage() {
               </li>
               <li>
                 Open Telegram and search for{" "}
-                {status?.bot_username ? (
+                {status?.bot_username || botConfig?.bot_username ? (
                   <span className="text-white font-mono">
-                    @{status.bot_username}
+                    @{status?.bot_username || botConfig?.bot_username}
                   </span>
                 ) : (
                   "the GlycemicGPT bot"
                 )}
               </li>
               <li>
-                Send the command <span className="font-mono text-white">/start YOUR_CODE</span> to the bot
+                Send the command{" "}
+                <span className="font-mono text-white">/start YOUR_CODE</span>{" "}
+                to the bot
               </li>
             </ol>
           </div>
 
           <button
             onClick={handleGenerateCode}
-            disabled={actionLoading || isOffline}
-            title={isOffline ? "Cannot generate code while disconnected" : undefined}
+            disabled={actionLoading || isOffline || !botConfigured}
+            title={
+              isOffline
+                ? "Cannot generate code while disconnected"
+                : !botConfigured
+                  ? "Bot must be configured first"
+                  : undefined
+            }
             className="w-full bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg px-4 py-3 transition-colors flex items-center justify-center gap-2"
             aria-label="Generate verification code"
           >
@@ -414,7 +708,11 @@ export default function TelegramSettingsPage() {
             <button
               onClick={handleTestMessage}
               disabled={actionLoading || isOffline}
-              title={isOffline ? "Cannot send test message while disconnected" : undefined}
+              title={
+                isOffline
+                  ? "Cannot send test message while disconnected"
+                  : undefined
+              }
               className="w-full bg-slate-800 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg px-4 py-3 transition-colors flex items-center justify-center gap-2"
               aria-label="Send test message"
             >
@@ -430,7 +728,11 @@ export default function TelegramSettingsPage() {
               <button
                 onClick={() => setConfirmDisconnect(true)}
                 disabled={isOffline}
-                title={isOffline ? "Cannot disconnect while disconnected from server" : undefined}
+                title={
+                  isOffline
+                    ? "Cannot disconnect while disconnected from server"
+                    : undefined
+                }
                 className="w-full text-red-400 hover:text-red-300 disabled:opacity-50 disabled:cursor-not-allowed text-sm transition-colors flex items-center justify-center gap-2 py-2"
                 aria-label="Disconnect Telegram"
               >

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -611,6 +611,78 @@ export interface TelegramTestMessageResponse {
 }
 
 /**
+ * Telegram Bot Configuration types (Story 12.3)
+ */
+export interface TelegramBotConfigResponse {
+  configured: boolean;
+  bot_username: string | null;
+  configured_at: string | null;
+}
+
+export interface TelegramBotValidateResponse {
+  valid: boolean;
+  bot_username: string;
+}
+
+/**
+ * Get Telegram bot configuration status
+ */
+export async function getTelegramBotConfig(): Promise<TelegramBotConfigResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/telegram/bot-config`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to fetch bot config: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Validate and save a Telegram bot token
+ */
+export async function saveTelegramBotToken(
+  token: string
+): Promise<TelegramBotValidateResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/telegram/bot-config`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ token }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to save bot token: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Remove the configured Telegram bot token
+ */
+export async function removeTelegramBotToken(): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/api/telegram/bot-config`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to remove bot token: ${response.status}`
+    );
+  }
+}
+
+/**
  * Get Telegram link status for the current user
  */
 export async function getTelegramStatus(): Promise<TelegramStatusResponse> {


### PR DESCRIPTION
## Summary

- Add two-step Telegram setup flow on the Telegram settings page: Bot Setup (admin configures token via @BotFather) and Account Linking (user links personal account)
- Token input with show/hide toggle, "Validate Token" button that calls the backend, and "Remove Bot Token" with confirmation dialog
- "Bot not configured" warning disables account linking section until admin sets up the bot
- Proper offline state handling: token input and validate button disabled when disconnected
- Handle `valid: false` API response and removal errors gracefully (dismiss confirmation, show error)
- 3 new API functions in `api.ts`: `getTelegramBotConfig`, `saveTelegramBotToken`, `removeTelegramBotToken`
- 25 tests covering configured/unconfigured states, validate flow, remove flow with error path, offline state, and navigation

Completes Epic 12: Integration & Communication Config (4/4 stories).

## Test plan

- [x] 25 unit tests pass (telegram-bot-config.test.tsx)
- [x] 60 total settings tests pass (no regressions)
- [x] Playwright visual verification: dashboard, telegram page, communications hub, settings page
- [x] Code review: all FAIL items addressed (F2: confirmation dismisses on error, F3: state transition after removal, W4: valid:false handling)