### PR TITLE
feat: add post-login disclaimer enforcement (Story 15.5)

### DIFF
--- a/apps/web/__tests__/auth-disclaimer-gate.test.tsx
+++ b/apps/web/__tests__/auth-disclaimer-gate.test.tsx
@@ -1,0 +1,540 @@
+/**
+ * Story 15.5: AuthDisclaimerGate Component Tests
+ *
+ * Tests disclaimer enforcement for authenticated users:
+ * - Shows modal when disclaimer_acknowledged is false
+ * - Renders children when disclaimer_acknowledged is true
+ * - Loading state while user data is being fetched
+ * - Acknowledgment flow (checkboxes, submit, refresh)
+ * - Dashboard content blocked while disclaimer shown
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock framer-motion to render children directly
+jest.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  motion: {
+    div: ({
+      children,
+      className,
+      role,
+      "aria-modal": ariaModal,
+      "aria-labelledby": ariaLabelledby,
+      ...rest
+    }: Record<string, unknown> & { children?: React.ReactNode }) => (
+      <div
+        className={className as string}
+        role={role as string}
+        aria-modal={ariaModal as boolean}
+        aria-labelledby={ariaLabelledby as string}
+      >
+        {children}
+      </div>
+    ),
+  },
+}));
+
+// Mock lucide-react icons
+jest.mock("lucide-react", () => ({
+  FlaskConical: ({ className }: { className?: string }) => (
+    <span data-testid="flask-icon" className={className} />
+  ),
+  Brain: ({ className }: { className?: string }) => (
+    <span data-testid="brain-icon" className={className} />
+  ),
+  ShieldOff: ({ className }: { className?: string }) => (
+    <span data-testid="shield-icon" className={className} />
+  ),
+  Stethoscope: ({ className }: { className?: string }) => (
+    <span data-testid="stethoscope-icon" className={className} />
+  ),
+  AlertTriangle: ({ className }: { className?: string }) => (
+    <span data-testid="alert-icon" className={className} />
+  ),
+  Check: ({ className }: { className?: string }) => (
+    <span data-testid="check-icon" className={className} />
+  ),
+  Loader2: ({ className }: { className?: string }) => (
+    <span data-testid="loader-icon" className={className} />
+  ),
+}));
+
+// Mock useUserContext
+const mockUseUserContext = jest.fn();
+jest.mock("@/providers/user-provider", () => ({
+  useUserContext: () => mockUseUserContext(),
+}));
+
+// Mock API functions
+const mockAcknowledgeDisclaimerAuth = jest.fn();
+const mockGetDisclaimerContent = jest.fn();
+jest.mock("@/lib/api", () => ({
+  acknowledgeDisclaimerAuth: (...args: unknown[]) =>
+    mockAcknowledgeDisclaimerAuth(...args),
+  getDisclaimerContent: (...args: unknown[]) =>
+    mockGetDisclaimerContent(...args),
+}));
+
+import { AuthDisclaimerGate } from "@/components/auth-disclaimer-gate";
+
+const mockDisclaimerContent = {
+  version: "1.0",
+  title: "Important Safety Information",
+  warnings: [
+    {
+      icon: "flask",
+      title: "Experimental Software",
+      text: "This is experimental software.",
+    },
+  ],
+  checkboxes: [
+    {
+      id: "checkbox_experimental",
+      label: "I understand this is experimental software",
+    },
+    {
+      id: "checkbox_not_medical_advice",
+      label: "I understand this is not medical advice",
+    },
+  ],
+  button_text: "I Understand & Accept",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetDisclaimerContent.mockResolvedValue(mockDisclaimerContent);
+});
+
+describe("AuthDisclaimerGate - Loading State", () => {
+  it("shows loading spinner while user data is being fetched", () => {
+    mockUseUserContext.mockReturnValue({
+      user: null,
+      isLoading: true,
+      error: null,
+      refreshUser: jest.fn(),
+    });
+
+    render(
+      <AuthDisclaimerGate>
+        <div data-testid="dashboard-content">Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    expect(screen.getByTestId("loader-icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("dashboard-content")).not.toBeInTheDocument();
+  });
+
+  it("does not flash the disclaimer modal during loading", () => {
+    mockUseUserContext.mockReturnValue({
+      user: null,
+      isLoading: true,
+      error: null,
+      refreshUser: jest.fn(),
+    });
+
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    expect(
+      screen.queryByText("Important Safety Information")
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("AuthDisclaimerGate - Acknowledged User", () => {
+  it("renders children when disclaimer_acknowledged is true", () => {
+    mockUseUserContext.mockReturnValue({
+      user: {
+        id: "1",
+        email: "test@example.com",
+        disclaimer_acknowledged: true,
+      },
+      isLoading: false,
+      error: null,
+      refreshUser: jest.fn(),
+    });
+
+    render(
+      <AuthDisclaimerGate>
+        <div data-testid="dashboard-content">Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    expect(screen.getByTestId("dashboard-content")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Important Safety Information")
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("AuthDisclaimerGate - Unacknowledged User", () => {
+  beforeEach(() => {
+    mockUseUserContext.mockReturnValue({
+      user: {
+        id: "1",
+        email: "test@example.com",
+        disclaimer_acknowledged: false,
+      },
+      isLoading: false,
+      error: null,
+      refreshUser: jest.fn(),
+    });
+  });
+
+  it("shows disclaimer modal when disclaimer_acknowledged is false", async () => {
+    render(
+      <AuthDisclaimerGate>
+        <div data-testid="dashboard-content">Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Important Safety Information")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("blocks dashboard content while disclaimer is shown", async () => {
+    render(
+      <AuthDisclaimerGate>
+        <div data-testid="dashboard-content">Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Important Safety Information")
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("dashboard-content")).not.toBeInTheDocument();
+  });
+
+  it("renders both required checkboxes", async () => {
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("I understand this is experimental software")
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("I understand this is not medical advice")
+    ).toBeInTheDocument();
+  });
+
+  it("disables the accept button until both checkboxes are checked", async () => {
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "I Understand & Accept" })
+      ).toBeInTheDocument();
+    });
+
+    const button = screen.getByRole("button", {
+      name: "I Understand & Accept",
+    });
+    expect(button).toBeDisabled();
+
+    // Check first checkbox
+    const checkboxes = screen.getAllByRole("checkbox");
+    await userEvent.click(checkboxes[0]);
+    expect(button).toBeDisabled();
+
+    // Check second checkbox
+    await userEvent.click(checkboxes[1]);
+    expect(button).not.toBeDisabled();
+  });
+
+  it("keeps accept button disabled when no checkboxes are checked", async () => {
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "I Understand & Accept" })
+      ).toBeInTheDocument();
+    });
+
+    const button = screen.getByRole("button", {
+      name: "I Understand & Accept",
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it("re-disables accept button when a checkbox is unchecked", async () => {
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "I Understand & Accept" })
+      ).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    const button = screen.getByRole("button", {
+      name: "I Understand & Accept",
+    });
+
+    // Check both
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(checkboxes[1]);
+    expect(button).not.toBeDisabled();
+
+    // Uncheck one
+    await userEvent.click(checkboxes[0]);
+    expect(button).toBeDisabled();
+  });
+});
+
+describe("AuthDisclaimerGate - Acknowledgment Flow", () => {
+  it("calls acknowledgeDisclaimerAuth and refreshUser on accept", async () => {
+    const mockRefreshUser = jest.fn().mockResolvedValue(undefined);
+    mockAcknowledgeDisclaimerAuth.mockResolvedValue({
+      success: true,
+      message: "ok",
+    });
+
+    mockUseUserContext.mockReturnValue({
+      user: {
+        id: "1",
+        email: "test@example.com",
+        disclaimer_acknowledged: false,
+      },
+      isLoading: false,
+      error: null,
+      refreshUser: mockRefreshUser,
+    });
+
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "I Understand & Accept" })
+      ).toBeInTheDocument();
+    });
+
+    // Check both checkboxes
+    const checkboxes = screen.getAllByRole("checkbox");
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(checkboxes[1]);
+
+    // Click accept
+    const button = screen.getByRole("button", {
+      name: "I Understand & Accept",
+    });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockAcknowledgeDisclaimerAuth).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(mockRefreshUser).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows saving state during acknowledgment", async () => {
+    let resolveAcknowledge: () => void;
+    mockAcknowledgeDisclaimerAuth.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveAcknowledge = resolve;
+      })
+    );
+
+    mockUseUserContext.mockReturnValue({
+      user: {
+        id: "1",
+        email: "test@example.com",
+        disclaimer_acknowledged: false,
+      },
+      isLoading: false,
+      error: null,
+      refreshUser: jest.fn(),
+    });
+
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "I Understand & Accept" })
+      ).toBeInTheDocument();
+    });
+
+    // Check both checkboxes
+    const checkboxes = screen.getAllByRole("checkbox");
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(checkboxes[1]);
+
+    // Click accept
+    await userEvent.click(
+      screen.getByRole("button", { name: "I Understand & Accept" })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Saving...")).toBeInTheDocument();
+    });
+
+    // Clean up
+    resolveAcknowledge!();
+  });
+
+  it("shows error on API failure", async () => {
+    mockAcknowledgeDisclaimerAuth.mockRejectedValue(
+      new Error("Network error")
+    );
+
+    mockUseUserContext.mockReturnValue({
+      user: {
+        id: "1",
+        email: "test@example.com",
+        disclaimer_acknowledged: false,
+      },
+      isLoading: false,
+      error: null,
+      refreshUser: jest.fn(),
+    });
+
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "I Understand & Accept" })
+      ).toBeInTheDocument();
+    });
+
+    // Check both checkboxes
+    const checkboxes = screen.getAllByRole("checkbox");
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(checkboxes[1]);
+
+    // Click accept
+    await userEvent.click(
+      screen.getByRole("button", { name: "I Understand & Accept" })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Network error")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("AuthDisclaimerGate - Fallback Content", () => {
+  it("uses fallback content when API fails to load disclaimer", async () => {
+    mockGetDisclaimerContent.mockRejectedValue(new Error("API error"));
+
+    mockUseUserContext.mockReturnValue({
+      user: {
+        id: "1",
+        email: "test@example.com",
+        disclaimer_acknowledged: false,
+      },
+      isLoading: false,
+      error: null,
+      refreshUser: jest.fn(),
+    });
+
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Important Safety Information")
+      ).toBeInTheDocument();
+    });
+
+    // Fallback should still have both checkboxes
+    expect(screen.getAllByRole("checkbox")).toHaveLength(2);
+  });
+});
+
+describe("AuthDisclaimerGate - No User", () => {
+  it("renders children when user is null (auth redirect handles this)", () => {
+    mockUseUserContext.mockReturnValue({
+      user: null,
+      isLoading: false,
+      error: "Not authenticated",
+      refreshUser: jest.fn(),
+    });
+
+    render(
+      <AuthDisclaimerGate>
+        <div data-testid="dashboard-content">Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    // When user is null and not loading, render children
+    // (middleware/apiFetch will handle the redirect)
+    expect(screen.getByTestId("dashboard-content")).toBeInTheDocument();
+  });
+});
+
+describe("AuthDisclaimerGate - Accessibility", () => {
+  it("renders modal with proper ARIA attributes", async () => {
+    mockUseUserContext.mockReturnValue({
+      user: {
+        id: "1",
+        email: "test@example.com",
+        disclaimer_acknowledged: false,
+      },
+      isLoading: false,
+      error: null,
+      refreshUser: jest.fn(),
+    });
+
+    render(
+      <AuthDisclaimerGate>
+        <div>Dashboard</div>
+      </AuthDisclaimerGate>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "disclaimer-title");
+  });
+});

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@
  * Story 4.5: Real-Time Updates via SSE
  * Story 4.6: Dashboard Accessibility
  * Story 6.3: Tiered Alert Delivery
+ * Story 15.5: Post-Login Disclaimer Enforcement
  * Wraps all dashboard pages with the DashboardLayout component,
  * AlertNotificationProvider (which includes GlucoseStreamProvider)
  * for real-time glucose data and alert notifications.
@@ -14,6 +15,7 @@
  */
 
 import { DashboardLayout } from "@/components/layout";
+import { AuthDisclaimerGate } from "@/components/auth-disclaimer-gate";
 import { AlertNotificationProvider, UserProvider } from "@/providers";
 
 /**
@@ -36,9 +38,11 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     <>
       <SkipLink />
       <UserProvider>
-        <AlertNotificationProvider>
-          <DashboardLayout>{children}</DashboardLayout>
-        </AlertNotificationProvider>
+        <AuthDisclaimerGate>
+          <AlertNotificationProvider>
+            <DashboardLayout>{children}</DashboardLayout>
+          </AlertNotificationProvider>
+        </AuthDisclaimerGate>
       </UserProvider>
     </>
   );

--- a/apps/web/src/components/auth-disclaimer-gate.tsx
+++ b/apps/web/src/components/auth-disclaimer-gate.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+/**
+ * Story 15.5: Auth Disclaimer Gate
+ *
+ * Blocks dashboard access until the authenticated user acknowledges
+ * the safety disclaimer. Wraps children and shows a blocking overlay
+ * when user.disclaimer_acknowledged is false.
+ */
+
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  FlaskConical,
+  Brain,
+  ShieldOff,
+  Stethoscope,
+  AlertTriangle,
+  Check,
+  Loader2,
+} from "lucide-react";
+import { useUserContext } from "@/providers/user-provider";
+import {
+  acknowledgeDisclaimerAuth,
+  getDisclaimerContent,
+  type DisclaimerContent,
+} from "@/lib/api";
+
+const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+  flask: FlaskConical,
+  brain: Brain,
+  "shield-x": ShieldOff,
+  stethoscope: Stethoscope,
+};
+
+export function AuthDisclaimerGate({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { user, isLoading, refreshUser } = useUserContext();
+  const [content, setContent] = useState<DisclaimerContent | null>(null);
+  const [checkboxes, setCheckboxes] = useState<Record<string, boolean>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [contentLoading, setContentLoading] = useState(true);
+
+  const needsDisclaimer = !isLoading && user && !user.disclaimer_acknowledged;
+
+  // Fetch disclaimer content when the gate determines it's needed
+  useEffect(() => {
+    if (!needsDisclaimer) {
+      setContentLoading(false);
+      return;
+    }
+
+    async function fetchContent() {
+      try {
+        const disclaimerContent = await getDisclaimerContent();
+        setContent(disclaimerContent);
+        const initialCheckboxes: Record<string, boolean> = {};
+        disclaimerContent.checkboxes.forEach((cb) => {
+          initialCheckboxes[cb.id] = false;
+        });
+        setCheckboxes(initialCheckboxes);
+      } catch {
+        // Use fallback content on error
+        setContent(null);
+        setCheckboxes({
+          checkbox_experimental: false,
+          checkbox_not_medical_advice: false,
+        });
+      } finally {
+        setContentLoading(false);
+      }
+    }
+
+    fetchContent();
+  }, [needsDisclaimer]);
+
+  // While user is loading, show a centered spinner (don't flash the modal)
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-slate-950">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+      </div>
+    );
+  }
+
+  // User acknowledged or no user (will be handled by auth redirect)
+  if (!needsDisclaimer) {
+    return <>{children}</>;
+  }
+
+  // Loading disclaimer content
+  if (contentLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-slate-950">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+      </div>
+    );
+  }
+
+  const handleCheckboxChange = (id: string) => {
+    setCheckboxes((prev) => ({
+      ...prev,
+      [id]: !prev[id],
+    }));
+    setError(null);
+  };
+
+  const allChecked =
+    Object.keys(checkboxes).length > 0 &&
+    Object.values(checkboxes).every(Boolean);
+
+  const handleAccept = async () => {
+    if (!allChecked) {
+      setError("Please check both acknowledgment boxes to continue");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await acknowledgeDisclaimerAuth();
+      await refreshUser();
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to save acknowledgment. Please try again."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Fallback content if API failed
+  const displayContent: DisclaimerContent = content ?? {
+    version: "1.0",
+    title: "Important Safety Information",
+    warnings: [
+      {
+        icon: "flask",
+        title: "Experimental Software",
+        text: "This is experimental open-source software. It has not been validated for clinical use and may contain bugs or errors.",
+      },
+      {
+        icon: "brain",
+        title: "AI Limitations",
+        text: "AI can and will make mistakes. All suggestions should be verified with your healthcare provider before acting on them.",
+      },
+      {
+        icon: "shield-x",
+        title: "Not FDA Approved",
+        text: "This software is not FDA approved for medical use. It is not intended to diagnose, treat, cure, or prevent any disease.",
+      },
+      {
+        icon: "stethoscope",
+        title: "Consult Your Healthcare Provider",
+        text: "Always consult your healthcare provider before making any changes to your diabetes management regimen.",
+      },
+    ],
+    checkboxes: [
+      {
+        id: "checkbox_experimental",
+        label:
+          "I understand this is experimental software and that AI suggestions may be incorrect",
+      },
+      {
+        id: "checkbox_not_medical_advice",
+        label:
+          "I understand this is not medical advice and I will consult my healthcare provider before making any changes",
+      },
+    ],
+    button_text: "I Understand & Accept",
+  };
+
+  return (
+    <AnimatePresence>
+      {/* Backdrop */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50"
+      />
+
+      {/* Modal */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 20 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 20 }}
+        transition={{ type: "spring", duration: 0.5 }}
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <div
+          className="bg-slate-900 border border-slate-700 rounded-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto shadow-2xl"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="disclaimer-title"
+        >
+          {/* Header */}
+          <div className="p-6 border-b border-slate-700">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-amber-500/20 rounded-lg">
+                <AlertTriangle className="w-6 h-6 text-amber-500" />
+              </div>
+              <h2
+                id="disclaimer-title"
+                className="text-xl font-semibold text-white"
+              >
+                {displayContent.title}
+              </h2>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="p-6 space-y-4">
+            {displayContent.warnings.map((warning, index) => {
+              const Icon = iconMap[warning.icon] || AlertTriangle;
+              return (
+                <motion.div
+                  key={index}
+                  initial={{ opacity: 0, x: -20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ delay: index * 0.1 }}
+                  className="flex gap-4 p-4 bg-slate-800/50 rounded-lg border border-slate-700"
+                >
+                  <div className="flex-shrink-0">
+                    <Icon className="w-5 h-5 text-amber-500" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium text-white mb-1">
+                      {warning.title}
+                    </h3>
+                    <p className="text-sm text-gray-400">{warning.text}</p>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+
+          {/* Checkboxes */}
+          <div className="px-6 pb-4 space-y-3">
+            {displayContent.checkboxes.map((checkbox) => (
+              <label
+                key={checkbox.id}
+                className="flex items-start gap-3 cursor-pointer group"
+              >
+                <div
+                  className={`
+                    flex-shrink-0 w-5 h-5 mt-0.5 rounded border-2 transition-all
+                    flex items-center justify-center
+                    ${
+                      checkboxes[checkbox.id]
+                        ? "bg-blue-600 border-blue-600"
+                        : "border-slate-500 group-hover:border-slate-400"
+                    }
+                  `}
+                  onClick={() => handleCheckboxChange(checkbox.id)}
+                >
+                  {checkboxes[checkbox.id] && (
+                    <Check className="w-3 h-3 text-white" />
+                  )}
+                </div>
+                <input
+                  type="checkbox"
+                  checked={checkboxes[checkbox.id] ?? false}
+                  onChange={() => handleCheckboxChange(checkbox.id)}
+                  className="sr-only"
+                />
+                <span className="text-sm text-gray-300">{checkbox.label}</span>
+              </label>
+            ))}
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="px-6 pb-4">
+              <p className="text-sm text-red-400">{error}</p>
+            </div>
+          )}
+
+          {/* Footer */}
+          <div className="p-6 border-t border-slate-700">
+            <button
+              onClick={handleAccept}
+              disabled={!allChecked || isSubmitting}
+              className={`
+                w-full py-3 px-4 rounded-lg font-medium transition-all
+                ${
+                  allChecked && !isSubmitting
+                    ? "bg-blue-600 hover:bg-blue-700 text-white"
+                    : "bg-slate-700 text-slate-400 cursor-not-allowed"
+                }
+              `}
+            >
+              {isSubmitting ? "Saving..." : displayContent.button_text}
+            </button>
+          </div>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/apps/web/src/hooks/use-current-user.ts
+++ b/apps/web/src/hooks/use-current-user.ts
@@ -3,17 +3,20 @@
  *
  * Fetches and caches the current user's profile (id, email, role).
  * Used by dashboard pages to determine role-based rendering.
+ *
+ * Story 15.5: Added refreshUser to allow re-fetching after disclaimer acknowledgment.
  */
 
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getCurrentUser, type CurrentUserResponse } from "@/lib/api";
 
 interface UseCurrentUserReturn {
   user: CurrentUserResponse | null;
   isLoading: boolean;
   error: string | null;
+  refreshUser: () => Promise<void>;
 }
 
 export function useCurrentUser(): UseCurrentUserReturn {
@@ -51,5 +54,15 @@ export function useCurrentUser(): UseCurrentUserReturn {
     };
   }, []);
 
-  return { user, isLoading, error };
+  const refreshUser = useCallback(async () => {
+    try {
+      const data = await getCurrentUser();
+      setUser(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch user");
+    }
+  }, []);
+
+  return { user, isLoading, error, refreshUser };
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -217,6 +217,29 @@ export async function getDisclaimerContent(): Promise<DisclaimerContent> {
 }
 
 /**
+ * Acknowledge the disclaimer for the authenticated user.
+ * Story 15.5: Sets disclaimer_acknowledged=true on the user record.
+ */
+export async function acknowledgeDisclaimerAuth(): Promise<{
+  success: boolean;
+  message: string;
+}> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/disclaimer/acknowledge-auth`,
+    { method: "POST" }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to acknowledge disclaimer: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
  * AI Insights API types (Story 5.7)
  */
 export interface InsightSummary {

--- a/apps/web/src/providers/user-provider.tsx
+++ b/apps/web/src/providers/user-provider.tsx
@@ -6,6 +6,8 @@
  * Wraps the useCurrentUser hook in a React context so that
  * Sidebar, MobileNav, and page components share a single
  * GET /api/auth/me request instead of each firing their own.
+ *
+ * Story 15.5: Added refreshUser to context for disclaimer acknowledgment.
  */
 
 import { createContext, useContext } from "react";
@@ -16,12 +18,14 @@ interface UserContextValue {
   user: CurrentUserResponse | null;
   isLoading: boolean;
   error: string | null;
+  refreshUser: () => Promise<void>;
 }
 
 const UserContext = createContext<UserContextValue>({
   user: null,
   isLoading: true,
   error: null,
+  refreshUser: async () => {},
 });
 
 export function UserProvider({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- Add `AuthDisclaimerGate` component that blocks dashboard access until authenticated users acknowledge the safety disclaimer
- Add `POST /api/disclaimer/acknowledge-auth` backend endpoint that persists acknowledgment to the user record
- Add `refreshUser()` to `useCurrentUser` hook and `UserProvider` context for seamless post-acknowledge state update
- Wire gate into dashboard layout between `UserProvider` and `AlertNotificationProvider`

## Acceptance Criteria Verified
- **AC1:** New user with `disclaimer_acknowledged=false` sees blocking disclaimer modal
- **AC2:** User with `disclaimer_acknowledged=true` does NOT see the modal
- **AC3:** Modal blocks all dashboard interaction (renders modal instead of children)
- **AC4:** After acknowledging, dashboard becomes interactive without page reload
- **AC5:** Acknowledgment persisted to user account in database (not localStorage)
- **AC6:** After logout and re-login, disclaimer is NOT shown again

## Test Plan
- [x] 15 frontend tests (loading state, acknowledged user, unacknowledged user, acknowledgment flow, fallback content, accessibility)
- [x] 3 backend tests (auth required, sets flag + commits, idempotent)
- [x] Full frontend suite passes (591 tests, 27 suites)
- [x] Full backend suite passes (1025 tests)
- [x] Playwright MCP visual testing: register -> disclaimer modal shown -> acknowledge -> dashboard loads -> logout -> login -> no modal