### PR TITLE
fix: prevent BLE disconnect and sync queue overflow during screen-off

### DIFF
--- a/apps/mobile/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/app/src/main/AndroidManifest.xml
@@ -26,6 +26,15 @@
     <!-- Self-update: install APK from GitHub Releases -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
+    <!-- Keep CPU alive during BLE polling when screen is off -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <!-- Battery optimization exemption: prevents OEM battery managers from killing foreground service -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
+    <!-- Auto-start pump connection service after device reboot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <!-- BLE hardware feature required - app is useless without BLE -->
     <uses-feature
         android:name="android.hardware.bluetooth_le"
@@ -62,6 +71,17 @@
             android:name=".service.AlertStreamService"
             android:foregroundServiceType="dataSync"
             android:exported="false" />
+
+        <!-- Auto-start pump connection service after device reboot -->
+        <receiver
+            android:name=".service.BootCompletedReceiver"
+            android:exported="true"
+            android:enabled="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
 
         <!-- Disable default WorkManager initializer; we use Configuration.Provider -->
         <provider

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Sync
@@ -100,6 +101,14 @@ fun SettingsScreen(
             onNavigateToPairing = onNavigateToPairing,
             onShowUnpair = settingsViewModel::showUnpairConfirm,
         )
+
+        // Battery optimization warning (between Pump and Sync)
+        if (state.isPumpPaired && state.isBatteryOptimized) {
+            Spacer(modifier = Modifier.height(8.dp))
+            BatteryOptimizationCard(
+                onRequestExemption = settingsViewModel::createBatteryOptimizationIntent,
+            )
+        }
 
         Spacer(modifier = Modifier.height(20.dp))
 
@@ -1059,6 +1068,59 @@ private fun WatchSection(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text("Check Watch Status")
+            }
+        }
+    }
+}
+
+@Composable
+private fun BatteryOptimizationCard(
+    onRequestExemption: () -> android.content.Intent,
+) {
+    val context = LocalContext.current
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Battery Optimization Active",
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    Text(
+                        text = "Android may stop the pump connection when the screen is off. Disable battery optimization for reliable overnight monitoring.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Button(
+                onClick = {
+                    try {
+                        context.startActivity(onRequestExemption())
+                    } catch (_: android.content.ActivityNotFoundException) {
+                        // Some OEMs don't support this intent; user must exempt manually
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("disable_battery_optimization_button"),
+            ) {
+                Text("Disable Battery Optimization")
             }
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -1,6 +1,10 @@
 package com.glycemicgpt.mobile.presentation.settings
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.PowerManager
+import android.provider.Settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.BuildConfig
@@ -73,6 +77,8 @@ data class SettingsUiState(
     // Watch
     val watchAppInstalled: Boolean? = null,
     val watchConnected: Boolean = false,
+    // Battery optimization
+    val isBatteryOptimized: Boolean = true,
 )
 
 @HiltViewModel
@@ -106,6 +112,8 @@ class SettingsViewModel @Inject constructor(
             appVersion = BuildConfig.VERSION_NAME,
             buildType = BuildConfig.BUILD_TYPE,
         )
+
+        checkBatteryOptimization()
 
         // Start services on app startup if conditions are met
         if (loggedIn) {
@@ -371,6 +379,19 @@ class SettingsViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    fun checkBatteryOptimization() {
+        val pm = appContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+        val isIgnoring = pm.isIgnoringBatteryOptimizations(appContext.packageName)
+        _uiState.value = _uiState.value.copy(isBatteryOptimized = !isIgnoring)
+    }
+
+    fun createBatteryOptimizationIntent(): Intent {
+        return Intent(
+            Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+            Uri.parse("package:${appContext.packageName}"),
+        )
     }
 
     private fun isValidUrl(url: String): Boolean {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BootCompletedReceiver.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BootCompletedReceiver.kt
@@ -1,0 +1,35 @@
+package com.glycemicgpt.mobile.service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.glycemicgpt.mobile.data.local.PumpCredentialStore
+import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * Starts PumpConnectionService after device reboot if a pump is paired.
+ *
+ * Complements the auto-start in GlycemicGptApp.onCreate() which handles
+ * cold app starts but not device reboots.
+ */
+@AndroidEntryPoint
+class BootCompletedReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var pumpCredentialStore: PumpCredentialStore
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED &&
+            intent.action != "android.intent.action.QUICKBOOT_POWERON"
+        ) return
+
+        if (pumpCredentialStore.isPaired()) {
+            Timber.d("Boot completed, starting PumpConnectionService (pump is paired)")
+            PumpConnectionService.start(context)
+        } else {
+            Timber.d("Boot completed, pump not paired -- skipping service start")
+        }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
@@ -28,6 +28,7 @@ class BackendSyncManagerTest {
     private val authTokenStore = mockk<AuthTokenStore>()
     private val appSettingsStore = mockk<AppSettingsStore> {
         every { backendSyncEnabled } returns true
+        every { dataRetentionDays } returns 7
     }
     private val moshi = Moshi.Builder().add(InstantAdapter()).build()
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/SyncQueuePruningTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/SyncQueuePruningTest.kt
@@ -1,0 +1,53 @@
+package com.glycemicgpt.mobile.service
+
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.glycemicgpt.mobile.data.local.dao.RawHistoryLogDao
+import com.glycemicgpt.mobile.data.local.dao.SyncDao
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.squareup.moshi.Moshi
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class SyncQueuePruningTest {
+
+    private val syncDao = mockk<SyncDao>(relaxed = true)
+    private val rawHistoryLogDao = mockk<RawHistoryLogDao>(relaxed = true)
+    private val api = mockk<GlycemicGptApi>()
+    private val authTokenStore = mockk<AuthTokenStore> {
+        every { isLoggedIn() } returns true
+    }
+    private val appSettingsStore = mockk<AppSettingsStore> {
+        every { backendSyncEnabled } returns true
+    }
+    private val moshi = Moshi.Builder().build()
+
+    private val manager = BackendSyncManager(
+        syncDao, rawHistoryLogDao, api, authTokenStore, appSettingsStore, moshi,
+    )
+
+    @Test
+    fun `pruneQueueIfNeeded does nothing when under limit`() = runTest {
+        coEvery { syncDao.countAll() } returns 100
+        manager.pruneQueueIfNeeded()
+        coVerify(exactly = 0) { syncDao.pruneOldest(any()) }
+    }
+
+    @Test
+    fun `pruneQueueIfNeeded prunes excess when over limit`() = runTest {
+        coEvery { syncDao.countAll() } returns 5500
+        manager.pruneQueueIfNeeded()
+        coVerify { syncDao.pruneOldest(500) }
+    }
+
+    @Test
+    fun `pruneQueueIfNeeded does nothing at exact limit`() = runTest {
+        coEvery { syncDao.countAll() } returns 5000
+        manager.pruneQueueIfNeeded()
+        coVerify(exactly = 0) { syncDao.pruneOldest(any()) }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PARTIAL_WAKE_LOCK` tied to BLE `ConnectionState.CONNECTED` with 30-minute safety timeout to keep the CPU alive for 15-second keep-alive polls when the screen is off
- Add `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission with a Settings UI card prompting users to exempt the app from OEM battery killers
- Add `RECEIVE_BOOT_COMPLETED` handler (`BootCompletedReceiver`) to auto-start the pump connection service after device reboot
- Cap the sync queue at 5,000 items with oldest-first pruning, reset orphaned `sending` items after crash, and periodically clean up exhausted-retry items
- Use `ContextCompat.registerReceiver` with `RECEIVER_NOT_EXPORTED` for Android 14+ compatibility
- Thread-safe wake lock access via `synchronized` blocks between coroutine and broadcast receiver threads

## Test plan

- [x] `./gradlew testDebugUnitTest` -- 258 tests pass (includes new `SyncQueuePruningTest` and `SettingsViewModelTest` battery optimization tests)
- [x] `./gradlew lintDebug` -- clean
- [x] `./gradlew assembleDebug` -- builds successfully
- [x] Emulator: Settings page shows no battery optimization card when pump is unpaired (correct conditional)
- [x] Emulator: `dumpsys package` confirms `WAKE_LOCK`, `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`, `RECEIVE_BOOT_COMPLETED` permissions and `BootCompletedReceiver` registration
- [ ] Physical phone: install APK, pair pump, verify pump stays connected overnight with screen off
- [ ] Physical phone: reboot device, verify pump auto-reconnects within 1-2 minutes