### PR TITLE
feat: security hardening with token refresh, rate limiting, and TLS (Story 16.12)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "anthropic>=0.40.0",
     "openai>=1.50.0",
     "setuptools>=69.0.0,<82",  # tconnectsync needs pkg_resources, removed in setuptools 82
+    "slowapi>=0.1.9",
 ]
 
 [project.optional-dependencies]

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
 
     # Session
     session_expire_hours: int = 24
+    # Mobile token lifetimes (Story 16.12)
+    access_token_expire_minutes: int = 60  # 1 hour for mobile access tokens
+    refresh_token_expire_days: int = 30  # 30 days for mobile refresh tokens
     cookie_secure: bool = (
         True  # Set to False for plain HTTP (e.g. Docker integration tests)
     )

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -5,11 +5,13 @@ from typing import Any
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi.errors import RateLimitExceeded
 
 from src.config import settings
 from src.database import close_database
 from src.logging_config import get_logger, setup_logging
 from src.middleware import CorrelationIdMiddleware
+from src.middleware.rate_limit import limiter, rate_limit_exceeded_handler
 from src.routers import (
     ai,
     alert_api,
@@ -73,6 +75,10 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
+# Rate limiting (Story 16.12)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
 # Middleware (order matters: first added = last executed)
 # Add CORS middleware

--- a/apps/api/src/middleware/correlation.py
+++ b/apps/api/src/middleware/correlation.py
@@ -61,12 +61,19 @@ class CorrelationIdMiddleware:
         client = scope.get("client")
         client_ip = client[0] if client else None
 
+        # Extract User-Agent for audit logging
+        user_agent = headers.get(b"user-agent", b"").decode() or None
+
+        # Extract request content-length from headers
+        req_content_length = headers.get(b"content-length", b"").decode() or None
+
         # Log request start
         logger.info(
             "Request started",
             method=method,
             path=path,
             client_ip=client_ip,
+            user_agent=user_agent,
         )
 
         async def send_wrapper(message: Message) -> None:
@@ -95,6 +102,7 @@ class CorrelationIdMiddleware:
                 path=path,
                 status_code=status_code,
                 duration_ms=round(duration_ms, 2),
+                content_length=req_content_length,
             )
         except Exception:
             duration_ms = (time.perf_counter() - start_time) * 1000

--- a/apps/api/src/middleware/rate_limit.py
+++ b/apps/api/src/middleware/rate_limit.py
@@ -1,0 +1,53 @@
+"""Story 16.12: Rate limiting middleware using slowapi.
+
+Protects auth and data push endpoints from abuse.
+"""
+
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from src.config import settings
+
+# Use in-memory storage during tests (no Redis dependency), otherwise Redis
+_storage_uri = (
+    "memory://"
+    if settings.testing
+    else (settings.redis_url if settings.redis_url else "memory://")
+)
+
+
+def _get_real_client_ip(request: Request) -> str:
+    """Extract real client IP, respecting X-Forwarded-For behind reverse proxies."""
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        # Take the first (leftmost) IP -- the original client
+        return forwarded_for.split(",")[0].strip()
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        return real_ip.strip()
+    return request.client.host if request.client else "unknown"
+
+
+limiter = Limiter(
+    key_func=_get_real_client_ip,
+    storage_uri=_storage_uri,
+    enabled=not settings.testing,
+)
+
+# Rate limits are applied per-endpoint via @limiter.limit() decorators:
+# Auth login endpoints: 10/minute
+# Refresh endpoint: 30/minute
+# Device registration: 10/minute
+# Pump push: 60/minute
+
+
+async def rate_limit_exceeded_handler(
+    request: Request, exc: RateLimitExceeded
+) -> JSONResponse:
+    """Return a 429 JSON response when rate limit is exceeded."""
+    return JSONResponse(
+        status_code=429,
+        content={"detail": f"Rate limit exceeded: {exc.detail}"},
+    )

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -110,7 +110,14 @@ class TokenResponse(BaseModel):
 class MobileLoginResponse(TokenResponse):
     """Response schema for mobile login (returns JWT in body instead of cookie)."""
 
+    refresh_token: str = Field(..., description="JWT refresh token for token renewal")
     user: UserResponse = Field(..., description="Authenticated user details")
+
+
+class RefreshTokenRequest(BaseModel):
+    """Request schema for mobile token refresh."""
+
+    refresh_token: str = Field(..., description="The refresh token to exchange")
 
 
 # ============================================================================

--- a/apps/api/tests/test_rate_limiting.py
+++ b/apps/api/tests/test_rate_limiting.py
@@ -1,0 +1,68 @@
+"""Story 16.12: Tests for rate limiting middleware."""
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.main import app
+from src.middleware.rate_limit import limiter
+
+
+def _email() -> str:
+    return f"rate_{uuid.uuid4().hex[:8]}@test.com"
+
+
+@pytest.fixture(autouse=True)
+def _enable_rate_limiting():
+    """Temporarily enable rate limiting for these tests."""
+    limiter.enabled = True
+    limiter.reset()
+    yield
+    limiter.enabled = False
+
+
+class TestRateLimiting:
+    async def test_login_rate_limit_triggers_429(self):
+        """Auth login endpoints should be rate-limited to 10/minute."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            # Send 11 requests rapidly (limit is 10/minute)
+            responses = []
+            for _ in range(11):
+                resp = await c.post(
+                    "/api/auth/login",
+                    json={"email": "nobody@example.com", "password": "wrong"},
+                )
+                responses.append(resp.status_code)
+
+            # At least one should be 429
+            assert 429 in responses, (
+                f"Expected 429 in responses but got: {set(responses)}"
+            )
+
+    async def test_rate_limit_returns_json_detail(self):
+        """Rate limit responses should include a JSON detail message."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            for _ in range(12):
+                resp = await c.post(
+                    "/api/auth/mobile/login",
+                    json={"email": "nobody@example.com", "password": "wrong"},
+                )
+
+            if resp.status_code == 429:
+                body = resp.json()
+                assert "detail" in body
+                assert "Rate limit" in body["detail"]
+
+    async def test_health_endpoint_not_limited_at_low_rate(self):
+        """Health endpoint has no explicit limit, so 5 requests should pass."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            for _ in range(5):
+                resp = await c.get("/health")
+                assert resp.status_code == 200

--- a/apps/api/tests/test_token_refresh.py
+++ b/apps/api/tests/test_token_refresh.py
@@ -1,0 +1,162 @@
+"""Story 16.12: Tests for mobile token refresh endpoint."""
+
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+
+from src.core.security import create_refresh_token, decode_refresh_token
+from src.main import app
+
+
+def _email() -> str:
+    return f"refresh_{uuid.uuid4().hex[:8]}@test.com"
+
+
+async def _register_and_mobile_login(
+    client: AsyncClient, email: str, password: str = "TestPass1"
+) -> dict:
+    """Register a user and return the full mobile login response."""
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+    resp = await client.post(
+        "/api/auth/mobile/login",
+        json={"email": email, "password": password},
+    )
+    assert resp.status_code == 200
+    return resp.json()
+
+
+class TestMobileLoginRefreshToken:
+    async def test_mobile_login_returns_refresh_token(self):
+        email = _email()
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            body = await _register_and_mobile_login(c, email)
+
+        assert "refresh_token" in body
+        assert "access_token" in body
+        assert body["token_type"] == "bearer"
+        assert body["expires_in"] == 3600  # 60 minutes
+
+    async def test_refresh_token_is_valid_jwt(self):
+        email = _email()
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            body = await _register_and_mobile_login(c, email)
+
+        payload = decode_refresh_token(body["refresh_token"])
+        assert payload is not None
+        assert payload["type"] == "refresh"
+        assert payload["email"] == email
+
+
+class TestMobileRefreshEndpoint:
+    async def test_refresh_returns_new_tokens(self):
+        email = _email()
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            login_body = await _register_and_mobile_login(c, email)
+
+            resp = await c.post(
+                "/api/auth/mobile/refresh",
+                json={"refresh_token": login_body["refresh_token"]},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "access_token" in body
+        assert "refresh_token" in body
+        assert body["user"]["email"] == email
+        assert body["expires_in"] == 3600
+
+    async def test_new_access_token_works(self):
+        email = _email()
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            login_body = await _register_and_mobile_login(c, email)
+
+            refresh_resp = await c.post(
+                "/api/auth/mobile/refresh",
+                json={"refresh_token": login_body["refresh_token"]},
+            )
+            new_token = refresh_resp.json()["access_token"]
+
+            me_resp = await c.get(
+                "/api/auth/me",
+                headers={"Authorization": f"Bearer {new_token}"},
+            )
+        assert me_resp.status_code == 200
+        assert me_resp.json()["email"] == email
+
+    async def test_invalid_refresh_token_returns_401(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.post(
+                "/api/auth/mobile/refresh",
+                json={"refresh_token": "invalid.token.here"},
+            )
+        assert resp.status_code == 401
+
+    async def test_access_token_used_as_refresh_returns_401(self):
+        email = _email()
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            login_body = await _register_and_mobile_login(c, email)
+
+            resp = await c.post(
+                "/api/auth/mobile/refresh",
+                json={"refresh_token": login_body["access_token"]},
+            )
+        assert resp.status_code == 401
+
+    async def test_expired_refresh_token_returns_401(self):
+        from datetime import timedelta
+
+        # Create an already-expired refresh token
+        fake_user_id = uuid.uuid4()
+        expired_token = create_refresh_token(
+            user_id=fake_user_id,
+            email="expired@test.com",
+            role="diabetic",
+            expires_delta=timedelta(seconds=-1),
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.post(
+                "/api/auth/mobile/refresh",
+                json={"refresh_token": expired_token},
+            )
+        assert resp.status_code == 401
+
+
+class TestRefreshTokenFunctions:
+    def test_create_and_decode_refresh_token(self):
+        user_id = uuid.uuid4()
+        token = create_refresh_token(user_id, "test@example.com", "diabetic")
+        payload = decode_refresh_token(token)
+        assert payload is not None
+        assert payload["sub"] == str(user_id)
+        assert payload["email"] == "test@example.com"
+        assert payload["role"] == "diabetic"
+        assert payload["type"] == "refresh"
+
+    def test_decode_access_token_as_refresh_returns_none(self):
+        from src.core.security import create_access_token
+
+        user_id = uuid.uuid4()
+        access_token = create_access_token(user_id, "test@example.com", "diabetic")
+        result = decode_refresh_token(access_token)
+        assert result is None
+
+    def test_decode_garbage_returns_none(self):
+        result = decode_refresh_token("not.a.valid.jwt")
+        assert result is None

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -507,6 +507,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -576,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "glycemicgpt-api"
-version = "0.1.77"
+version = "0.1.84"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -594,6 +606,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "redis" },
     { name = "setuptools" },
+    { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tconnectsync" },
     { name = "uvicorn", extra = ["standard"] },
@@ -632,6 +645,7 @@ requires-dist = [
     { name = "redis", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "setuptools", specifier = ">=69.0.0,<82" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.25" },
     { name = "tconnectsync", specifier = ">=2.3.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
@@ -883,6 +897,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173, upload-time = "2026-01-14T12:55:59.315Z" },
     { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668, upload-time = "2026-01-14T12:56:00.261Z" },
     { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550, upload-time = "2026-01-14T12:56:01.542Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -1602,6 +1630,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1962,4 +2002,58 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/37/ae31f40bec90de2f88d9597d0b5281e23ffe85b893a47ca5d9c05c63a4f6/wrapt-2.1.1.tar.gz", hash = "sha256:5fdcb09bf6db023d88f312bd0767594b414655d58090fc1c46b3414415f67fac", size = 81329, upload-time = "2026-02-03T02:12:13.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/cb/4d5255d19bbd12be7f8ee2c1fb4269dddec9cef777ef17174d357468efaa/wrapt-2.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ab8e3793b239db021a18782a5823fcdea63b9fe75d0e340957f5828ef55fcc02", size = 61143, upload-time = "2026-02-03T02:11:46.313Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/07/7ed02daa35542023464e3c8b7cb937fa61f6c61c0361ecf8f5fecf8ad8da/wrapt-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7c0300007836373d1c2df105b40777986accb738053a92fe09b615a7a4547e9f", size = 61740, upload-time = "2026-02-03T02:12:51.966Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/60/a237a4e4a36f6d966061ccc9b017627d448161b19e0a3ab80a7c7c97f859/wrapt-2.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2b27c070fd1132ab23957bcd4ee3ba707a91e653a9268dc1afbd39b77b2799f7", size = 121327, upload-time = "2026-02-03T02:11:06.796Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/fe/9139058a3daa8818fc67e6460a2340e8bbcf3aef8b15d0301338bbe181ca/wrapt-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b0e36d845e8b6f50949b6b65fc6cd279f47a1944582ed4ec8258cd136d89a64", size = 122903, upload-time = "2026-02-03T02:12:48.657Z" },
+    { url = "https://files.pythonhosted.org/packages/91/10/b8479202b4164649675846a531763531f0a6608339558b5a0a718fc49a8d/wrapt-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4aeea04a9889370fcfb1ef828c4cc583f36a875061505cd6cd9ba24d8b43cc36", size = 121333, upload-time = "2026-02-03T02:11:32.148Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/75/75fc793b791d79444aca2c03ccde64e8b99eda321b003f267d570b7b0985/wrapt-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d88b46bb0dce9f74b6817bc1758ff2125e1ca9e1377d62ea35b6896142ab6825", size = 120458, upload-time = "2026-02-03T02:11:16.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8f/c3f30d511082ca6d947c405f9d8f6c8eaf83cfde527c439ec2c9a30eb5ea/wrapt-2.1.1-cp312-cp312-win32.whl", hash = "sha256:63decff76ca685b5c557082dfbea865f3f5f6d45766a89bff8dc61d336348833", size = 58086, upload-time = "2026-02-03T02:12:35.041Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c8/37625b643eea2849f10c3b90f69c7462faa4134448d4443234adaf122ae5/wrapt-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:b828235d26c1e35aca4107039802ae4b1411be0fe0367dd5b7e4d90e562fcbcd", size = 60328, upload-time = "2026-02-03T02:12:45.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/79/56242f07572d5682ba8065a9d4d9c2218313f576e3c3471873c2a5355ffd/wrapt-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:75128507413a9f1bcbe2db88fd18fbdbf80f264b82fa33a6996cdeaf01c52352", size = 58722, upload-time = "2026-02-03T02:12:27.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3cf290212855b19af9fcc41b725b5620b32f470d6aad970c2593500817eb/wrapt-2.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ce9646e17fa7c3e2e7a87e696c7de66512c2b4f789a8db95c613588985a2e139", size = 61150, upload-time = "2026-02-03T02:12:50.575Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/33/5b8f89a82a9859ce82da4870c799ad11ce15648b6e1c820fec3e23f4a19f/wrapt-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:428cfc801925454395aa468ba7ddb3ed63dc0d881df7b81626cdd433b4e2b11b", size = 61743, upload-time = "2026-02-03T02:11:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2f/60c51304fbdf47ce992d9eefa61fbd2c0e64feee60aaa439baf42ea6f40b/wrapt-2.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5797f65e4d58065a49088c3b32af5410751cd485e83ba89e5a45e2aa8905af98", size = 121341, upload-time = "2026-02-03T02:11:20.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/03/ce5256e66dd94e521ad5e753c78185c01b6eddbed3147be541f4d38c0cb7/wrapt-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a2db44a71202c5ae4bb5f27c6d3afbc5b23053f2e7e78aa29704541b5dad789", size = 122947, upload-time = "2026-02-03T02:11:33.596Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/50ca8854b81b946a11a36fcd6ead32336e6db2c14b6e4a8b092b80741178/wrapt-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8d5350c3590af09c1703dd60ec78a7370c0186e11eaafb9dda025a30eee6492d", size = 121370, upload-time = "2026-02-03T02:11:09.886Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d9/d6a7c654e0043319b4cc137a4caaf7aa16b46b51ee8df98d1060254705b7/wrapt-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d9b076411bed964e752c01b49fd224cc385f3a96f520c797d38412d70d08359", size = 120465, upload-time = "2026-02-03T02:11:37.592Z" },
+    { url = "https://files.pythonhosted.org/packages/55/90/65be41e40845d951f714b5a77e84f377a3787b1e8eee6555a680da6d0db5/wrapt-2.1.1-cp313-cp313-win32.whl", hash = "sha256:0bb7207130ce6486727baa85373503bf3334cc28016f6928a0fa7e19d7ecdc06", size = 58090, upload-time = "2026-02-03T02:12:53.342Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/66/6a09e0294c4fc8c26028a03a15191721c9271672467cc33e6617ee0d91d2/wrapt-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:cbfee35c711046b15147b0ae7db9b976f01c9520e6636d992cd9e69e5e2b03b1", size = 60341, upload-time = "2026-02-03T02:12:36.384Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/20ceb8b701e9a71555c87a5ddecbed76ec16742cf1e4b87bbaf26735f998/wrapt-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:7d2756061022aebbf57ba14af9c16e8044e055c22d38de7bf40d92b565ecd2b0", size = 58731, upload-time = "2026-02-03T02:12:01.328Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b4/fe95beb8946700b3db371f6ce25115217e7075ca063663b8cca2888ba55c/wrapt-2.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4814a3e58bc6971e46baa910ecee69699110a2bf06c201e24277c65115a20c20", size = 62969, upload-time = "2026-02-03T02:11:51.245Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/89/477b0bdc784e3299edf69c279697372b8bd4c31d9c6966eae405442899df/wrapt-2.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:106c5123232ab9b9f4903692e1fa0bdc231510098f04c13c3081f8ad71c3d612", size = 63606, upload-time = "2026-02-03T02:12:02.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/55/9d0c1269ab76de87715b3b905df54dd25d55bbffd0b98696893eb613469f/wrapt-2.1.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1a40b83ff2535e6e56f190aff123821eea89a24c589f7af33413b9c19eb2c738", size = 152536, upload-time = "2026-02-03T02:11:24.492Z" },
+    { url = "https://files.pythonhosted.org/packages/44/18/2004766030462f79ad86efaa62000b5e39b1ff001dcce86650e1625f40ae/wrapt-2.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:789cea26e740d71cf1882e3a42bb29052bc4ada15770c90072cb47bf73fb3dbf", size = 158697, upload-time = "2026-02-03T02:12:32.214Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/bb/0a880fa0f35e94ee843df4ee4dd52a699c9263f36881311cfb412c09c3e5/wrapt-2.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ba49c14222d5e5c0ee394495a8655e991dc06cbca5398153aefa5ac08cd6ccd7", size = 155563, upload-time = "2026-02-03T02:11:49.737Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ff/cd1b7c4846c8678fac359a6eb975dc7ab5bd606030adb22acc8b4a9f53f1/wrapt-2.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ac8cda531fe55be838a17c62c806824472bb962b3afa47ecbd59b27b78496f4e", size = 150161, upload-time = "2026-02-03T02:12:33.613Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ec/67c90a7082f452964b4621e4890e9a490f1add23cdeb7483cc1706743291/wrapt-2.1.1-cp313-cp313t-win32.whl", hash = "sha256:b8af75fe20d381dd5bcc9db2e86a86d7fcfbf615383a7147b85da97c1182225b", size = 59783, upload-time = "2026-02-03T02:11:39.863Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/08/466afe4855847d8febdfa2c57c87e991fc5820afbdef01a273683dfd15a0/wrapt-2.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:45c5631c9b6c792b78be2d7352129f776dd72c605be2c3a4e9be346be8376d83", size = 63082, upload-time = "2026-02-03T02:12:09.075Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/62/60b629463c28b15b1eeadb3a0691e17568622b12aa5bfa7ebe9b514bfbeb/wrapt-2.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:da815b9263947ac98d088b6414ac83507809a1d385e4632d9489867228d6d81c", size = 60251, upload-time = "2026-02-03T02:11:21.794Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a0/1c2396e272f91efe6b16a6a8bce7ad53856c8f9ae4f34ceaa711d63ec9e1/wrapt-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aa1765054245bb01a37f615503290d4e207e3fd59226e78341afb587e9c1236", size = 61311, upload-time = "2026-02-03T02:12:44.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/9a/d2faba7e61072a7507b5722db63562fdb22f5a24e237d460d18755627f15/wrapt-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:feff14b63a6d86c1eee33a57f77573649f2550935981625be7ff3cb7342efe05", size = 61805, upload-time = "2026-02-03T02:11:59.905Z" },
+    { url = "https://files.pythonhosted.org/packages/db/56/073989deb4b5d7d6e7ea424476a4ae4bda02140f2dbeaafb14ba4864dd60/wrapt-2.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81fc5f22d5fcfdbabde96bb3f5379b9f4476d05c6d524d7259dc5dfb501d3281", size = 120308, upload-time = "2026-02-03T02:12:04.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b6/84f37261295e38167a29eb82affaf1dc15948dc416925fe2091beee8e4ac/wrapt-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951b228ecf66def855d22e006ab9a1fc12535111ae7db2ec576c728f8ddb39e8", size = 122688, upload-time = "2026-02-03T02:11:23.148Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/80/32db2eec6671f80c65b7ff175be61bc73d7f5223f6910b0c921bbc4bd11c/wrapt-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ddf582a95641b9a8c8bd643e83f34ecbbfe1b68bc3850093605e469ab680ae3", size = 121115, upload-time = "2026-02-03T02:12:39.068Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ef/dcd00383df0cd696614127902153bf067971a5aabcd3c9dcb2d8ef354b2a/wrapt-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fc5c500966bf48913f795f1984704e6d452ba2414207b15e1f8c339a059d5b16", size = 119484, upload-time = "2026-02-03T02:11:48.419Z" },
+    { url = "https://files.pythonhosted.org/packages/76/29/0630280cdd2bd8f86f35cb6854abee1c9d6d1a28a0c6b6417cd15d378325/wrapt-2.1.1-cp314-cp314-win32.whl", hash = "sha256:4aa4baadb1f94b71151b8e44a0c044f6af37396c3b8bcd474b78b49e2130a23b", size = 58514, upload-time = "2026-02-03T02:11:58.616Z" },
+    { url = "https://files.pythonhosted.org/packages/db/19/5bed84f9089ed2065f6aeda5dfc4f043743f642bc871454b261c3d7d322b/wrapt-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:860e9d3fd81816a9f4e40812f28be4439ab01f260603c749d14be3c0a1170d19", size = 60763, upload-time = "2026-02-03T02:12:24.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/b967f2f9669e4249b4fe82e630d2a01bc6b9e362b9b12ed91bbe23ae8df4/wrapt-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3c59e103017a2c1ea0ddf589cbefd63f91081d7ce9d491d69ff2512bb1157e23", size = 59051, upload-time = "2026-02-03T02:11:29.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/19/6fed62be29f97eb8a56aff236c3f960a4b4a86e8379dc7046a8005901a97/wrapt-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9fa7c7e1bee9278fc4f5dd8275bc8d25493281a8ec6c61959e37cc46acf02007", size = 63059, upload-time = "2026-02-03T02:12:06.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1c/b757fd0adb53d91547ed8fad76ba14a5932d83dde4c994846a2804596378/wrapt-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39c35e12e8215628984248bd9c8897ce0a474be2a773db207eb93414219d8469", size = 63618, upload-time = "2026-02-03T02:12:23.197Z" },
+    { url = "https://files.pythonhosted.org/packages/10/fe/e5ae17b1480957c7988d991b93df9f2425fc51f128cf88144d6a18d0eb12/wrapt-2.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:94ded4540cac9125eaa8ddf5f651a7ec0da6f5b9f248fe0347b597098f8ec14c", size = 152544, upload-time = "2026-02-03T02:11:43.915Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cc/99aed210c6b547b8a6e4cb9d1425e4466727158a6aeb833aa7997e9e08dd/wrapt-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da0af328373f97ed9bdfea24549ac1b944096a5a71b30e41c9b8b53ab3eec04a", size = 158700, upload-time = "2026-02-03T02:12:30.684Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0e/d442f745f4957944d5f8ad38bc3a96620bfff3562533b87e486e979f3d99/wrapt-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4ad839b55f0bf235f8e337ce060572d7a06592592f600f3a3029168e838469d3", size = 155561, upload-time = "2026-02-03T02:11:28.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/9891816280e0018c48f8dfd61b136af7b0dcb4a088895db2531acde5631b/wrapt-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d89c49356e5e2a50fa86b40e0510082abcd0530f926cbd71cf25bee6b9d82d7", size = 150188, upload-time = "2026-02-03T02:11:57.053Z" },
+    { url = "https://files.pythonhosted.org/packages/24/98/e2f273b6d70d41f98d0739aa9a269d0b633684a5fb17b9229709375748d4/wrapt-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:f4c7dd22cf7f36aafe772f3d88656559205c3af1b7900adfccb70edeb0d2abc4", size = 60425, upload-time = "2026-02-03T02:11:35.007Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/06/b500bfc38a4f82d89f34a13069e748c82c5430d365d9e6b75afb3ab74457/wrapt-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f76bc12c583ab01e73ba0ea585465a41e48d968f6d1311b4daec4f8654e356e3", size = 63855, upload-time = "2026-02-03T02:12:15.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cc/5f6193c32166faee1d2a613f278608e6f3b95b96589d020f0088459c46c9/wrapt-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7ea74fc0bec172f1ae5f3505b6655c541786a5cabe4bbc0d9723a56ac32eb9b9", size = 60443, upload-time = "2026-02-03T02:11:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/da/5a086bf4c22a41995312db104ec2ffeee2cf6accca9faaee5315c790377d/wrapt-2.1.1-py3-none-any.whl", hash = "sha256:3b0f4629eb954394a3d7c7a1c8cca25f0b07cefe6aa8545e862e9778152de5b7", size = 43886, upload-time = "2026-02-03T02:11:45.048Z" },
 ]

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
@@ -6,6 +6,7 @@ import androidx.work.Configuration
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import com.glycemicgpt.mobile.logging.ReleaseTree
 import com.glycemicgpt.mobile.service.DataRetentionWorker
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
@@ -27,6 +28,8 @@ class GlycemicGptApp : Application(), Configuration.Provider {
         super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
+        } else {
+            Timber.plant(ReleaseTree())
         }
         scheduleDataRetention()
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
@@ -56,7 +56,10 @@ class AuthTokenStore @Inject constructor(
         val token = prefs.getString(KEY_TOKEN, null) ?: return null
         val expiresAt = prefs.getLong(KEY_EXPIRES_AT, 0L)
         if (expiresAt > 0 && System.currentTimeMillis() >= expiresAt) {
-            clearToken()
+            // Only clear the access token, NOT the refresh token.
+            // The refresh token is needed by TokenRefreshInterceptor to
+            // obtain a new access token when the current one expires.
+            clearAccessToken()
             return null
         }
         return token
@@ -64,11 +67,27 @@ class AuthTokenStore @Inject constructor(
 
     fun isLoggedIn(): Boolean = getToken() != null
 
+    fun saveRefreshToken(token: String) {
+        prefs.edit()
+            .putString(KEY_REFRESH_TOKEN, token)
+            .apply()
+    }
+
+    fun getRefreshToken(): String? = prefs.getString(KEY_REFRESH_TOKEN, null)
+
+    fun clearAccessToken() {
+        prefs.edit()
+            .remove(KEY_TOKEN)
+            .remove(KEY_EXPIRES_AT)
+            .apply()
+    }
+
     fun clearToken() {
         prefs.edit()
             .remove(KEY_TOKEN)
             .remove(KEY_EXPIRES_AT)
             .remove(KEY_USER_EMAIL)
+            .remove(KEY_REFRESH_TOKEN)
             .apply()
     }
 
@@ -76,10 +95,13 @@ class AuthTokenStore @Inject constructor(
         prefs.edit().clear().apply()
     }
 
+    fun getRawToken(): String? = prefs.getString(KEY_TOKEN, null)
+
     companion object {
         private const val KEY_BASE_URL = "base_url"
         private const val KEY_TOKEN = "jwt_token"
         private const val KEY_EXPIRES_AT = "expires_at_ms"
         private const val KEY_USER_EMAIL = "user_email"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -11,6 +11,7 @@ import com.glycemicgpt.mobile.data.remote.dto.LoginRequest
 import com.glycemicgpt.mobile.data.remote.dto.LoginResponse
 import com.glycemicgpt.mobile.data.remote.dto.PumpPushRequest
 import com.glycemicgpt.mobile.data.remote.dto.PumpPushResponse
+import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
 import com.glycemicgpt.mobile.data.remote.dto.TandemUploadSettingsRequest
 import com.glycemicgpt.mobile.data.remote.dto.TandemUploadStatus
 import com.glycemicgpt.mobile.data.remote.dto.TandemUploadTriggerResponse
@@ -32,6 +33,9 @@ interface GlycemicGptApi {
 
     @POST("/api/auth/mobile/login")
     suspend fun login(@Body request: LoginRequest): Response<LoginResponse>
+
+    @POST("/api/auth/mobile/refresh")
+    suspend fun refreshToken(@Body request: RefreshTokenRequest): Response<LoginResponse>
 
     @POST("/api/integrations/pump/push")
     suspend fun pushPumpEvents(@Body request: PumpPushRequest): Response<PumpPushResponse>

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptor.kt
@@ -1,0 +1,128 @@
+package com.glycemicgpt.mobile.data.remote
+
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
+import com.squareup.moshi.Moshi
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * OkHttp Interceptor that transparently refreshes expired access tokens.
+ *
+ * When a request receives a 401 response and a refresh token is available,
+ * this interceptor:
+ * 1. Calls the /api/auth/mobile/refresh endpoint (using a separate OkHttpClient)
+ * 2. On success: saves new tokens and retries the original request
+ * 3. On failure: clears all tokens (user must re-login)
+ *
+ * Uses synchronized block to prevent concurrent refresh attempts.
+ */
+@Singleton
+class TokenRefreshInterceptor @Inject constructor(
+    private val authTokenStore: AuthTokenStore,
+    private val baseUrlInterceptor: BaseUrlInterceptor,
+    private val moshi: Moshi,
+) : Interceptor {
+
+    private val lock = Any()
+
+    // Separate OkHttpClient for refresh calls to avoid interceptor recursion
+    private val refreshClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(baseUrlInterceptor)
+            .build()
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val original = chain.request()
+        val response = chain.proceed(original)
+
+        // Only attempt refresh on 401 responses
+        if (response.code != 401) return response
+
+        // Don't try to refresh the refresh endpoint itself
+        if (original.url.encodedPath.contains("/api/auth/mobile/refresh")) return response
+
+        val refreshToken = authTokenStore.getRefreshToken() ?: return response
+
+        synchronized(lock) {
+            // Double-check: another thread may have already refreshed
+            val currentToken = authTokenStore.getRawToken()
+            val originalAuth = original.header("Authorization")
+            if (currentToken != null && originalAuth != "Bearer $currentToken") {
+                // Token was already refreshed by another thread; retry with new token
+                response.close()
+                val retryRequest = original.newBuilder()
+                    .header("Authorization", "Bearer $currentToken")
+                    .build()
+                return chain.proceed(retryRequest)
+            }
+
+            // Attempt token refresh
+            val newAccessToken = performRefresh(refreshToken)
+            if (newAccessToken != null) {
+                response.close()
+                val retryRequest = original.newBuilder()
+                    .header("Authorization", "Bearer $newAccessToken")
+                    .build()
+                return chain.proceed(retryRequest)
+            }
+        }
+
+        return response
+    }
+
+    /**
+     * Calls the refresh endpoint and saves new tokens on success.
+     * Returns the new access token, or null on failure.
+     */
+    private fun performRefresh(refreshToken: String): String? {
+        return try {
+            val body = RefreshTokenRequest(refreshToken = refreshToken)
+            val adapter = moshi.adapter(RefreshTokenRequest::class.java)
+            val json = adapter.toJson(body)
+
+            val request = Request.Builder()
+                .url("http://localhost/api/auth/mobile/refresh") // BaseUrlInterceptor rewrites this
+                .post(json.toRequestBody("application/json".toMediaType()))
+                .build()
+
+            val refreshResponse = refreshClient.newCall(request).execute()
+
+            if (refreshResponse.isSuccessful) {
+                val responseBody = refreshResponse.body?.string() ?: return null
+                val loginAdapter = moshi.adapter(
+                    com.glycemicgpt.mobile.data.remote.dto.LoginResponse::class.java,
+                )
+                val loginResponse = loginAdapter.fromJson(responseBody) ?: return null
+
+                val expiresAtMs = System.currentTimeMillis() + (loginResponse.expiresIn * 1000L)
+                authTokenStore.saveCredentials(
+                    authTokenStore.getBaseUrl() ?: "",
+                    loginResponse.accessToken,
+                    expiresAtMs,
+                    loginResponse.user.email,
+                )
+                authTokenStore.saveRefreshToken(loginResponse.refreshToken)
+
+                Timber.d("Token refreshed successfully")
+                loginResponse.accessToken
+            } else {
+                Timber.w("Token refresh failed with HTTP ${refreshResponse.code}")
+                authTokenStore.clearToken()
+                null
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Token refresh failed")
+            authTokenStore.clearToken()
+            null
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
@@ -18,9 +18,15 @@ data class LoginRequest(
 @JsonClass(generateAdapter = true)
 data class LoginResponse(
     @Json(name = "access_token") val accessToken: String,
+    @Json(name = "refresh_token") val refreshToken: String,
     @Json(name = "token_type") val tokenType: String,
     @Json(name = "expires_in") val expiresIn: Int,
     val user: UserDto,
+)
+
+@JsonClass(generateAdapter = true)
+data class RefreshTokenRequest(
+    @Json(name = "refresh_token") val refreshToken: String,
 )
 
 @JsonClass(generateAdapter = true)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/NetworkModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.glycemicgpt.mobile.di
 import com.glycemicgpt.mobile.data.remote.AuthInterceptor
 import com.glycemicgpt.mobile.data.remote.BaseUrlInterceptor
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.TokenRefreshInterceptor
 import com.glycemicgpt.mobile.data.remote.InstantAdapter
 import com.squareup.moshi.Moshi
 import dagger.Module
@@ -33,6 +34,7 @@ object NetworkModule {
     fun provideOkHttpClient(
         authInterceptor: AuthInterceptor,
         baseUrlInterceptor: BaseUrlInterceptor,
+        tokenRefreshInterceptor: TokenRefreshInterceptor,
     ): OkHttpClient {
         val logging = HttpLoggingInterceptor().apply {
             level = if (BuildConfig.DEBUG) {
@@ -44,6 +46,7 @@ object NetworkModule {
         return OkHttpClient.Builder()
             .addInterceptor(baseUrlInterceptor)
             .addInterceptor(authInterceptor)
+            .addInterceptor(tokenRefreshInterceptor)
             .addInterceptor(logging)
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(15, TimeUnit.SECONDS)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/logging/ReleaseTree.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/logging/ReleaseTree.kt
@@ -1,0 +1,37 @@
+package com.glycemicgpt.mobile.logging
+
+import android.util.Log
+import timber.log.Timber
+
+/**
+ * Timber Tree for release builds that:
+ * - Only logs WARN and ERROR levels (drops DEBUG/INFO)
+ * - Scrubs sensitive patterns (BG values, tokens, emails) from messages
+ */
+class ReleaseTree : Timber.Tree() {
+
+    override fun isLoggable(tag: String?, priority: Int): Boolean {
+        return priority >= Log.WARN
+    }
+
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        val scrubbed = scrubSensitiveData(message)
+        Log.println(priority, tag ?: "GlycemicGPT", scrubbed)
+    }
+
+    companion object {
+        private val BG_MG_PATTERN = Regex("""\b\d{2,3}\s*mg/dL\b""")
+        private val BG_MMOL_PATTERN = Regex("""\b\d{1,2}\.\d\s*mmol/L\b""")
+        private val TOKEN_PATTERN = Regex("""\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b""")
+        private val EMAIL_PATTERN = Regex("""\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b""")
+
+        fun scrubSensitiveData(message: String): String {
+            var result = message
+            result = TOKEN_PATTERN.replace(result, "[TOKEN]")
+            result = EMAIL_PATTERN.replace(result, "[EMAIL]")
+            result = BG_MG_PATTERN.replace(result, "[BG]")
+            result = BG_MMOL_PATTERN.replace(result, "[BG]")
+            return result
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -197,6 +197,7 @@ class SettingsViewModel @Inject constructor(
                     }
                     val expiresAtMs = System.currentTimeMillis() + (body.expiresIn * 1000L)
                     authTokenStore.saveCredentials(url, body.accessToken, expiresAtMs, body.user.email)
+                    authTokenStore.saveRefreshToken(body.refreshToken)
                     _uiState.value = _uiState.value.copy(
                         isLoggingIn = false,
                         isLoggedIn = true,

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptorTest.kt
@@ -1,0 +1,83 @@
+package com.glycemicgpt.mobile.data.remote
+
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.squareup.moshi.Moshi
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TokenRefreshInterceptorTest {
+
+    private val authTokenStore = mockk<AuthTokenStore>(relaxed = true)
+    private val baseUrlInterceptor = mockk<BaseUrlInterceptor>(relaxed = true)
+    private val moshi = Moshi.Builder().build()
+
+    private fun createInterceptor() =
+        TokenRefreshInterceptor(authTokenStore, baseUrlInterceptor, moshi)
+
+    private fun buildResponse(code: Int, request: Request): Response =
+        Response.Builder()
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message(if (code == 200) "OK" else "Unauthorized")
+            .request(request)
+            .body("".toResponseBody())
+            .build()
+
+    @Test
+    fun `non-401 responses pass through unchanged`() {
+        val interceptor = createInterceptor()
+        val request = Request.Builder().url("http://localhost/api/test").build()
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+            every { proceed(any()) } returns buildResponse(200, request)
+        }
+
+        val response = interceptor.intercept(chain)
+        assertEquals(200, response.code)
+    }
+
+    @Test
+    fun `401 without refresh token passes through`() {
+        every { authTokenStore.getRefreshToken() } returns null
+
+        val interceptor = createInterceptor()
+        val request = Request.Builder()
+            .url("http://localhost/api/test")
+            .header("Authorization", "Bearer expired-token")
+            .build()
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+            every { proceed(any()) } returns buildResponse(401, request)
+        }
+
+        val response = interceptor.intercept(chain)
+        assertEquals(401, response.code)
+    }
+
+    @Test
+    fun `401 on refresh endpoint itself does not retry`() {
+        every { authTokenStore.getRefreshToken() } returns "some-refresh-token"
+
+        val interceptor = createInterceptor()
+        val request = Request.Builder()
+            .url("http://localhost/api/auth/mobile/refresh")
+            .build()
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+            every { proceed(any()) } returns buildResponse(401, request)
+        }
+
+        val response = interceptor.intercept(chain)
+        assertEquals(401, response.code)
+        // Should NOT attempt refresh for the refresh endpoint itself
+        verify(exactly = 0) { authTokenStore.clearToken() }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/logging/ReleaseTreeTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/logging/ReleaseTreeTest.kt
@@ -1,0 +1,62 @@
+package com.glycemicgpt.mobile.logging
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReleaseTreeTest {
+
+    @Test
+    fun `scrubs JWT tokens from messages`() {
+        // Fake three-part dot-separated string matching JWT structure (not a real token)
+        val msg = "Token: aaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb.cccccccccccccccccccccccc"
+        val result = ReleaseTree.scrubSensitiveData(msg)
+        assertEquals("Token: [TOKEN]", result)
+    }
+
+    @Test
+    fun `scrubs email addresses`() {
+        val msg = "User logged in: patient@example.com"
+        val result = ReleaseTree.scrubSensitiveData(msg)
+        assertEquals("User logged in: [EMAIL]", result)
+    }
+
+    @Test
+    fun `scrubs blood glucose values`() {
+        val msg = "Current reading: 250 mg/dL"
+        val result = ReleaseTree.scrubSensitiveData(msg)
+        assertEquals("Current reading: [BG]", result)
+    }
+
+    @Test
+    fun `scrubs BG value without space before unit`() {
+        val msg = "Reading: 85mg/dL"
+        val result = ReleaseTree.scrubSensitiveData(msg)
+        assertEquals("Reading: [BG]", result)
+    }
+
+    @Test
+    fun `scrubs mmol per L values`() {
+        val msg = "Reading: 5.4 mmol/L"
+        val result = ReleaseTree.scrubSensitiveData(msg)
+        assertEquals("Reading: [BG]", result)
+    }
+
+    @Test
+    fun `preserves non-sensitive messages`() {
+        val msg = "Connection test failed: timeout"
+        val result = ReleaseTree.scrubSensitiveData(msg)
+        assertEquals("Connection test failed: timeout", result)
+    }
+
+    @Test
+    fun `scrubs multiple sensitive values in one message`() {
+        val msg = "Alert for user@test.com: 320 mg/dL"
+        val result = ReleaseTree.scrubSensitiveData(msg)
+        assertFalse(result.contains("user@test.com"))
+        assertFalse(result.contains("320"))
+        assertTrue(result.contains("[EMAIL]"))
+        assertTrue(result.contains("[BG]"))
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -174,6 +174,7 @@ class SettingsViewModelTest {
         coEvery { api.login(any()) } returns Response.success(
             LoginResponse(
                 accessToken = "jwt123",
+                refreshToken = "refresh123",
                 tokenType = "bearer",
                 expiresIn = 3600,
                 user = UserDto(id = "1", email = "user@test.com", role = "user"),
@@ -188,6 +189,7 @@ class SettingsViewModelTest {
         assertFalse(vm.uiState.value.isLoggingIn)
         assertNull(vm.uiState.value.loginError)
         verify { authTokenStore.saveCredentials(any(), "jwt123", any(), "user@test.com") }
+        verify { authTokenStore.saveRefreshToken("refresh123") }
     }
 
     @Test

--- a/docs/k8s-external-access.md
+++ b/docs/k8s-external-access.md
@@ -1,0 +1,85 @@
+# Kubernetes External Access & TLS Setup
+
+This guide covers exposing GlycemicGPT to the internet with TLS encryption, which is required for the mobile app to connect securely.
+
+## Prerequisites
+
+- A Kubernetes cluster with an ingress controller (nginx-ingress or traefik)
+- A domain name pointing to your cluster's external IP
+- kubectl configured for your cluster
+
+## 1. Install cert-manager
+
+cert-manager automates TLS certificate provisioning from Let's Encrypt.
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
+```
+
+## 2. Create ClusterIssuer
+
+Edit `k8s/base/cert-manager-issuer.yaml` and set your email address, then apply:
+
+```bash
+kubectl apply -f k8s/base/cert-manager-issuer.yaml
+```
+
+## 3. Configure DNS
+
+Point your domain to the cluster's external IP:
+
+```
+glycemicgpt.yourdomain.com  A  <your-cluster-external-ip>
+```
+
+If using a cloud provider with a load balancer, use a CNAME record pointing to the load balancer hostname.
+
+## 4. Update Ingress
+
+Edit `k8s/base/ingress.yaml` and replace `glycemicgpt.local` with your domain in both the `rules[].host` and `tls[].hosts[]` fields.
+
+```bash
+kubectl apply -f k8s/base/ingress.yaml
+```
+
+cert-manager will automatically provision a TLS certificate from Let's Encrypt.
+
+## 5. Verify
+
+```bash
+# Check certificate status
+kubectl get certificate -n glycemicgpt
+
+# Test HTTPS
+curl https://glycemicgpt.yourdomain.com/health
+```
+
+## Mobile App Configuration
+
+In the mobile app Settings screen, set the Server URL to:
+
+```
+https://glycemicgpt.yourdomain.com
+```
+
+The app enforces HTTPS in release builds. HTTP is only allowed in debug builds for local development.
+
+## Self-Signed Certificates (Alternative)
+
+For internal/homelab setups without a public domain, you can use self-signed certificates:
+
+```bash
+# Generate self-signed cert
+openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -days 365 -nodes \
+  -subj "/CN=glycemicgpt.local"
+
+# Create K8s secret
+kubectl create secret tls glycemicgpt-tls \
+  --cert=tls.crt --key=tls.key \
+  -n glycemicgpt
+```
+
+Remove the `cert-manager.io/cluster-issuer` annotation from the ingress when using self-signed certs.
+
+Note: The mobile app's network security config allows user-installed CAs in debug builds. For release builds with self-signed certs, you would need to add the CA to the app's trust store.

--- a/k8s/base/cert-manager-issuer.yaml
+++ b/k8s/base/cert-manager-issuer.yaml
@@ -1,0 +1,19 @@
+---
+# Story 16.12: cert-manager ClusterIssuer for Let's Encrypt
+# Prerequisites:
+#   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # Let's Encrypt production endpoint
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: admin@example.com  # Change to your email for certificate expiry notifications
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx  # Change to "traefik" if using traefik

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -17,6 +17,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     # Enable websocket/SSE support
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    # TLS via cert-manager (Story 16.12)
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # Force HTTPS and enable HSTS
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "31536000"
+    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
     # traefik annotations (if using traefik)
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
 spec:
@@ -62,8 +69,7 @@ spec:
                 name: glycemicgpt-web
                 port:
                   number: 3000
-  # TLS configuration (uncomment and configure for HTTPS)
-  # tls:
-  #   - hosts:
-  #       - glycemicgpt.local
-  #     secretName: glycemicgpt-tls
+  tls:
+    - hosts:
+        - glycemicgpt.local  # Change to your domain
+      secretName: glycemicgpt-tls


### PR DESCRIPTION
## Summary

- Add JWT refresh token flow (1h access + 30d refresh) for seamless mobile session renewal without forced re-login
- Add slowapi rate limiting on auth (10/min), refresh (30/min), device registration (10/min), and pump push (60/min) endpoints with X-Forwarded-For support for K8s reverse proxy
- Add TokenRefreshInterceptor (OkHttp) for transparent 401 retry with synchronized refresh and thread-safe double-check pattern
- Add ReleaseTree (Timber) to scrub sensitive data (BG values in mg/dL and mmol/L, JWT tokens, emails) from release build logs
- Add enhanced audit logging with User-Agent and content-length in correlation middleware
- Enable K8s TLS via cert-manager with Let's Encrypt ClusterIssuer, HSTS headers, and force-SSL-redirect
- Fix critical bug where access token expiry cleared the refresh token, making the entire refresh flow non-functional

## Test plan

- [x] Backend lint clean (`ruff check` + `ruff format --check`)
- [x] Backend tests pass (1183 passed, 1 skipped)
- [x] Mobile unit tests pass (all green)
- [x] Mobile lint clean
- [x] Mobile APK builds successfully
- [x] Adversarial review completed with 10 findings, critical issues fixed
- [x] Verify refresh token survives access token expiry (clearAccessToken vs clearToken)
- [x] Verify rate limiter uses real client IP behind reverse proxy