### PR TITLE
feat: sync pump settings profiles from Tandem API (Story 15.8)

### DIFF
--- a/apps/api/migrations/versions/031_create_pump_profiles.py
+++ b/apps/api/migrations/versions/031_create_pump_profiles.py
@@ -1,0 +1,72 @@
+"""Create pump_profiles table for storing Tandem pump settings profiles.
+
+Stores time-segmented pump profiles (basal rates, correction factors,
+carb ratios, target BG) synced from Tandem t:connect API.
+
+Revision ID: 031_create_pump_profiles
+Revises: 030_ai_provider_sidecar_fields
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "031_create_pump_profiles"
+down_revision = "030_ai_provider_sidecar_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pump_profiles",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("profile_name", sa.String(100), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("segments", postgresql.JSONB(), nullable=False, server_default="[]"),
+        sa.Column("insulin_duration_min", sa.Integer(), nullable=True),
+        sa.Column("carb_entry_enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("max_bolus_units", sa.Float(), nullable=True),
+        sa.Column("cgm_high_alert_mgdl", sa.Integer(), nullable=True),
+        sa.Column("cgm_low_alert_mgdl", sa.Integer(), nullable=True),
+        sa.Column(
+            "synced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "profile_name", name="uq_pump_profile_user_name"),
+    )
+    op.create_index(
+        "ix_pump_profiles_user_id",
+        "pump_profiles",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pump_profiles_user_id", table_name="pump_profiles")
+    op.drop_table("pump_profiles")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -26,6 +26,7 @@ from src.models.integration import (
 )
 from src.models.meal_analysis import MealAnalysis
 from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.pump_profile import PumpProfile
 from src.models.safety_log import SafetyLog
 from src.models.suggestion_response import SuggestionResponse
 from src.models.target_glucose_range import TargetGlucoseRange
@@ -64,6 +65,7 @@ __all__ = [
     "NotificationStatus",
     "PumpEvent",
     "PumpEventType",
+    "PumpProfile",
     "SafetyLog",
     "SuggestionResponse",
     "TargetGlucoseRange",

--- a/apps/api/src/models/pump_profile.py
+++ b/apps/api/src/models/pump_profile.py
@@ -1,0 +1,109 @@
+"""Story 15.8: Pump profile model.
+
+Stores pump settings profiles synced from Tandem t:connect, including
+time-segmented basal rates, correction factors, carb ratios, and target BG.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, TimestampMixin
+
+
+class PumpProfile(Base, TimestampMixin):
+    """Stores a pump settings profile from Tandem t:connect.
+
+    Each profile contains time-segmented insulin delivery settings
+    (basal rates, correction factors, carb ratios, target BG) stored
+    as a JSONB array in the segments column.
+    """
+
+    __tablename__ = "pump_profiles"
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "profile_name", name="uq_pump_profile_user_name"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    profile_name: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+    )
+
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
+
+    # Time-segmented settings as JSONB array
+    # Each element: {time, start_minutes, basal_rate, correction_factor,
+    #                carb_ratio, target_bg}
+    segments: Mapped[list] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=list,
+    )
+
+    insulin_duration_min: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+
+    carb_entry_enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        nullable=False,
+    )
+
+    max_bolus_units: Mapped[float | None] = mapped_column(
+        Float,
+        nullable=True,
+    )
+
+    cgm_high_alert_mgdl: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+
+    cgm_low_alert_mgdl: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+
+    synced_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    user = relationship("User", back_populates="pump_profiles")
+
+    def __repr__(self) -> str:
+        return (
+            f"<PumpProfile(user_id={self.user_id}, name={self.profile_name!r}, "
+            f"active={self.is_active}, segments={len(self.segments or [])})>"
+        )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -102,6 +102,11 @@ class User(Base, TimestampMixin):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    pump_profiles = relationship(
+        "PumpProfile",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
     ai_provider_config = relationship(
         "AIProviderConfig",
         back_populates="user",

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -769,6 +769,7 @@ async def sync_tandem_data(
             message="Sync completed successfully",
             events_fetched=result["events_fetched"],
             events_stored=result["events_stored"],
+            profiles_stored=result.get("profiles_stored", 0),
             last_event=last_event,
         )
 

--- a/apps/api/src/schemas/pump.py
+++ b/apps/api/src/schemas/pump.py
@@ -44,6 +44,7 @@ class TandemSyncResponse(BaseModel):
     message: str
     events_fetched: int
     events_stored: int
+    profiles_stored: int = 0
     last_event: PumpEventResponse | None = None
 
 


### PR DESCRIPTION
## Summary

- Extracts pump profiles (basal rates, correction factors, carb ratios, target BG, CGM alerts) from Tandem t:connect metadata during existing sync flow and stores them in a new `pump_profiles` table
- Surfaces the active pump profile in AI chat context so the AI can reference programmed pump settings when answering questions about insulin management
- Hardened against malformed API data with per-profile try/except, defensive attribute access, null byte sanitization, and profile name truncation

## Changes

### New files
- `apps/api/src/models/pump_profile.py` - PumpProfile SQLAlchemy model with JSONB segments column and TimestampMixin
- `apps/api/migrations/versions/031_create_pump_profiles.py` - Migration creating pump_profiles table with upsert constraint

### Modified files
- `apps/api/src/services/tandem_sync.py` - `fetch_with_retry()` now returns raw settings alongside events; new `_store_pump_settings()` function parses PumpSettings dataclass, converts milliunits to units, and upserts profiles
- `apps/api/src/services/telegram_chat.py` - New `_build_pump_profile_section()` adds active profile as 6th context section for AI chat
- `apps/api/src/schemas/pump.py` - Added `profiles_stored` field to TandemSyncResponse
- `apps/api/src/routers/integrations.py` - Passes profiles_stored from sync result
- `apps/api/src/models/__init__.py` - Exports PumpProfile
- `apps/api/src/models/user.py` - Added pump_profiles relationship

### Tests
- `apps/api/tests/test_tandem_sync.py` - 10 new tests: profile storage, milliunits conversion, time conversion, CGM alerts, upsert behavior, settings extraction, graceful degradation
- `apps/api/tests/test_telegram_chat.py` - 6 new tests: profile section formatting, None handling, empty segments, CGM alerts display

## Design decisions
- JSONB segments column avoids a junction table since profiles are always displayed as a unit
- ON CONFLICT DO UPDATE on (user_id, profile_name) for idempotent upserts
- Profile sync failure does not block pump event sync (graceful degradation)
- Uses `scalars().first()` instead of `scalar_one_or_none()` to handle potential data corruption gracefully

## Test plan
- [x] All 111 targeted tests pass (test_tandem_sync.py + test_telegram_chat.py)
- [x] Full backend suite passes (1121 passed, 1 skipped)
- [x] Ruff lint and format clean
- [x] Docker stack builds and runs (API healthy, migration applied)
- [x] Playwright visual verification: Landing, Dashboard, AI Chat, Settings, Alerts all render correctly
- [x] Adversarial review completed and all findings fixed
- [x] Re-review confirmed all fixes properly implemented