### PR TITLE
feat: implement BLE history log download from Tandem pump

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/connection/TandemBleDriver.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/connection/TandemBleDriver.kt
@@ -9,14 +9,18 @@ import com.glycemicgpt.mobile.domain.model.BolusEvent
 import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.HistoryLogRange
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.model.PumpHardwareInfo
 import com.glycemicgpt.mobile.domain.model.PumpSettings
 import com.glycemicgpt.mobile.domain.model.ReservoirReading
 import com.glycemicgpt.mobile.domain.pump.PumpDriver
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import timber.log.Timber
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -132,15 +136,61 @@ class TandemBleDriver @Inject constructor(
         return Result.success(egv.copy(trendArrow = trend))
     }
 
-    override suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> = runStatusRequest(
-        opcode = TandemProtocol.OPCODE_HISTORY_LOG_STATUS_REQ,
-    ) { cargo ->
-        // HistoryLogStatusResponse returns 8 bytes (firstSeq + lastSeq).
-        // The record parser expects 18-byte records, so it safely returns
-        // emptyList() for the status response. Full log fetching via
-        // OPCODE_HISTORY_LOG_REQ (60) with 5-byte cargo will be added
-        // when we implement incremental log download.
-        StatusResponseParser.parseHistoryLogResponse(cargo, sinceSequence)
+    override suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> {
+        // Phase 1: Get the available sequence range from the pump.
+        val rangeResult = runStatusRequest(
+            opcode = TandemProtocol.OPCODE_HISTORY_LOG_STATUS_REQ,
+        ) { cargo ->
+            StatusResponseParser.parseHistoryLogStatusResponse(cargo)
+                ?: throw IllegalStateException("Failed to parse history log status (need 8 bytes, got ${cargo.size})")
+        }
+        if (rangeResult.isFailure) return Result.failure(rangeResult.exceptionOrNull()!!)
+
+        val range = rangeResult.getOrThrow()
+        Timber.d("History log range: firstSeq=%d lastSeq=%d sinceSequence=%d",
+            range.firstSeq, range.lastSeq, sinceSequence)
+
+        if (range.lastSeq <= sinceSequence) return Result.success(emptyList())
+
+        // Phase 2: Fetch records in batches via opcode 60.
+        // Cap total records per poll to avoid monopolizing the BLE link.
+        // The next poll cycle will continue from where we left off.
+        val startSeq = maxOf(sinceSequence + 1, range.firstSeq)
+        val allRecords = mutableListOf<HistoryLogRecord>()
+        var cursor = startSeq
+
+        while (cursor <= range.lastSeq && allRecords.size < MAX_RECORDS_PER_POLL) {
+            val count = minOf(HISTORY_LOG_BATCH_SIZE, range.lastSeq - cursor + 1)
+            val cargo = buildHistoryLogCargo(cursor, count)
+
+            val batchResult = runStatusRequest(
+                opcode = TandemProtocol.OPCODE_HISTORY_LOG_REQ,
+                cargo = cargo,
+                timeoutMs = TandemProtocol.HISTORY_LOG_TIMEOUT_MS,
+            ) { responseCargo ->
+                StatusResponseParser.parseHistoryLogResponse(responseCargo, sinceSequence)
+            }
+
+            if (batchResult.isFailure) {
+                Timber.w(batchResult.exceptionOrNull(), "History log batch failed at cursor=%d", cursor)
+                break
+            }
+
+            val records = batchResult.getOrThrow()
+            if (records.isEmpty()) break
+
+            allRecords.addAll(records)
+            cursor = records.maxOf { it.sequenceNumber } + 1
+
+            // Brief pause between batches to avoid overwhelming the pump
+            // and to let other BLE requests interleave.
+            if (cursor <= range.lastSeq) {
+                delay(INTER_BATCH_DELAY_MS)
+            }
+        }
+
+        Timber.d("Fetched %d history log records total (cap=%d)", allRecords.size, MAX_RECORDS_PER_POLL)
+        return Result.success(allRecords)
     }
 
     override suspend fun getPumpHardwareInfo(): Result<PumpHardwareInfo> {
@@ -173,10 +223,12 @@ class TandemBleDriver @Inject constructor(
      */
     private suspend fun <T> runStatusRequest(
         opcode: Int,
+        cargo: ByteArray = ByteArray(0),
+        timeoutMs: Long = TandemProtocol.STATUS_READ_TIMEOUT_MS,
         parser: (ByteArray) -> T,
     ): Result<T> {
         return try {
-            val responseCargo = connectionManager.sendStatusRequest(opcode)
+            val responseCargo = connectionManager.sendStatusRequest(opcode, cargo, timeoutMs)
             val result = parser(responseCargo)
             val parsedStr = result.toString()
             Timber.d("BLE_RAW PARSED opcode=0x%02x result=%s", opcode, parsedStr)
@@ -187,5 +239,30 @@ class TandemBleDriver @Inject constructor(
             debugStore.updateLast(opcode, BleDebugStore.Direction.RX, error = e.message ?: e.javaClass.simpleName)
             Result.failure(e)
         }
+    }
+
+    /** Build the 5-byte cargo for HistoryLogRequest (opcode 60). */
+    private fun buildHistoryLogCargo(startSeq: Int, count: Int): ByteArray {
+        require(count in 1..MAX_RECORDS_PER_REQUEST) {
+            "count must be 1..$MAX_RECORDS_PER_REQUEST, got $count"
+        }
+        val buf = ByteBuffer.allocate(5).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(startSeq)
+        buf.put(count.toByte())
+        return buf.array()
+    }
+
+    companion object {
+        /** Number of records to request per BLE round-trip (max 14 due to 255-byte cargo limit). */
+        private const val HISTORY_LOG_BATCH_SIZE = 10
+
+        /** Absolute max records per request (255 bytes / 18 bytes per record). */
+        private const val MAX_RECORDS_PER_REQUEST = 14
+
+        /** Max records fetched per poll call to avoid monopolizing the BLE link. */
+        private const val MAX_RECORDS_PER_POLL = 200
+
+        /** Delay between batch requests to let other BLE operations interleave. */
+        private const val INTER_BATCH_DELAY_MS = 150L
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/messages/StatusResponseParser.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/messages/StatusResponseParser.kt
@@ -7,6 +7,7 @@ import com.glycemicgpt.mobile.domain.model.BolusEvent
 import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.ControlIqMode
+import com.glycemicgpt.mobile.domain.model.HistoryLogRange
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.model.PumpHardwareInfo
@@ -305,6 +306,23 @@ object StatusResponseParser {
                 timestamp = timestamp,
             ),
         )
+    }
+
+    /**
+     * Parse HistoryLogStatusResponse (opcode 59).
+     *
+     * Cargo layout (8 bytes, little-endian):
+     *   bytes 0-3: firstSeq (uint32 LE) -- oldest available log sequence
+     *   bytes 4-7: lastSeq (uint32 LE) -- newest available log sequence
+     *
+     * @return [HistoryLogRange] or null if cargo is too short.
+     */
+    fun parseHistoryLogStatusResponse(cargo: ByteArray): HistoryLogRange? {
+        if (cargo.size < 8) return null
+        val buf = ByteBuffer.wrap(cargo, 0, 8).order(ByteOrder.LITTLE_ENDIAN)
+        val firstSeq = buf.int
+        val lastSeq = buf.int
+        return HistoryLogRange(firstSeq, lastSeq)
     }
 
     /**

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/protocol/TandemProtocol.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/protocol/TandemProtocol.kt
@@ -108,6 +108,9 @@ object TandemProtocol {
     /** Default timeout for a status read request (milliseconds). */
     const val STATUS_READ_TIMEOUT_MS = 5000L
 
+    /** Timeout for history log fetch requests (longer due to multi-packet responses). */
+    const val HISTORY_LOG_TIMEOUT_MS = 10_000L
+
     // -- V1 Authentication opcodes (firmware < v7.7) -------------------------
 
     const val OPCODE_CENTRAL_CHALLENGE_REQ = 16

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
@@ -61,6 +61,11 @@ enum class CgmTrend {
     UNKNOWN,
 }
 
+data class HistoryLogRange(
+    val firstSeq: Int,
+    val lastSeq: Int,
+)
+
 data class HistoryLogRecord(
     val sequenceNumber: Int,
     val rawBytesB64: String,

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/ble/messages/StatusResponseParserTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/ble/messages/StatusResponseParserTest.kt
@@ -554,6 +554,68 @@ class StatusResponseParserTest {
         assertNull(StatusResponseParser.parsePumpVersionResponse(ByteArray(0)))
     }
 
+    // -- HistoryLogStatusResponse tests (opcode 59, 8-byte cargo) ---------------
+
+    @Test
+    fun `parseHistoryLogStatusResponse with valid range`() {
+        val buf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(100) // firstSeq
+        buf.putInt(500) // lastSeq
+        val result = StatusResponseParser.parseHistoryLogStatusResponse(buf.array())
+        assertNotNull(result)
+        assertEquals(100, result!!.firstSeq)
+        assertEquals(500, result.lastSeq)
+    }
+
+    @Test
+    fun `parseHistoryLogStatusResponse with zero range`() {
+        val buf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(0)
+        buf.putInt(0)
+        val result = StatusResponseParser.parseHistoryLogStatusResponse(buf.array())
+        assertNotNull(result)
+        assertEquals(0, result!!.firstSeq)
+        assertEquals(0, result.lastSeq)
+    }
+
+    @Test
+    fun `parseHistoryLogStatusResponse returns null for short cargo`() {
+        assertNull(StatusResponseParser.parseHistoryLogStatusResponse(ByteArray(7)))
+    }
+
+    @Test
+    fun `parseHistoryLogStatusResponse returns null for empty cargo`() {
+        assertNull(StatusResponseParser.parseHistoryLogStatusResponse(ByteArray(0)))
+    }
+
+    @Test
+    fun `parseHistoryLogStatusResponse ignores extra bytes`() {
+        val buf = ByteBuffer.allocate(12).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(10) // firstSeq
+        buf.putInt(99) // lastSeq
+        buf.putInt(42) // extra garbage
+        val result = StatusResponseParser.parseHistoryLogStatusResponse(buf.array())
+        assertNotNull(result)
+        assertEquals(10, result!!.firstSeq)
+        assertEquals(99, result.lastSeq)
+    }
+
+    // -- HistoryLogResponse tests (opcode 61, N x 18-byte records) ------------
+    // NOTE: parseHistoryLogResponse uses android.util.Base64 internally,
+    // which is not available in JVM unit tests. Edge-case tests (short cargo,
+    // empty cargo) that return before hitting Base64 are kept here. Full
+    // record parsing is covered by on-device instrumented tests.
+
+    @Test
+    fun `parseHistoryLogResponse returns empty for short cargo`() {
+        assertTrue(StatusResponseParser.parseHistoryLogResponse(ByteArray(17), sinceSequence = 0).isEmpty())
+    }
+
+    @Test
+    fun `parseHistoryLogResponse returns empty for empty cargo`() {
+        assertTrue(StatusResponseParser.parseHistoryLogResponse(ByteArray(0), sinceSequence = 0).isEmpty())
+    }
+
     // -- PumpFeatures tests (opcode 79, 8-byte cargo) -------------------------
 
     @Test


### PR DESCRIPTION
## Summary

- Implements the actual BLE history log download in `getHistoryLogs()` which was previously a stub
- Two-phase fetch: opcode 58 gets the sequence range (firstSeq/lastSeq), then opcode 60 fetches records in batches of 10
- All downstream infrastructure was already built: parser, Room DAO, polling loop, backend sync, Tandem cloud upload -- this wires up the missing piece

## Changes

- **TandemBleDriver.kt**: Rewrote `getHistoryLogs()` with two-phase fetch, added `cargo`/`timeoutMs` params to `runStatusRequest()`, added `buildHistoryLogCargo()` helper with bounds validation
- **StatusResponseParser.kt**: Added `parseHistoryLogStatusResponse()` to parse opcode 59 (8-byte firstSeq/lastSeq)
- **TandemProtocol.kt**: Added `HISTORY_LOG_TIMEOUT_MS = 10s` constant
- **PumpModels.kt**: Added `HistoryLogRange` data class (replaces generic `Pair`)
- **StatusResponseParserTest.kt**: Added 7 tests for the new status parser and history log edge cases

## Safeguards

- 200-record per-poll cap prevents monopolizing the BLE link during large initial syncs
- 150ms inter-batch delay lets other BLE requests (CGM, IoB, basal) interleave
- `require(count in 1..14)` in cargo builder prevents silent byte truncation

## Test plan

- [x] Unit tests pass (`./gradlew :app:testDebugUnitTest`)
- [x] Lint clean (`./gradlew :app:lintDebug`)
- [x] Build succeeds (`./gradlew assembleDebug`)
- [x] Emulator: app launches without crashes
- [ ] Physical phone with pump: verify history log records appear in logcat and backend DB