### PR TITLE
fix: correct Tandem cloud upload authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,11 +38,6 @@ OPENAI_API_KEY=
 # Telegram Bot
 TELEGRAM_BOT_TOKEN=
 
-# Tandem Cloud Upload (Story 16.6)
-# HMAC key and client ID for Tandem t:connect cloud uploads
-TANDEM_UPLOAD_HMAC_KEY=
-TANDEM_UPLOAD_CLIENT_ID=
-
 # Session
 SESSION_EXPIRE_HOURS=24
 

--- a/apps/api/migrations/versions/034_add_tandem_pumper_id.py
+++ b/apps/api/migrations/versions/034_add_tandem_pumper_id.py
@@ -1,0 +1,27 @@
+"""Add tandem_pumper_id column to tandem_upload_state.
+
+Caches the Tandem pumperId (from JWT claims) so it can be included
+in upload payloads even when using a cached access token.
+
+Revision ID: 034_add_tandem_pumper_id
+Revises: 033_add_device_registrations
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "034_add_tandem_pumper_id"
+down_revision = "033_add_device_registrations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tandem_upload_state",
+        sa.Column("tandem_pumper_id", sa.String(100), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tandem_upload_state", "tandem_pumper_id")

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -81,9 +81,6 @@ class Settings(BaseSettings):
     # Tandem Cloud Upload (Story 16.6)
     tandem_upload_enabled: bool = True
     tandem_upload_check_interval_minutes: int = 1  # Check for due uploads every minute
-    tandem_upload_hmac_key: str = ""  # HMAC-SHA1 key for TDCToken signing
-    tandem_upload_client_id: str = ""  # Okta client ID for Tandem SSO
-    tandem_upload_sso_base: str = "https://sso.tandemdiabetes.com"
     tandem_upload_config_base: str = "https://assets.tandemdiabetes.com"
 
     # AI Sidecar (Story 15.2)

--- a/apps/api/src/models/tandem_upload_state.py
+++ b/apps/api/src/models/tandem_upload_state.py
@@ -87,6 +87,12 @@ class TandemUploadState(Base, TimestampMixin):
         nullable=True,
     )
 
+    # Tandem pumperId from JWT claims (for deviceAssignmentId in uploads)
+    tandem_pumper_id: Mapped[str | None] = mapped_column(
+        String(100),
+        nullable=True,
+    )
+
     # Relationship to user
     user = relationship("User", back_populates="tandem_upload_state")
 


### PR DESCRIPTION
## Summary

- Fix `_authenticate_fresh()` to read `api.accessToken` (camelCase) instead of guessing wrong attribute names -- this was the root cause of "Could not extract Tandem access token from API" errors
- Hardcode HMAC-SHA1 signing key as a module constant (public protocol constant from official app binary) instead of requiring `TANDEM_UPLOAD_HMAC_KEY` env var -- zero-config deployment
- Remove `tandem_upload_hmac_key`, `tandem_upload_client_id`, `tandem_upload_sso_base` from config and `.env.example`
- Add EU region support for token refresh endpoint (matching tconnectsync's US/EU region handling)
- Persist `tandem_pumper_id` in `TandemUploadState` so `deviceAssignmentId` survives across cached-token paths (migration 034)
- Compute real `expires_in` from `accessTokenExpiresAt` arrow datetime instead of hardcoded 3600
- Add tests for `_authenticate_fresh` (camelCase extraction, missing token, expiry computation) and `device_assignment_id` parameter

## Test plan

- [x] All 24 tandem upload tests pass (`pytest tests/test_tandem_upload.py`)
- [x] Ruff check and format clean
- [x] Docker stack rebuilt and healthy
- [x] DB confirms `last_upload_status=success`, `last_error=NULL` for real user after fresh auth
- [x] API logs show "Authenticated with Tandem via OIDC PKCE" on upload job
- [x] Adversarial review completed -- all HIGH/MEDIUM findings addressed
- [x] Security review of staged diff -- PASS (0 HIGH, 0 MEDIUM)