### PR TITLE
fix: R8 release build failure from Tink missing errorprone annotations

### DIFF
--- a/apps/mobile/app/proguard-rules.pro
+++ b/apps/mobile/app/proguard-rules.pro
@@ -13,6 +13,9 @@
 -keep class * extends androidx.room.RoomDatabase
 -keep @androidx.room.Entity class *
 
+# Tink (used by EncryptedSharedPreferences)
+-dontwarn com.google.errorprone.annotations.**
+
 # OkHttp
 -dontwarn okhttp3.internal.platform.**
 -dontwarn org.conscrypt.**

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
@@ -1,5 +1,6 @@
 package com.glycemicgpt.mobile.service
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.dao.SyncDao
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
@@ -31,6 +32,7 @@ data class SyncStatus(
  * Checks for pending items every [POLL_INTERVAL_MS] and can be triggered
  * immediately via [triggerSync].
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
 class BackendSyncManager @Inject constructor(
     private val syncDao: SyncDao,


### PR DESCRIPTION
## Summary

- Add `-dontwarn com.google.errorprone.annotations.**` to ProGuard rules to fix R8 minification failure in release builds. EncryptedSharedPreferences uses Google Tink which references errorprone annotations not present at runtime.
- Add `@OptIn(ExperimentalCoroutinesApi::class)` to BackendSyncManager for `onTimeout` usage in `select` block.

This has been failing since Story 16.4 introduced EncryptedSharedPreferences (releases 0.1.75 and 0.1.76 both failed).

## Test plan

- [x] Debug unit tests pass (97/97)
- [ ] CI release workflow should now succeed with R8 minification