### PR TITLE
ci: add attribution guardrails (Story 20.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,31 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+  check-attribution:
+    name: Attribution Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for prohibited Co-Authored-By lines
+        run: |
+          if git log --format="%B" origin/main..HEAD 2>/dev/null | grep -qiE '^Co-Authored-By:.*(claude|anthropic|noreply@anthropic)'; then
+            echo "ERROR: Found prohibited Co-Authored-By attribution in commit messages."
+            echo "The following commits contain AI tool attribution:"
+            git log --format="%h %s" origin/main..HEAD | while read -r hash rest; do
+              if git log -1 --format="%B" "$hash" | grep -qiE '^Co-Authored-By:.*(claude|anthropic|noreply@anthropic)'; then
+                echo "  - $hash $rest"
+              fi
+            done
+            echo ""
+            echo "Install the commit-msg hook: cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg"
+            exit 1
+          fi
+          echo "No prohibited attribution found."
+
   test-sidecar:
     name: Sidecar Tests
     runs-on: ubuntu-latest

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Strips AI tool co-author attribution from commit messages.
+# Install: cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
+
+MSG_FILE="$1"
+if [ -f "$MSG_FILE" ]; then
+    sed -i '/^Co-[Aa]uthored-[Bb]y:.*\([Cc]laude\|[Aa]nthropic\|noreply@anthropic\)/d' "$MSG_FILE"
+    # Remove trailing blank lines
+    while [ "$(tail -c 2 "$MSG_FILE" | od -An -tx1 | tr -d ' ')" = "0a0a" ]; do
+        truncate -s -1 "$MSG_FILE"
+    done
+fi


### PR DESCRIPTION
## Summary

- Rewrote git history to remove all 226 Co-Authored-By trailers from commit messages (force-pushed all branches)
- Added `scripts/hooks/commit-msg` git hook that auto-strips prohibited Co-Authored-By lines
- Added `check-attribution` CI job to `.github/workflows/ci.yml` that fails PRs containing AI attribution

## Three Lines of Defense

1. **CLAUDE.md instruction** (already existed) -- tells Claude Code to never add Co-Authored-By
2. **commit-msg git hook** (new) -- auto-strips prohibited lines on every local commit
3. **CI check** (new) -- scans all PR commits and fails if attribution is found

## Test plan

- [x] History rewrite verified: `git log --all --grep="Co-Authored-By"` returns 0 on all reachable branches
- [x] Hook tested: creates commit with Co-Authored-By line, hook strips it automatically
- [x] CI job will run on this PR to verify it works
- [x] Hook setup: `cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg`