### PR TITLE
fix: correct BLE status response opcodes and parser byte layouts

### DIFF
--- a/apps/mobile/app/src/debug/res/xml/network_security_config.xml
+++ b/apps/mobile/app/src/debug/res/xml/network_security_config.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Debug builds: allow cleartext to emulator host (10.0.2.2) for local testing -->
-    <base-config cleartextTrafficPermitted="false">
+    <!-- Debug builds: allow cleartext (HTTP) for local development testing.
+         The release build (src/main) enforces HTTPS-only. -->
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
+            <certificates src="user" />
         </trust-anchors>
     </base-config>
-
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="false">10.0.2.2</domain>
-        <domain includeSubdomains="false">localhost</domain>
-    </domain-config>
 </network-security-config>

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/protocol/TandemProtocol.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/protocol/TandemProtocol.kt
@@ -92,10 +92,10 @@ object TandemProtocol {
     const val OPCODE_CURRENT_BATTERY_V1_RESP = 53
     const val OPCODE_CURRENT_BATTERY_V2_REQ = 144   // CurrentBatteryV2Request (11 bytes resp, fw v7.7+)
     const val OPCODE_CURRENT_BATTERY_V2_RESP = 145
-    const val OPCODE_PUMP_SETTINGS_REQ = 90
-    const val OPCODE_PUMP_SETTINGS_RESP = 91
-    const val OPCODE_BOLUS_CALC_DATA_REQ = 75
-    const val OPCODE_BOLUS_CALC_DATA_RESP = 76
+    const val OPCODE_LAST_BOLUS_STATUS_REQ = 48     // LastBolusStatusRequest (17-byte resp)
+    const val OPCODE_LAST_BOLUS_STATUS_RESP = 49    // LastBolusStatusResponse
+    const val OPCODE_PUMP_SETTINGS_REQ = 82          // PumpSettingsRequest (was 90 -- wrong)
+    const val OPCODE_PUMP_SETTINGS_RESP = 83
     // Note: value 34/35 overlap with JPAKE_1B on AUTHORIZATION characteristic.
     // No conflict -- status requests route to CURRENT_STATUS_UUID.
     const val OPCODE_CGM_EGV_REQ = 34               // CurrentEGVGuiDataRequest
@@ -134,17 +134,19 @@ object TandemProtocol {
 
     const val OPCODE_API_VERSION_REQ = 32
     const val OPCODE_API_VERSION_RESP = 33
-    const val OPCODE_PUMP_VERSION_REQ = 78
-    const val OPCODE_PUMP_VERSION_RESP = 79
-    const val OPCODE_TIME_SINCE_RESET_REQ = 80
-    const val OPCODE_TIME_SINCE_RESET_RESP = 81
+    const val OPCODE_PUMP_VERSION_REQ = 84           // PumpVersionRequest (was 78 -- wrong)
+    const val OPCODE_PUMP_VERSION_RESP = 85
+    const val OPCODE_TIME_SINCE_RESET_REQ = 54       // TimeSinceResetRequest (was 80 -- wrong)
+    const val OPCODE_TIME_SINCE_RESET_RESP = 55
 
     // -- History log / hardware info opcodes --------------------------------
 
-    const val OPCODE_LOG_ENTRY_SEQ_REQ = 26
-    const val OPCODE_LOG_ENTRY_SEQ_RESP = 27
-    const val OPCODE_PUMP_GLOBALS_REQ = 88
-    const val OPCODE_PUMP_GLOBALS_RESP = 89
+    const val OPCODE_HISTORY_LOG_STATUS_REQ = 58     // HistoryLogStatusRequest (was LOG_ENTRY_SEQ 26 -- wrong)
+    const val OPCODE_HISTORY_LOG_STATUS_RESP = 59
+    const val OPCODE_HISTORY_LOG_REQ = 60             // HistoryLogRequest (5-byte cargo: uint32 startLog + byte count)
+    const val OPCODE_HISTORY_LOG_RESP = 61
+    const val OPCODE_PUMP_GLOBALS_REQ = 86            // PumpGlobalsRequest (was 88 -- wrong)
+    const val OPCODE_PUMP_GLOBALS_RESP = 87
 
     // -- Connection parameters ---------------------------------------------
 
@@ -169,10 +171,10 @@ object TandemProtocol {
         OPCODE_CURRENT_BATTERY_V1_RESP -> "BatteryV1_RESP"
         OPCODE_CURRENT_BATTERY_V2_REQ -> "BatteryV2_REQ"
         OPCODE_CURRENT_BATTERY_V2_RESP -> "BatteryV2_RESP"
+        OPCODE_LAST_BOLUS_STATUS_REQ -> "LastBolus_REQ"
+        OPCODE_LAST_BOLUS_STATUS_RESP -> "LastBolus_RESP"
         OPCODE_PUMP_SETTINGS_REQ -> "PumpSettings_REQ"
         OPCODE_PUMP_SETTINGS_RESP -> "PumpSettings_RESP"
-        OPCODE_BOLUS_CALC_DATA_REQ -> "BolusCalc_REQ"
-        OPCODE_BOLUS_CALC_DATA_RESP -> "BolusCalc_RESP"
         OPCODE_CGM_EGV_REQ -> "CGM_EGV_REQ"
         OPCODE_CGM_EGV_RESP -> "CGM_EGV_RESP"
         OPCODE_HOME_SCREEN_MIRROR_REQ -> "HomeScreenMirror_REQ"
@@ -191,8 +193,10 @@ object TandemProtocol {
         OPCODE_JPAKE_3_SESSION_KEY_RESP -> "JPAKE_3_KEY_RESP"
         OPCODE_JPAKE_4_KEY_CONFIRM_REQ -> "JPAKE_4_CONFIRM_REQ"
         OPCODE_JPAKE_4_KEY_CONFIRM_RESP -> "JPAKE_4_CONFIRM_RESP"
-        OPCODE_LOG_ENTRY_SEQ_REQ -> "HistoryLog_REQ"
-        OPCODE_LOG_ENTRY_SEQ_RESP -> "HistoryLog_RESP"
+        OPCODE_HISTORY_LOG_STATUS_REQ -> "HistoryLogStatus_REQ"
+        OPCODE_HISTORY_LOG_STATUS_RESP -> "HistoryLogStatus_RESP"
+        OPCODE_HISTORY_LOG_REQ -> "HistoryLog_REQ"
+        OPCODE_HISTORY_LOG_RESP -> "HistoryLog_RESP"
         OPCODE_PUMP_GLOBALS_REQ -> "PumpGlobals_REQ"
         OPCODE_PUMP_GLOBALS_RESP -> "PumpGlobals_RESP"
         OPCODE_API_VERSION_REQ -> "ApiVersion_REQ"

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/PumpCredentialStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/PumpCredentialStore.kt
@@ -48,6 +48,32 @@ class PumpCredentialStore @Inject constructor(
     /** Whether a pump is currently paired. */
     fun isPaired(): Boolean = getPairedAddress() != null
 
+    /**
+     * Save JPAKE-derived credentials for confirmation mode reconnect.
+     * These are persisted after a successful bootstrap JPAKE handshake and
+     * allow subsequent connections to skip rounds 1-2.
+     */
+    fun saveJpakeCredentials(derivedSecretHex: String, serverNonceHex: String) {
+        prefs.edit()
+            .putString(KEY_JPAKE_DERIVED_SECRET, derivedSecretHex)
+            .putString(KEY_JPAKE_SERVER_NONCE, serverNonceHex)
+            .apply()
+    }
+
+    /** Get the saved JPAKE derived secret (hex string), or null if not available. */
+    fun getJpakeDerivedSecret(): String? = prefs.getString(KEY_JPAKE_DERIVED_SECRET, null)
+
+    /** Get the saved JPAKE server nonce (hex string), or null if not available. */
+    fun getJpakeServerNonce(): String? = prefs.getString(KEY_JPAKE_SERVER_NONCE, null)
+
+    /** Clear JPAKE credentials only (e.g., on confirmation mode failure). */
+    fun clearJpakeCredentials() {
+        prefs.edit()
+            .remove(KEY_JPAKE_DERIVED_SECRET)
+            .remove(KEY_JPAKE_SERVER_NONCE)
+            .apply()
+    }
+
     /** Clear all pairing data (unpair). */
     fun clearPairing() {
         prefs.edit().clear().apply()
@@ -57,5 +83,7 @@ class PumpCredentialStore @Inject constructor(
         private const val KEY_ADDRESS = "paired_pump_address"
         private const val KEY_PAIRING_CODE = "pairing_code"
         private const val KEY_PAIRED_AT = "paired_at"
+        private const val KEY_JPAKE_DERIVED_SECRET = "jpake_derived_secret"
+        private const val KEY_JPAKE_SERVER_NONCE = "jpake_server_nonce"
     }
 }


### PR DESCRIPTION
## Summary

- Fixed 11 incorrect opcode pairs in TandemProtocol.kt verified against pumpX2 source:
  - Basal 114->40, Insulin 41->36, Battery 57->split V1 52/V2 144, CGM 100->34, HomeScreenMirror 56
  - PumpSettings 90->82, PumpVersion 78->84, TimeSinceReset 80->54
  - HistoryLogStatus 26->58 (added HistoryLog 60), PumpGlobals 88->86
  - Replaced invalid BolusCalcData(75) with LastBolusStatus(48) using correct 17-byte layout
- Rewrote all StatusResponseParser methods with correct byte layouts
- Added Battery V1/V2 fallback (tries V2 firmware v7.7+ first, falls back to V1)
- Split CGM status into EGV (glucose value) + HomeScreenMirror (trend arrows) with graceful degradation
- Accept LOW/HIGH CGM status codes (1-3) for clinically important out-of-range readings
- Stabilized BLE connection: skip JPAKE on bonded reconnect, detect bond loss, zero-response tracking
- Added removeBond() and refreshGattCache() helpers for stale encryption key recovery
- Deferred medium/slow polling loops (60s/120s) to reduce connection churn
- Clear stale packet assemblers on reconnect
- Debug cleartext network config for local dev
- Rewrote all unit tests with pumpX2-verified hex test vectors (231 tests passing)

## Test plan

- [x] Unit tests pass (./gradlew testDebugUnitTest -- 231 tests)
- [x] Lint clean (./gradlew lintDebug)
- [x] Build succeeds (./gradlew assembleDebug)
- [x] Debug APK installed on physical phone, pump connected via BLE
- [x] Data pipeline verified: pump -> mobile app -> backend API -> web dashboard
- [x] IoB, Basal Rate, BG values confirmed matching between phone and web dashboard
- [x] Adversarial review completed (all findings addressed)
- [x] Security review passed (no secrets, no vulnerabilities)
- [ ] Connection stability: monitoring reconnect behavior after bond loss