### PR TITLE
feat: refactor AI provider frontend for sidecar subscription UX (Story 15.5)

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1843,6 +1843,7 @@ export interface AIProviderConfigResponse {
   status: AIProviderStatus;
   model_name: string | null;
   base_url: string | null;
+  sidecar_provider: SidecarProviderName | null;
   masked_api_key: string;
   last_validated_at: string | null;
   last_error: string | null;
@@ -1924,6 +1925,38 @@ export async function deleteAIProvider(): Promise<AIProviderDeleteResponse> {
   return response.json();
 }
 
+// ── Story 15.4: Subscription Configure ──
+
+export type SidecarProviderName = "claude" | "codex";
+
+export interface SubscriptionConfigureRequest {
+  sidecar_provider: SidecarProviderName;
+  model_name?: string | null;
+}
+
+export async function configureSubscriptionProvider(
+  request: SubscriptionConfigureRequest
+): Promise<AIProviderConfigResponse> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/ai/subscription/configure`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail ||
+        `Failed to configure subscription provider: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
 // ── Story 15.2: Subscription Auth ──
 
 export interface SubscriptionAuthStartResponse {
@@ -1952,7 +1985,7 @@ export interface SidecarHealthResponse {
 }
 
 export async function startSubscriptionAuth(
-  provider: string
+  provider: SidecarProviderName
 ): Promise<SubscriptionAuthStartResponse> {
   const response = await apiFetch(
     `${API_BASE_URL}/api/ai/subscription/auth/start`,
@@ -1974,7 +2007,7 @@ export async function startSubscriptionAuth(
 }
 
 export async function submitSubscriptionToken(
-  provider: string,
+  provider: SidecarProviderName,
   token: string
 ): Promise<SubscriptionAuthTokenResponse> {
   const response = await apiFetch(
@@ -2012,7 +2045,7 @@ export async function getSubscriptionAuthStatus(): Promise<SubscriptionAuthStatu
 }
 
 export async function revokeSubscriptionAuth(
-  provider: string
+  provider: SidecarProviderName
 ): Promise<void> {
   const response = await apiFetch(
     `${API_BASE_URL}/api/ai/subscription/auth/revoke`,


### PR DESCRIPTION
## Summary

- Refactors the AI Provider settings page to show sidecar-managed subscription UX for Claude Subscription and ChatGPT Subscription providers
- Adds `configureSubscriptionProvider` API function with `SidecarProviderName` type safety ("claude" | "codex")
- Auto-configures DB provider config after successful token submission to sidecar
- Shows "Managed by sidecar" with Wifi icon instead of masked API key for sidecar-managed providers
- Adds model name field always visible for subscription providers (before and after auth)
- Adds confirmation dialog for "Sign out" since it now revokes sidecar auth AND deletes DB config
- Clears error/success banners on provider switch to prevent stale cross-provider messages
- Adds loading spinner on "Sign in" button during auth start
- Adds maxLength={5000} on token textarea matching backend Pydantic validation
- Refreshes subscription auth state after provider deletion via "Remove AI Provider"

## Files Changed

- `apps/web/src/lib/api.ts` - New `SidecarProviderName` type, `SubscriptionConfigureRequest` interface, `configureSubscriptionProvider` function, typed auth function params, `sidecar_provider` field on response
- `apps/web/src/app/dashboard/settings/ai-provider/page.tsx` - Sidecar subscription UX with auto-configure, confirmation dialogs, loading states, and form state management

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Backend tests pass (1084 passed, 1 skipped)
- [ ] AI Provider page renders correctly in offline mode (Playwright MCP verified)
- [ ] Dashboard renders without regressions (Playwright MCP verified)
- [ ] Subscription provider descriptions show "built-in AI sidecar" text
- [ ] Claude API (default) shows API key and model name fields
- [ ] Provider switch clears error/success banners
- [ ] Direct API and self-hosted provider UX unchanged