### PR TITLE
feat: add sidecar DB fields and null-safe API key handling (Story 15.7)

### DIFF
--- a/apps/api/migrations/versions/030_ai_provider_sidecar_fields.py
+++ b/apps/api/migrations/versions/030_ai_provider_sidecar_fields.py
@@ -1,0 +1,55 @@
+"""Add sidecar_provider column and make encrypted_api_key nullable.
+
+Subscription providers (claude_subscription, chatgpt_subscription) use
+the managed AI sidecar for authentication instead of user-provided API
+keys. This migration:
+
+1. Adds sidecar_provider (String, nullable) to track which sidecar
+   provider is active ("claude" or "codex").
+2. Makes encrypted_api_key nullable so subscription types can omit it.
+
+Revision ID: 030_ai_provider_sidecar_fields
+Revises: 029_insulin_config_bg_reading
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "030_ai_provider_sidecar_fields"
+down_revision = "029_insulin_config_bg_reading"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add sidecar_provider column (nullable — only set for subscription types)
+    op.add_column(
+        "ai_provider_configs",
+        sa.Column("sidecar_provider", sa.String(50), nullable=True),
+    )
+
+    # Make encrypted_api_key nullable for subscription types that use
+    # sidecar OAuth instead of a user-provided API key
+    op.alter_column(
+        "ai_provider_configs",
+        "encrypted_api_key",
+        existing_type=sa.Text(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Restore NOT NULL on encrypted_api_key (backfill NULLs first)
+    op.execute(
+        "UPDATE ai_provider_configs "
+        "SET encrypted_api_key = 'migrated-placeholder' "
+        "WHERE encrypted_api_key IS NULL"
+    )
+    op.alter_column(
+        "ai_provider_configs",
+        "encrypted_api_key",
+        existing_type=sa.Text(),
+        nullable=False,
+    )
+
+    op.drop_column("ai_provider_configs", "sidecar_provider")

--- a/apps/api/src/models/ai_provider.py
+++ b/apps/api/src/models/ai_provider.py
@@ -77,10 +77,16 @@ class AIProviderConfig(Base, TimestampMixin):
         nullable=False,
     )
 
-    # Encrypted API key
-    encrypted_api_key: Mapped[str] = mapped_column(
+    # Encrypted API key (nullable for subscription types using sidecar OAuth)
+    encrypted_api_key: Mapped[str | None] = mapped_column(
         Text,
-        nullable=False,
+        nullable=True,
+    )
+
+    # Which sidecar provider is active ("claude" or "codex"), null for non-subscription types
+    sidecar_provider: Mapped[str | None] = mapped_column(
+        String(50),
+        nullable=True,
     )
 
     # Optional model name override (e.g., "claude-sonnet-4-5-20250929", "gpt-4o")

--- a/apps/api/src/schemas/ai_provider.py
+++ b/apps/api/src/schemas/ai_provider.py
@@ -128,8 +128,10 @@ class AIProviderConfigResponse(BaseModel):
     status: AIProviderStatus
     model_name: str | None = None
     base_url: str | None = None
+    sidecar_provider: str | None = None
     masked_api_key: str = Field(
-        ..., description="Masked API key showing only last 4 characters"
+        ...,
+        description="Masked API key (last 4 chars) or 'sidecar-managed' for subscription types",
     )
     last_validated_at: datetime | None = None
     last_error: str | None = None

--- a/apps/api/src/services/ai_client.py
+++ b/apps/api/src/services/ai_client.py
@@ -119,7 +119,12 @@ async def get_ai_client(
             detail="No AI provider configured. Please configure an AI provider first.",
         )
 
-    api_key = decrypt_credential(config.encrypted_api_key)
+    # Subscription types using sidecar OAuth may have no stored API key;
+    # they use a placeholder key since the sidecar handles authentication.
+    if config.encrypted_api_key:
+        api_key = decrypt_credential(config.encrypted_api_key)
+    else:
+        api_key = "sidecar-managed"
     model = config.model_name or DEFAULT_MODELS.get(config.provider_type, "")
 
     if config.provider_type in _ANTHROPIC_SDK_TYPES:


### PR DESCRIPTION
## Summary

- Alembic migration 030: adds `sidecar_provider` column (String, nullable) and makes `encrypted_api_key` nullable on `ai_provider_configs`
- Model, schema, router, and client factory updated with null-safety for subscription providers using sidecar OAuth (no stored API key)
- `configure_ai_provider` now clears stale `sidecar_provider` when reconfiguring providers
- Response schema exposes `sidecar_provider` field
- 4 new tests covering all null-safety code paths

## Changes

**New file:**
- `apps/api/migrations/versions/030_ai_provider_sidecar_fields.py` - Alembic migration

**Modified:**
- `apps/api/src/models/ai_provider.py` - Nullable `encrypted_api_key`, new `sidecar_provider` column
- `apps/api/src/schemas/ai_provider.py` - Added `sidecar_provider` to response, updated `masked_api_key` description
- `apps/api/src/routers/ai.py` - Null-safe `get_ai_provider`, `test_ai_provider`, `_build_response`; clear stale `sidecar_provider` on reconfigure
- `apps/api/src/services/ai_client.py` - Null-safe `get_ai_client` factory
- `apps/api/tests/test_ai_provider.py` - 3 new sidecar null-safety tests
- `apps/api/tests/test_ai_client.py` - 1 new factory null-safety test

## Test plan

- [x] Backend: 1067 passed, 1 skipped
- [x] Sidecar: 40 passed
- [x] Frontend: 641 passed
- [x] Ruff lint/format: all checks passed
- [x] Migration runs cleanly (upgrade + downgrade paths)
- [x] Playwright MCP visual verification: dashboard, settings, AI provider pages render correctly
- [x] Adversarial review: 4 findings fixed, 6 deferred to Story 15.4