### PR TITLE
fix: display IoB with full 2-decimal precision on web dashboard

### DIFF
--- a/apps/web/__tests__/components/dashboard/glucose-hero.accessibility.test.tsx
+++ b/apps/web/__tests__/components/dashboard/glucose-hero.accessibility.test.tsx
@@ -154,7 +154,7 @@ describe("GlucoseHero Accessibility", () => {
       const iobContainer = metricsGroup.querySelector('[aria-label*="Insulin on board"]');
       expect(iobContainer).toHaveAttribute(
         "aria-label",
-        "Insulin on board: 2.5 units"
+        "Insulin on board: 2.50 units"
       );
     });
 

--- a/apps/web/__tests__/components/dashboard/glucose-hero.test.tsx
+++ b/apps/web/__tests__/components/dashboard/glucose-hero.test.tsx
@@ -177,7 +177,7 @@ describe("GlucoseHero", () => {
     it("displays IoB value with unit", () => {
       render(<GlucoseHero {...defaultProps} iob={2.4} />);
 
-      expect(screen.getByTestId("iob-value")).toHaveTextContent("2.4u");
+      expect(screen.getByTestId("iob-value")).toHaveTextContent("2.40u");
     });
 
     it("displays CoB value with unit", () => {
@@ -198,10 +198,10 @@ describe("GlucoseHero", () => {
       expect(screen.getByTestId("cob-value")).toHaveTextContent("--");
     });
 
-    it("formats IoB to 1 decimal place", () => {
+    it("formats IoB to 2 decimal places", () => {
       render(<GlucoseHero {...defaultProps} iob={2.456} />);
 
-      expect(screen.getByTestId("iob-value")).toHaveTextContent("2.5u");
+      expect(screen.getByTestId("iob-value")).toHaveTextContent("2.46u");
     });
 
     it("rounds CoB to nearest integer", () => {
@@ -441,7 +441,7 @@ describe("GlucoseHero", () => {
     it("allows negative IoB (rare but possible)", () => {
       render(<GlucoseHero {...defaultProps} iob={-0.5} />);
 
-      expect(screen.getByTestId("iob-value")).toHaveTextContent("-0.5u");
+      expect(screen.getByTestId("iob-value")).toHaveTextContent("-0.50u");
     });
   });
 

--- a/apps/web/src/components/dashboard/alert-card.tsx
+++ b/apps/web/src/components/dashboard/alert-card.tsx
@@ -123,7 +123,7 @@ export function AlertCard({
           {formatTimeAgo(alert.created_at)}
         </span>
         {alert.iob_value != null && (
-          <span>IoB: {alert.iob_value.toFixed(1)}u</span>
+          <span>IoB: {alert.iob_value.toFixed(2)}u</span>
         )}
         {alert.trend_rate != null && (
           <span>

--- a/apps/web/src/components/dashboard/glucose-hero.tsx
+++ b/apps/web/src/components/dashboard/glucose-hero.tsx
@@ -307,7 +307,7 @@ export function GlucoseHero({
         >
           <div
             className="flex flex-col items-center"
-            aria-label={safeIob !== null ? `Insulin on board: ${safeIob.toFixed(1)} units` : "Insulin on board: unavailable"}
+            aria-label={safeIob !== null ? `Insulin on board: ${safeIob.toFixed(2)} units` : "Insulin on board: unavailable"}
           >
             <span className="text-slate-500 text-xs uppercase tracking-wide" aria-hidden="true">
               IoB
@@ -318,7 +318,7 @@ export function GlucoseHero({
               data-testid="iob-value"
               aria-hidden="true"
             >
-              {safeIob !== null ? `${safeIob.toFixed(1)}u` : "--"}
+              {safeIob !== null ? `${safeIob.toFixed(2)}u` : "--"}
             </span>
           </div>
           <div className="w-px h-6 bg-slate-700" aria-hidden="true" />


### PR DESCRIPTION
## Summary

- Changed IoB display from `.toFixed(1)` to `.toFixed(2)` in glucose-hero and alert-card components
- Web dashboard now shows the exact value synced from the pump (e.g. 8.91u instead of 8.9u)
- Matches the mobile app which already uses 2-decimal precision (`"%.2f"`)
- Updated 3 unit tests and 1 accessibility test to match new formatting

## Test plan

- [x] All glucose-hero tests pass (87/87)
- [x] Visually verified on Docker stack: dashboard shows 8.91u matching phone display
- [x] Accessibility aria-label updated to match