### PR TITLE
feat: add login page with email/password authentication (Story 15.1)

### DIFF
--- a/_bmad-output/PROGRESS.md
+++ b/_bmad-output/PROGRESS.md
@@ -20,11 +20,13 @@
 | 12 | Integration & Communication Config | 4/4 | **Complete** |
 | 13 | E2E Testing & Real Data Verification | 3/3 | **Complete** |
 | 14 | Expanded AI Provider Support | 0/4 | **In Progress** |
+| 15 | Frontend Auth UI & Route Protection | 0/6 | **Pending** |
 
 **MVP Stories:** 54/54 complete (100%)
 **Post-MVP Fix Stories:** 13/13 complete (100%)
 **Epic 14 (AI Provider Expansion):** 0/4 in progress
-**Overall Progress:** 67/71 stories complete (94%)
+**Epic 15 (Frontend Auth UI):** 0/6 pending
+**Overall Progress:** 67/77 stories complete (87%)
 
 ---
 
@@ -277,3 +279,18 @@ All 5 stories completed:
 - [ ] Story 14.2: Backend Support for 5 Provider Types
 - [ ] Story 14.3: Frontend AI Provider Page Redesign
 - [ ] Story 14.4: Tests for Expanded Provider System
+
+---
+
+## Epic 15: Frontend Authentication UI & Route Protection
+
+**Goal:** Build login/register pages, add Next.js middleware for route protection, fix logout, add global 401 handling, and enforce post-login disclaimer. Discovered during Docker deployment testing - the backend auth system (Epic 2) is complete but the frontend has no auth pages or route protection.
+
+**Epic Details:** [epic-15-frontend-auth-ui.md](planning-artifacts/epic-15-frontend-auth-ui.md)
+
+- [ ] Story 15.1: Login Page
+- [ ] Story 15.2: Registration Page
+- [ ] Story 15.3: Next.js Auth Middleware & Route Protection
+- [ ] Story 15.4: Logout, Auth State & Global 401 Handling
+- [ ] Story 15.5: Post-Login Disclaimer Enforcement
+- [ ] Story 15.6: Landing Page & Auth Navigation Polish

--- a/apps/web/__tests__/login.test.tsx
+++ b/apps/web/__tests__/login.test.tsx
@@ -1,0 +1,386 @@
+/**
+ * Story 15.1: Login Page Tests
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock next/navigation
+const mockReplace = jest.fn();
+const mockGet = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({ get: mockGet }),
+}));
+
+// Mock next/image
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { priority, ...rest } = props;
+    return <img {...rest} data-priority={priority ? "true" : undefined} />;
+  },
+}));
+
+// Mock API functions
+const mockLoginUser = jest.fn();
+const mockGetCurrentUser = jest.fn();
+jest.mock("@/lib/api", () => ({
+  loginUser: (...args: unknown[]) => mockLoginUser(...args),
+  getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+}));
+
+import LoginPage from "@/app/login/page";
+
+describe("Login Page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockReturnValue(null);
+    // Default: not authenticated
+    mockGetCurrentUser.mockRejectedValue(new Error("Not authenticated"));
+  });
+
+  it("renders email and password fields", async () => {
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+  });
+
+  it("renders Sign In heading and button", async () => {
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /sign in/i })
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it("renders Register link", async () => {
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /register/i })).toHaveAttribute(
+        "href",
+        "/register"
+      );
+    });
+  });
+
+  it("renders Back to home link", async () => {
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /back to home/i })
+      ).toHaveAttribute("href", "/");
+    });
+  });
+
+  it("calls loginUser with correct payload on submit", async () => {
+    mockLoginUser.mockResolvedValue({
+      message: "Login successful",
+      user: { id: "1", email: "test@test.com" },
+      disclaimer_required: false,
+    });
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "test@test.com"
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "TestPass123");
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockLoginUser).toHaveBeenCalledWith("test@test.com", "TestPass123");
+    });
+  });
+
+  it("redirects to dashboard on successful login", async () => {
+    mockLoginUser.mockResolvedValue({
+      message: "Login successful",
+      user: { id: "1", email: "test@test.com" },
+      disclaimer_required: false,
+    });
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "test@test.com"
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "TestPass123");
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("displays error message on failed login", async () => {
+    mockLoginUser.mockRejectedValue(new Error("Invalid email or password"));
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "bad@test.com"
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "WrongPass123");
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Invalid email or password"
+      );
+    });
+  });
+
+  it("toggles password visibility", async () => {
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+    });
+
+    const passwordInput = screen.getByLabelText(/^password$/i);
+    expect(passwordInput).toHaveAttribute("type", "password");
+
+    const toggleButton = screen.getByRole("button", {
+      name: /show password/i,
+    });
+    fireEvent.click(toggleButton);
+
+    expect(passwordInput).toHaveAttribute("type", "text");
+
+    const hideButton = screen.getByRole("button", { name: /hide password/i });
+    fireEvent.click(hideButton);
+
+    expect(passwordInput).toHaveAttribute("type", "password");
+  });
+
+  it("shows loading state during submission", async () => {
+    // Never resolve to keep the loading state
+    mockLoginUser.mockReturnValue(new Promise(() => {}));
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "test@test.com"
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "TestPass123");
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/signing in/i)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /signing in/i })
+    ).toBeDisabled();
+  });
+
+  it("redirects authenticated users to dashboard", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      id: "1",
+      email: "test@test.com",
+    });
+
+    render(<LoginPage />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("uses redirect parameter when present and valid", async () => {
+    mockGet.mockImplementation((key: string) =>
+      key === "redirect" ? "/dashboard/settings" : null
+    );
+    mockLoginUser.mockResolvedValue({
+      message: "Login successful",
+      user: { id: "1", email: "test@test.com" },
+      disclaimer_required: false,
+    });
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "test@test.com"
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "TestPass123");
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard/settings");
+    });
+  });
+
+  it("ignores redirect parameter with external URL", async () => {
+    mockGet.mockImplementation((key: string) =>
+      key === "redirect" ? "https://evil.com" : null
+    );
+    mockLoginUser.mockResolvedValue({
+      message: "Login successful",
+      user: { id: "1", email: "test@test.com" },
+      disclaimer_required: false,
+    });
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "test@test.com"
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "TestPass123");
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("shows expired session banner when expired=true", async () => {
+    mockGet.mockImplementation((key: string) =>
+      key === "expired" ? "true" : null
+    );
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/your session has expired/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not show expired banner without parameter", async () => {
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/your session has expired/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("ignores redirect parameter with path-prefix attack", async () => {
+    mockGet.mockImplementation((key: string) =>
+      key === "redirect" ? "/dashboardevil" : null
+    );
+    mockLoginUser.mockResolvedValue({
+      message: "Login successful",
+      user: { id: "1", email: "test@test.com" },
+      disclaimer_required: false,
+    });
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "test@test.com"
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "TestPass123");
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("redirects authenticated users using redirect parameter", async () => {
+    mockGet.mockImplementation((key: string) =>
+      key === "redirect" ? "/dashboard/settings" : null
+    );
+    mockGetCurrentUser.mockResolvedValue({
+      id: "1",
+      email: "test@test.com",
+    });
+
+    render(<LoginPage />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard/settings");
+    });
+  });
+
+  it("displays fallback error for non-Error rejections", async () => {
+    mockLoginUser.mockRejectedValue("string error");
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "bad@test.com"
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "WrongPass123");
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "An unexpected error occurred"
+      );
+    });
+  });
+
+  it("trims whitespace from email before submission", async () => {
+    mockLoginUser.mockResolvedValue({
+      message: "Login successful",
+      user: { id: "1", email: "test@test.com" },
+      disclaimer_required: false,
+    });
+
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "  test@test.com  "
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "TestPass123");
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockLoginUser).toHaveBeenCalledWith(
+        "test@test.com",
+        "TestPass123"
+      );
+    });
+  });
+});

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glycemicgpt-web",
-  "version": "0.1.0",
+  "version": "0.1.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glycemicgpt-web",
-      "version": "0.1.0",
+      "version": "0.1.55",
       "dependencies": {
         "@tanstack/react-query": "^5.60.0",
         "class-variance-authority": "^0.7.1",
@@ -22,6 +22,7 @@
         "@eslint/eslintrc": "^3.2.0",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2027,6 +2028,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,30 +11,31 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.60.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.11.0",
+    "lucide-react": "^0.460.0",
     "next": "15.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@tanstack/react-query": "^5.60.0",
-    "framer-motion": "^11.11.0",
-    "lucide-react": "^0.460.0",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^2.5.0",
-    "class-variance-authority": "^0.7.1"
+    "tailwind-merge": "^2.5.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
+    "@testing-library/jest-dom": "^6.6.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "typescript": "^5",
-    "tailwindcss": "^3.4.0",
-    "postcss": "^8",
     "autoprefixer": "^10.0.1",
     "eslint": "^9",
     "eslint-config-next": "15.2.0",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/jest-dom": "^6.6.0",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5"
   }
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+/**
+ * Story 15.1: Login Page
+ *
+ * Email/password login form with redirect to dashboard on success.
+ * Redirects already-authenticated users to the dashboard.
+ */
+
+import { Suspense, useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import {
+  LogIn,
+  Loader2,
+  AlertTriangle,
+  Eye,
+  EyeOff,
+  Info,
+} from "lucide-react";
+import clsx from "clsx";
+import { loginUser, getCurrentUser } from "@/lib/api";
+
+function getRedirectTarget(searchParams: URLSearchParams): string {
+  const redirect = searchParams.get("redirect");
+  return redirect &&
+    (redirect === "/dashboard" || redirect.startsWith("/dashboard/"))
+    ? redirect
+    : "/dashboard";
+}
+
+function LoadingSpinner() {
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center">
+      <div className="text-center">
+        <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+        <p className="text-slate-400">Loading...</p>
+      </div>
+    </div>
+  );
+}
+
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Auth check state
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  // Form state
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Expired session banner
+  const expired = searchParams.get("expired") === "true";
+
+  // Check if user is already authenticated
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkAuth() {
+      try {
+        await getCurrentUser();
+        if (!cancelled) {
+          router.replace(getRedirectTarget(searchParams));
+        }
+      } catch {
+        if (!cancelled) {
+          setIsCheckingAuth(false);
+        }
+      }
+    }
+
+    checkAuth();
+    return () => {
+      cancelled = true;
+    };
+  }, [router, searchParams]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await loginUser(email.trim(), password);
+      router.replace(getRedirectTarget(searchParams));
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "An unexpected error occurred"
+      );
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isCheckingAuth) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center p-4">
+      <div className="max-w-md w-full bg-slate-900 rounded-xl border border-slate-800 p-8">
+        {/* Branding */}
+        <div className="text-center mb-6">
+          <div className="flex justify-center mb-4">
+            <Image
+              src="/logo.png"
+              alt="GlycemicGPT"
+              width={64}
+              height={64}
+              className="rounded-xl"
+              priority
+            />
+          </div>
+          <h1 className="text-2xl font-bold text-slate-200">Sign In</h1>
+          <p className="text-sm text-slate-400 mt-1">
+            Welcome back to GlycemicGPT
+          </p>
+        </div>
+
+        {/* Expired session banner */}
+        {expired && (
+          <div
+            className="bg-amber-500/10 rounded-lg p-3 border border-amber-500/20 mb-4"
+            role="alert"
+          >
+            <div className="flex items-center gap-2">
+              <Info className="h-4 w-4 text-amber-400 shrink-0" />
+              <p className="text-sm text-amber-400">
+                Your session has expired. Please sign in again.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Error banner */}
+        {error && (
+          <div
+            className="bg-red-500/10 rounded-lg p-3 border border-red-500/20 mb-4"
+            role="alert"
+          >
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />
+              <p className="text-sm text-red-400">{error}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Login form */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-slate-300 mb-1"
+            >
+              Email Address
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className={clsx(
+                "w-full rounded-lg border px-3 py-2 text-sm",
+                "bg-slate-800 border-slate-700 text-slate-200",
+                "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                "placeholder:text-slate-500"
+              )}
+              placeholder="your@email.com"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-slate-300 mb-1"
+            >
+              Password
+            </label>
+            <div className="relative">
+              <input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                required
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className={clsx(
+                  "w-full rounded-lg border px-3 py-2 pr-10 text-sm",
+                  "bg-slate-800 border-slate-700 text-slate-200",
+                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                  "placeholder:text-slate-500"
+                )}
+                placeholder="Enter your password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-slate-400 hover:text-slate-200"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className={clsx(
+              "w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium",
+              "bg-blue-600 text-white hover:bg-blue-500",
+              "transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+              "disabled:opacity-50 disabled:cursor-not-allowed"
+            )}
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Signing In...
+              </>
+            ) : (
+              <>
+                <LogIn className="h-4 w-4" />
+                Sign In
+              </>
+            )}
+          </button>
+        </form>
+
+        {/* Navigation links */}
+        <div className="mt-6 text-center space-y-2">
+          <p className="text-sm text-slate-400">
+            Don&apos;t have an account?{" "}
+            <Link
+              href="/register"
+              className="text-blue-400 hover:text-blue-300"
+            >
+              Register
+            </Link>
+          </p>
+          <p className="text-xs text-slate-500">
+            <Link href="/" className="hover:text-slate-400">
+              Back to home
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={<LoadingSpinner />}>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,9 +2,88 @@
  * API client configuration and utilities.
  *
  * Story 1.3: First-Run Safety Disclaimer
+ * Story 15.1: Authentication API functions
  */
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+// ============================================================================
+// Story 15.1: Authentication
+// ============================================================================
+
+export interface LoginResponse {
+  message: string;
+  user: CurrentUserResponse;
+  disclaimer_required: boolean;
+}
+
+export interface RegisterResponse {
+  id: string;
+  email: string;
+  role: string;
+  message: string;
+  disclaimer_required: boolean;
+}
+
+/**
+ * Log in with email and password. Sets httpOnly session cookie on success.
+ */
+export async function loginUser(
+  email: string,
+  password: string
+): Promise<LoginResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.detail || `Login failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Register a new user account.
+ */
+export async function registerUser(
+  email: string,
+  password: string
+): Promise<RegisterResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Registration failed: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Log out the current user. Clears session cookie.
+ */
+export async function logoutUser(): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/api/auth/logout`, {
+    method: "POST",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.detail || `Logout failed: ${response.status}`);
+  }
+}
 
 /**
  * Disclaimer API types


### PR DESCRIPTION
## Summary

- Add `/login` page with email/password authentication form connected to the existing backend auth system (Epic 2)
- Add auth API functions (`loginUser`, `registerUser`, `logoutUser`) to the frontend API client
- Add `@testing-library/user-event` dev dependency for realistic form interaction testing

## Details

### Login Page (`apps/web/src/app/login/page.tsx`)
- Email/password form with client-side validation (`required`, `type="email"`)
- Error banner with `role="alert"` for failed login attempts
- Expired session banner (`?expired=true`) with `role="alert"` for screen reader accessibility
- Password visibility toggle (Show/Hide) with proper `aria-label`
- "Signing In..." loading state with disabled button during submission
- Redirect parameter support restricted to `/dashboard` and `/dashboard/*` paths (blocks external URLs and path-prefix attacks like `/dashboardevil`)
- Authenticated user detection on mount - redirects to dashboard if already logged in
- Email trimming before submission to handle copy-paste whitespace
- Suspense boundary wrapping `useSearchParams()` for Next.js 15 App Router static generation
- Links to `/register` and `/` (back to home)

### Auth API Functions (`apps/web/src/lib/api.ts`)
- `loginUser(email, password)` - POST /api/auth/login with `credentials: "include"` for httpOnly cookie
- `registerUser(email, password)` - POST /api/auth/register
- `logoutUser()` - POST /api/auth/logout with `credentials: "include"`
- `LoginResponse` and `RegisterResponse` TypeScript interfaces

### Tests (`apps/web/__tests__/login.test.tsx`)
- 18 unit tests covering all 10 acceptance criteria
- Security tests: external URL blocking, path-prefix attack prevention
- Edge cases: non-Error rejection handling, email whitespace trimming, authenticated user redirect with parameter

## Test plan

- [x] All 518 tests pass (500 existing + 18 new) - no regressions
- [x] Production build succeeds with `/login` as static page
- [x] Docker deployment tested end-to-end: landing page -> login -> dashboard
- [x] Error banner displays on invalid credentials
- [x] Expired session banner displays with `?expired=true`
- [x] Successful login redirects to `/dashboard`
- [x] Dashboard, Settings, AI Chat pages verified functional after login
- [x] Code reviewed by subagent - all 9 findings fixed and re-verified