### PR TITLE
fix: use correct BLE opcode for pump hardware info parsing

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/protocol/TandemProtocol.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/protocol/TandemProtocol.kt
@@ -94,6 +94,8 @@ object TandemProtocol {
     const val OPCODE_CURRENT_BATTERY_V2_RESP = 145
     const val OPCODE_LAST_BOLUS_STATUS_REQ = 48     // LastBolusStatusRequest (17-byte resp)
     const val OPCODE_LAST_BOLUS_STATUS_RESP = 49    // LastBolusStatusResponse
+    const val OPCODE_PUMP_FEATURES_V1_REQ = 78        // PumpFeaturesV1Request (8-byte bitmask resp)
+    const val OPCODE_PUMP_FEATURES_V1_RESP = 79
     const val OPCODE_PUMP_SETTINGS_REQ = 82          // PumpSettingsRequest (was 90 -- wrong)
     const val OPCODE_PUMP_SETTINGS_RESP = 83
     // Note: value 34/35 overlap with JPAKE_1B on AUTHORIZATION characteristic.
@@ -173,6 +175,8 @@ object TandemProtocol {
         OPCODE_CURRENT_BATTERY_V2_RESP -> "BatteryV2_RESP"
         OPCODE_LAST_BOLUS_STATUS_REQ -> "LastBolus_REQ"
         OPCODE_LAST_BOLUS_STATUS_RESP -> "LastBolus_RESP"
+        OPCODE_PUMP_FEATURES_V1_REQ -> "PumpFeaturesV1_REQ"
+        OPCODE_PUMP_FEATURES_V1_RESP -> "PumpFeaturesV1_RESP"
         OPCODE_PUMP_SETTINGS_REQ -> "PumpSettings_REQ"
         OPCODE_PUMP_SETTINGS_RESP -> "PumpSettings_RESP"
         OPCODE_CGM_EGV_REQ -> "CGM_EGV_REQ"


### PR DESCRIPTION
## Summary

- Fixed pump hardware info parser that was using the wrong BLE opcode (86/87 PumpGlobals instead of 84/85 PumpVersion)
- PumpGlobals (14 bytes) contains quick bolus settings; PumpVersion (48 bytes) contains serial number, model, firmware versions
- Added separate PumpFeaturesV1 (opcode 78/79) parser for the feature bitmask with correct bit positions from pumpX2 reference
- Hardware info now flows to the backend, unblocking Tandem cloud uploads

## What was broken

The `parsePumpGlobalsResponse` parser expected 24+ bytes but PumpGlobals always returns 14 bytes, so it returned null on every poll. This left `pump_hardware_info` empty in the database, causing the Tandem cloud upload to fail with "No pump hardware info available. Pair your pump first."

## Verified on physical device

- Serial number 1390308, model 1002717, dexcomG6=true, controlIQ=true parsed correctly from BLE
- Backend `pump_hardware_info` table populated successfully
- All unit tests pass including new pumpX2 test vectors (tslim X2 and Mobi)

## Test plan

- [x] `./gradlew testDebugUnitTest` passes (8 new parser tests)
- [x] `./gradlew lintDebug` clean
- [x] `./gradlew assembleDebug` succeeds
- [x] Physical phone: hardware info parsing confirmed via logcat
- [x] Backend DB: `pump_hardware_info` row created
- [x] Adversarial code review passed
- [x] Security review of staged diff passed