### PR TITLE
fix: resolve release workflow YAML parse error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,15 +85,18 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Decode signing keystore
-        if: secrets.RELEASE_KEYSTORE_BASE64 != ''
+        env:
+          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
         run: |
-          echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 -d > /tmp/release-keystore.jks
+          if [ -n "$KEYSTORE_BASE64" ]; then
+            echo "$KEYSTORE_BASE64" | base64 -d > /tmp/release-keystore.jks
+            echo "RELEASE_KEYSTORE_FILE=/tmp/release-keystore.jks" >> "$GITHUB_ENV"
+          fi
 
       - name: Build release APK
         working-directory: apps/mobile
         run: ./gradlew assembleRelease
         env:
-          RELEASE_KEYSTORE_FILE: ${{ secrets.RELEASE_KEYSTORE_BASE64 != '' && '/tmp/release-keystore.jks' || '' }}
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}


### PR DESCRIPTION
## Summary

- Fix release workflow that has been failing on every push since Epic 16 was introduced
- Root cause: `secrets` context cannot be used in step-level `if` expressions in GitHub Actions (`Unrecognized named-value: 'secrets'` on line 88)
- Move keystore base64 check from invalid `if:` condition into a shell `if [ -n ... ]` conditional
- Pass `RELEASE_KEYSTORE_FILE` via `$GITHUB_ENV` instead of an inline ternary expression that also referenced `secrets`

## Test plan

- [x] Workflow YAML validated locally (the `if:` expression that caused parsing failure is removed)
- [ ] Merge and verify the release workflow runs successfully on next push to main