### PR TITLE
feat: complete home screen dashboard with CGM, freshness, pull-to-refresh (Story 16.7)

### DIFF
--- a/_bmad-output/PROGRESS.md
+++ b/_bmad-output/PROGRESS.md
@@ -21,14 +21,14 @@
 | 13 | E2E Testing & Real Data Verification | 3/3 | **Complete** |
 | 14 | Expanded AI Provider Support | 4/4 | **Complete** |
 | 15 | Frontend Auth UI & Route Protection | 8/8 | **Complete** |
-| 16 | Android Mobile App with BLE Pump Connectivity | 2/12 | In Progress |
+| 16 | Android Mobile App with BLE Pump Connectivity | 7/12 | In Progress |
 
 **MVP Stories:** 54/54 complete (100%)
 **Post-MVP Fix Stories:** 13/13 complete (100%)
 **Epic 14 (AI Provider Expansion):** 4/4 complete
 **Epic 15 (Frontend Auth UI):** 8/8 complete
-**Epic 16 (Mobile App + BLE):** 2/12 in progress
-**Overall Progress:** 81/91 stories complete (89%)
+**Epic 16 (Mobile App + BLE):** 7/12 in progress
+**Overall Progress:** 86/91 stories complete (95%)
 
 ---
 
@@ -311,11 +311,11 @@ All 5 stories completed:
 
 - [x] Story 16.1: Android Project Scaffolding & Build Configuration (PR #168)
 - [x] Story 16.2: BLE Connection Manager & Pump Pairing (PR #169)
-- [ ] Story 16.3: PumpDriver Interface & Tandem BLE Implementation
-- [ ] Story 16.4: Real-Time Data Polling & Local Storage
-- [ ] Story 16.5: Backend Sync -- Push Real-Time Data to GlycemicGPT API
-- [ ] Story 16.6: Tandem Cloud Upload at Faster Intervals
-- [ ] Story 16.7: App Home Screen & Pump Status Dashboard
+- [x] Story 16.3: PumpDriver Interface & Tandem BLE Implementation (PR #173)
+- [x] Story 16.4: Real-Time Data Polling & Local Storage (PR #175)
+- [x] Story 16.5: Backend Sync -- Push Real-Time Data to GlycemicGPT API (PR #177)
+- [x] Story 16.6: Tandem Cloud Upload at Faster Intervals (PR #179)
+- [x] Story 16.7: App Home Screen & Pump Status Dashboard
 - [ ] Story 16.8: App Settings & Configuration
 - [ ] Story 16.9: Wear OS Watch Face Companion
 - [ ] Story 16.10: TTS/STT Voice AI Chat

--- a/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/5.json
+++ b/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/5.json
@@ -1,0 +1,457 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "daeb7476641dcecc7c409d068b7bbd00",
+    "entities": [
+      {
+        "tableName": "iob_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `iob` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iob",
+            "columnName": "iob",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_iob_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_iob_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "basal_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `rate` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `controlIqMode` TEXT NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "controlIqMode",
+            "columnName": "controlIqMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_basal_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_basal_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "bolus_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `units` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `isCorrection` INTEGER NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "units",
+            "columnName": "units",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCorrection",
+            "columnName": "isCorrection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bolus_events_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bolus_events_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          },
+          {
+            "name": "index_bolus_events_units_timestampMs",
+            "unique": true,
+            "columnNames": [
+              "units",
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bolus_events_units_timestampMs` ON `${TABLE_NAME}` (`units`, `timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "battery_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `percentage` INTEGER NOT NULL, `isCharging` INTEGER NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentage",
+            "columnName": "percentage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCharging",
+            "columnName": "isCharging",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_battery_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reservoir_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `unitsRemaining` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitsRemaining",
+            "columnName": "unitsRemaining",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reservoir_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reservoir_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sync_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eventType` TEXT NOT NULL, `eventTimestampMs` INTEGER NOT NULL, `payload` TEXT NOT NULL, `status` TEXT NOT NULL, `retryCount` INTEGER NOT NULL, `createdAtMs` INTEGER NOT NULL, `lastAttemptMs` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTimestampMs",
+            "columnName": "eventTimestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptMs",
+            "columnName": "lastAttemptMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_queue_status_createdAtMs",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "createdAtMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_queue_status_createdAtMs` ON `${TABLE_NAME}` (`status`, `createdAtMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "raw_history_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sequenceNumber` INTEGER NOT NULL, `rawBytesB64` TEXT NOT NULL, `eventTypeId` INTEGER NOT NULL, `pumpTimeSeconds` INTEGER NOT NULL, `sentToBackend` INTEGER NOT NULL, `createdAtMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceNumber",
+            "columnName": "sequenceNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawBytesB64",
+            "columnName": "rawBytesB64",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTypeId",
+            "columnName": "eventTypeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pumpTimeSeconds",
+            "columnName": "pumpTimeSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentToBackend",
+            "columnName": "sentToBackend",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_raw_history_logs_sequenceNumber",
+            "unique": true,
+            "columnNames": [
+              "sequenceNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_raw_history_logs_sequenceNumber` ON `${TABLE_NAME}` (`sequenceNumber`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cgm_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `glucoseMgDl` INTEGER NOT NULL, `trendArrow` TEXT NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "glucoseMgDl",
+            "columnName": "glucoseMgDl",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trendArrow",
+            "columnName": "trendArrow",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cgm_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cgm_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'daeb7476641dcecc7c409d068b7bbd00')"
+    ]
+  }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/connection/TandemBleDriver.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/connection/TandemBleDriver.kt
@@ -5,6 +5,7 @@ import com.glycemicgpt.mobile.ble.protocol.TandemProtocol
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BatteryStatus
 import com.glycemicgpt.mobile.domain.model.BolusEvent
+import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
 import com.glycemicgpt.mobile.domain.model.IoBReading
@@ -88,6 +89,13 @@ class TandemBleDriver @Inject constructor(
     ) { cargo ->
         StatusResponseParser.parseInsulinStatusResponse(cargo)
             ?: throw IllegalStateException("Failed to parse insulin status response")
+    }
+
+    override suspend fun getCgmStatus(): Result<CgmReading> = runStatusRequest(
+        opcode = TandemProtocol.OPCODE_CGM_STATUS_REQ,
+    ) { cargo ->
+        StatusResponseParser.parseCgmStatusResponse(cargo)
+            ?: throw IllegalStateException("Failed to parse CGM status response")
     }
 
     override suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> = runStatusRequest(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/protocol/TandemProtocol.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/protocol/TandemProtocol.kt
@@ -91,6 +91,8 @@ object TandemProtocol {
     const val OPCODE_PUMP_SETTINGS_RESP = 91
     const val OPCODE_BOLUS_CALC_DATA_REQ = 75
     const val OPCODE_BOLUS_CALC_DATA_RESP = 76
+    const val OPCODE_CGM_STATUS_REQ = 100
+    const val OPCODE_CGM_STATUS_RESP = 101
 
     /** Default timeout for a status read request (milliseconds). */
     const val STATUS_READ_TIMEOUT_MS = 5000L

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
@@ -8,6 +8,7 @@ import com.glycemicgpt.mobile.data.local.dao.SyncDao
 import com.glycemicgpt.mobile.data.local.entity.BasalReadingEntity
 import com.glycemicgpt.mobile.data.local.entity.BatteryReadingEntity
 import com.glycemicgpt.mobile.data.local.entity.BolusEventEntity
+import com.glycemicgpt.mobile.data.local.entity.CgmReadingEntity
 import com.glycemicgpt.mobile.data.local.entity.IoBReadingEntity
 import com.glycemicgpt.mobile.data.local.entity.RawHistoryLogEntity
 import com.glycemicgpt.mobile.data.local.entity.ReservoirReadingEntity
@@ -22,8 +23,9 @@ import com.glycemicgpt.mobile.data.local.entity.SyncQueueEntity
         ReservoirReadingEntity::class,
         SyncQueueEntity::class,
         RawHistoryLogEntity::class,
+        CgmReadingEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Transaction
 import com.glycemicgpt.mobile.data.local.entity.BasalReadingEntity
 import com.glycemicgpt.mobile.data.local.entity.BatteryReadingEntity
 import com.glycemicgpt.mobile.data.local.entity.BolusEventEntity
+import com.glycemicgpt.mobile.data.local.entity.CgmReadingEntity
 import com.glycemicgpt.mobile.data.local.entity.IoBReadingEntity
 import com.glycemicgpt.mobile.data.local.entity.ReservoirReadingEntity
 import kotlinx.coroutines.flow.Flow
@@ -79,6 +80,17 @@ interface PumpDao {
     @Query("DELETE FROM reservoir_readings WHERE timestampMs < :beforeMs")
     suspend fun deleteReservoirBefore(beforeMs: Long): Int
 
+    // -- CGM ------------------------------------------------------------------
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCgm(reading: CgmReadingEntity)
+
+    @Query("SELECT * FROM cgm_readings ORDER BY timestampMs DESC LIMIT 1")
+    fun observeLatestCgm(): Flow<CgmReadingEntity?>
+
+    @Query("DELETE FROM cgm_readings WHERE timestampMs < :beforeMs")
+    suspend fun deleteCgmBefore(beforeMs: Long): Int
+
     // -- Transactional cleanup ------------------------------------------------
 
     @Transaction
@@ -89,6 +101,7 @@ interface PumpDao {
         total += deleteBolusBefore(beforeMs)
         total += deleteBatteryBefore(beforeMs)
         total += deleteReservoirBefore(beforeMs)
+        total += deleteCgmBefore(beforeMs)
         return total
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/PumpEntities.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/PumpEntities.kt
@@ -61,3 +61,14 @@ data class ReservoirReadingEntity(
     val unitsRemaining: Float,
     val timestampMs: Long,
 )
+
+@Entity(
+    tableName = "cgm_readings",
+    indices = [Index(value = ["timestampMs"])],
+)
+data class CgmReadingEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val glucoseMgDl: Int,
+    val trendArrow: String,
+    val timestampMs: Long,
+)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
@@ -44,6 +44,23 @@ data class ReservoirReading(
     val timestamp: Instant,
 )
 
+data class CgmReading(
+    val glucoseMgDl: Int,
+    val trendArrow: CgmTrend,
+    val timestamp: Instant,
+)
+
+enum class CgmTrend {
+    DOUBLE_UP,
+    SINGLE_UP,
+    FORTY_FIVE_UP,
+    FLAT,
+    FORTY_FIVE_DOWN,
+    SINGLE_DOWN,
+    DOUBLE_DOWN,
+    UNKNOWN,
+}
+
 data class HistoryLogRecord(
     val sequenceNumber: Int,
     val rawBytesB64: String,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/pump/PumpDriver.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/pump/PumpDriver.kt
@@ -3,6 +3,7 @@ package com.glycemicgpt.mobile.domain.pump
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BatteryStatus
 import com.glycemicgpt.mobile.domain.model.BolusEvent
+import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
 import com.glycemicgpt.mobile.domain.model.IoBReading
@@ -32,6 +33,7 @@ interface PumpDriver {
     suspend fun getPumpSettings(): Result<PumpSettings>
     suspend fun getBatteryStatus(): Result<BatteryStatus>
     suspend fun getReservoirLevel(): Result<ReservoirReading>
+    suspend fun getCgmStatus(): Result<CgmReading>
     suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>>
     suspend fun getPumpHardwareInfo(): Result<PumpHardwareInfo>
     fun observeConnectionState(): Flow<ConnectionState>

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.data.repository.PumpDataRepository
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BatteryStatus
+import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.model.ReservoirReading
@@ -14,8 +15,10 @@ import com.glycemicgpt.mobile.service.SyncStatus
 import timber.log.Timber
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -48,14 +51,22 @@ class HomeViewModel @Inject constructor(
     val reservoir: StateFlow<ReservoirReading?> = repository.observeLatestReservoir()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
+    val cgm: StateFlow<CgmReading?> = repository.observeLatestCgm()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
     val syncStatus: StateFlow<SyncStatus> = backendSyncManager.syncStatus
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
     /**
      * Manually trigger a pump data refresh. Reads are saved to the repository,
      * which will automatically update the observed StateFlows above.
      */
     fun refreshData() {
+        if (_isRefreshing.value) return
         viewModelScope.launch {
+            _isRefreshing.value = true
             try {
                 coroutineScope {
                     launch {
@@ -70,9 +81,14 @@ class HomeViewModel @Inject constructor(
                     launch {
                         pumpDriver.getReservoirLevel().onSuccess { repository.saveReservoir(it) }
                     }
+                    launch {
+                        pumpDriver.getCgmStatus().onSuccess { repository.saveCgm(it) }
+                    }
                 }
             } catch (e: Exception) {
                 Timber.w(e, "Error during manual data refresh")
+            } finally {
+                _isRefreshing.value = false
             }
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -131,6 +131,7 @@ class PumpPollingOrchestrator @Inject constructor(
         while (true) {
             pollIoB()
             pollBasal()
+            pollCgm()
             delay(effectiveInterval(INTERVAL_FAST_MS))
         }
     }
@@ -187,6 +188,16 @@ class PumpPollingOrchestrator @Inject constructor(
                 }
             }
             .onFailure { Timber.w(it, "Failed to poll bolus history") }
+    }
+
+    private suspend fun pollCgm() {
+        try {
+            pumpDriver.getCgmStatus()
+                .onSuccess { repository.saveCgm(it) }
+                .onFailure { Timber.w(it, "Failed to poll CGM status") }
+        } catch (e: Exception) {
+            Timber.w(e, "CGM poll exception")
+        }
     }
 
     private suspend fun pollBattery() {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
@@ -1,0 +1,194 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.ControlIqMode
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
+import com.glycemicgpt.mobile.domain.pump.PumpDriver
+import com.glycemicgpt.mobile.service.BackendSyncManager
+import com.glycemicgpt.mobile.service.SyncStatus
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val connectionStateFlow = MutableStateFlow(ConnectionState.DISCONNECTED)
+    private val iobFlow = MutableStateFlow<IoBReading?>(null)
+    private val basalFlow = MutableStateFlow<BasalReading?>(null)
+    private val batteryFlow = MutableStateFlow<BatteryStatus?>(null)
+    private val reservoirFlow = MutableStateFlow<ReservoirReading?>(null)
+    private val cgmFlow = MutableStateFlow<CgmReading?>(null)
+    private val syncStatusFlow = MutableStateFlow(SyncStatus())
+
+    private val pumpDriver = mockk<PumpDriver>(relaxed = true) {
+        every { observeConnectionState() } returns connectionStateFlow
+        coEvery { getIoB() } returns Result.success(
+            IoBReading(iob = 2.5f, timestamp = Instant.now()),
+        )
+        coEvery { getBasalRate() } returns Result.success(
+            BasalReading(
+                rate = 0.8f,
+                isAutomated = true,
+                controlIqMode = ControlIqMode.STANDARD,
+                timestamp = Instant.now(),
+            ),
+        )
+        coEvery { getBatteryStatus() } returns Result.success(
+            BatteryStatus(percentage = 80, isCharging = false, timestamp = Instant.now()),
+        )
+        coEvery { getReservoirLevel() } returns Result.success(
+            ReservoirReading(unitsRemaining = 150f, timestamp = Instant.now()),
+        )
+        coEvery { getCgmStatus() } returns Result.success(
+            CgmReading(glucoseMgDl = 120, trendArrow = CgmTrend.FLAT, timestamp = Instant.now()),
+        )
+    }
+
+    private val repository = mockk<PumpDataRepository>(relaxed = true) {
+        every { observeLatestIoB() } returns iobFlow
+        every { observeLatestBasal() } returns basalFlow
+        every { observeLatestBattery() } returns batteryFlow
+        every { observeLatestReservoir() } returns reservoirFlow
+        every { observeLatestCgm() } returns cgmFlow
+    }
+
+    private val backendSyncManager = mockk<BackendSyncManager>(relaxed = true) {
+        every { syncStatus } returns syncStatusFlow
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager)
+
+    @Test
+    fun `initial state has null readings and not refreshing`() = runTest {
+        val vm = createViewModel()
+
+        assertNull(vm.iob.value)
+        assertNull(vm.basalRate.value)
+        assertNull(vm.battery.value)
+        assertNull(vm.reservoir.value)
+        assertNull(vm.cgm.value)
+        assertFalse(vm.isRefreshing.value)
+        assertEquals(ConnectionState.DISCONNECTED, vm.connectionState.value)
+    }
+
+    @Test
+    fun `cgm flow emits when repository updates`() = runTest {
+        val vm = createViewModel()
+
+        // Subscribe to activate WhileSubscribed stateIn
+        val collected = mutableListOf<CgmReading?>()
+        val job = backgroundScope.launch(testDispatcher) {
+            vm.cgm.collect { collected.add(it) }
+        }
+
+        assertNull(vm.cgm.value)
+
+        val reading = CgmReading(glucoseMgDl = 180, trendArrow = CgmTrend.SINGLE_UP, timestamp = Instant.now())
+        cgmFlow.value = reading
+
+        assertNotNull(vm.cgm.value)
+        assertEquals(180, vm.cgm.value!!.glucoseMgDl)
+        assertEquals(CgmTrend.SINGLE_UP, vm.cgm.value!!.trendArrow)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `refreshData calls all pump driver methods including CGM`() = runTest {
+        val vm = createViewModel()
+
+        vm.refreshData()
+        advanceUntilIdle()
+
+        coVerify(atLeast = 1) { pumpDriver.getIoB() }
+        coVerify(atLeast = 1) { pumpDriver.getBasalRate() }
+        coVerify(atLeast = 1) { pumpDriver.getBatteryStatus() }
+        coVerify(atLeast = 1) { pumpDriver.getReservoirLevel() }
+        coVerify(atLeast = 1) { pumpDriver.getCgmStatus() }
+    }
+
+    @Test
+    fun `refreshData saves CGM result to repository`() = runTest {
+        val vm = createViewModel()
+
+        vm.refreshData()
+        advanceUntilIdle()
+
+        coVerify(atLeast = 1) { repository.saveCgm(any()) }
+    }
+
+    @Test
+    fun `refreshData sets isRefreshing to false when done`() = runTest {
+        val vm = createViewModel()
+
+        vm.refreshData()
+        advanceUntilIdle()
+
+        assertFalse(vm.isRefreshing.value)
+    }
+
+    @Test
+    fun `refreshData resets isRefreshing on failure`() = runTest {
+        coEvery { pumpDriver.getIoB() } throws RuntimeException("BLE error")
+        val vm = createViewModel()
+
+        vm.refreshData()
+        advanceUntilIdle()
+
+        assertFalse(vm.isRefreshing.value)
+    }
+
+    @Test
+    fun `connection state flows from pump driver`() = runTest {
+        val vm = createViewModel()
+
+        // Subscribe to activate WhileSubscribed stateIn
+        val job = backgroundScope.launch(testDispatcher) {
+            vm.connectionState.collect {}
+        }
+
+        assertEquals(ConnectionState.DISCONNECTED, vm.connectionState.value)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        assertEquals(ConnectionState.CONNECTED, vm.connectionState.value)
+
+        job.cancel()
+    }
+}


### PR DESCRIPTION
## Summary

- Add CGM/BG reading from pump via BLE opcode 100/101 with full data pipeline (domain model, BLE parser, Room entity v5, DAO, repository, 30s polling, ViewModel StateFlow)
- Enhance StatusCard composable with Control-IQ mode badges (Sleep/Exercise/Auto) and data freshness indicators on all cards (color-coded: green <2m, yellow <10m, red >10m)
- Display CGM trend arrow symbol on the Last BG card
- Wrap home screen in PullToRefreshBox for manual pull-to-refresh gesture with isRefreshing state
- Add re-entry guard to refreshData() to prevent concurrent BLE requests
- Add try-catch isolation around CGM polling so failures don't block IoB/basal in the fast loop
- Fix banner spacing to use Spacer composables instead of string space concatenation

## Changes

**Domain layer (2 files)**
- `PumpModels.kt`: Add `CgmReading` data class and `CgmTrend` enum (8 trend values)
- `PumpDriver.kt`: Add `getCgmStatus(): Result<CgmReading>` to pump driver interface

**BLE protocol layer (3 files)**
- `TandemProtocol.kt`: Add CGM request/response opcodes 100/101
- `StatusResponseParser.kt`: Add `parseCgmStatusResponse()` - reads UInt16 LE glucose, trend byte, filters 0 and >500 values
- `TandemBleDriver.kt`: Add `getCgmStatus()` implementation via `runStatusRequest`

**Data layer (5 files)**
- `PumpEntities.kt`: Add `CgmReadingEntity` (tableName="cgm_readings", indexed on timestampMs)
- `PumpDao.kt`: Add CGM insert/observe/delete methods, update `deleteAllBefore` transaction
- `AppDatabase.kt`: Register CgmReadingEntity, bump version 4 to 5
- `PumpDataRepository.kt`: Add `saveCgm()`/`observeLatestCgm()` with entity-to-domain mappers
- `AppDatabase/5.json`: Room schema export for version 5

**Service layer (1 file)**
- `PumpPollingOrchestrator.kt`: Add `pollCgm()` to 30s fast loop with failure isolation

**Presentation layer (2 files)**
- `HomeViewModel.kt`: Add cgm StateFlow, isRefreshing state, refreshData re-entry guard, CGM in refresh
- `HomeScreen.kt`: PullToRefreshBox, enhanced StatusCard (badges, freshness), FreshnessLabel composable, trend arrow display, Spacer-based banner spacing

**Tests (4 files, 21 new tests)**
- `StatusResponseParserTest.kt`: 10 new CGM parsing tests (valid, boundaries, all trends, error cases)
- `PumpDataRepositoryTest.kt`: 4 new CGM save/observe/mapper tests
- `PumpPollingOrchestratorTest.kt`: CGM mock setup + fast loop polling test
- `HomeViewModelTest.kt`: New file with 7 tests (initial state, CGM flow, refresh lifecycle, failure handling, connection state)

## Test plan

- [x] `./gradlew assembleDebug` compiles successfully
- [x] `./gradlew test` - all 119+ unit tests pass (0 failures)
- [x] Install APK on Android emulator and verify:
  - Home screen displays all cards (IoB, Basal Rate, Reservoir, Battery, Last BG) with "--" fallback
  - Connection status banner shows "No pump connected" with Bluetooth icon
  - Sync status banner shows "Not synced" with cloud icon
  - Bottom navigation (Home, AI Chat, Alerts, Settings) functional
  - Dark theme consistent (slate/blue)
  - "Pair your pump in Settings to start" hint visible when disconnected
- [x] Adversarial code review completed and findings addressed