### PR TITLE
feat: auth token persistence and proactive refresh (Story 20.1)

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -152,6 +152,7 @@ dependencies {
     // Unit tests
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
+    testImplementation(libs.mockwebserver)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.turbine)
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
@@ -1,0 +1,232 @@
+package com.glycemicgpt.mobile.data.auth
+
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.glycemicgpt.mobile.data.remote.dto.LoginResponse
+import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Manages authentication state and proactive token refresh.
+ *
+ * Responsibilities:
+ * - Exposes observable [AuthState] via [authState]
+ * - Validates tokens on startup
+ * - Proactively refreshes access tokens before expiry
+ * - Handles refresh failures gracefully (emits [AuthState.Expired])
+ *
+ * Thread safety: [performRefresh] is protected by a [Mutex] to prevent
+ * concurrent refresh attempts (e.g., proactive timer + interceptor 401).
+ */
+@Singleton
+class AuthManager @Inject constructor(
+    private val authTokenStore: AuthTokenStore,
+    private val refreshClientProvider: RefreshClientProvider,
+    private val moshi: Moshi,
+) {
+    /** Dispatcher for blocking IO operations. Overridable for testing. */
+    var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Unauthenticated)
+    val authState: StateFlow<AuthState> = _authState.asStateFlow()
+
+    private var refreshJob: Job? = null
+    private val refreshMutex = Mutex()
+
+    /**
+     * Validates stored tokens on startup and schedules proactive refresh.
+     * Call this from Application.onCreate() or the first ViewModel that loads.
+     */
+    fun validateOnStartup(scope: CoroutineScope) {
+        val refreshToken = authTokenStore.getRefreshToken()
+        if (refreshToken == null) {
+            _authState.value = AuthState.Unauthenticated
+            return
+        }
+
+        // Check if refresh token is expired
+        if (authTokenStore.isRefreshTokenExpired()) {
+            Timber.w("Refresh token expired on startup")
+            _authState.value = AuthState.Expired()
+            return
+        }
+
+        val accessToken = authTokenStore.getToken()
+        if (accessToken != null) {
+            // Valid access token exists
+            _authState.value = AuthState.Authenticated
+            scheduleProactiveRefresh(scope)
+            return
+        }
+
+        // Access token expired but refresh token is valid -- attempt refresh
+        scope.launch {
+            performRefresh(scope)
+        }
+    }
+
+    /**
+     * Schedules a coroutine that refreshes the access token before it expires.
+     * Re-schedules itself after each successful refresh.
+     */
+    fun scheduleProactiveRefresh(scope: CoroutineScope) {
+        refreshJob?.cancel()
+        refreshJob = scope.launch {
+            val expiresAt = authTokenStore.getTokenExpiresAtMs()
+            if (expiresAt <= 0) return@launch
+
+            val refreshAt = expiresAt - AuthTokenStore.PROACTIVE_REFRESH_WINDOW_MS
+            val delayMs = (refreshAt - System.currentTimeMillis()).coerceAtLeast(0)
+
+            Timber.d("Proactive refresh scheduled in ${delayMs / 1000}s")
+            delay(delayMs)
+
+            performRefresh(scope)
+        }
+    }
+
+    /**
+     * Attempts to refresh the access token using the stored refresh token.
+     * Updates [authState] based on the result.
+     *
+     * Protected by [refreshMutex] to prevent concurrent refresh attempts.
+     * Runs the blocking OkHttp call on [Dispatchers.IO].
+     */
+    suspend fun performRefresh(scope: CoroutineScope) {
+        refreshMutex.withLock {
+            // Re-check after acquiring the lock -- another coroutine may have refreshed already
+            val existingToken = authTokenStore.getToken()
+            if (existingToken != null && _authState.value is AuthState.Authenticated) {
+                return
+            }
+
+            val refreshToken = authTokenStore.getRefreshToken()
+            if (refreshToken == null) {
+                _authState.value = AuthState.Unauthenticated
+                return
+            }
+
+            if (authTokenStore.isRefreshTokenExpired()) {
+                Timber.w("Refresh token expired, cannot refresh")
+                _authState.value = AuthState.Expired()
+                return
+            }
+
+            val baseUrl = authTokenStore.getBaseUrl()
+            if (baseUrl.isNullOrBlank()) {
+                Timber.w("No base URL configured, cannot refresh")
+                _authState.value = AuthState.Expired()
+                return
+            }
+
+            _authState.value = AuthState.Refreshing
+
+            try {
+                val body = RefreshTokenRequest(refreshToken = refreshToken)
+                val adapter = moshi.adapter(RefreshTokenRequest::class.java)
+                val json = adapter.toJson(body)
+
+                val request = Request.Builder()
+                    .url("http://localhost/api/auth/mobile/refresh")
+                    .post(json.toRequestBody("application/json".toMediaType()))
+                    .build()
+
+                val response = withContext(ioDispatcher) {
+                    refreshClientProvider.refreshClient.newCall(request).execute()
+                }
+
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        val responseBody = resp.body?.string()
+                        if (responseBody == null) {
+                            Timber.w("Refresh response body is null")
+                            _authState.value = AuthState.Expired()
+                            return
+                        }
+
+                        val loginAdapter = moshi.adapter(LoginResponse::class.java)
+                        val loginResponse = loginAdapter.fromJson(responseBody)
+                        if (loginResponse == null) {
+                            Timber.w("Failed to parse refresh response")
+                            _authState.value = AuthState.Expired()
+                            return
+                        }
+
+                        val expiresAtMs = System.currentTimeMillis() + (loginResponse.expiresIn * 1000L)
+                        authTokenStore.saveCredentials(
+                            baseUrl,
+                            loginResponse.accessToken,
+                            expiresAtMs,
+                            loginResponse.user.email,
+                        )
+                        authTokenStore.saveRefreshToken(loginResponse.refreshToken)
+
+                        Timber.d("Proactive token refresh succeeded")
+                        _authState.value = AuthState.Authenticated
+                        scheduleProactiveRefresh(scope)
+                    } else {
+                        Timber.w("Proactive token refresh failed with HTTP ${resp.code}")
+                        authTokenStore.clearToken()
+                        _authState.value = AuthState.Expired()
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e // Never swallow coroutine cancellation
+            } catch (e: Exception) {
+                Timber.w(e, "Proactive token refresh failed")
+                // Network error -- don't clear tokens, stay authenticated if we had a valid token
+                val currentToken = authTokenStore.getRawToken()
+                if (currentToken != null) {
+                    _authState.value = AuthState.Authenticated
+                    // Retry later
+                    scheduleProactiveRefresh(scope)
+                } else {
+                    _authState.value = AuthState.Expired()
+                }
+            }
+        }
+    }
+
+    /** Called after a successful login to set the authenticated state. */
+    fun onLoginSuccess(scope: CoroutineScope) {
+        _authState.value = AuthState.Authenticated
+        scheduleProactiveRefresh(scope)
+    }
+
+    /** Called on logout to reset state. */
+    fun onLogout() {
+        refreshJob?.cancel()
+        refreshJob = null
+        _authState.value = AuthState.Unauthenticated
+    }
+
+    /** Called by TokenRefreshInterceptor when a refresh attempt fails. */
+    fun onRefreshFailed() {
+        refreshJob?.cancel()
+        _authState.value = AuthState.Expired()
+    }
+
+    /** Called by TokenRefreshInterceptor after a successful interceptor-driven refresh. */
+    fun onInterceptorRefreshSuccess(scope: CoroutineScope) {
+        _authState.value = AuthState.Authenticated
+        scheduleProactiveRefresh(scope)
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthState.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthState.kt
@@ -1,0 +1,19 @@
+package com.glycemicgpt.mobile.data.auth
+
+/**
+ * Represents the authentication state of the user's session.
+ * Observable via StateFlow from [AuthManager].
+ */
+sealed class AuthState {
+    /** User has a valid access token. */
+    data object Authenticated : AuthState()
+
+    /** Token refresh is in progress. */
+    data object Refreshing : AuthState()
+
+    /** Session expired (refresh token invalid or expired). User must re-login. */
+    data class Expired(val message: String = "Session expired, please sign in again") : AuthState()
+
+    /** User is not logged in (no tokens stored). */
+    data object Unauthenticated : AuthState()
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/RefreshClientProvider.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/RefreshClientProvider.kt
@@ -1,0 +1,26 @@
+package com.glycemicgpt.mobile.data.auth
+
+import com.glycemicgpt.mobile.data.remote.BaseUrlInterceptor
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Provides a dedicated OkHttpClient for token refresh calls.
+ * This client only has the BaseUrlInterceptor (no auth/token-refresh interceptors)
+ * to avoid recursion during token refresh.
+ */
+@Singleton
+class RefreshClientProvider @Inject constructor(
+    private val baseUrlInterceptor: BaseUrlInterceptor,
+) {
+    val refreshClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(baseUrlInterceptor)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .build()
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
@@ -1,0 +1,258 @@
+package com.glycemicgpt.mobile.data.auth
+
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.squareup.moshi.Moshi
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import okhttp3.Call
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthManagerTest {
+
+    private val authTokenStore = mockk<AuthTokenStore>(relaxed = true)
+    private val moshi = Moshi.Builder().build()
+    private lateinit var refreshClientProvider: RefreshClientProvider
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var testScope: TestScope
+
+    /** Builds a fake OkHttp [Response] with the given code and JSON body. */
+    private fun fakeResponse(code: Int, body: String = ""): Response {
+        val request = Request.Builder().url("http://localhost/api/auth/mobile/refresh").build()
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message(if (code == 200) "OK" else "Error")
+            .body(body.toResponseBody("application/json".toMediaType()))
+            .build()
+    }
+
+    /** Creates a mock OkHttpClient that returns the given response on any call. */
+    private fun mockClientReturning(response: Response): OkHttpClient {
+        val call = mockk<Call> { every { execute() } returns response }
+        return mockk { every { newCall(any()) } returns call }
+    }
+
+    /** Creates a mock OkHttpClient that throws on any call. */
+    private fun mockClientThrowing(exception: Exception): OkHttpClient {
+        val call = mockk<Call> { every { execute() } throws exception }
+        return mockk { every { newCall(any()) } returns call }
+    }
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        testScope = TestScope(testDispatcher)
+
+        // Default: base URL is configured
+        every { authTokenStore.getBaseUrl() } returns "https://test.example.com"
+
+        // Default: mock client returns 200 (overridden per test as needed)
+        refreshClientProvider = mockk()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createManager() = AuthManager(authTokenStore, refreshClientProvider, moshi).also {
+        it.ioDispatcher = testDispatcher
+    }
+
+    // --- validateOnStartup ---
+
+    @Test
+    fun `validateOnStartup sets Unauthenticated when no refresh token`() {
+        every { authTokenStore.getRefreshToken() } returns null
+
+        val manager = createManager()
+        manager.validateOnStartup(testScope)
+
+        assertEquals(AuthState.Unauthenticated, manager.authState.value)
+    }
+
+    @Test
+    fun `validateOnStartup sets Expired when refresh token is expired`() {
+        every { authTokenStore.getRefreshToken() } returns "expired-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns true
+
+        val manager = createManager()
+        manager.validateOnStartup(testScope)
+
+        assertTrue(manager.authState.value is AuthState.Expired)
+    }
+
+    @Test
+    fun `validateOnStartup sets Authenticated when access token is valid`() {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getToken() } returns "valid-access-token"
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() + 3_600_000
+
+        val manager = createManager()
+        manager.validateOnStartup(testScope)
+
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+    }
+
+    // --- performRefresh (also covers the validateOnStartup->performRefresh delegation path) ---
+
+    @Test
+    fun `performRefresh succeeds and saves new tokens`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() + 3_600_000
+
+        val body = """
+            {
+                "access_token": "refreshed-access",
+                "refresh_token": "refreshed-refresh",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "user": {"id": "1", "email": "user@test.com", "role": "user"}
+            }
+        """.trimIndent()
+        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(200, body))
+
+        val manager = createManager()
+        manager.performRefresh(testScope)
+
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+        verify { authTokenStore.saveCredentials("https://test.example.com", "refreshed-access", any(), "user@test.com") }
+        verify { authTokenStore.saveRefreshToken("refreshed-refresh") }
+    }
+
+    @Test
+    fun `performRefresh sets Unauthenticated when no refresh token`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns null
+
+        val manager = createManager()
+        manager.performRefresh(testScope)
+
+        assertEquals(AuthState.Unauthenticated, manager.authState.value)
+    }
+
+    @Test
+    fun `performRefresh sets Expired when refresh token is expired`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns "expired-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns true
+
+        val manager = createManager()
+        manager.performRefresh(testScope)
+
+        assertTrue(manager.authState.value is AuthState.Expired)
+    }
+
+    @Test
+    fun `performRefresh sets Expired when no base URL configured`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getBaseUrl() } returns null
+
+        val manager = createManager()
+        manager.performRefresh(testScope)
+
+        assertTrue(manager.authState.value is AuthState.Expired)
+    }
+
+    @Test
+    fun `performRefresh sets Expired on HTTP error`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(401))
+
+        val manager = createManager()
+        manager.performRefresh(testScope)
+
+        assertTrue(manager.authState.value is AuthState.Expired)
+        verify { authTokenStore.clearToken() }
+    }
+
+    @Test
+    fun `performRefresh stays Authenticated on network error if raw token exists`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getRawToken() } returns "existing-token"
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() + 3_600_000
+        every { refreshClientProvider.refreshClient } returns mockClientThrowing(IOException("Network unreachable"))
+
+        val manager = createManager()
+        manager.performRefresh(testScope)
+
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+    }
+
+    @Test
+    fun `performRefresh sets Expired on network error if no raw token`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getRawToken() } returns null
+        every { refreshClientProvider.refreshClient } returns mockClientThrowing(IOException("Network unreachable"))
+
+        val manager = createManager()
+        manager.performRefresh(testScope)
+
+        assertTrue(manager.authState.value is AuthState.Expired)
+    }
+
+    // --- onLoginSuccess / onLogout ---
+
+    @Test
+    fun `onLoginSuccess sets Authenticated`() {
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() + 3_600_000
+
+        val manager = createManager()
+        manager.onLoginSuccess(testScope)
+
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+    }
+
+    @Test
+    fun `onLogout sets Unauthenticated`() {
+        val manager = createManager()
+        manager.onLoginSuccess(testScope)
+        manager.onLogout()
+
+        assertEquals(AuthState.Unauthenticated, manager.authState.value)
+    }
+
+    @Test
+    fun `onRefreshFailed sets Expired`() {
+        val manager = createManager()
+        manager.onRefreshFailed()
+
+        assertTrue(manager.authState.value is AuthState.Expired)
+    }
+
+    @Test
+    fun `onInterceptorRefreshSuccess sets Authenticated`() {
+        val manager = createManager()
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() + 3_600_000
+
+        manager.onInterceptorRefreshSuccess(testScope)
+
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthTokenStoreTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthTokenStoreTest.kt
@@ -1,0 +1,46 @@
+package com.glycemicgpt.mobile.data.auth
+
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AuthTokenStoreTest {
+
+    @Test
+    fun `extractJwtExpiration parses valid JWT`() {
+        // JWT payload: {"sub":"1","email":"test@test.com","exp":1893456000,"type":"refresh"}
+        // exp = 1893456000 (Jan 1, 2030 UTC)
+        val payloadJson = """{"sub":"1","email":"test@test.com","exp":1893456000,"type":"refresh"}"""
+        val payloadBase64 = java.util.Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(payloadJson.toByteArray())
+
+        val jwt = "eyJhbGciOiJIUzI1NiJ9.$payloadBase64.signature"
+        val result = AuthTokenStore.extractJwtExpiration(jwt)
+
+        assertEquals(1893456000L * 1000L, result)
+    }
+
+    @Test
+    fun `extractJwtExpiration returns 0 for malformed JWT`() {
+        assertEquals(0L, AuthTokenStore.extractJwtExpiration("not-a-jwt"))
+        assertEquals(0L, AuthTokenStore.extractJwtExpiration(""))
+        assertEquals(0L, AuthTokenStore.extractJwtExpiration("one.two"))
+    }
+
+    @Test
+    fun `extractJwtExpiration returns 0 when exp is missing`() {
+        val payloadJson = """{"sub":"1","email":"test@test.com","type":"refresh"}"""
+        val payloadBase64 = java.util.Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(payloadJson.toByteArray())
+
+        val jwt = "header.$payloadBase64.signature"
+        val result = AuthTokenStore.extractJwtExpiration(jwt)
+
+        assertEquals(0L, result)
+    }
+
+    @Test
+    fun `PROACTIVE_REFRESH_WINDOW_MS is 5 minutes`() {
+        assertEquals(5 * 60 * 1000L, AuthTokenStore.PROACTIVE_REFRESH_WINDOW_MS)
+    }
+}

--- a/apps/mobile/gradle/libs.versions.toml
+++ b/apps/mobile/gradle/libs.versions.toml
@@ -103,6 +103,7 @@ espresso = { group = "androidx.test.espresso", name = "espresso-core", version.r
 compose-ui-test = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 [plugins]


### PR DESCRIPTION
## Summary

- Add `AuthManager` with observable `AuthState` sealed class (Authenticated, Refreshing, Expired, Unauthenticated) and mutex-protected token refresh
- Implement proactive access token refresh 5 minutes before expiry via coroutine scheduling
- Extract JWT `exp` claim from refresh tokens to detect expiration client-side
- Add `SessionExpiredBanner` in NavHost that navigates to Settings on tap
- Integrate auth lifecycle into `SettingsViewModel` (login/logout) and `GlycemicGptApp` (startup validation)
- Add `RefreshClientProvider` with dedicated OkHttpClient to prevent interceptor recursion during refresh
- Update `TokenRefreshInterceptor` to use AuthManager for state coordination and proper response cleanup

## Test plan

- [x] 14 unit tests for AuthManager covering all auth state transitions, refresh success/failure/network-error paths
- [x] 4 unit tests for AuthTokenStore JWT extraction (valid, malformed, missing exp, constant value)
- [x] Updated TokenRefreshInterceptor tests for expired refresh token and double-check retry scenarios
- [x] Updated SettingsViewModel tests verifying auth lifecycle callbacks
- [x] All 294+ unit tests pass (app + wear modules)
- [x] Lint clean, build succeeds
- [x] Visual verification on emulator: home screen loads, Settings shows "Authenticated" state, no crash on startup
- [x] Adversarial code review completed (14 findings addressed)
- [x] Security review of staged diff: PASS (no secrets, no vulnerabilities)