### PR TITLE
feat: add logout, auth state display, and global 401 handling (Story 15.4)

### DIFF
--- a/apps/web/__tests__/api-fetch.test.ts
+++ b/apps/web/__tests__/api-fetch.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Story 15.4: apiFetch wrapper tests
+ *
+ * Tests the global 401 handling in the apiFetch wrapper.
+ */
+
+// Save original window.location
+const originalLocation = window.location;
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.resetModules();
+  // Mock window.location.href as writable
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: { ...originalLocation, href: "http://localhost:3000/dashboard" },
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: originalLocation,
+  });
+});
+
+describe("apiFetch", () => {
+  it("passes credentials: include by default", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+    });
+    global.fetch = mockFetch;
+
+    const { apiFetch } = require("@/lib/api");
+    await apiFetch("http://localhost:8000/api/settings/alert-thresholds");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8000/api/settings/alert-thresholds",
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+
+  it("redirects to /login?expired=true on 401 from non-auth endpoint", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 401, ok: false });
+
+    const { apiFetch } = require("@/lib/api");
+    // apiFetch returns a never-resolving promise on 401 redirect,
+    // so we race it with a short timeout
+    const result = await Promise.race([
+      apiFetch("http://localhost:8000/api/settings/alert-thresholds"),
+      new Promise((resolve) => setTimeout(() => resolve("pending"), 50)),
+    ]);
+
+    expect(window.location.href).toBe("/login?expired=true");
+    expect(result).toBe("pending");
+  });
+
+  it("does NOT redirect on 401 from /api/auth/me", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 401, ok: false });
+
+    const { apiFetch } = require("@/lib/api");
+    const response = await apiFetch("http://localhost:8000/api/auth/me");
+
+    expect(window.location.href).toBe("http://localhost:3000/dashboard");
+    expect(response.status).toBe(401);
+  });
+
+  it("does NOT redirect on 401 from /api/auth/login", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 401, ok: false });
+
+    const { apiFetch } = require("@/lib/api");
+    const response = await apiFetch("http://localhost:8000/api/auth/login");
+
+    expect(window.location.href).toBe("http://localhost:3000/dashboard");
+    expect(response.status).toBe(401);
+  });
+
+  it("does NOT redirect on 401 from /api/auth/register", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 401, ok: false });
+
+    const { apiFetch } = require("@/lib/api");
+    const response = await apiFetch("http://localhost:8000/api/auth/register");
+
+    expect(window.location.href).toBe("http://localhost:3000/dashboard");
+    expect(response.status).toBe(401);
+  });
+
+  it("does NOT redirect on 401 from /api/auth/logout", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 401, ok: false });
+
+    const { apiFetch } = require("@/lib/api");
+    const response = await apiFetch("http://localhost:8000/api/auth/logout");
+
+    expect(window.location.href).toBe("http://localhost:3000/dashboard");
+    expect(response.status).toBe(401);
+  });
+
+  it("does NOT redirect on non-401 errors", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 500, ok: false });
+
+    const { apiFetch } = require("@/lib/api");
+    const response = await apiFetch(
+      "http://localhost:8000/api/settings/alert-thresholds"
+    );
+
+    expect(window.location.href).toBe("http://localhost:3000/dashboard");
+    expect(response.status).toBe(500);
+  });
+
+  it("returns the response object for normal responses", async () => {
+    const mockResponse = { status: 200, ok: true, json: jest.fn() };
+    global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+    const { apiFetch } = require("@/lib/api");
+    const result = await apiFetch("http://localhost:8000/api/alerts/active");
+
+    expect(result).toBe(mockResponse);
+  });
+
+  it("merges custom options with credentials", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ status: 200, ok: true });
+    global.fetch = mockFetch;
+
+    const { apiFetch } = require("@/lib/api");
+    await apiFetch("http://localhost:8000/api/ai/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "test" }),
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8000/api/ai/chat",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "test" }),
+      })
+    );
+  });
+
+  it("uses exact pathname match (not substring) for auth endpoint exclusion", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 401, ok: false });
+
+    const { apiFetch } = require("@/lib/api");
+    // /api/auth/me-sessions contains /api/auth/me as substring but should NOT be excluded
+    const result = await Promise.race([
+      apiFetch("http://localhost:8000/api/auth/me-sessions"),
+      new Promise((resolve) => setTimeout(() => resolve("pending"), 50)),
+    ]);
+
+    expect(window.location.href).toBe("/login?expired=true");
+    expect(result).toBe("pending");
+  });
+});
+
+describe("apiFetch integration - 401 through higher-level function", () => {
+  it("getAlertThresholds triggers redirect on 401", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 401, ok: false });
+
+    const { getAlertThresholds } = require("@/lib/api");
+    // The function should never resolve (apiFetch returns never-resolving promise)
+    const result = await Promise.race([
+      getAlertThresholds().catch(() => "caught"),
+      new Promise((resolve) => setTimeout(() => resolve("pending"), 50)),
+    ]);
+
+    expect(window.location.href).toBe("/login?expired=true");
+    expect(result).toBe("pending");
+  });
+});

--- a/apps/web/__tests__/header.test.tsx
+++ b/apps/web/__tests__/header.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Story 15.4: Header Component Tests
+ *
+ * Tests logout functionality, user info display, and loading states.
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+// Mock sidebar's MobileNav
+jest.mock("@/components/layout/sidebar", () => ({
+  MobileNav: () => <div data-testid="mobile-nav" />,
+}));
+
+// Mock logoutUser
+const mockLogoutUser = jest.fn();
+jest.mock("@/lib/api", () => ({
+  logoutUser: (...args: unknown[]) => mockLogoutUser(...args),
+}));
+
+// Mock useUserContext
+const mockUseUserContext = jest.fn();
+jest.mock("@/providers/user-provider", () => ({
+  useUserContext: () => mockUseUserContext(),
+}));
+
+// Mock lucide-react icons
+jest.mock("lucide-react", () => ({
+  User: ({ className }: { className?: string }) => (
+    <span data-testid="user-icon" className={className} />
+  ),
+  LogOut: ({ className }: { className?: string }) => (
+    <span data-testid="logout-icon" className={className} />
+  ),
+  Settings: ({ className }: { className?: string }) => (
+    <span data-testid="settings-icon" className={className} />
+  ),
+  ChevronDown: ({ className }: { className?: string }) => (
+    <span data-testid="chevron-icon" className={className} />
+  ),
+  Activity: ({ className }: { className?: string }) => (
+    <span data-testid="activity-icon" className={className} />
+  ),
+  Loader2: ({ className }: { className?: string }) => (
+    <span data-testid="loader-icon" className={className} />
+  ),
+}));
+
+import { Header } from "@/components/layout/header";
+
+// Save and mock window.location
+const originalLocation = window.location;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseUserContext.mockReturnValue({
+    user: null,
+    isLoading: true,
+    error: null,
+  });
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: { ...originalLocation, href: "http://localhost:3000/dashboard" },
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: originalLocation,
+  });
+});
+
+function openDropdown() {
+  const trigger = screen.getByRole("button", { expanded: false });
+  return userEvent.click(trigger);
+}
+
+describe("Header - User Info Display", () => {
+  it("shows 'Account' as fallback when user is loading", () => {
+    mockUseUserContext.mockReturnValue({
+      user: null,
+      isLoading: true,
+      error: null,
+    });
+
+    render(<Header />);
+    expect(screen.getByText("Account")).toBeInTheDocument();
+  });
+
+  it("shows user email when available", () => {
+    mockUseUserContext.mockReturnValue({
+      user: { email: "test@example.com", display_name: null },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<Header />);
+    expect(screen.getByText("test@example.com")).toBeInTheDocument();
+  });
+
+  it("shows display name when available (preferred over email)", () => {
+    mockUseUserContext.mockReturnValue({
+      user: { email: "test@example.com", display_name: "John Doe" },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<Header />);
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.queryByText("test@example.com")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Account' when user is null", () => {
+    mockUseUserContext.mockReturnValue({
+      user: null,
+      isLoading: false,
+      error: "Failed",
+    });
+
+    render(<Header />);
+    expect(screen.getByText("Account")).toBeInTheDocument();
+  });
+});
+
+describe("Header - Logout", () => {
+  beforeEach(() => {
+    mockUseUserContext.mockReturnValue({
+      user: { email: "test@example.com", display_name: null },
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("calls logoutUser and redirects to /login on sign out", async () => {
+    mockLogoutUser.mockResolvedValue(undefined);
+
+    render(<Header />);
+    await openDropdown();
+
+    const signOutButton = screen.getByRole("button", { name: /sign out/i });
+    await userEvent.click(signOutButton);
+
+    await waitFor(() => {
+      expect(mockLogoutUser).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(window.location.href).toBe("/login");
+    });
+  });
+
+  it("redirects to /login even if logout API fails", async () => {
+    mockLogoutUser.mockRejectedValue(new Error("Network error"));
+
+    render(<Header />);
+    await openDropdown();
+
+    const signOutButton = screen.getByRole("button", { name: /sign out/i });
+    await userEvent.click(signOutButton);
+
+    await waitFor(() => {
+      expect(window.location.href).toBe("/login");
+    });
+  });
+
+  it("shows loading state on sign out button during logout", async () => {
+    // Make logout hang so we can observe the loading state
+    let resolveLogout: () => void;
+    mockLogoutUser.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveLogout = resolve;
+      })
+    );
+
+    render(<Header />);
+    await openDropdown();
+
+    const signOutButton = screen.getByRole("button", { name: /sign out/i });
+    await userEvent.click(signOutButton);
+
+    // Should show "Signing out..." text
+    await waitFor(() => {
+      expect(screen.getByText("Signing out...")).toBeInTheDocument();
+    });
+
+    // Should show loader icon
+    expect(screen.getByTestId("loader-icon")).toBeInTheDocument();
+
+    // Button should be disabled
+    const disabledButton = screen.getByRole("button", {
+      name: /signing out/i,
+    });
+    expect(disabledButton).toBeDisabled();
+
+    // Resolve to clean up
+    resolveLogout!();
+  });
+
+  it("disables sign out button during logout to prevent double-clicks", async () => {
+    let resolveLogout: () => void;
+    mockLogoutUser.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveLogout = resolve;
+      })
+    );
+
+    render(<Header />);
+    await openDropdown();
+
+    const signOutButton = screen.getByRole("button", { name: /sign out/i });
+    await userEvent.click(signOutButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /signing out/i })
+      ).toBeDisabled();
+    });
+
+    resolveLogout!();
+  });
+});
+
+describe("Header - Dropdown menu", () => {
+  it("shows settings link in dropdown", async () => {
+    mockUseUserContext.mockReturnValue({
+      user: { email: "test@example.com", display_name: null },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<Header />);
+    await openDropdown();
+
+    const settingsLink = screen.getByRole("link", { name: /settings/i });
+    expect(settingsLink).toHaveAttribute("href", "/dashboard/settings");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `apiFetch` wrapper in `api.ts` with automatic 401 detection and redirect to `/login?expired=true` for expired sessions
- Migrate ~40 authenticated API functions to use `apiFetch` for consistent credential handling and 401 interception
- Auth endpoints (`/api/auth/login`, `/api/auth/register`, `/api/auth/me`, `/api/auth/logout`) excluded from 401 redirect using exact pathname matching
- Fix header logout: calls `logoutUser()` API, shows loading state with spinner, redirects to `/login` regardless of API success/failure (best-effort)
- Display user email/display name in header account dropdown with `max-w-[120px] truncate`
- Never-resolving promise pattern prevents callers from processing stale 401 responses
- Document all public endpoints that intentionally use raw `fetch`

## Test plan

- [x] 11 apiFetch wrapper tests: credentials, 401 redirect, auth endpoint exclusion (login/register/me/logout), exact pathname matching, non-401 pass-through, integration test via getAlertThresholds
- [x] 9 header tests: user email/name/fallback display, logout API call, redirect after success/failure, loading state, disabled button
- [x] 576 total tests passing
- [x] Subagent code review: 9 issues found, all fixed, re-review confirmed clean
- [x] Docker deployment + Playwright MCP visual testing:
  - Header shows user email with truncation
  - Sign out -> redirects to /login, cookie cleared
  - /login?expired=true shows "Your session has expired" banner
  - Re-login -> dashboard with user email in header
  - Full logout -> login -> dashboard round-trip verified