### PR TITLE
feat: refactor AI provider backend for sidecar auto-routing (Story 15.4)

### DIFF
--- a/apps/api/src/schemas/ai_provider.py
+++ b/apps/api/src/schemas/ai_provider.py
@@ -173,6 +173,47 @@ class AIChatResponse(BaseModel):
     )
 
 
+# ── Story 15.4: Subscription Configuration ──
+
+# Subscription provider types that use the managed sidecar
+_SUBSCRIPTION_TYPES = {
+    AIProviderType.CLAUDE_SUBSCRIPTION,
+    AIProviderType.CHATGPT_SUBSCRIPTION,
+}
+
+# Map sidecar provider names to AIProviderType
+SIDECAR_PROVIDER_MAP: dict[str, AIProviderType] = {
+    "claude": AIProviderType.CLAUDE_SUBSCRIPTION,
+    "codex": AIProviderType.CHATGPT_SUBSCRIPTION,
+}
+
+
+class SubscriptionConfigureRequest(BaseModel):
+    """Request schema for configuring a subscription provider via sidecar.
+
+    Unlike AIProviderConfigRequest, this does not require api_key or base_url.
+    The sidecar handles authentication and the API auto-populates the base_url.
+    """
+
+    sidecar_provider: str = Field(
+        ..., description="Sidecar provider name: 'claude' or 'codex'"
+    )
+    model_name: str | None = Field(
+        default=None,
+        max_length=100,
+        description="Optional model name override",
+    )
+
+    @model_validator(mode="after")
+    def validate_provider(self) -> "SubscriptionConfigureRequest":
+        if self.sidecar_provider not in SIDECAR_PROVIDER_MAP:
+            raise ValueError(
+                f"Invalid sidecar provider '{self.sidecar_provider}'. "
+                f"Must be one of: {', '.join(sorted(SIDECAR_PROVIDER_MAP))}."
+            )
+        return self
+
+
 # ── Story 15.2: Subscription Auth Schemas ──
 
 VALID_SIDECAR_PROVIDERS = {"claude", "codex"}


### PR DESCRIPTION
## Summary

- Add `POST /api/ai/subscription/configure` endpoint that validates sidecar health/auth and creates provider config without requiring manual base_url or api_key
- Auto-route subscription provider types (Claude/ChatGPT Subscription) through the managed ai-sidecar container in the AI client factory
- Add `SubscriptionConfigureRequest` schema with sidecar provider name validation via `SIDECAR_PROVIDER_MAP`
- Add `validate_sidecar_connection()` in sidecar service with `_VALID_SIDECAR_PROVIDERS` guard for provider name validation
- Revoke sidecar auth on provider deletion when `sidecar_provider` is set, with warning log on revocation failure
- Distinguish 502 (sidecar unreachable) from 400 (validation/auth errors) in subscription configure responses
- Test provider fallback returns `success=False` and sets ERROR status when no API key and no sidecar configuration

## Test plan

- [x] All 1084 backend tests pass (`uv run pytest`)
- [x] Ruff lint and format pass
- [x] Two rounds of adversarial code review with all actionable findings fixed
- [x] Playwright MCP visual verification: dashboard and AI provider page render correctly
- [x] Subscription configure: validates sidecar health, auth status, rejects unknown providers
- [x] Client factory: auto-routes subscriptions through sidecar URL, preserves explicit base_url
- [x] Delete: revokes sidecar auth, succeeds even if revocation fails
- [x] Auth: subscription configure endpoint requires authentication (401)
- [x] Sidecar unreachable returns 502, not 400