### PR TITLE
fix: reduce slow-loop polling delays for faster battery/reservoir updates

### DIFF
--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
@@ -77,10 +77,12 @@ class PumpPollingOrchestratorTest {
 
     /**
      * Time to advance past ALL loop initial delays + staggers.
-     * Slow loop has the largest delay (120s) and 4 reads with stagger.
+     * Uses the largest initial delay across all loops as the base.
      */
-    private val ALL_SETTLE_MS = PumpPollingOrchestrator.SLOW_LOOP_INITIAL_DELAY_MS +
-        PumpPollingOrchestrator.REQUEST_STAGGER_MS * 4 + 100
+    private val ALL_SETTLE_MS = maxOf(
+        PumpPollingOrchestrator.MEDIUM_LOOP_INITIAL_DELAY_MS,
+        PumpPollingOrchestrator.SLOW_LOOP_INITIAL_DELAY_MS,
+    ) + PumpPollingOrchestrator.REQUEST_STAGGER_MS * 4 + 100
 
     /** Alias for tests that only need fast loop data. */
     private val SETTLE_TIME_MS = FAST_SETTLE_MS
@@ -121,7 +123,7 @@ class PumpPollingOrchestratorTest {
         orchestrator.start(this)
 
         connectionStateFlow.value = ConnectionState.CONNECTED
-        // Advance past ALL loop initial delays (slow loop takes 120s)
+        // Advance past ALL loop initial delays (medium loop takes 60s)
         advanceTimeBy(ALL_SETTLE_MS)
 
         coVerify(atLeast = 1) { pumpDriver.getIoB() }
@@ -138,7 +140,7 @@ class PumpPollingOrchestratorTest {
         orchestrator.start(this)
 
         connectionStateFlow.value = ConnectionState.CONNECTED
-        // Advance past ALL loop initial delays (slow loop takes 120s)
+        // Advance past ALL loop initial delays (medium loop takes 60s)
         advanceTimeBy(ALL_SETTLE_MS)
 
         coVerify(atLeast = 1) { repository.saveIoB(any()) }


### PR DESCRIPTION
## Summary

- Reduced slow-loop initial delay from 120s to 30s so battery and reservoir cards populate within ~30 seconds of pump connection instead of 2+ minutes
- Reduced slow-loop polling interval from 15 minutes to 5 minutes for more timely battery/reservoir updates on a medical device monitor
- Updated test timing references to use `maxOf()` across loop delays for resilience against future constant changes

## Test plan

- [x] `./gradlew testDebugUnitTest` -- 258 tests pass
- [x] `./gradlew lintDebug` -- clean
- [x] `./gradlew assembleDebug` -- build succeeds
- [x] Emulator: app launches and renders home screen correctly
- [ ] Phone: connect pump, verify battery/reservoir cards populate within ~30s
- [ ] Phone: verify data continues refreshing every ~5 minutes