### PR TITLE
fix: add BLE runtime permission requests to prevent pump scan crash

### DIFF
--- a/apps/mobile/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/app/src/main/AndroidManifest.xml
@@ -2,11 +2,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- BLE permissions -->
+    <!-- BLE permissions (Android 12+ / API 31+) -->
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
+    <!-- Location required for BLE scanning on Android 11 (API 30) only -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
+        android:maxSdkVersion="30" />
 
     <!-- Network permissions -->
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
## Summary

- Fixes crash when tapping "Scan for Pumps" on Android 12+ (API 31+) caused by missing runtime permission grants for BLUETOOTH_SCAN and BLUETOOTH_CONNECT
- Adds `ActivityResultContracts.RequestMultiplePermissions()` launcher to PairingScreen that requests the correct permissions before initiating BLE scan
- Shows an error card with rationale text when permissions are denied
- Scopes manifest permissions properly: `neverForLocation` on BLUETOOTH_SCAN, `maxSdkVersion=30` on location permissions (only needed for Android 11)

## Root Cause

The app used `@SuppressLint("MissingPermission")` on BLE calls which silences compile-time lint warnings but does not prevent `SecurityException` at runtime. Android 12+ requires explicit runtime grants for BLUETOOTH_SCAN and BLUETOOTH_CONNECT.

## Test plan

- [ ] On Android 12+ device/emulator: tap "Scan for Pumps" -> permission dialog appears
- [ ] Grant permissions -> scan starts without crash
- [ ] Deny permissions -> error card shown with rationale text
- [ ] On Android 11 device: location permission requested instead of Bluetooth permissions
- [ ] `./gradlew :app:lintDebug` passes
- [ ] `./gradlew :app:testDebugUnitTest` passes
- [ ] `./gradlew :app:assembleDebug` builds successfully