### PR TITLE
feat: add registration page with password strength indicators (Story 15.2)

### DIFF
--- a/apps/web/__tests__/register.test.tsx
+++ b/apps/web/__tests__/register.test.tsx
@@ -1,0 +1,628 @@
+/**
+ * Story 15.2: Registration Page Tests
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock next/navigation
+const mockReplace = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+// Mock next/image
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { priority, ...rest } = props;
+    return <img {...rest} data-priority={priority ? "true" : undefined} />;
+  },
+}));
+
+// Mock API functions
+const mockRegisterUser = jest.fn();
+const mockLoginUser = jest.fn();
+const mockGetCurrentUser = jest.fn();
+jest.mock("@/lib/api", () => ({
+  registerUser: (...args: unknown[]) => mockRegisterUser(...args),
+  loginUser: (...args: unknown[]) => mockLoginUser(...args),
+  getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+}));
+
+import RegisterPage from "@/app/register/page";
+
+describe("Registration Page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: not authenticated
+    mockGetCurrentUser.mockRejectedValue(new Error("Not authenticated"));
+  });
+
+  it("renders email, password, and confirm password fields", async () => {
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^confirm password$/i)).toBeInTheDocument();
+  });
+
+  it("renders Create Account heading and button", async () => {
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /create account/i })
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /create account/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders Sign in link to /login", async () => {
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /sign in/i })
+      ).toHaveAttribute("href", "/login");
+    });
+  });
+
+  it("renders Back to home link", async () => {
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /back to home/i })
+      ).toHaveAttribute("href", "/");
+    });
+  });
+
+  describe("password strength indicators", () => {
+    it("shows requirements when password field is focused", async () => {
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+      });
+
+      // Requirements should NOT be visible initially
+      expect(screen.queryByText(/at least 8 characters/i)).not.toBeInTheDocument();
+
+      // Focus the password field
+      fireEvent.focus(screen.getByLabelText(/^password$/i));
+
+      // Requirements should now be visible
+      expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
+      expect(screen.getByText(/one uppercase letter/i)).toBeInTheDocument();
+      expect(screen.getByText(/one lowercase letter/i)).toBeInTheDocument();
+      expect(screen.getByText(/one number/i)).toBeInTheDocument();
+    });
+
+    it("shows requirements when password has content", async () => {
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(screen.getByLabelText(/^password$/i), "a");
+
+      expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
+    });
+
+    it("marks met requirements with green styling", async () => {
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(screen.getByLabelText(/^password$/i), "Abcdefg1");
+
+      // All requirements met
+      const items = screen.getByRole("list", { name: /password requirements/i });
+      const listItems = items.querySelectorAll("li");
+      listItems.forEach((li) => {
+        expect(li.className).toContain("text-green-400");
+      });
+    });
+
+    it("marks unmet requirements with slate styling", async () => {
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+      });
+
+      // Type only lowercase - missing uppercase, number, and length
+      await userEvent.type(screen.getByLabelText(/^password$/i), "abc");
+
+      const items = screen.getByRole("list", { name: /password requirements/i });
+      const listItems = items.querySelectorAll("li");
+
+      // "One lowercase letter" should be green
+      const lowercaseItem = Array.from(listItems).find((li) =>
+        li.textContent?.includes("One lowercase letter")
+      );
+      expect(lowercaseItem?.className).toContain("text-green-400");
+
+      // "At least 8 characters" should be slate
+      const lengthItem = Array.from(listItems).find((li) =>
+        li.textContent?.includes("At least 8 characters")
+      );
+      expect(lengthItem?.className).toContain("text-slate-500");
+    });
+  });
+
+  describe("form validation", () => {
+    it("shows error when passwords do not match", async () => {
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText(/email address/i),
+        "test@test.com"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^password$/i),
+        "TestPass123"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "DifferentPass123"
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /create account/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          "Passwords do not match"
+        );
+      });
+
+      // Should NOT call API
+      expect(mockRegisterUser).not.toHaveBeenCalled();
+    });
+
+    it("shows error when password does not meet requirements", async () => {
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText(/email address/i),
+        "test@test.com"
+      );
+      await userEvent.type(screen.getByLabelText(/^password$/i), "weak");
+      await userEvent.type(screen.getByLabelText(/^confirm password$/i), "weak");
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /create account/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          "Password does not meet requirements"
+        );
+      });
+
+      // Should NOT call API
+      expect(mockRegisterUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("form submission", () => {
+    it("calls registerUser then loginUser on valid submit", async () => {
+      mockRegisterUser.mockResolvedValue({
+        id: "1",
+        email: "new@test.com",
+        role: "diabetic",
+        message: "Registration successful",
+        disclaimer_required: true,
+      });
+      mockLoginUser.mockResolvedValue({
+        message: "Login successful",
+        user: { id: "1", email: "new@test.com" },
+        disclaimer_required: true,
+      });
+
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText(/email address/i),
+        "new@test.com"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^password$/i),
+        "TestPass123"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "TestPass123"
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /create account/i })
+      );
+
+      await waitFor(() => {
+        expect(mockRegisterUser).toHaveBeenCalledWith(
+          "new@test.com",
+          "TestPass123"
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockLoginUser).toHaveBeenCalledWith(
+          "new@test.com",
+          "TestPass123"
+        );
+      });
+    });
+
+    it("redirects to dashboard after successful registration", async () => {
+      mockRegisterUser.mockResolvedValue({
+        id: "1",
+        email: "new@test.com",
+        role: "diabetic",
+        message: "Registration successful",
+        disclaimer_required: true,
+      });
+      mockLoginUser.mockResolvedValue({
+        message: "Login successful",
+        user: { id: "1", email: "new@test.com" },
+        disclaimer_required: true,
+      });
+
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText(/email address/i),
+        "new@test.com"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^password$/i),
+        "TestPass123"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "TestPass123"
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /create account/i })
+      );
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+      });
+    });
+
+    it("displays duplicate email error from API", async () => {
+      mockRegisterUser.mockRejectedValue(
+        new Error("An account with this email already exists")
+      );
+
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText(/email address/i),
+        "existing@test.com"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^password$/i),
+        "TestPass123"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "TestPass123"
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /create account/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          "An account with this email already exists"
+        );
+      });
+    });
+
+    it("displays fallback error for non-Error rejections", async () => {
+      mockRegisterUser.mockRejectedValue("unknown error");
+
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText(/email address/i),
+        "new@test.com"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^password$/i),
+        "TestPass123"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "TestPass123"
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /create account/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          "An unexpected error occurred"
+        );
+      });
+    });
+
+    it("shows loading state during submission", async () => {
+      // Never resolve to keep the loading state
+      mockRegisterUser.mockReturnValue(new Promise(() => {}));
+
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText(/email address/i),
+        "new@test.com"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^password$/i),
+        "TestPass123"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "TestPass123"
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /create account/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/creating account/i)).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole("button", { name: /creating account/i })
+      ).toBeDisabled();
+    });
+
+    it("trims whitespace from email before submission", async () => {
+      mockRegisterUser.mockResolvedValue({
+        id: "1",
+        email: "new@test.com",
+        role: "diabetic",
+        message: "Registration successful",
+        disclaimer_required: true,
+      });
+      mockLoginUser.mockResolvedValue({
+        message: "Login successful",
+        user: { id: "1", email: "new@test.com" },
+        disclaimer_required: true,
+      });
+
+      render(<RegisterPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText(/email address/i),
+        "  new@test.com  "
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^password$/i),
+        "TestPass123"
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "TestPass123"
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /create account/i })
+      );
+
+      await waitFor(() => {
+        expect(mockRegisterUser).toHaveBeenCalledWith(
+          "new@test.com",
+          "TestPass123"
+        );
+      });
+    });
+  });
+
+  it("redirects authenticated users to dashboard", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      id: "1",
+      email: "test@test.com",
+    });
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("toggles password visibility", async () => {
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+    });
+
+    const passwordInput = screen.getByLabelText(/^password$/i);
+    expect(passwordInput).toHaveAttribute("type", "password");
+
+    const toggleButton = screen.getByRole("button", {
+      name: /^show password$/i,
+    });
+    fireEvent.click(toggleButton);
+
+    expect(passwordInput).toHaveAttribute("type", "text");
+
+    const hideButton = screen.getByRole("button", {
+      name: /^hide password$/i,
+    });
+    fireEvent.click(hideButton);
+
+    expect(passwordInput).toHaveAttribute("type", "password");
+  });
+
+  it("toggles confirm password visibility", async () => {
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^confirm password$/i)).toBeInTheDocument();
+    });
+
+    const confirmInput = screen.getByLabelText(/^confirm password$/i);
+    expect(confirmInput).toHaveAttribute("type", "password");
+
+    const toggleButton = screen.getByRole("button", {
+      name: /show confirm password/i,
+    });
+    fireEvent.click(toggleButton);
+
+    expect(confirmInput).toHaveAttribute("type", "text");
+  });
+
+  it("redirects to login when auto-login fails after successful registration", async () => {
+    mockRegisterUser.mockResolvedValue({
+      id: "1",
+      email: "new@test.com",
+      role: "diabetic",
+      message: "Registration successful",
+      disclaimer_required: true,
+    });
+    mockLoginUser.mockRejectedValue(new Error("Login service unavailable"));
+
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "new@test.com"
+    );
+    await userEvent.type(
+      screen.getByLabelText(/^password$/i),
+      "TestPass123"
+    );
+    await userEvent.type(
+      screen.getByLabelText(/^confirm password$/i),
+      "TestPass123"
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /create account/i })
+    );
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("keeps button enabled after client-side validation error", async () => {
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "test@test.com"
+    );
+    await userEvent.type(screen.getByLabelText(/^password$/i), "weak");
+    await userEvent.type(screen.getByLabelText(/^confirm password$/i), "weak");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /create account/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    // Button should still show "Create Account", not loading state
+    expect(
+      screen.getByRole("button", { name: /create account/i })
+    ).not.toBeDisabled();
+  });
+
+  it("clears previous error on resubmit", async () => {
+    mockRegisterUser.mockRejectedValueOnce(
+      new Error("An account with this email already exists")
+    );
+    mockRegisterUser.mockResolvedValueOnce({
+      id: "1",
+      email: "new@test.com",
+      role: "diabetic",
+      message: "Registration successful",
+      disclaimer_required: true,
+    });
+    mockLoginUser.mockResolvedValue({
+      message: "Login successful",
+      user: { id: "1", email: "new@test.com" },
+      disclaimer_required: true,
+    });
+
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/email address/i),
+      "new@test.com"
+    );
+    await userEvent.type(
+      screen.getByLabelText(/^password$/i),
+      "TestPass123"
+    );
+    await userEvent.type(
+      screen.getByLabelText(/^confirm password$/i),
+      "TestPass123"
+    );
+
+    // First submit: should show error
+    fireEvent.click(
+      screen.getByRole("button", { name: /create account/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "An account with this email already exists"
+      );
+    });
+
+    // Second submit: error should clear
+    fireEvent.click(
+      screen.getByRole("button", { name: /create account/i })
+    );
+
+    // Error should be cleared during resubmission
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+});

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+/**
+ * Story 15.2: Registration Page
+ *
+ * Email/password registration form with password strength indicators,
+ * auto-login after registration, and redirect to dashboard.
+ */
+
+import { Suspense, useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import {
+  UserPlus,
+  Loader2,
+  AlertTriangle,
+  Eye,
+  EyeOff,
+  CheckCircle2,
+  Circle,
+} from "lucide-react";
+import clsx from "clsx";
+import { registerUser, loginUser, getCurrentUser } from "@/lib/api";
+
+function LoadingSpinner() {
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center">
+      <div className="text-center">
+        <Loader2 className="h-8 w-8 text-blue-400 animate-spin mx-auto mb-3" />
+        <p className="text-slate-400">Loading...</p>
+      </div>
+    </div>
+  );
+}
+
+const PASSWORD_REQUIREMENTS = [
+  { label: "At least 8 characters", test: (p: string) => p.length >= 8 },
+  { label: "One uppercase letter", test: (p: string) => /[A-Z]/.test(p) },
+  { label: "One lowercase letter", test: (p: string) => /[a-z]/.test(p) },
+  { label: "One number", test: (p: string) => /\d/.test(p) },
+];
+
+function PasswordRequirements({ password }: { password: string }) {
+  return (
+    <ul className="mt-2 space-y-1.5" aria-label="Password requirements" aria-live="polite">
+      {PASSWORD_REQUIREMENTS.map((req) => {
+        const met = req.test(password);
+        return (
+          <li
+            key={req.label}
+            className={clsx(
+              "flex items-center gap-1.5 text-xs",
+              met ? "text-green-400" : "text-slate-500"
+            )}
+          >
+            {met ? (
+              <CheckCircle2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            ) : (
+              <Circle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            )}
+            {req.label}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function allRequirementsMet(password: string): boolean {
+  return PASSWORD_REQUIREMENTS.every((req) => req.test(password));
+}
+
+function RegisterForm() {
+  const router = useRouter();
+
+  // Auth check state
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  // Form state
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [passwordTouched, setPasswordTouched] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Check if user is already authenticated
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkAuth() {
+      try {
+        await getCurrentUser();
+        if (!cancelled) {
+          router.replace("/dashboard");
+        }
+      } catch {
+        if (!cancelled) {
+          setIsCheckingAuth(false);
+        }
+      }
+    }
+
+    checkAuth();
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    // Client-side validation
+    if (!allRequirementsMet(password)) {
+      setError("Password does not meet requirements");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await registerUser(email.trim(), password);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "An unexpected error occurred"
+      );
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      await loginUser(email.trim(), password);
+      router.replace("/dashboard");
+    } catch {
+      // Account was created but auto-login failed; redirect to login
+      router.replace("/login");
+    }
+  };
+
+  if (isCheckingAuth) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center p-4">
+      <div className="max-w-md w-full bg-slate-900 rounded-xl border border-slate-800 p-8">
+        {/* Branding */}
+        <div className="text-center mb-6">
+          <div className="flex justify-center mb-4">
+            <Image
+              src="/logo.png"
+              alt="GlycemicGPT"
+              width={64}
+              height={64}
+              className="rounded-xl"
+              priority
+            />
+          </div>
+          <h1 className="text-2xl font-bold text-slate-200">Create Account</h1>
+          <p className="text-sm text-slate-400 mt-1">
+            Get started with GlycemicGPT
+          </p>
+        </div>
+
+        {/* Error banner */}
+        {error && (
+          <div
+            className="bg-red-500/10 rounded-lg p-3 border border-red-500/20 mb-4"
+            role="alert"
+          >
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />
+              <p className="text-sm text-red-400">{error}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Registration form */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-slate-300 mb-1"
+            >
+              Email Address
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className={clsx(
+                "w-full rounded-lg border px-3 py-2 text-sm",
+                "bg-slate-800 border-slate-700 text-slate-200",
+                "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                "placeholder:text-slate-500"
+              )}
+              placeholder="your@email.com"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-slate-300 mb-1"
+            >
+              Password
+            </label>
+            <div className="relative">
+              <input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                required
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                onFocus={() => setPasswordTouched(true)}
+                className={clsx(
+                  "w-full rounded-lg border px-3 py-2 pr-10 text-sm",
+                  "bg-slate-800 border-slate-700 text-slate-200",
+                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                  "placeholder:text-slate-500"
+                )}
+                placeholder="Create a password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-slate-400 hover:text-slate-200"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+            {(passwordTouched || password.length > 0) && (
+              <PasswordRequirements password={password} />
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="confirmPassword"
+              className="block text-sm font-medium text-slate-300 mb-1"
+            >
+              Confirm Password
+            </label>
+            <div className="relative">
+              <input
+                id="confirmPassword"
+                type={showConfirmPassword ? "text" : "password"}
+                required
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className={clsx(
+                  "w-full rounded-lg border px-3 py-2 pr-10 text-sm",
+                  "bg-slate-800 border-slate-700 text-slate-200",
+                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                  "placeholder:text-slate-500"
+                )}
+                placeholder="Confirm your password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-slate-400 hover:text-slate-200"
+                aria-label={
+                  showConfirmPassword
+                    ? "Hide confirm password"
+                    : "Show confirm password"
+                }
+              >
+                {showConfirmPassword ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className={clsx(
+              "w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium",
+              "bg-blue-600 text-white hover:bg-blue-500",
+              "transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+              "disabled:opacity-50 disabled:cursor-not-allowed"
+            )}
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Creating Account...
+              </>
+            ) : (
+              <>
+                <UserPlus className="h-4 w-4" />
+                Create Account
+              </>
+            )}
+          </button>
+        </form>
+
+        {/* Navigation links */}
+        <div className="mt-6 text-center space-y-2">
+          <p className="text-sm text-slate-400">
+            Already have an account?{" "}
+            <Link
+              href="/login"
+              className="text-blue-400 hover:text-blue-300"
+            >
+              Sign in
+            </Link>
+          </p>
+          <p className="text-xs text-slate-500">
+            <Link href="/" className="hover:text-slate-400">
+              Back to home
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function RegisterPage() {
+  return (
+    <Suspense fallback={<LoadingSpinner />}>
+      <RegisterForm />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `/register` page with email/password/confirm password registration form
- Real-time password strength indicators with green/slate checklist UI
- Auto-login after successful registration with redirect to dashboard
- Graceful fallback: if auto-login fails, redirects to login page instead of showing confusing error

## Details

### Registration Page (`apps/web/src/app/register/page.tsx`)
- Email/password/confirm password form with client-side validation
- Real-time password strength indicators (8+ chars, uppercase, lowercase, number) with CheckCircle2/Circle icons
- Indicators appear only when password field is focused or has content (hidden on pristine state)
- Client-side validation runs before API: password requirements check, then password mismatch check
- Auto-login flow: `registerUser()` -> `loginUser()` -> `router.replace("/dashboard")`
- Separate try/catch blocks for register vs login: login failure redirects to `/login`
- Duplicate email error (409) displays "An account with this email already exists"
- Email trimming before submission
- Authenticated user detection on mount redirects to dashboard
- Suspense boundary wrapping for Next.js 15 App Router static generation
- Accessibility: `aria-live="polite"` on requirements list, `aria-hidden="true"` on decorative icons, `role="alert"` on error banner

### Tests (`apps/web/__tests__/register.test.tsx`)
- 22 unit tests covering all 11 acceptance criteria
- Password strength indicator tests: focus trigger, content trigger, green/slate styling
- Client-side validation: password mismatch, weak password (both verify no API call)
- API flow: register + login chain, duplicate email error, non-Error fallback
- Edge cases: auto-login failure redirects to /login, button stays enabled after validation error, error clearing on resubmit

## Test plan

- [x] All 540 tests pass (518 existing + 22 new) - no regressions
- [x] Production build succeeds with `/register` as static page
- [x] Docker deployment tested end-to-end: register new user -> auto-login -> dashboard
- [x] Duplicate email error banner displays correctly
- [x] Password strength indicators show green for met requirements
- [x] Sign in link navigates to /login, login Register link navigates to /register
- [x] Dashboard, Settings, core app pages verified functional
- [x] Code reviewed by subagent - all 6 findings fixed and re-verified