### PR TITLE
feat: enhance AI Chat with comprehensive pump data context (Story 15.7)

### DIFF
--- a/_bmad-output/PROGRESS.md
+++ b/_bmad-output/PROGRESS.md
@@ -20,13 +20,13 @@
 | 12 | Integration & Communication Config | 4/4 | **Complete** |
 | 13 | E2E Testing & Real Data Verification | 3/3 | **Complete** |
 | 14 | Expanded AI Provider Support | 0/4 | **In Progress** |
-| 15 | Frontend Auth UI & Route Protection | 0/6 | **Pending** |
+| 15 | Frontend Auth UI & Route Protection | 6/8 | **In Progress** |
 
 **MVP Stories:** 54/54 complete (100%)
 **Post-MVP Fix Stories:** 13/13 complete (100%)
 **Epic 14 (AI Provider Expansion):** 0/4 in progress
-**Epic 15 (Frontend Auth UI):** 0/6 pending
-**Overall Progress:** 67/77 stories complete (87%)
+**Epic 15 (Frontend Auth UI):** 6/8 in progress
+**Overall Progress:** 73/79 stories complete (92%)
 
 ---
 
@@ -288,9 +288,11 @@ All 5 stories completed:
 
 **Epic Details:** [epic-15-frontend-auth-ui.md](planning-artifacts/epic-15-frontend-auth-ui.md)
 
-- [ ] Story 15.1: Login Page
-- [ ] Story 15.2: Registration Page
-- [ ] Story 15.3: Next.js Auth Middleware & Route Protection
-- [ ] Story 15.4: Logout, Auth State & Global 401 Handling
-- [ ] Story 15.5: Post-Login Disclaimer Enforcement
-- [ ] Story 15.6: Landing Page & Auth Navigation Polish
+- [x] Story 15.1: Login Page - [PR #147](https://github.com/jlengelbrecht/GlycemicGPT/pull/147)
+- [x] Story 15.2: Registration Page - [PR #149](https://github.com/jlengelbrecht/GlycemicGPT/pull/149)
+- [x] Story 15.3: Next.js Auth Middleware & Route Protection - [PR #151](https://github.com/jlengelbrecht/GlycemicGPT/pull/151)
+- [x] Story 15.4: Logout, Auth State & Global 401 Handling - [PR #153](https://github.com/jlengelbrecht/GlycemicGPT/pull/153)
+- [x] Story 15.5: Post-Login Disclaimer Enforcement - [PR #157](https://github.com/jlengelbrecht/GlycemicGPT/pull/157)
+- [x] Story 15.6: Landing Page & Auth Navigation Polish (implemented in prior stories)
+- [ ] Story 15.7: Enhance AI Chat with Comprehensive Pump Data Context
+- [ ] Story 15.8: Sync Pump Settings & Therapy Data from Tandem APIs

--- a/apps/api/tests/test_caregiver_ai_chat.py
+++ b/apps/api/tests/test_caregiver_ai_chat.py
@@ -245,9 +245,9 @@ class TestHandleCaregiverChatWeb:
                 return_value=mock_client,
             ),
             patch(
-                "src.services.telegram_chat._build_glucose_context",
+                "src.services.telegram_chat._build_diabetes_context",
                 new_callable=AsyncMock,
-                return_value="Recent glucose data: 120 mg/dL",
+                return_value="[Glucose - last 6h]\n- Current: 120 mg/dL",
             ),
         ):
             result = await handle_caregiver_chat_web(
@@ -301,7 +301,7 @@ class TestHandleCaregiverChatWeb:
                 return_value=mock_client,
             ),
             patch(
-                "src.services.telegram_chat._build_glucose_context",
+                "src.services.telegram_chat._build_diabetes_context",
                 new_callable=AsyncMock,
                 return_value="",
             ),


### PR DESCRIPTION
## Summary

- Rename `_build_glucose_context()` to `_build_diabetes_context()` with 5 independently resilient section builders: glucose (6h window expanded from 2h), IoB projections, pump activity (manual boluses, auto-corrections, basal adjustments), Control-IQ summary (24h automated events, suspends, mode breakdown), and user settings (target range, insulin config)
- Fix `_normalize_pump_event()` to properly extract units and automation flags from tconnectsync Event IDs 279 (LidBasalDelivery) and 280 (LidBolusDelivery) which use milliunits and different field names than the normalizer expected -- previously all pump events were stored with NULL units and `is_automated=false`
- Update system prompts across all 4 chat handlers (web user, telegram user, web caregiver, telegram caregiver) to allow discussing pump patterns, Control-IQ behavior, and settings optimization while framing observations as things to discuss with the user's endocrinologist

## Test plan

- [x] All 1105 backend tests pass (47 telegram_chat, 13 caregiver_ai_chat, 48 tandem_sync)
- [x] 20 new section builder tests covering all 5 builders (glucose, IoB, pump, Control-IQ, settings)
- [x] Ruff lint and format clean
- [x] Full Docker stack verified healthy (db, redis, ai-sidecar, api, web)
- [x] End-to-end: AI Chat asked "What has Control-IQ been doing?" -- response includes specific auto-correction counts/units, basal adjustment breakdown, suspend counts, and pattern observations with recommendations to discuss with endo
- [x] Verified AI no longer says "I don't have visibility into Control-IQ automation actions"