### PR TITLE
feat: landing page auth navigation polish (Story 15.6)

### DIFF
--- a/apps/web/__tests__/invite-page.test.tsx
+++ b/apps/web/__tests__/invite-page.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Story 15.6: Invite Page Link Tests
+ *
+ * Tests that the invite accept page links point to /login instead of /.
+ */
+
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+// Mock next/navigation
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ token: "test-token-123" }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock lucide-react
+jest.mock("lucide-react", () => ({
+  UserPlus: ({ className }: { className?: string }) => (
+    <span data-testid="user-plus-icon" className={className} />
+  ),
+  Loader2: ({ className }: { className?: string }) => (
+    <span data-testid="loader-icon" className={className} />
+  ),
+  AlertTriangle: ({ className }: { className?: string }) => (
+    <span data-testid="alert-icon" className={className} />
+  ),
+  CheckCircle: ({ className }: { className?: string }) => (
+    <span data-testid="check-icon" className={className} />
+  ),
+  XCircle: ({ className }: { className?: string }) => (
+    <span data-testid="x-icon" className={className} />
+  ),
+  Clock: ({ className }: { className?: string }) => (
+    <span data-testid="clock-icon" className={className} />
+  ),
+  Eye: ({ className }: { className?: string }) => (
+    <span data-testid="eye-icon" className={className} />
+  ),
+  EyeOff: ({ className }: { className?: string }) => (
+    <span data-testid="eye-off-icon" className={className} />
+  ),
+}));
+
+// Mock API functions
+const mockGetInvitationDetails = jest.fn();
+const mockAcceptCaregiverInvitation = jest.fn();
+jest.mock("@/lib/api", () => ({
+  getInvitationDetails: (...args: unknown[]) =>
+    mockGetInvitationDetails(...args),
+  acceptCaregiverInvitation: (...args: unknown[]) =>
+    mockAcceptCaregiverInvitation(...args),
+}));
+
+import InviteAcceptPage from "@/app/invite/[token]/page";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("Invite Page - Log in link", () => {
+  it("shows 'Log in' link pointing to /login on the registration form", async () => {
+    mockGetInvitationDetails.mockResolvedValue({
+      patient_email: "patient@example.com",
+      status: "pending",
+      expires_at: new Date(Date.now() + 86400000).toISOString(),
+    });
+
+    render(<InviteAcceptPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/already have a caregiver account/i)).toBeInTheDocument();
+    });
+
+    const loginLink = screen.getByRole("link", { name: "Log in" });
+    expect(loginLink).toHaveAttribute("href", "/login");
+  });
+});
+
+describe("Invite Page - Error state links", () => {
+  it("shows 'Go to Home' link on error state pointing to /", async () => {
+    mockGetInvitationDetails.mockRejectedValue(new Error("Not found"));
+
+    render(<InviteAcceptPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid Invitation")).toBeInTheDocument();
+    });
+
+    const homeLink = screen.getByRole("link", { name: "Go to Home" });
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
+});
+
+describe("Invite Page - Post-accept redirect", () => {
+  it("redirects to /login after successful form submission", async () => {
+    mockGetInvitationDetails.mockResolvedValue({
+      patient_email: "patient@example.com",
+      status: "pending",
+      expires_at: new Date(Date.now() + 86400000).toISOString(),
+    });
+    mockAcceptCaregiverInvitation.mockResolvedValue({
+      message: "Success",
+      user_id: "123",
+    });
+
+    render(<InviteAcceptPage />);
+
+    // Wait for form to load
+    await waitFor(() => {
+      expect(screen.getByLabelText("Email Address")).toBeInTheDocument();
+    });
+
+    // Fill form fields
+    fireEvent.change(screen.getByLabelText("Email Address"), {
+      target: { value: "caregiver@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "Password123" },
+    });
+    fireEvent.change(screen.getByLabelText("Confirm Password"), {
+      target: { value: "Password123" },
+    });
+
+    // Submit form
+    fireEvent.click(
+      screen.getByRole("button", { name: /create account & accept/i })
+    );
+
+    // Wait for API call
+    await waitFor(() => {
+      expect(mockAcceptCaregiverInvitation).toHaveBeenCalledWith(
+        "test-token-123",
+        "caregiver@example.com",
+        "Password123"
+      );
+    });
+
+    // Advance timer past the 3-second redirect delay
+    jest.advanceTimersByTime(3000);
+
+    expect(mockPush).toHaveBeenCalledWith("/login");
+  });
+});
+
+describe("Invite Page - Already accepted state", () => {
+  it("shows 'Go to Home' link when invitation is already accepted", async () => {
+    mockGetInvitationDetails.mockResolvedValue({
+      patient_email: "patient@example.com",
+      status: "accepted",
+      expires_at: new Date(Date.now() + 86400000).toISOString(),
+    });
+
+    render(<InviteAcceptPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Already Accepted")).toBeInTheDocument();
+    });
+
+    const homeLink = screen.getByRole("link", { name: "Go to Home" });
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
+});

--- a/apps/web/__tests__/page.test.tsx
+++ b/apps/web/__tests__/page.test.tsx
@@ -1,26 +1,185 @@
 /**
  * Tests for the main page component.
  * Story 1.1 AC: Web UI accessible at localhost:3000
+ * Story 15.6: Landing page auth navigation polish
  */
 
-import { render, screen } from '@testing-library/react';
-import Home from '../src/app/page';
+import { render, screen, waitFor } from "@testing-library/react";
 
-describe('Home Page', () => {
-  it('renders the GlycemicGPT heading', () => {
+// Mock next/image
+jest.mock("next/image", () => {
+  return function MockImage({
+    alt,
+    ...props
+  }: {
+    alt: string;
+    [key: string]: unknown;
+  }) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img alt={alt} {...props} />;
+  };
+});
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+// Mock DisclaimerModal
+jest.mock("@/components/disclaimer-modal", () => ({
+  DisclaimerModal: () => <div data-testid="disclaimer-modal" />,
+}));
+
+// Mock getCurrentUser
+const mockGetCurrentUser = jest.fn();
+jest.mock("@/lib/api", () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+import Home from "../src/app/page";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Home Page", () => {
+  it("renders the GlycemicGPT heading", () => {
+    mockGetCurrentUser.mockRejectedValue(new Error("Not authenticated"));
     render(<Home />);
-    const heading = screen.getByRole('heading', { level: 1 });
-    expect(heading).toHaveTextContent('GlycemicGPT');
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("GlycemicGPT");
   });
 
-  it('renders the tagline', () => {
+  it("renders the tagline", () => {
+    mockGetCurrentUser.mockRejectedValue(new Error("Not authenticated"));
     render(<Home />);
-    expect(screen.getByText('Your on-call endo at home')).toBeInTheDocument();
+    expect(screen.getByText("Your on-call endo at home")).toBeInTheDocument();
+  });
+});
+
+describe("Home Page - Unauthenticated", () => {
+  beforeEach(() => {
+    mockGetCurrentUser.mockRejectedValue(new Error("Not authenticated"));
   });
 
-  it('renders the Get Started link', () => {
+  it("shows Sign In and Create Account buttons when not authenticated", async () => {
     render(<Home />);
-    const link = screen.getByRole('link', { name: /get started/i });
-    expect(link).toHaveAttribute('href', '/login');
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Sign In" })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("link", { name: "Create Account" })
+    ).toBeInTheDocument();
+  });
+
+  it("Sign In links to /login", async () => {
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Sign In" })).toHaveAttribute(
+        "href",
+        "/login"
+      );
+    });
+  });
+
+  it("Create Account links to /register", async () => {
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: "Create Account" })
+      ).toHaveAttribute("href", "/register");
+    });
+  });
+
+  it("does not show Go to Dashboard when unauthenticated", async () => {
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Sign In" })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("link", { name: "Go to Dashboard" })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Home Page - Authenticated", () => {
+  beforeEach(() => {
+    mockGetCurrentUser.mockResolvedValue({
+      id: "1",
+      email: "test@example.com",
+      disclaimer_acknowledged: true,
+    });
+  });
+
+  it("shows Go to Dashboard when authenticated", async () => {
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: "Go to Dashboard" })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("Go to Dashboard links to /dashboard", async () => {
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: "Go to Dashboard" })
+      ).toHaveAttribute("href", "/dashboard");
+    });
+  });
+
+  it("does not show Sign In or Create Account when authenticated", async () => {
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: "Go to Dashboard" })
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("link", { name: "Sign In" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Create Account" })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Home Page - Initial State", () => {
+  it("shows Sign In and Create Account by default while checking auth", () => {
+    // Make getCurrentUser hang (never resolve)
+    mockGetCurrentUser.mockReturnValue(new Promise(() => {}));
+
+    render(<Home />);
+
+    // While auth check is in progress (isAuthenticated === null), show sign in/register
+    expect(screen.getByRole("link", { name: "Sign In" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Create Account" })
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/invite/[token]/page.tsx
+++ b/apps/web/src/app/invite/[token]/page.tsx
@@ -93,7 +93,7 @@ export default function InviteAcceptPage() {
       setSuccess(true);
       // Redirect to login after 3 seconds
       setTimeout(() => {
-        router.push("/");
+        router.push("/login");
       }, 3000);
     } catch (err) {
       setFormError(
@@ -231,7 +231,7 @@ export default function InviteAcceptPage() {
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4" aria-label="Caregiver account registration">
           <div>
             <label
               htmlFor="email"
@@ -346,7 +346,7 @@ export default function InviteAcceptPage() {
 
         <p className="text-xs text-slate-500 text-center mt-4">
           Already have a caregiver account?{" "}
-          <Link href="/" className="text-blue-400 hover:text-blue-300">
+          <Link href="/login" className="text-blue-400 hover:text-blue-300">
             Log in
           </Link>{" "}
           first, then visit this link again.

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,13 +4,40 @@
  * GlycemicGPT Home Page.
  *
  * Story 1.3: First-Run Safety Disclaimer
+ * Story 15.6: Landing Page & Auth Navigation Polish
+ *
  * Shows the disclaimer modal on first visit.
+ * Detects auth state to show "Go to Dashboard" for authenticated users,
+ * or "Sign In" / "Create Account" buttons for visitors.
  */
 
+import { useState, useEffect } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { DisclaimerModal } from "@/components/disclaimer-modal";
+import { getCurrentUser } from "@/lib/api";
 
 export default function Home() {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkAuth() {
+      try {
+        await getCurrentUser();
+        if (!cancelled) setIsAuthenticated(true);
+      } catch {
+        if (!cancelled) setIsAuthenticated(false);
+      }
+    }
+
+    checkAuth();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <>
       <DisclaimerModal />
@@ -36,12 +63,29 @@ export default function Home() {
               pump data with actionable insights.
             </p>
             <div className="flex gap-4 justify-center">
-              <a
-                href="/login"
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
-              >
-                Get Started
-              </a>
+              {isAuthenticated ? (
+                <Link
+                  href="/dashboard"
+                  className="px-6 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors font-medium"
+                >
+                  Go to Dashboard
+                </Link>
+              ) : (
+                <>
+                  <Link
+                    href="/login"
+                    className="px-6 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors font-medium"
+                  >
+                    Sign In
+                  </Link>
+                  <Link
+                    href="/register"
+                    className="px-6 py-2 border border-slate-600 text-slate-300 hover:bg-slate-700 rounded-lg transition-colors font-medium"
+                  >
+                    Create Account
+                  </Link>
+                </>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Replace single "Get Started" CTA on the landing page with dual "Sign In" / "Create Account" buttons for unauthenticated visitors, and a single "Go to Dashboard" button for authenticated users
- Update invite acceptance page to redirect to `/login` instead of `/` after successful registration
- Fix the "Log in" link on the invite page to point to `/login`
- Add `aria-label` to the caregiver registration form for accessibility

## Test plan

- [x] 10 updated landing page tests covering authenticated, unauthenticated, and initial auth-check states
- [x] 4 new invite page tests covering login link href, error state links, form submission redirect, and already-accepted state
- [x] Full frontend suite passes (602 tests, 28 suites)
- [x] Playwright MCP visual verification of both auth states on the landing page
- [x] Verified navigation from Sign In -> /login and Create Account -> /register
- [x] Verified dashboard loads correctly for authenticated users