### PR TITLE
fix: convert carbRatio from milliunits in Tandem pump profile sync

### DIFF
--- a/apps/api/src/services/tandem_sync.py
+++ b/apps/api/src/services/tandem_sync.py
@@ -586,13 +586,14 @@ async def _store_pump_settings(
                     time_str = f"{display_hour}:{minutes:02d} {period}"
 
                     basal_raw = getattr(seg, "basalRate", 0) or 0
+                    cr_raw = getattr(seg, "carbRatio", 0) or 0
                     segments.append(
                         {
                             "time": time_str,
                             "start_minutes": start_time,
                             "basal_rate": float(basal_raw) / 1000.0,
                             "correction_factor": int(getattr(seg, "isf", 0) or 0),
-                            "carb_ratio": int(getattr(seg, "carbRatio", 0) or 0),
+                            "carb_ratio": float(cr_raw) / 1000.0,
                             "target_bg": int(getattr(seg, "targetBg", 0) or 0),
                         }
                     )

--- a/apps/api/src/services/telegram_chat.py
+++ b/apps/api/src/services/telegram_chat.py
@@ -306,7 +306,7 @@ async def _build_pump_profile_section(
         cr = seg.get("carb_ratio") or 0
         tgt = seg.get("target_bg") or 0
         lines.append(
-            f"- {time_str}: Basal {basal:.3f} u/hr, CF 1:{cf}, CR 1:{cr}, Target {tgt}"
+            f"- {time_str}: Basal {basal:.3f} u/hr, CF 1:{cf}, CR 1:{cr:g}, Target {tgt}"
         )
 
     extras = []

--- a/apps/api/tests/test_tandem_sync.py
+++ b/apps/api/tests/test_tandem_sync.py
@@ -956,14 +956,14 @@ def _make_raw_settings(
                         "startTime": 0,
                         "basalRate": 1500,  # milliunits/hr -> 1.5 u/hr
                         "isf": 31,
-                        "carbRatio": 8,
+                        "carbRatio": 8000,  # milliunits -> 8.0
                         "targetBg": 110,
                     },
                     {
                         "startTime": 300,  # 5:00 AM
                         "basalRate": 1650,
                         "isf": 25,
-                        "carbRatio": 7,
+                        "carbRatio": 7000,  # milliunits -> 7.0
                         "targetBg": 110,
                     },
                 ],
@@ -1041,10 +1041,12 @@ class TestStorePumpSettings:
         params = stmt.compile().params
         # max_bolus should be 30.0 (30000 / 1000)
         assert params["max_bolus_units"] == 30.0
-        # Segments should have converted basal rates
+        # Segments should have converted basal rates and carb ratios
         segments = params["segments"]
         assert segments[0]["basal_rate"] == 1.5  # 1500 / 1000
         assert segments[1]["basal_rate"] == 1.65  # 1650 / 1000
+        assert segments[0]["carb_ratio"] == 8.0  # 8000 / 1000
+        assert segments[1]["carb_ratio"] == 7.0  # 7000 / 1000
 
     @pytest.mark.asyncio
     async def test_time_conversion(self):
@@ -1078,7 +1080,7 @@ class TestStorePumpSettings:
                         "startTime": 0,
                         "basalRate": 1000,
                         "isf": 30,
-                        "carbRatio": 8,
+                        "carbRatio": 8000,  # milliunits -> 8.0
                         "targetBg": 110,
                     },
                 ],
@@ -1094,7 +1096,7 @@ class TestStorePumpSettings:
                         "startTime": 0,
                         "basalRate": 800,
                         "isf": 35,
-                        "carbRatio": 10,
+                        "carbRatio": 10000,  # milliunits -> 10.0
                         "targetBg": 120,
                     },
                 ],
@@ -1138,7 +1140,7 @@ class TestStorePumpSettings:
                         "startTime": 0,
                         "basalRate": 1000,
                         "isf": 30,
-                        "carbRatio": 8,
+                        "carbRatio": 8000,  # milliunits -> 8.0
                         "targetBg": 110,
                     },
                 ],
@@ -1154,7 +1156,7 @@ class TestStorePumpSettings:
                         "startTime": 0,
                         "basalRate": 800,
                         "isf": 35,
-                        "carbRatio": 10,
+                        "carbRatio": 10000,  # milliunits -> 10.0
                         "targetBg": 120,
                     },
                 ],

--- a/apps/api/tests/test_telegram_chat.py
+++ b/apps/api/tests/test_telegram_chat.py
@@ -419,7 +419,7 @@ def make_pump_profile(
             "start_minutes": 0,
             "basal_rate": 1.5,
             "correction_factor": 31,
-            "carb_ratio": 8,
+            "carb_ratio": 8.0,
             "target_bg": 110,
         },
         {
@@ -427,7 +427,7 @@ def make_pump_profile(
             "start_minutes": 300,
             "basal_rate": 1.65,
             "correction_factor": 25,
-            "carb_ratio": 7,
+            "carb_ratio": 7.0,
             "target_bg": 110,
         },
     ]


### PR DESCRIPTION
## Summary

- Fix carbRatio unit conversion in `_store_pump_settings()` -- tconnectsync returns carbRatio in milliunits (e.g. 8000 = 1:8g), same as basalRate and maxBolus. Previously stored raw values (8000) instead of dividing by 1000 (8.0).
- Update display format in `_build_pump_profile_section()` to use `:g` format for float carb ratios (drops trailing zeros: 8.0 -> "8", 7.5 -> "7.5")
- Update test data to use milliunits for carbRatio and add carb_ratio conversion assertions

## Test plan

- [x] All 111 targeted tests pass (test_tandem_sync.py + test_telegram_chat.py)
- [x] Full backend suite passes (1121 tests)
- [x] Ruff lint and format clean
- [x] Docker rebuild + fresh Tandem sync stores correct values (8.0, 7.5, 6.5)
- [x] AI Chat correctly displays pump profile with carb ratios
- [x] AI Chat provides contextual advice referencing specific carb ratios per time segment
- [x] Dashboard, Settings, Alerts pages render without regressions