### PR TITLE
feat: real-time data polling and local Room storage (Story 16.4)

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -82,6 +82,10 @@ android {
     }
 }
 
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 dependencies {
     // AndroidX Core
     implementation(libs.androidx.core.ktx)
@@ -128,6 +132,8 @@ dependencies {
 
     // Background work
     implementation(libs.work.runtime)
+    implementation(libs.hilt.work)
+    ksp(libs.hilt.work.compiler)
 
     // Logging
     implementation(libs.timber)

--- a/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/1.json
+++ b/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/1.json
@@ -1,0 +1,264 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "420d03e9bd5955bf3641c9e9a7175a84",
+    "entities": [
+      {
+        "tableName": "iob_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `iob` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iob",
+            "columnName": "iob",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_iob_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_iob_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "basal_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `rate` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `controlIqMode` TEXT NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "controlIqMode",
+            "columnName": "controlIqMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_basal_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_basal_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "bolus_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `units` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `isCorrection` INTEGER NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "units",
+            "columnName": "units",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCorrection",
+            "columnName": "isCorrection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bolus_events_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bolus_events_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          },
+          {
+            "name": "index_bolus_events_units_timestampMs",
+            "unique": true,
+            "columnNames": [
+              "units",
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bolus_events_units_timestampMs` ON `${TABLE_NAME}` (`units`, `timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "battery_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `percentage` INTEGER NOT NULL, `isCharging` INTEGER NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentage",
+            "columnName": "percentage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCharging",
+            "columnName": "isCharging",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_battery_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reservoir_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `unitsRemaining` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitsRemaining",
+            "columnName": "unitsRemaining",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reservoir_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reservoir_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '420d03e9bd5955bf3641c9e9a7175a84')"
+    ]
+  }
+}

--- a/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/2.json
+++ b/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/2.json
@@ -1,0 +1,264 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "420d03e9bd5955bf3641c9e9a7175a84",
+    "entities": [
+      {
+        "tableName": "iob_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `iob` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iob",
+            "columnName": "iob",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_iob_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_iob_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "basal_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `rate` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `controlIqMode` TEXT NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "controlIqMode",
+            "columnName": "controlIqMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_basal_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_basal_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "bolus_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `units` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `isCorrection` INTEGER NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "units",
+            "columnName": "units",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCorrection",
+            "columnName": "isCorrection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bolus_events_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bolus_events_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          },
+          {
+            "name": "index_bolus_events_units_timestampMs",
+            "unique": true,
+            "columnNames": [
+              "units",
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bolus_events_units_timestampMs` ON `${TABLE_NAME}` (`units`, `timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "battery_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `percentage` INTEGER NOT NULL, `isCharging` INTEGER NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentage",
+            "columnName": "percentage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCharging",
+            "columnName": "isCharging",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_battery_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reservoir_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `unitsRemaining` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitsRemaining",
+            "columnName": "unitsRemaining",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reservoir_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reservoir_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '420d03e9bd5955bf3641c9e9a7175a84')"
+    ]
+  }
+}

--- a/apps/mobile/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/app/src/main/AndroidManifest.xml
@@ -48,6 +48,18 @@
             android:foregroundServiceType="connectedDevice"
             android:exported="false" />
 
+        <!-- Disable default WorkManager initializer; we use Configuration.Provider -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
@@ -1,15 +1,45 @@
 package com.glycemicgpt.mobile
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.glycemicgpt.mobile.service.DataRetentionWorker
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
 @HiltAndroidApp
-class GlycemicGptApp : Application() {
+class GlycemicGptApp : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
     override fun onCreate() {
         super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
+        scheduleDataRetention()
+    }
+
+    private fun scheduleDataRetention() {
+        val request = PeriodicWorkRequestBuilder<DataRetentionWorker>(
+            1, TimeUnit.DAYS,
+        ).build()
+
+        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+            DataRetentionWorker.WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request,
+        )
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
@@ -1,0 +1,25 @@
+package com.glycemicgpt.mobile.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.glycemicgpt.mobile.data.local.dao.PumpDao
+import com.glycemicgpt.mobile.data.local.entity.BasalReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.BatteryReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.BolusEventEntity
+import com.glycemicgpt.mobile.data.local.entity.IoBReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.ReservoirReadingEntity
+
+@Database(
+    entities = [
+        IoBReadingEntity::class,
+        BasalReadingEntity::class,
+        BolusEventEntity::class,
+        BatteryReadingEntity::class,
+        ReservoirReadingEntity::class,
+    ],
+    version = 2,
+    exportSchema = true,
+)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun pumpDao(): PumpDao
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
@@ -1,0 +1,94 @@
+package com.glycemicgpt.mobile.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.glycemicgpt.mobile.data.local.entity.BasalReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.BatteryReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.BolusEventEntity
+import com.glycemicgpt.mobile.data.local.entity.IoBReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.ReservoirReadingEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PumpDao {
+
+    // -- IoB ------------------------------------------------------------------
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertIoB(reading: IoBReadingEntity)
+
+    @Query("SELECT * FROM iob_readings ORDER BY timestampMs DESC LIMIT 1")
+    fun observeLatestIoB(): Flow<IoBReadingEntity?>
+
+    @Query("SELECT * FROM iob_readings WHERE timestampMs >= :sinceMs ORDER BY timestampMs DESC")
+    suspend fun getIoBSince(sinceMs: Long): List<IoBReadingEntity>
+
+    @Query("DELETE FROM iob_readings WHERE timestampMs < :beforeMs")
+    suspend fun deleteIoBBefore(beforeMs: Long): Int
+
+    // -- Basal ----------------------------------------------------------------
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertBasal(reading: BasalReadingEntity)
+
+    @Query("SELECT * FROM basal_readings ORDER BY timestampMs DESC LIMIT 1")
+    fun observeLatestBasal(): Flow<BasalReadingEntity?>
+
+    @Query("DELETE FROM basal_readings WHERE timestampMs < :beforeMs")
+    suspend fun deleteBasalBefore(beforeMs: Long): Int
+
+    // -- Bolus ----------------------------------------------------------------
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertBolus(event: BolusEventEntity)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertBoluses(events: List<BolusEventEntity>)
+
+    @Query("SELECT * FROM bolus_events WHERE timestampMs >= :sinceMs ORDER BY timestampMs DESC")
+    suspend fun getBolusesSince(sinceMs: Long): List<BolusEventEntity>
+
+    @Query("SELECT MAX(timestampMs) FROM bolus_events")
+    suspend fun getLatestBolusTimestamp(): Long?
+
+    @Query("DELETE FROM bolus_events WHERE timestampMs < :beforeMs")
+    suspend fun deleteBolusBefore(beforeMs: Long): Int
+
+    // -- Battery --------------------------------------------------------------
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertBattery(reading: BatteryReadingEntity)
+
+    @Query("SELECT * FROM battery_readings ORDER BY timestampMs DESC LIMIT 1")
+    fun observeLatestBattery(): Flow<BatteryReadingEntity?>
+
+    @Query("DELETE FROM battery_readings WHERE timestampMs < :beforeMs")
+    suspend fun deleteBatteryBefore(beforeMs: Long): Int
+
+    // -- Reservoir ------------------------------------------------------------
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertReservoir(reading: ReservoirReadingEntity)
+
+    @Query("SELECT * FROM reservoir_readings ORDER BY timestampMs DESC LIMIT 1")
+    fun observeLatestReservoir(): Flow<ReservoirReadingEntity?>
+
+    @Query("DELETE FROM reservoir_readings WHERE timestampMs < :beforeMs")
+    suspend fun deleteReservoirBefore(beforeMs: Long): Int
+
+    // -- Transactional cleanup ------------------------------------------------
+
+    @Transaction
+    suspend fun deleteAllBefore(beforeMs: Long): Int {
+        var total = 0
+        total += deleteIoBBefore(beforeMs)
+        total += deleteBasalBefore(beforeMs)
+        total += deleteBolusBefore(beforeMs)
+        total += deleteBatteryBefore(beforeMs)
+        total += deleteReservoirBefore(beforeMs)
+        return total
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/PumpEntities.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/PumpEntities.kt
@@ -1,0 +1,63 @@
+package com.glycemicgpt.mobile.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "iob_readings",
+    indices = [Index(value = ["timestampMs"])],
+)
+data class IoBReadingEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val iob: Float,
+    val timestampMs: Long,
+)
+
+@Entity(
+    tableName = "basal_readings",
+    indices = [Index(value = ["timestampMs"])],
+)
+data class BasalReadingEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val rate: Float,
+    val isAutomated: Boolean,
+    val controlIqMode: String,
+    val timestampMs: Long,
+)
+
+@Entity(
+    tableName = "bolus_events",
+    indices = [
+        Index(value = ["timestampMs"]),
+        Index(value = ["units", "timestampMs"], unique = true),
+    ],
+)
+data class BolusEventEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val units: Float,
+    val isAutomated: Boolean,
+    val isCorrection: Boolean,
+    val timestampMs: Long,
+)
+
+@Entity(
+    tableName = "battery_readings",
+    indices = [Index(value = ["timestampMs"])],
+)
+data class BatteryReadingEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val percentage: Int,
+    val isCharging: Boolean,
+    val timestampMs: Long,
+)
+
+@Entity(
+    tableName = "reservoir_readings",
+    indices = [Index(value = ["timestampMs"])],
+)
+data class ReservoirReadingEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val unitsRemaining: Float,
+    val timestampMs: Long,
+)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/PumpDataRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/PumpDataRepository.kt
@@ -1,0 +1,162 @@
+package com.glycemicgpt.mobile.data.repository
+
+import com.glycemicgpt.mobile.data.local.dao.PumpDao
+import com.glycemicgpt.mobile.data.local.entity.BasalReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.BatteryReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.BolusEventEntity
+import com.glycemicgpt.mobile.data.local.entity.IoBReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.ReservoirReadingEntity
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
+import com.glycemicgpt.mobile.domain.model.BolusEvent
+import com.glycemicgpt.mobile.domain.model.ControlIqMode
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import timber.log.Timber
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repository that bridges domain models and Room persistence.
+ *
+ * All write methods accept domain models and convert to entities internally.
+ * All read methods return domain models or Flows of domain models.
+ */
+@Singleton
+class PumpDataRepository @Inject constructor(
+    private val pumpDao: PumpDao,
+) {
+
+    companion object {
+        /** Default data retention: 7 days. */
+        val DEFAULT_RETENTION_MS: Long = TimeUnit.DAYS.toMillis(7)
+    }
+
+    // -- IoB ------------------------------------------------------------------
+
+    suspend fun saveIoB(reading: IoBReading) {
+        pumpDao.insertIoB(
+            IoBReadingEntity(
+                iob = reading.iob,
+                timestampMs = reading.timestamp.toEpochMilli(),
+            ),
+        )
+    }
+
+    fun observeLatestIoB(): Flow<IoBReading?> =
+        pumpDao.observeLatestIoB().map { it?.toDomain() }
+
+    // -- Basal ----------------------------------------------------------------
+
+    suspend fun saveBasal(reading: BasalReading) {
+        pumpDao.insertBasal(
+            BasalReadingEntity(
+                rate = reading.rate,
+                isAutomated = reading.isAutomated,
+                controlIqMode = reading.controlIqMode.name,
+                timestampMs = reading.timestamp.toEpochMilli(),
+            ),
+        )
+    }
+
+    fun observeLatestBasal(): Flow<BasalReading?> =
+        pumpDao.observeLatestBasal().map { it?.toDomain() }
+
+    // -- Bolus ----------------------------------------------------------------
+
+    suspend fun saveBoluses(events: List<BolusEvent>) {
+        if (events.isEmpty()) return
+        pumpDao.insertBoluses(
+            events.map {
+                BolusEventEntity(
+                    units = it.units,
+                    isAutomated = it.isAutomated,
+                    isCorrection = it.isCorrection,
+                    timestampMs = it.timestamp.toEpochMilli(),
+                )
+            },
+        )
+    }
+
+    suspend fun getLatestBolusTimestamp(): Instant? {
+        val ms = pumpDao.getLatestBolusTimestamp() ?: return null
+        return Instant.ofEpochMilli(ms)
+    }
+
+    // -- Battery --------------------------------------------------------------
+
+    suspend fun saveBattery(status: BatteryStatus) {
+        pumpDao.insertBattery(
+            BatteryReadingEntity(
+                percentage = status.percentage,
+                isCharging = status.isCharging,
+                timestampMs = status.timestamp.toEpochMilli(),
+            ),
+        )
+    }
+
+    fun observeLatestBattery(): Flow<BatteryStatus?> =
+        pumpDao.observeLatestBattery().map { it?.toDomain() }
+
+    // -- Reservoir ------------------------------------------------------------
+
+    suspend fun saveReservoir(reading: ReservoirReading) {
+        pumpDao.insertReservoir(
+            ReservoirReadingEntity(
+                unitsRemaining = reading.unitsRemaining,
+                timestampMs = reading.timestamp.toEpochMilli(),
+            ),
+        )
+    }
+
+    fun observeLatestReservoir(): Flow<ReservoirReading?> =
+        pumpDao.observeLatestReservoir().map { it?.toDomain() }
+
+    // -- Cleanup --------------------------------------------------------------
+
+    /**
+     * Delete all readings older than [retentionMs] from now.
+     * Returns total number of rows deleted.
+     */
+    suspend fun deleteOldReadings(retentionMs: Long = DEFAULT_RETENTION_MS): Int {
+        val cutoff = System.currentTimeMillis() - retentionMs
+        val total = pumpDao.deleteAllBefore(cutoff)
+        if (total > 0) {
+            Timber.d("Data retention cleanup: deleted %d old readings", total)
+        }
+        return total
+    }
+}
+
+// -- Entity -> Domain mappers ------------------------------------------------
+
+private fun IoBReadingEntity.toDomain() = IoBReading(
+    iob = iob,
+    timestamp = Instant.ofEpochMilli(timestampMs),
+)
+
+private fun BasalReadingEntity.toDomain() = BasalReading(
+    rate = rate,
+    isAutomated = isAutomated,
+    controlIqMode = try {
+        ControlIqMode.valueOf(controlIqMode)
+    } catch (_: IllegalArgumentException) {
+        ControlIqMode.STANDARD
+    },
+    timestamp = Instant.ofEpochMilli(timestampMs),
+)
+
+private fun BatteryReadingEntity.toDomain() = BatteryStatus(
+    percentage = percentage,
+    isCharging = isCharging,
+    timestamp = Instant.ofEpochMilli(timestampMs),
+)
+
+private fun ReservoirReadingEntity.toDomain() = ReservoirReading(
+    unitsRemaining = unitsRemaining,
+    timestamp = Instant.ofEpochMilli(timestampMs),
+)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
@@ -1,0 +1,27 @@
+package com.glycemicgpt.mobile.di
+
+import android.content.Context
+import androidx.room.Room
+import com.glycemicgpt.mobile.data.local.AppDatabase
+import com.glycemicgpt.mobile.data.local.dao.PumpDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
+        Room.databaseBuilder(context, AppDatabase::class.java, "glycemicgpt.db")
+            .fallbackToDestructiveMigration()
+            .build()
+
+    @Provides
+    fun providePumpDao(db: AppDatabase): PumpDao = db.pumpDao()
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/DataRetentionWorker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/DataRetentionWorker.kt
@@ -1,0 +1,38 @@
+package com.glycemicgpt.mobile.service
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+
+/**
+ * WorkManager worker that runs daily to clean up old pump readings.
+ *
+ * Deletes all readings older than the configured retention period (default 7 days).
+ */
+@HiltWorker
+class DataRetentionWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val repository: PumpDataRepository,
+) : CoroutineWorker(context, workerParams) {
+
+    companion object {
+        const val WORK_NAME = "data_retention_cleanup"
+    }
+
+    override suspend fun doWork(): Result {
+        return try {
+            val deleted = repository.deleteOldReadings()
+            Timber.d("DataRetentionWorker: cleaned up %d old readings", deleted)
+            Result.success()
+        } catch (e: Exception) {
+            Timber.e(e, "DataRetentionWorker failed")
+            Result.retry()
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -1,0 +1,171 @@
+package com.glycemicgpt.mobile.service
+
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.pump.PumpDriver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Orchestrates periodic polling of pump data and persists results to Room.
+ *
+ * Poll intervals:
+ * - IoB + basal rate: every 30 seconds (AC1)
+ * - Bolus history: every 5 minutes (AC2)
+ * - Battery + reservoir: every 15 minutes (AC3)
+ *
+ * Polling pauses when BLE connection is lost and resumes on reconnect (AC7).
+ * Reduces frequency when phone battery is low (AC8).
+ */
+@Singleton
+class PumpPollingOrchestrator @Inject constructor(
+    private val pumpDriver: PumpDriver,
+    private val repository: PumpDataRepository,
+) {
+
+    companion object {
+        const val INTERVAL_FAST_MS = 30_000L       // IoB + basal
+        const val INTERVAL_MEDIUM_MS = 300_000L     // bolus history (5 min)
+        const val INTERVAL_SLOW_MS = 900_000L       // battery + reservoir (15 min)
+
+        // When phone battery is low, slow everything down by this factor
+        const val LOW_BATTERY_MULTIPLIER = 3
+    }
+
+    private val lock = Any()
+    private var fastJob: Job? = null
+    private var mediumJob: Job? = null
+    private var slowJob: Job? = null
+    private var connectionWatcherJob: Job? = null
+
+    @Volatile
+    var phoneBatteryLow: Boolean = false
+
+    /**
+     * Start watching connection state and polling when connected.
+     * Call this from the foreground service's onCreate.
+     */
+    fun start(scope: CoroutineScope) {
+        stop() // cancel any previous jobs
+        synchronized(lock) {
+            connectionWatcherJob = scope.launch {
+                pumpDriver.observeConnectionState().collectLatest { state ->
+                    if (state == ConnectionState.CONNECTED) {
+                        Timber.d("Pump connected, starting polling")
+                        startPollingLoops(scope)
+                    } else {
+                        Timber.d("Pump disconnected (state=%s), pausing polling", state)
+                        cancelPollingLoops()
+                    }
+                }
+            }
+        }
+    }
+
+    /** Stop all polling. Call from service onDestroy. */
+    fun stop() {
+        synchronized(lock) {
+            cancelPollingLoops()
+            connectionWatcherJob?.cancel()
+            connectionWatcherJob = null
+        }
+    }
+
+    private fun startPollingLoops(scope: CoroutineScope) {
+        synchronized(lock) {
+            cancelPollingLoops()
+
+            fastJob = scope.launch { pollFastLoop() }
+            mediumJob = scope.launch { pollMediumLoop() }
+            slowJob = scope.launch { pollSlowLoop() }
+        }
+    }
+
+    private fun cancelPollingLoops() {
+        synchronized(lock) {
+            fastJob?.cancel()
+            mediumJob?.cancel()
+            slowJob?.cancel()
+            fastJob = null
+            mediumJob = null
+            slowJob = null
+        }
+    }
+
+    private fun effectiveInterval(baseMs: Long): Long =
+        if (phoneBatteryLow) baseMs * LOW_BATTERY_MULTIPLIER else baseMs
+
+    /**
+     * Fast loop: IoB + basal rate every 30s.
+     * Runs an initial poll immediately, then repeats at interval.
+     */
+    private suspend fun pollFastLoop() {
+        while (true) {
+            pollIoB()
+            pollBasal()
+            delay(effectiveInterval(INTERVAL_FAST_MS))
+        }
+    }
+
+    /** Medium loop: bolus history every 5 min. */
+    private suspend fun pollMediumLoop() {
+        while (true) {
+            pollBolusHistory()
+            delay(effectiveInterval(INTERVAL_MEDIUM_MS))
+        }
+    }
+
+    /** Slow loop: battery + reservoir every 15 min. */
+    private suspend fun pollSlowLoop() {
+        while (true) {
+            pollBattery()
+            pollReservoir()
+            delay(effectiveInterval(INTERVAL_SLOW_MS))
+        }
+    }
+
+    private suspend fun pollIoB() {
+        pumpDriver.getIoB()
+            .onSuccess { repository.saveIoB(it) }
+            .onFailure { Timber.w(it, "Failed to poll IoB") }
+    }
+
+    private suspend fun pollBasal() {
+        pumpDriver.getBasalRate()
+            .onSuccess { repository.saveBasal(it) }
+            .onFailure { Timber.w(it, "Failed to poll basal rate") }
+    }
+
+    private suspend fun pollBolusHistory() {
+        val since = repository.getLatestBolusTimestamp()
+            ?: Instant.now().minus(7, ChronoUnit.DAYS)
+        pumpDriver.getBolusHistory(since)
+            .onSuccess { events ->
+                if (events.isNotEmpty()) {
+                    repository.saveBoluses(events)
+                    Timber.d("Saved %d new bolus events", events.size)
+                }
+            }
+            .onFailure { Timber.w(it, "Failed to poll bolus history") }
+    }
+
+    private suspend fun pollBattery() {
+        pumpDriver.getBatteryStatus()
+            .onSuccess { repository.saveBattery(it) }
+            .onFailure { Timber.w(it, "Failed to poll battery") }
+    }
+
+    private suspend fun pollReservoir() {
+        pumpDriver.getReservoirLevel()
+            .onSuccess { repository.saveReservoir(it) }
+            .onFailure { Timber.w(it, "Failed to poll reservoir") }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/PumpDataRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/PumpDataRepositoryTest.kt
@@ -1,0 +1,195 @@
+package com.glycemicgpt.mobile.data.repository
+
+import com.glycemicgpt.mobile.data.local.dao.PumpDao
+import com.glycemicgpt.mobile.data.local.entity.BasalReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.BatteryReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.IoBReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.ReservoirReadingEntity
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
+import com.glycemicgpt.mobile.domain.model.BolusEvent
+import com.glycemicgpt.mobile.domain.model.ControlIqMode
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.Instant
+
+class PumpDataRepositoryTest {
+
+    private val pumpDao = mockk<PumpDao>(relaxed = true)
+    private val repository = PumpDataRepository(pumpDao)
+
+    // -- IoB ------------------------------------------------------------------
+
+    @Test
+    fun `saveIoB converts domain model to entity`() = runTest {
+        val slot = slot<IoBReadingEntity>()
+        coEvery { pumpDao.insertIoB(capture(slot)) } returns Unit
+
+        val now = Instant.now()
+        repository.saveIoB(IoBReading(iob = 2.5f, timestamp = now))
+
+        assertEquals(2.5f, slot.captured.iob, 0.001f)
+        assertEquals(now.toEpochMilli(), slot.captured.timestampMs)
+    }
+
+    @Test
+    fun `observeLatestIoB maps entity to domain`() = runTest {
+        val entity = IoBReadingEntity(id = 1, iob = 3.0f, timestampMs = 1000L)
+        coEvery { pumpDao.observeLatestIoB() } returns flowOf(entity)
+
+        val result = repository.observeLatestIoB().first()
+        assertNotNull(result)
+        assertEquals(3.0f, result!!.iob, 0.001f)
+    }
+
+    @Test
+    fun `observeLatestIoB returns null when no data`() = runTest {
+        coEvery { pumpDao.observeLatestIoB() } returns flowOf(null)
+
+        val result = repository.observeLatestIoB().first()
+        assertNull(result)
+    }
+
+    // -- Basal ----------------------------------------------------------------
+
+    @Test
+    fun `saveBasal stores controlIqMode as string`() = runTest {
+        val slot = slot<BasalReadingEntity>()
+        coEvery { pumpDao.insertBasal(capture(slot)) } returns Unit
+
+        repository.saveBasal(
+            BasalReading(
+                rate = 1.2f,
+                isAutomated = true,
+                controlIqMode = ControlIqMode.SLEEP,
+                timestamp = Instant.now(),
+            ),
+        )
+
+        assertEquals("SLEEP", slot.captured.controlIqMode)
+        assertEquals(1.2f, slot.captured.rate, 0.001f)
+    }
+
+    @Test
+    fun `observeLatestBasal maps mode string back to enum`() = runTest {
+        val entity = BasalReadingEntity(
+            id = 1,
+            rate = 0.5f,
+            isAutomated = false,
+            controlIqMode = "EXERCISE",
+            timestampMs = 1000L,
+        )
+        coEvery { pumpDao.observeLatestBasal() } returns flowOf(entity)
+
+        val result = repository.observeLatestBasal().first()
+        assertNotNull(result)
+        assertEquals(ControlIqMode.EXERCISE, result!!.controlIqMode)
+    }
+
+    @Test
+    fun `observeLatestBasal handles unknown mode gracefully`() = runTest {
+        val entity = BasalReadingEntity(
+            id = 1,
+            rate = 0.5f,
+            isAutomated = false,
+            controlIqMode = "UNKNOWN_MODE",
+            timestampMs = 1000L,
+        )
+        coEvery { pumpDao.observeLatestBasal() } returns flowOf(entity)
+
+        val result = repository.observeLatestBasal().first()
+        assertNotNull(result)
+        assertEquals(ControlIqMode.STANDARD, result!!.controlIqMode)
+    }
+
+    // -- Battery --------------------------------------------------------------
+
+    @Test
+    fun `saveBattery converts domain model to entity`() = runTest {
+        val slot = slot<BatteryReadingEntity>()
+        coEvery { pumpDao.insertBattery(capture(slot)) } returns Unit
+
+        repository.saveBattery(
+            BatteryStatus(percentage = 72, isCharging = true, timestamp = Instant.now()),
+        )
+
+        assertEquals(72, slot.captured.percentage)
+        assertEquals(true, slot.captured.isCharging)
+    }
+
+    // -- Reservoir ------------------------------------------------------------
+
+    @Test
+    fun `saveReservoir converts domain model to entity`() = runTest {
+        val slot = slot<ReservoirReadingEntity>()
+        coEvery { pumpDao.insertReservoir(capture(slot)) } returns Unit
+
+        repository.saveReservoir(
+            ReservoirReading(unitsRemaining = 150f, timestamp = Instant.now()),
+        )
+
+        assertEquals(150f, slot.captured.unitsRemaining, 0.001f)
+    }
+
+    // -- Bolus ----------------------------------------------------------------
+
+    @Test
+    fun `saveBoluses skips empty list`() = runTest {
+        repository.saveBoluses(emptyList())
+        coVerify(exactly = 0) { pumpDao.insertBoluses(any()) }
+    }
+
+    @Test
+    fun `saveBoluses converts domain models`() = runTest {
+        val events = listOf(
+            BolusEvent(
+                units = 3.5f,
+                isAutomated = true,
+                isCorrection = false,
+                timestamp = Instant.now(),
+            ),
+        )
+        repository.saveBoluses(events)
+        coVerify(exactly = 1) { pumpDao.insertBoluses(any()) }
+    }
+
+    @Test
+    fun `getLatestBolusTimestamp returns null when no data`() = runTest {
+        coEvery { pumpDao.getLatestBolusTimestamp() } returns null
+
+        val result = repository.getLatestBolusTimestamp()
+        assertNull(result)
+    }
+
+    @Test
+    fun `getLatestBolusTimestamp converts millis to Instant`() = runTest {
+        val ms = 1700000000000L
+        coEvery { pumpDao.getLatestBolusTimestamp() } returns ms
+
+        val result = repository.getLatestBolusTimestamp()
+        assertNotNull(result)
+        assertEquals(ms, result!!.toEpochMilli())
+    }
+
+    // -- Cleanup --------------------------------------------------------------
+
+    @Test
+    fun `deleteOldReadings calls transactional deleteAllBefore`() = runTest {
+        coEvery { pumpDao.deleteAllBefore(any()) } returns 15
+
+        val total = repository.deleteOldReadings()
+        assertEquals(15, total)
+        coVerify(exactly = 1) { pumpDao.deleteAllBefore(any()) }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
@@ -1,0 +1,193 @@
+package com.glycemicgpt.mobile.service
+
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.ControlIqMode
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
+import com.glycemicgpt.mobile.domain.pump.PumpDriver
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PumpPollingOrchestratorTest {
+
+    private val connectionStateFlow = MutableStateFlow(ConnectionState.DISCONNECTED)
+    private val pumpDriver = mockk<PumpDriver>(relaxed = true) {
+        every { observeConnectionState() } returns connectionStateFlow
+        coEvery { getIoB() } returns Result.success(
+            IoBReading(iob = 2.5f, timestamp = Instant.now()),
+        )
+        coEvery { getBasalRate() } returns Result.success(
+            BasalReading(
+                rate = 0.8f,
+                isAutomated = true,
+                controlIqMode = ControlIqMode.STANDARD,
+                timestamp = Instant.now(),
+            ),
+        )
+        coEvery { getBatteryStatus() } returns Result.success(
+            BatteryStatus(percentage = 80, isCharging = false, timestamp = Instant.now()),
+        )
+        coEvery { getReservoirLevel() } returns Result.success(
+            ReservoirReading(unitsRemaining = 150f, timestamp = Instant.now()),
+        )
+        coEvery { getBolusHistory(any()) } returns Result.success(emptyList())
+    }
+    private val repository = mockk<PumpDataRepository>(relaxed = true) {
+        coEvery { getLatestBolusTimestamp() } returns null
+    }
+
+    private fun createOrchestrator() = PumpPollingOrchestrator(pumpDriver, repository)
+
+    @Test
+    fun `does not poll when disconnected`() = runTest {
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        advanceTimeBy(60_000)
+
+        coVerify(exactly = 0) { pumpDriver.getIoB() }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `polls immediately when connected`() = runTest {
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(100) // let coroutines run
+
+        coVerify(atLeast = 1) { pumpDriver.getIoB() }
+        coVerify(atLeast = 1) { pumpDriver.getBasalRate() }
+        coVerify(atLeast = 1) { pumpDriver.getBatteryStatus() }
+        coVerify(atLeast = 1) { pumpDriver.getReservoirLevel() }
+        coVerify(atLeast = 1) { pumpDriver.getBolusHistory(any()) }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `saves readings to repository on poll`() = runTest {
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(100)
+
+        coVerify(atLeast = 1) { repository.saveIoB(any()) }
+        coVerify(atLeast = 1) { repository.saveBasal(any()) }
+        coVerify(atLeast = 1) { repository.saveBattery(any()) }
+        coVerify(atLeast = 1) { repository.saveReservoir(any()) }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `polls IoB again after fast interval`() = runTest {
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(100) // initial poll
+        coVerify(exactly = 1) { pumpDriver.getIoB() }
+
+        advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS)
+        coVerify(exactly = 2) { pumpDriver.getIoB() }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `stops polling on disconnect`() = runTest {
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(100)
+        coVerify(exactly = 1) { pumpDriver.getIoB() }
+
+        connectionStateFlow.value = ConnectionState.DISCONNECTED
+        advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS + 100)
+        // Should not have polled again after disconnect
+        coVerify(exactly = 1) { pumpDriver.getIoB() }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `resumes polling on reconnect`() = runTest {
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(100)
+        coVerify(exactly = 1) { pumpDriver.getIoB() }
+
+        connectionStateFlow.value = ConnectionState.DISCONNECTED
+        advanceTimeBy(1000)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(100)
+        coVerify(exactly = 2) { pumpDriver.getIoB() }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `low battery multiplies poll interval`() = runTest {
+        val orchestrator = createOrchestrator()
+        orchestrator.phoneBatteryLow = true
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(100)
+        coVerify(exactly = 1) { pumpDriver.getIoB() }
+
+        // Normal interval passes but should NOT trigger another poll
+        advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS)
+        coVerify(exactly = 1) { pumpDriver.getIoB() }
+
+        // Full low-battery interval passes
+        advanceTimeBy(
+            PumpPollingOrchestrator.INTERVAL_FAST_MS *
+                (PumpPollingOrchestrator.LOW_BATTERY_MULTIPLIER - 1),
+        )
+        coVerify(exactly = 2) { pumpDriver.getIoB() }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `phoneBatteryLow defaults to false`() {
+        val orchestrator = createOrchestrator()
+        assertFalse(orchestrator.phoneBatteryLow)
+    }
+
+    @Test
+    fun `continues polling when individual read fails`() = runTest {
+        coEvery { pumpDriver.getIoB() } returns Result.failure(RuntimeException("timeout"))
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(100)
+
+        // Other reads should still succeed
+        coVerify(atLeast = 1) { repository.saveBasal(any()) }
+        coVerify(atLeast = 1) { repository.saveBattery(any()) }
+
+        // Should continue polling despite IoB failure
+        advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS)
+        coVerify(exactly = 2) { pumpDriver.getIoB() }
+        orchestrator.stop()
+    }
+}

--- a/apps/mobile/gradle/libs.versions.toml
+++ b/apps/mobile/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ navigation-compose = { group = "androidx.navigation", name = "navigation-compose
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
+hilt-work = { group = "androidx.hilt", name = "hilt-work", version = "1.2.0" }
+hilt-work-compiler = { group = "androidx.hilt", name = "hilt-compiler", version = "1.2.0" }
 
 # Room (local database)
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
## Summary

- Add Room database with 5 entity types (IoB, basal, bolus, battery, reservoir) for persistent pump data storage
- Implement three-tier PumpPollingOrchestrator: IoB+basal every 30s, bolus history every 5min, battery+reservoir every 15min
- Polling is connection-aware (pauses on disconnect, resumes on reconnect) and battery-aware (3x slower when phone battery <15%)
- HomeViewModel switched from in-memory MutableStateFlow to Room-backed reactive Flows via stateIn()
- DataRetentionWorker runs daily via WorkManager to clean up readings older than 7 days
- 22 new unit tests (PumpPollingOrchestratorTest: 9, PumpDataRepositoryTest: 13)

### Adversarial review fixes applied
- @Index on all timestampMs columns for query performance
- Unique composite index on bolus_events (units, timestampMs) to prevent duplicates
- Guard against multiple battery receiver registrations in PumpConnectionService
- Synchronized polling job fields to prevent race conditions
- Transactional data retention cleanup via DAO @Transaction
- Exception logging in HomeViewModel.refreshData() instead of silent catch
- Room schema export enabled for future migration support
- Default bolus lookback increased from 24h to 7 days (matches retention)

## Test plan

- [x] All 85 unit tests pass (0 failures, 0 errors)
- [x] Debug APK builds successfully
- [x] Home screen renders correctly on Android emulator
- [x] Settings screen renders correctly on Android emulator
- [x] No crashes in logcat after DB version bump
- [x] Room schema files generated for v1 and v2