### PR TITLE
fix: correct BLE authentication protocol to match Tandem pump spec

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/auth/HmacHelper.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/auth/HmacHelper.kt
@@ -24,10 +24,10 @@ object HmacHelper {
     }
 
     /**
-     * Build the HMAC response for the Tandem legacy auth challenge.
+     * Build the HMAC response for the Tandem auth challenge.
      *
-     * @param pairingCode 16-character pairing code (ASCII bytes used as key)
-     * @param challengeKey Challenge bytes from the pump's CentralChallengeResponse
+     * @param pairingCode Pairing code from pump screen (ASCII bytes used as HMAC key)
+     * @param challengeKey 8-byte HMAC key from bytes 22-29 of CentralChallengeResponse
      */
     fun buildChallengeResponse(pairingCode: String, challengeKey: ByteArray): ByteArray {
         val keyBytes = pairingCode.toByteArray(Charsets.US_ASCII)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
@@ -87,6 +87,7 @@ enum class ConnectionState {
     SCANNING,
     CONNECTING,
     AUTHENTICATING,
+    AUTH_FAILED,
     CONNECTED,
     RECONNECTING,
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -226,6 +226,11 @@ private fun ConnectionStatusBanner(state: ConnectionState) {
             "Scanning...",
             MaterialTheme.colorScheme.tertiary,
         )
+        ConnectionState.AUTH_FAILED -> Triple(
+            Icons.Default.BluetoothDisabled,
+            "Pairing failed",
+            MaterialTheme.colorScheme.error,
+        )
         ConnectionState.DISCONNECTED -> Triple(
             Icons.Default.BluetoothDisabled,
             "No pump connected",

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingScreen.kt
@@ -97,6 +97,19 @@ fun PairingScreen(
                 ConnectingCard(connectionState)
             }
 
+            // Auth failed -- show error with retry option
+            connectionState == ConnectionState.AUTH_FAILED && selectedPump != null -> {
+                AuthFailedCard(onRetry = { viewModel.pair() })
+                Spacer(modifier = Modifier.height(16.dp))
+                PairingCodeInput(
+                    pump = selectedPump!!,
+                    pairingCode = pairingCode,
+                    onCodeChanged = { viewModel.updatePairingCode(it) },
+                    onPair = { viewModel.pair() },
+                    onCancel = { viewModel.clearSelection() },
+                )
+            }
+
             // Pump selected, show pairing code input
             selectedPump != null -> {
                 PairingCodeInput(
@@ -167,6 +180,31 @@ private fun PairedStatusCard(
                 Spacer(modifier = Modifier.width(4.dp))
                 Text("Unpair")
             }
+        }
+    }
+}
+
+@Composable
+private fun AuthFailedCard(onRetry: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Pairing failed",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "The pump rejected the pairing attempt. Please verify the " +
+                    "code matches what is displayed on your pump screen and try again.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
         }
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/ble/auth/TandemAuthenticatorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/ble/auth/TandemAuthenticatorTest.kt
@@ -13,6 +13,24 @@ class TandemAuthenticatorTest {
 
     private val authenticator = TandemAuthenticator()
 
+    /** Build a valid 30-byte CentralChallengeResponse cargo. */
+    private fun buildChallengeResponseCargo(hmacKey: ByteArray = ByteArray(8) { 0x42 }): ByteArray {
+        val cargo = ByteArray(30)
+        // Bytes 0-1: appInstanceId echo (LE short)
+        cargo[0] = 0x01
+        cargo[1] = 0x00
+        // Bytes 2-21: centralChallengeHash (20 bytes, pump's HMAC)
+        for (i in 2..21) cargo[i] = 0xAA.toByte()
+        // Bytes 22-29: hmacKey (8 bytes)
+        hmacKey.copyInto(cargo, 22)
+        return cargo
+    }
+
+    /** Build a PumpChallengeResponse cargo: 2-byte appId + 1 success byte. */
+    private fun buildPumpResponseCargo(success: Boolean): ByteArray {
+        return byteArrayOf(0x01, 0x00, if (success) 1 else 0)
+    }
+
     @Test
     fun `initial state is IDLE`() = runTest {
         assertEquals(AuthState.IDLE, authenticator.authState.first())
@@ -29,19 +47,31 @@ class TandemAuthenticatorTest {
     fun `processChallengeResponse returns null when not in CHALLENGE_SENT state`() {
         // Still in IDLE state
         val result = authenticator.processChallengeResponse(
-            responseCargo = byteArrayOf(0x01, 0x02, 0x03),
-            code = "TESTCODE12345678",
+            responseCargo = buildChallengeResponseCargo(),
+            code = "123456",
             txId = 2,
         )
         assertNull(result)
     }
 
     @Test
-    fun `processChallengeResponse transitions to RESPONSE_SENT`() = runTest {
+    fun `processChallengeResponse returns null for cargo shorter than 30 bytes`() = runTest {
+        authenticator.buildCentralChallengeRequest(txId = 1)
+        val result = authenticator.processChallengeResponse(
+            responseCargo = ByteArray(8) { 0x42 },
+            code = "123456",
+            txId = 2,
+        )
+        assertNull(result)
+        assertEquals(AuthState.FAILED, authenticator.authState.first())
+    }
+
+    @Test
+    fun `processChallengeResponse transitions to RESPONSE_SENT with valid 30-byte cargo`() = runTest {
         authenticator.buildCentralChallengeRequest(txId = 1)
         val chunks = authenticator.processChallengeResponse(
-            responseCargo = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08),
-            code = "TESTCODE12345678",
+            responseCargo = buildChallengeResponseCargo(),
+            code = "123456",
             txId = 2,
         )
         assertNotNull(chunks)
@@ -51,50 +81,49 @@ class TandemAuthenticatorTest {
 
     @Test
     fun `processPumpChallengeResponse returns false when not in RESPONSE_SENT state`() = runTest {
-        val result = authenticator.processPumpChallengeResponse(byteArrayOf(0x00))
+        val result = authenticator.processPumpChallengeResponse(buildPumpResponseCargo(true))
         assertFalse(result)
         assertEquals(AuthState.FAILED, authenticator.authState.first())
     }
 
     @Test
-    fun `processPumpChallengeResponse succeeds with zero status byte`() = runTest {
-        // Walk through full handshake
+    fun `processPumpChallengeResponse succeeds when byte 2 is 1`() = runTest {
         authenticator.buildCentralChallengeRequest(txId = 1)
         authenticator.processChallengeResponse(
-            responseCargo = ByteArray(8) { 0x42 },
-            code = "TESTCODE12345678",
+            responseCargo = buildChallengeResponseCargo(),
+            code = "123456",
             txId = 2,
         )
 
-        val success = authenticator.processPumpChallengeResponse(byteArrayOf(0x00))
+        val success = authenticator.processPumpChallengeResponse(buildPumpResponseCargo(true))
         assertTrue(success)
         assertEquals(AuthState.AUTHENTICATED, authenticator.authState.first())
     }
 
     @Test
-    fun `processPumpChallengeResponse fails with non-zero status byte`() = runTest {
+    fun `processPumpChallengeResponse fails when byte 2 is 0`() = runTest {
         authenticator.buildCentralChallengeRequest(txId = 1)
         authenticator.processChallengeResponse(
-            responseCargo = ByteArray(8) { 0x42 },
-            code = "TESTCODE12345678",
+            responseCargo = buildChallengeResponseCargo(),
+            code = "123456",
             txId = 2,
         )
 
-        val success = authenticator.processPumpChallengeResponse(byteArrayOf(0x01))
+        val success = authenticator.processPumpChallengeResponse(buildPumpResponseCargo(false))
         assertFalse(success)
         assertEquals(AuthState.FAILED, authenticator.authState.first())
     }
 
     @Test
-    fun `processPumpChallengeResponse fails with empty cargo`() = runTest {
+    fun `processPumpChallengeResponse fails with cargo shorter than 3 bytes`() = runTest {
         authenticator.buildCentralChallengeRequest(txId = 1)
         authenticator.processChallengeResponse(
-            responseCargo = ByteArray(8) { 0x42 },
-            code = "TESTCODE12345678",
+            responseCargo = buildChallengeResponseCargo(),
+            code = "123456",
             txId = 2,
         )
 
-        val success = authenticator.processPumpChallengeResponse(byteArrayOf())
+        val success = authenticator.processPumpChallengeResponse(byteArrayOf(0x01, 0x00))
         assertFalse(success)
         assertEquals(AuthState.FAILED, authenticator.authState.first())
     }


### PR DESCRIPTION
## Summary

- Fixes pump pairing never completing -- the BLE authentication handshake had four protocol format bugs compared to the pumpX2 reference implementation
- Adds `AUTH_FAILED` connection state with a visible error card so users see why pairing failed instead of silently returning to the code entry screen

## Root Cause

Verified against the [pumpX2](https://github.com/jwoglom/pumpX2) reference source code. Four discrepancies were found:

| Message | Our Code (Wrong) | pumpX2 (Correct) |
|---------|-------------------|-------------------|
| CentralChallengeRequest cargo | 16 bytes: 8-byte appInstanceId + 8-byte challenge | **10 bytes**: 2-byte LE short appInstanceId + 8-byte challenge |
| CentralChallengeResponse parsing | Entire 30-byte cargo used as HMAC key | HMAC key is **bytes 22-29** only (last 8 of 30 bytes) |
| PumpChallengeRequest cargo | 28 bytes: 8-byte appInstanceId + 20-byte HMAC | **22 bytes**: 2-byte LE appInstanceId + 20-byte HMAC |
| PumpChallengeResponse success check | `cargo[0] == 0` | `cargo[2] == 1` (byte 2, value 1 = success) |

## Files Changed

- `TandemAuthenticator.kt` -- Corrected all four protocol format issues
- `HmacHelper.kt` -- Updated documentation
- `BleConnectionManager.kt` -- Added error handling for null auth chunks, uses AUTH_FAILED state
- `PumpModels.kt` -- Added `AUTH_FAILED` to ConnectionState enum
- `PairingScreen.kt` -- Shows error card when auth fails with retry guidance
- `HomeScreen.kt` -- Handles AUTH_FAILED in connection status banner
- `TandemAuthenticatorTest.kt` -- Updated tests for correct protocol format

## Test plan

- [ ] Pair pump on physical device: scan, enter 6-digit code, verify pairing completes
- [ ] Enter wrong pairing code: verify "Pairing failed" error card appears
- [ ] `./gradlew :app:testDebugUnitTest` passes
- [ ] `./gradlew :app:lintDebug` clean
- [ ] `./gradlew :app:assembleDebug` builds