### PR TITLE
feat: add web-based AI chat interface (Story 11.2)

### DIFF
--- a/apps/api/src/schemas/ai_provider.py
+++ b/apps/api/src/schemas/ai_provider.py
@@ -56,3 +56,24 @@ class AIProviderDeleteResponse(BaseModel):
     """Response schema for deleting AI provider configuration."""
 
     message: str = Field(default="AI provider configuration removed successfully")
+
+
+class AIChatRequest(BaseModel):
+    """Request schema for AI chat messages."""
+
+    message: str = Field(
+        ...,
+        min_length=1,
+        max_length=2000,
+        description="The user's question about their glucose data",
+    )
+
+
+class AIChatResponse(BaseModel):
+    """Response schema for AI chat messages."""
+
+    response: str = Field(..., description="AI-generated response text")
+    disclaimer: str = Field(
+        default="Not medical advice. Consult your healthcare provider.",
+        description="Safety disclaimer",
+    )

--- a/apps/web/__tests__/ai-chat.test.tsx
+++ b/apps/web/__tests__/ai-chat.test.tsx
@@ -1,0 +1,851 @@
+/**
+ * Story 11.2: Web-Based AI Chat Interface
+ *
+ * Tests for the AI Chat page including all states (loading, no-provider,
+ * offline, ready), message sending, error handling, and UI interactions.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+  usePathname: () => "/dashboard/ai-chat",
+}));
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+// Mock API functions
+const mockGetAIProvider = jest.fn();
+const mockSendAIChat = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  getAIProvider: (...args: unknown[]) => mockGetAIProvider(...args),
+  sendAIChat: (...args: unknown[]) => mockSendAIChat(...args),
+}));
+
+import AIChatPage from "@/app/dashboard/ai-chat/page";
+
+// jsdom doesn't implement scrollIntoView
+Element.prototype.scrollIntoView = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("AI Chat Page", () => {
+  describe("loading state", () => {
+    it("shows loading spinner while checking provider", () => {
+      mockGetAIProvider.mockReturnValue(new Promise(() => {}));
+      render(<AIChatPage />);
+      expect(screen.getByText("Checking AI provider...")).toBeInTheDocument();
+    });
+  });
+
+  describe("no provider configured", () => {
+    beforeEach(() => {
+      mockGetAIProvider.mockRejectedValue(
+        new Error("No AI provider configured")
+      );
+    });
+
+    it("shows configure prompt when no provider", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("AI Chat")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(/configure an AI provider first/)
+      ).toBeInTheDocument();
+    });
+
+    it("links to AI provider settings", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Configure AI Provider")).toBeInTheDocument();
+      });
+
+      const link = screen.getByText("Configure AI Provider").closest("a");
+      expect(link).toHaveAttribute(
+        "href",
+        "/dashboard/settings/ai-provider"
+      );
+    });
+  });
+
+  describe("offline state", () => {
+    beforeEach(() => {
+      mockGetAIProvider.mockRejectedValue(new Error("Failed to fetch"));
+    });
+
+    it("shows offline message when server unreachable", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Unable to Connect")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(/Cannot reach the server/)
+      ).toBeInTheDocument();
+    });
+
+    it("shows retry button", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /retry connection/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("retries and transitions to ready on success", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /retry connection/i })
+        ).toBeInTheDocument();
+      });
+
+      // Now getAIProvider succeeds on retry
+      mockGetAIProvider.mockResolvedValue({
+        provider_type: "claude",
+        status: "connected",
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /retry connection/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Start a conversation")
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("ready state - empty chat", () => {
+    beforeEach(() => {
+      mockGetAIProvider.mockResolvedValue({
+        provider_type: "claude",
+        status: "connected",
+      });
+    });
+
+    it("shows chat header", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("AI Chat")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText("Ask questions about your glucose data")
+      ).toBeInTheDocument();
+    });
+
+    it("shows empty state with suggestions", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Start a conversation")
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText("How am I doing today?")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Why do I spike after breakfast?")
+      ).toBeInTheDocument();
+    });
+
+    it("fills input when clicking a suggestion", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("How am I doing today?")
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("How am I doing today?"));
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        "Ask about your glucose data..."
+      );
+      expect(textarea).toHaveValue("How am I doing today?");
+    });
+
+    it("shows disclaimer text", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Not medical advice. Consult your healthcare provider."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows send button disabled when input is empty", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /send message/i })
+        ).toBeDisabled();
+      });
+    });
+
+    it("enables send button when input has text", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "Hello" } }
+        );
+      });
+
+      expect(
+        screen.getByRole("button", { name: /send message/i })
+      ).not.toBeDisabled();
+    });
+
+    it("does not show clear button when no messages", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Start a conversation")
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole("button", { name: /clear chat history/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("sending messages", () => {
+    beforeEach(() => {
+      mockGetAIProvider.mockResolvedValue({
+        provider_type: "claude",
+        status: "connected",
+      });
+    });
+
+    it("sends message and shows response", async () => {
+      mockSendAIChat.mockResolvedValue({
+        response: "Your glucose looks stable today.",
+        disclaimer: "Not medical advice. Consult your healthcare provider.",
+      });
+
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        "Ask about your glucose data..."
+      );
+
+      await act(async () => {
+        fireEvent.change(textarea, {
+          target: { value: "How am I doing?" },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      // User message should appear
+      await waitFor(() => {
+        expect(screen.getByText("How am I doing?")).toBeInTheDocument();
+      });
+
+      // AI response should appear
+      await waitFor(() => {
+        expect(
+          screen.getByText("Your glucose looks stable today.")
+        ).toBeInTheDocument();
+      });
+
+      expect(mockSendAIChat).toHaveBeenCalledWith("How am I doing?");
+    });
+
+    it("shows typing indicator while waiting", async () => {
+      let resolveChat: (value: unknown) => void;
+      mockSendAIChat.mockReturnValue(
+        new Promise((resolve) => {
+          resolveChat = resolve;
+        })
+      );
+
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "Test message" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      // Typing indicator should show
+      expect(screen.getByText("AI is thinking...")).toBeInTheDocument();
+
+      // Resolve the promise
+      await act(async () => {
+        resolveChat!({
+          response: "Response",
+          disclaimer: "Disclaimer",
+        });
+      });
+
+      // Typing indicator should be gone
+      expect(
+        screen.queryByText("AI is thinking...")
+      ).not.toBeInTheDocument();
+    });
+
+    it("clears input after sending", async () => {
+      mockSendAIChat.mockResolvedValue({
+        response: "Reply",
+        disclaimer: "Disclaimer",
+      });
+
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        "Ask about your glucose data..."
+      );
+
+      await act(async () => {
+        fireEvent.change(textarea, {
+          target: { value: "My question" },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      // Input should be cleared immediately
+      expect(textarea).toHaveValue("");
+    });
+
+    it("sends on Enter key (without shift)", async () => {
+      mockSendAIChat.mockResolvedValue({
+        response: "Reply",
+        disclaimer: "Disclaimer",
+      });
+
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        "Ask about your glucose data..."
+      );
+
+      await act(async () => {
+        fireEvent.change(textarea, {
+          target: { value: "Enter test" },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      });
+
+      expect(mockSendAIChat).toHaveBeenCalledWith("Enter test");
+    });
+
+    it("does NOT send on Shift+Enter", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        "Ask about your glucose data..."
+      );
+
+      await act(async () => {
+        fireEvent.change(textarea, {
+          target: { value: "Multi-line" },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+      });
+
+      expect(mockSendAIChat).not.toHaveBeenCalled();
+    });
+
+    it("shows error on send failure", async () => {
+      mockSendAIChat.mockRejectedValue(
+        new Error("Unable to get a response from the AI provider")
+      );
+
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "Failing message" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Unable to get a response from the AI provider"
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows disclaimer on AI response", async () => {
+      mockSendAIChat.mockResolvedValue({
+        response: "Your readings look good.",
+        disclaimer: "Not medical advice. Consult your healthcare provider.",
+      });
+
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "How are my readings?" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      // After sending, the disclaimer should appear on the AI response
+      // (in addition to the static disclaimer bar already present)
+      await waitFor(() => {
+        const disclaimers = screen.getAllByText(
+          "Not medical advice. Consult your healthcare provider."
+        );
+        // One from the static bar, one from the AI response bubble
+        expect(disclaimers.length).toBeGreaterThanOrEqual(2);
+      });
+    });
+  });
+
+  describe("clear chat", () => {
+    beforeEach(() => {
+      mockGetAIProvider.mockResolvedValue({
+        provider_type: "claude",
+        status: "connected",
+      });
+      mockSendAIChat.mockResolvedValue({
+        response: "Response text",
+        disclaimer: "Disclaimer",
+      });
+    });
+
+    it("shows clear button after messages exist", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      // Send a message first
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "Test" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /clear chat history/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("clears all messages when clear is clicked", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      // Send a message
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "Test" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Response text")).toBeInTheDocument();
+      });
+
+      // Clear chat
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /clear chat history/i })
+        );
+      });
+
+      // Messages should be gone, empty state should return
+      expect(screen.queryByText("Test")).not.toBeInTheDocument();
+      expect(screen.queryByText("Response text")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Start a conversation")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("multiple messages", () => {
+    beforeEach(() => {
+      mockGetAIProvider.mockResolvedValue({
+        provider_type: "claude",
+        status: "connected",
+      });
+    });
+
+    it("supports multiple exchanges in sequence", async () => {
+      mockSendAIChat
+        .mockResolvedValueOnce({
+          response: "First reply",
+          disclaimer: "Disclaimer",
+        })
+        .mockResolvedValueOnce({
+          response: "Second reply",
+          disclaimer: "Disclaimer",
+        });
+
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      // Send first message
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "First question" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("First reply")).toBeInTheDocument();
+      });
+
+      // Send second message
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "Second question" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Second reply")).toBeInTheDocument();
+      });
+
+      // Both exchanges should be visible
+      expect(screen.getByText("First question")).toBeInTheDocument();
+      expect(screen.getByText("First reply")).toBeInTheDocument();
+      expect(screen.getByText("Second question")).toBeInTheDocument();
+      expect(screen.getByText("Second reply")).toBeInTheDocument();
+    });
+  });
+
+  describe("does not send empty messages", () => {
+    beforeEach(() => {
+      mockGetAIProvider.mockResolvedValue({
+        provider_type: "claude",
+        status: "connected",
+      });
+    });
+
+    it("does not send whitespace-only input", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "   " } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      expect(mockSendAIChat).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("accessibility", () => {
+    beforeEach(() => {
+      mockGetAIProvider.mockResolvedValue({
+        provider_type: "claude",
+        status: "connected",
+      });
+    });
+
+    it("has role=log on messages area", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("log")).toBeInTheDocument();
+      });
+    });
+
+    it("has aria-label on message input", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText("Message input")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("has maxLength on textarea", async () => {
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toHaveAttribute("maxLength", "2000");
+      });
+    });
+
+    it("shows typing indicator with role=status", async () => {
+      mockSendAIChat.mockReturnValue(new Promise(() => {}));
+
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "Test" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  describe("error recovery", () => {
+    beforeEach(() => {
+      mockGetAIProvider.mockResolvedValue({
+        provider_type: "claude",
+        status: "connected",
+      });
+    });
+
+    it("clears error on next successful send", async () => {
+      // First send fails
+      mockSendAIChat.mockRejectedValueOnce(new Error("AI provider error"));
+
+      render(<AIChatPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Ask about your glucose data...")
+        ).toBeInTheDocument();
+      });
+
+      // Send failing message
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "Failing message" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("AI provider error")).toBeInTheDocument();
+      });
+
+      // Second send succeeds
+      mockSendAIChat.mockResolvedValueOnce({
+        response: "Success!",
+        disclaimer: "Disclaimer",
+      });
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("Ask about your glucose data..."),
+          { target: { value: "Working message" } }
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /send message/i })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Success!")).toBeInTheDocument();
+      });
+
+      // Error should be cleared
+      expect(
+        screen.queryByText("AI provider error")
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/dashboard/ai-chat/page.tsx
+++ b/apps/web/src/app/dashboard/ai-chat/page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+/**
+ * Story 11.2: Web-Based AI Chat Interface
+ *
+ * Chat interface for asking the AI questions about glucose data.
+ * Messages are standalone Q&A (no persistent conversation history).
+ * Shows a prompt to configure AI if no provider is set up.
+ */
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { MessageSquare, Send, AlertTriangle, Settings, Loader2, Trash2 } from "lucide-react";
+import Link from "next/link";
+import { sendAIChat, getAIProvider } from "@/lib/api";
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Date;
+  disclaimer?: string;
+}
+
+type PageState = "loading" | "no-provider" | "ready" | "offline";
+
+export default function AIChatPage() {
+  const [pageState, setPageState] = useState<PageState>("loading");
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  // Check if AI provider is configured on mount
+  useEffect(() => {
+    let cancelled = false;
+    async function checkProvider() {
+      try {
+        await getAIProvider();
+        if (!cancelled) setPageState("ready");
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : "";
+        if (message.includes("No AI provider configured") || message.includes("404")) {
+          setPageState("no-provider");
+        } else {
+          setPageState("offline");
+        }
+      }
+    }
+    checkProvider();
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleRetry = useCallback(async () => {
+    setPageState("loading");
+    try {
+      await getAIProvider();
+      setPageState("ready");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "";
+      if (message.includes("No AI provider configured") || message.includes("404")) {
+        setPageState("no-provider");
+      } else {
+        setPageState("offline");
+      }
+    }
+  }, []);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || isSending) return;
+
+    setError(null);
+
+    const userMessage: ChatMessage = {
+      id: `user-${Date.now()}`,
+      role: "user",
+      content: trimmed,
+      timestamp: new Date(),
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+    setIsSending(true);
+
+    try {
+      const response = await sendAIChat(trimmed);
+      const assistantMessage: ChatMessage = {
+        id: `assistant-${Date.now()}`,
+        role: "assistant",
+        content: response.response,
+        timestamp: new Date(),
+        disclaimer: response.disclaimer,
+      };
+      setMessages((prev) => [...prev, assistantMessage]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to get response";
+      setError(message);
+    } finally {
+      setIsSending(false);
+      inputRef.current?.focus();
+    }
+  }, [input, isSending]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    },
+    [handleSend]
+  );
+
+  const handleClearChat = useCallback(() => {
+    setMessages([]);
+    setError(null);
+  }, []);
+
+  // Loading state
+  if (pageState === "loading") {
+    return (
+      <div className="flex flex-col h-full items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-400" />
+        <p className="mt-4 text-slate-400">Checking AI provider...</p>
+      </div>
+    );
+  }
+
+  // No AI provider configured
+  if (pageState === "no-provider") {
+    return (
+      <div className="flex flex-col h-full items-center justify-center px-4">
+        <div className="max-w-md text-center space-y-6">
+          <div className="mx-auto w-16 h-16 rounded-full bg-slate-800 flex items-center justify-center">
+            <MessageSquare className="h-8 w-8 text-slate-500" />
+          </div>
+          <h1 className="text-2xl font-bold text-white">AI Chat</h1>
+          <p className="text-slate-400">
+            To use AI Chat, you need to configure an AI provider first. Set up your
+            Claude or OpenAI API key in Settings.
+          </p>
+          <Link
+            href="/dashboard/settings/ai-provider"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white rounded-lg font-medium transition-colors"
+          >
+            <Settings className="h-5 w-5" />
+            Configure AI Provider
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Offline state
+  if (pageState === "offline") {
+    return (
+      <div className="flex flex-col h-full items-center justify-center px-4">
+        <div className="max-w-md text-center space-y-6">
+          <div className="mx-auto w-16 h-16 rounded-full bg-slate-800 flex items-center justify-center">
+            <AlertTriangle className="h-8 w-8 text-yellow-500" />
+          </div>
+          <h1 className="text-2xl font-bold text-white">Unable to Connect</h1>
+          <p className="text-slate-400">
+            Cannot reach the server. Please check your connection and try again.
+          </p>
+          <button
+            onClick={handleRetry}
+            className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors"
+          >
+            Retry Connection
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Ready state - main chat interface
+  return (
+    <div className="flex flex-col h-[calc(100vh-4rem)]">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-slate-800">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-blue-600 flex items-center justify-center">
+            <MessageSquare className="h-5 w-5 text-white" />
+          </div>
+          <div>
+            <h1 className="text-xl font-bold text-white">AI Chat</h1>
+            <p className="text-sm text-slate-400">
+              Ask questions about your glucose data
+            </p>
+          </div>
+        </div>
+        {messages.length > 0 && (
+          <button
+            onClick={handleClearChat}
+            className="flex items-center gap-2 px-3 py-2 text-sm text-slate-400 hover:text-white hover:bg-slate-800 rounded-lg transition-colors"
+            aria-label="Clear chat history"
+          >
+            <Trash2 className="h-4 w-4" />
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Messages area */}
+      <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6" role="log" aria-live="polite" aria-label="Chat messages">
+        {messages.length === 0 && (
+          <div className="flex flex-col items-center justify-center h-full text-center space-y-4">
+            <div className="w-16 h-16 rounded-full bg-slate-800 flex items-center justify-center">
+              <MessageSquare className="h-8 w-8 text-slate-500" />
+            </div>
+            <div>
+              <p className="text-lg font-medium text-white">
+                Start a conversation
+              </p>
+              <p className="text-sm text-slate-400 mt-1">
+                Ask about your glucose patterns, trends, or any diabetes-related questions.
+              </p>
+            </div>
+            <div className="flex flex-wrap justify-center gap-2 max-w-lg">
+              {[
+                "How am I doing today?",
+                "Why do I spike after breakfast?",
+                "What are my patterns this week?",
+                "How is my time in range?",
+              ].map((suggestion) => (
+                <button
+                  key={suggestion}
+                  onClick={() => {
+                    setInput(suggestion);
+                    inputRef.current?.focus();
+                  }}
+                  className="px-3 py-2 text-sm text-slate-300 bg-slate-800 hover:bg-slate-700 rounded-lg border border-slate-700 transition-colors"
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+          >
+            <div
+              className={`max-w-[80%] rounded-2xl px-4 py-3 ${
+                msg.role === "user"
+                  ? "bg-blue-600 text-white"
+                  : "bg-slate-800 text-slate-200"
+              }`}
+            >
+              <div className="whitespace-pre-wrap text-sm leading-relaxed">
+                {msg.content}
+              </div>
+              {msg.disclaimer && (
+                <p className="mt-2 pt-2 border-t border-slate-700 text-xs text-slate-400 flex items-center gap-1">
+                  <AlertTriangle className="h-3 w-3" />
+                  {msg.disclaimer}
+                </p>
+              )}
+              <p className="text-xs mt-1 opacity-60">
+                {msg.timestamp.toLocaleTimeString([], {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </p>
+            </div>
+          </div>
+        ))}
+
+        {/* Typing indicator */}
+        {isSending && (
+          <div className="flex justify-start" role="status" aria-label="AI is generating a response">
+            <div className="bg-slate-800 rounded-2xl px-4 py-3">
+              <div className="flex items-center gap-2 text-sm text-slate-400">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                AI is thinking...
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Error message */}
+        {error && (
+          <div className="flex justify-center">
+            <div className="bg-red-900/30 border border-red-700 rounded-lg px-4 py-3 max-w-md">
+              <p className="text-sm text-red-300 flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+                {error}
+              </p>
+            </div>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Disclaimer bar */}
+      <div className="px-6 py-1 text-center">
+        <p className="text-xs text-slate-500">
+          Not medical advice. Consult your healthcare provider.
+        </p>
+      </div>
+
+      {/* Input area */}
+      <div className="px-6 py-4 border-t border-slate-800">
+        <div className="flex items-end gap-3">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about your glucose data..."
+            aria-label="Message input"
+            disabled={isSending}
+            rows={1}
+            maxLength={2000}
+            className="flex-1 bg-slate-800 border border-slate-700 rounded-xl px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 resize-none text-sm"
+            style={{ maxHeight: "120px" }}
+          />
+          <button
+            onClick={handleSend}
+            disabled={!input.trim() || isSending}
+            className="flex items-center justify-center w-12 h-12 bg-blue-600 hover:bg-blue-700 disabled:bg-slate-700 disabled:cursor-not-allowed text-white rounded-xl transition-colors flex-shrink-0"
+            aria-label="Send message"
+          >
+            {isSending ? (
+              <Loader2 className="h-5 w-5 animate-spin" />
+            ) : (
+              <Send className="h-5 w-5" />
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -20,6 +20,7 @@ import {
   LayoutDashboard,
   FileText,
   Bell,
+  MessageSquare,
   Settings,
   Menu,
   X,
@@ -36,6 +37,7 @@ const diabeticNavigation: NavItem[] = [
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { name: "Daily Briefs", href: "/dashboard/briefs", icon: FileText },
   { name: "Alerts", href: "/dashboard/alerts", icon: Bell },
+  { name: "AI Chat", href: "/dashboard/ai-chat", icon: MessageSquare },
   { name: "Settings", href: "/dashboard/settings", icon: Settings },
 ];
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1743,3 +1743,26 @@ export async function deleteAIProvider(): Promise<AIProviderDeleteResponse> {
   }
   return response.json();
 }
+
+// ── Story 11.2: AI Chat ──
+
+export interface AIChatResponse {
+  response: string;
+  disclaimer: string;
+}
+
+export async function sendAIChat(message: string): Promise<AIChatResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/ai/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ message }),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to send message: ${response.status}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary

- Add AI Chat page at `/dashboard/ai-chat` with full chat interface for asking questions about glucose data
- Add "AI Chat" sidebar navigation item between "Alerts" and "Settings" with MessageSquare icon
- Add backend `POST /api/ai/chat` endpoint with glucose context, web-optimized system prompt, and proper auth
- Add `handle_chat_web()` service function optimized for web (plain text, allows markdown, 1200 max tokens)
- Add `AIChatRequest`/`AIChatResponse` Pydantic schemas and `sendAIChat()` frontend API client

## Details

**Chat page features:**
- Three states: no-provider (links to AI Provider settings), offline (retry button), ready (chat interface)
- Message input with Enter to send, Shift+Enter for newline, 2000 char max
- Conversation history with user/assistant message bubbles and timestamps
- Typing indicator ("AI is thinking...") while awaiting response
- Suggestion chips for common questions ("How am I doing today?", etc.)
- Clear chat button to reset conversation
- Static "Not medical advice" disclaimer bar + per-response disclaimer
- Inline error display on send failure with auto-recovery on next success

**Accessibility:**
- `role="log"` with `aria-live="polite"` on messages container
- `role="status"` on typing indicator
- `aria-label` on message input and send/clear buttons
- Keyboard support (Enter/Shift+Enter)

**Backend:**
- `POST /api/ai/chat` secured with `DiabeticOrAdminUser` auth
- Web-optimized system prompt (allows markdown, no Telegram HTML formatting)
- Glucose context from last 2 hours of readings + IoB data
- Error handling: 404 (no provider), 502 (AI error/empty response)

## Test plan

- [x] All 29 AI chat tests pass
- [x] All 464 total tests pass (no regressions)
- [x] Playwright: AI Chat nav item visible in sidebar
- [x] Playwright: AI Chat page loads with offline state (expected - no API server)
- [x] Playwright: Dashboard still fully functional