### PR TITLE
feat: add glucose trend chart with IoB overlay to mobile home screen

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
@@ -27,6 +27,9 @@ interface PumpDao {
     @Query("SELECT * FROM iob_readings WHERE timestampMs >= :sinceMs ORDER BY timestampMs DESC")
     suspend fun getIoBSince(sinceMs: Long): List<IoBReadingEntity>
 
+    @Query("SELECT * FROM iob_readings WHERE timestampMs >= :sinceMs ORDER BY timestampMs ASC LIMIT :limit")
+    fun observeIoBHistory(sinceMs: Long, limit: Int = 2000): Flow<List<IoBReadingEntity>>
+
     @Query("DELETE FROM iob_readings WHERE timestampMs < :beforeMs")
     suspend fun deleteIoBBefore(beforeMs: Long): Int
 
@@ -87,6 +90,9 @@ interface PumpDao {
 
     @Query("SELECT * FROM cgm_readings ORDER BY timestampMs DESC LIMIT 1")
     fun observeLatestCgm(): Flow<CgmReadingEntity?>
+
+    @Query("SELECT * FROM cgm_readings WHERE timestampMs >= :sinceMs ORDER BY timestampMs ASC LIMIT :limit")
+    fun observeCgmHistory(sinceMs: Long, limit: Int = 2000): Flow<List<CgmReadingEntity>>
 
     @Query("DELETE FROM cgm_readings WHERE timestampMs < :beforeMs")
     suspend fun deleteCgmBefore(beforeMs: Long): Int

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/PumpDataRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/PumpDataRepository.kt
@@ -53,6 +53,11 @@ class PumpDataRepository @Inject constructor(
     fun observeLatestIoB(): Flow<IoBReading?> =
         pumpDao.observeLatestIoB().map { it?.toDomain() }
 
+    fun observeIoBHistory(since: Instant): Flow<List<IoBReading>> =
+        pumpDao.observeIoBHistory(since.toEpochMilli()).map { entities ->
+            entities.map { it.toDomain() }
+        }
+
     // -- Basal ----------------------------------------------------------------
 
     suspend fun saveBasal(reading: BasalReading) {
@@ -133,6 +138,11 @@ class PumpDataRepository @Inject constructor(
 
     fun observeLatestCgm(): Flow<CgmReading?> =
         pumpDao.observeLatestCgm().map { it?.toDomain() }
+
+    fun observeCgmHistory(since: Instant): Flow<List<CgmReading>> =
+        pumpDao.observeCgmHistory(since.toEpochMilli()).map { entities ->
+            entities.map { it.toDomain() }
+        }
 
     // -- Cleanup --------------------------------------------------------------
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseHero.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseHero.kt
@@ -1,0 +1,192 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.ControlIqMode
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
+
+object GlucoseThresholds {
+    const val URGENT_LOW = 55
+    const val LOW = 70
+    const val HIGH = 180
+    const val URGENT_HIGH = 250
+}
+
+fun glucoseColor(mgDl: Int): Color = when {
+    mgDl < GlucoseThresholds.URGENT_LOW -> GlucoseColors.UrgentLow
+    mgDl < GlucoseThresholds.LOW -> GlucoseColors.Low
+    mgDl <= GlucoseThresholds.HIGH -> GlucoseColors.InRange
+    mgDl <= GlucoseThresholds.URGENT_HIGH -> GlucoseColors.High
+    else -> GlucoseColors.UrgentHigh
+}
+
+fun trendArrowSymbol(trend: CgmTrend): String = when (trend) {
+    CgmTrend.DOUBLE_UP -> "\u21C8"
+    CgmTrend.SINGLE_UP -> "\u2191"
+    CgmTrend.FORTY_FIVE_UP -> "\u2197"
+    CgmTrend.FLAT -> "\u2192"
+    CgmTrend.FORTY_FIVE_DOWN -> "\u2198"
+    CgmTrend.SINGLE_DOWN -> "\u2193"
+    CgmTrend.DOUBLE_DOWN -> "\u21CA"
+    CgmTrend.UNKNOWN -> "?"
+}
+
+@Composable
+fun GlucoseHero(
+    cgm: CgmReading?,
+    iob: IoBReading?,
+    basalRate: BasalReading?,
+    modifier: Modifier = Modifier,
+) {
+    val a11yDescription = if (cgm != null) {
+        "Glucose ${cgm.glucoseMgDl} milligrams per deciliter, " +
+            "${cgm.trendArrow.name.lowercase().replace('_', ' ')}"
+    } else {
+        "No glucose data available"
+    }
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = a11yDescription },
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            if (cgm != null) {
+                val color = glucoseColor(cgm.glucoseMgDl)
+
+                // Primary: large glucose value + trend arrow
+                Row(
+                    verticalAlignment = Alignment.Bottom,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = "${cgm.glucoseMgDl}",
+                        fontSize = 64.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = color,
+                        modifier = Modifier.testTag("glucose_hero_value"),
+                    )
+                    Text(
+                        text = trendArrowSymbol(cgm.trendArrow),
+                        fontSize = 40.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = color,
+                        modifier = Modifier
+                            .padding(bottom = 8.dp, start = 4.dp)
+                            .testTag("glucose_hero_trend"),
+                    )
+                }
+
+                Text(
+                    text = "mg/dL",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+                FreshnessLabel(cgm.timestamp)
+
+                // Secondary metrics: IoB + Basal (like web's IoB/CoB)
+                if (iob != null || basalRate != null) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        if (iob != null) {
+                            SecondaryMetric(
+                                label = "IoB",
+                                value = "%.2fu".format(iob.iob),
+                                modifier = Modifier.testTag("hero_iob"),
+                            )
+                        }
+                        if (iob != null && basalRate != null) {
+                            Spacer(modifier = Modifier.width(24.dp))
+                        }
+                        if (basalRate != null) {
+                            val basalText = "%.2f u/hr".format(basalRate.rate)
+                            val modeLabel = when (basalRate.controlIqMode) {
+                                ControlIqMode.SLEEP -> " Sleep"
+                                ControlIqMode.EXERCISE -> " Exercise"
+                                ControlIqMode.STANDARD -> if (basalRate.isAutomated) " Auto" else ""
+                            }
+                            SecondaryMetric(
+                                label = "Basal",
+                                value = basalText + modeLabel,
+                                modifier = Modifier.testTag("hero_basal"),
+                            )
+                        }
+                    }
+                }
+            } else {
+                Text(
+                    text = "--",
+                    fontSize = 64.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = "mg/dL",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SecondaryMetric(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseTrendChart.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseTrendChart.kt
@@ -1,0 +1,323 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+enum class ChartPeriod(val label: String, val hours: Long) {
+    THREE_HOURS("3H", 3),
+    SIX_HOURS("6H", 6),
+    TWELVE_HOURS("12H", 12),
+    TWENTY_FOUR_HOURS("24H", 24),
+}
+
+@Composable
+fun GlucoseTrendChart(
+    readings: List<CgmReading>,
+    iobReadings: List<IoBReading>,
+    selectedPeriod: ChartPeriod,
+    onPeriodSelected: (ChartPeriod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            // Period selector
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                ChartPeriod.entries.forEach { period ->
+                    FilterChip(
+                        selected = period == selectedPeriod,
+                        onClick = { onPeriodSelected(period) },
+                        label = {
+                            Text(
+                                text = period.label,
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                        },
+                        modifier = Modifier
+                            .padding(horizontal = 4.dp)
+                            .testTag("period_chip_${period.label}"),
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                        shape = RoundedCornerShape(8.dp),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (readings.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(220.dp)
+                        .testTag("chart_empty_state"),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "No glucose readings yet",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                val textMeasurer = rememberTextMeasurer()
+                val axisLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
+                val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+                val iobColor = MaterialTheme.colorScheme.primary
+                val nowMs = remember(readings, selectedPeriod) {
+                    System.currentTimeMillis()
+                }
+                val iobSuffix = if (iobReadings.isNotEmpty()) ", with insulin on board overlay" else ""
+                val a11yLabel = "Glucose trend chart showing ${readings.size} readings " +
+                    "over the last ${selectedPeriod.label}" + iobSuffix
+
+                Canvas(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(220.dp)
+                        .testTag("glucose_chart")
+                        .semantics { contentDescription = a11yLabel },
+                ) {
+                    drawGlucoseChart(
+                        readings = readings,
+                        iobReadings = iobReadings,
+                        period = selectedPeriod,
+                        nowMs = nowMs,
+                        textMeasurer = textMeasurer,
+                        axisLabelColor = axisLabelColor,
+                        gridColor = gridColor,
+                        iobColor = iobColor,
+                    )
+                }
+
+                // IoB legend
+                if (iobReadings.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        Text(
+                            text = "IoB",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = iobColor.copy(alpha = 0.7f),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun DrawScope.drawGlucoseChart(
+    readings: List<CgmReading>,
+    iobReadings: List<IoBReading>,
+    period: ChartPeriod,
+    nowMs: Long,
+    textMeasurer: TextMeasurer,
+    axisLabelColor: Color,
+    gridColor: Color,
+    iobColor: Color,
+) {
+    val leftPadding = 36.dp.toPx()
+    val bottomPadding = 24.dp.toPx()
+    val topPadding = 8.dp.toPx()
+    val rightPadding = if (iobReadings.isNotEmpty()) 32.dp.toPx() else 8.dp.toPx()
+
+    val chartWidth = size.width - leftPadding - rightPadding
+    val chartHeight = size.height - topPadding - bottomPadding
+
+    // Y-axis range: 40 to 300 mg/dL
+    val yMin = 40f
+    val yMax = 300f
+    val yRange = yMax - yMin
+
+    // X-axis range
+    val periodMs = period.hours * 3600_000L
+    val xMin = nowMs - periodMs
+    val xMax = nowMs
+
+    // Target range band (70-180 mg/dL)
+    val bandTopY = topPadding + chartHeight * (1f - (GlucoseThresholds.HIGH - yMin) / yRange)
+    val bandBottomY = topPadding + chartHeight * (1f - (GlucoseThresholds.LOW - yMin) / yRange)
+    drawRect(
+        color = GlucoseColors.InRange.copy(alpha = 0.08f),
+        topLeft = Offset(leftPadding, bandTopY),
+        size = Size(chartWidth, bandBottomY - bandTopY),
+    )
+
+    // Grid lines
+    val gridValues = listOf(70f, 180f, 250f)
+    val dashedEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 8f))
+    for (value in gridValues) {
+        val y = topPadding + chartHeight * (1f - (value - yMin) / yRange)
+        drawLine(
+            color = gridColor,
+            start = Offset(leftPadding, y),
+            end = Offset(leftPadding + chartWidth, y),
+            pathEffect = dashedEffect,
+            strokeWidth = 1f,
+        )
+    }
+
+    // Y-axis labels (left: glucose)
+    val yLabelValues = listOf(70, 180, 250)
+    val labelStyle = TextStyle(fontSize = 10.sp, color = axisLabelColor)
+    for (value in yLabelValues) {
+        val y = topPadding + chartHeight * (1f - (value - yMin) / yRange)
+        val textResult = textMeasurer.measure("$value", labelStyle)
+        drawText(
+            textResult,
+            topLeft = Offset(
+                leftPadding - textResult.size.width - 3.dp.toPx(),
+                y - textResult.size.height / 2f,
+            ),
+        )
+    }
+
+    // X-axis time labels (shorter format to avoid overlap)
+    val timeFormatter = DateTimeFormatter.ofPattern(
+        if (period.hours <= 6) "h:mm" else "ha",
+    ).withZone(ZoneId.systemDefault())
+
+    val tickCount = when (period) {
+        ChartPeriod.THREE_HOURS -> 3
+        ChartPeriod.SIX_HOURS -> 3
+        ChartPeriod.TWELVE_HOURS -> 4
+        ChartPeriod.TWENTY_FOUR_HOURS -> 4
+    }
+
+    for (i in 0..tickCount) {
+        val tickMs = xMin + (xMax - xMin) * i.toLong() / tickCount.toLong()
+        val x = leftPadding + chartWidth * i.toFloat() / tickCount.toFloat()
+        val label = timeFormatter.format(Instant.ofEpochMilli(tickMs))
+        val textResult = textMeasurer.measure(label, labelStyle)
+        drawText(
+            textResult,
+            topLeft = Offset(
+                x - textResult.size.width / 2f,
+                size.height - bottomPadding + 4.dp.toPx(),
+            ),
+        )
+    }
+
+    // IoB overlay (filled area + line on secondary axis)
+    if (iobReadings.size >= 2) {
+        val maxIob = iobReadings.maxOf { it.iob }.coerceAtLeast(1f)
+        val iobAreaPath = Path()
+        val iobLinePath = Path()
+        var started = false
+        var lastInRangeX = 0f
+
+        for (reading in iobReadings) {
+            val ts = reading.timestamp.toEpochMilli()
+            if (ts < xMin || ts > xMax) continue
+
+            val x = leftPadding + chartWidth * (ts - xMin).toFloat() / (xMax - xMin).toFloat()
+            // IoB uses full chart height, scaled to maxIob
+            val y = topPadding + chartHeight * (1f - reading.iob / maxIob)
+            lastInRangeX = x
+
+            if (!started) {
+                iobAreaPath.moveTo(x, topPadding + chartHeight) // bottom
+                iobAreaPath.lineTo(x, y)
+                iobLinePath.moveTo(x, y)
+                started = true
+            } else {
+                iobAreaPath.lineTo(x, y)
+                iobLinePath.lineTo(x, y)
+            }
+        }
+
+        if (started) {
+            // Close the area path back to bottom
+            iobAreaPath.lineTo(lastInRangeX, topPadding + chartHeight)
+            iobAreaPath.close()
+
+            drawPath(iobAreaPath, iobColor.copy(alpha = 0.06f), style = Fill)
+            drawPath(iobLinePath, iobColor.copy(alpha = 0.4f), style = androidx.compose.ui.graphics.drawscope.Stroke(width = 1.5.dp.toPx()))
+
+            // Right Y-axis labels for IoB
+            val iobLabelStyle = TextStyle(fontSize = 9.sp, color = iobColor.copy(alpha = 0.6f))
+            val topLabel = textMeasurer.measure("%.1fu".format(maxIob), iobLabelStyle)
+            drawText(topLabel, topLeft = Offset(leftPadding + chartWidth + 3.dp.toPx(), topPadding))
+            val bottomLabel = textMeasurer.measure("0u", iobLabelStyle)
+            drawText(
+                bottomLabel,
+                topLeft = Offset(
+                    leftPadding + chartWidth + 3.dp.toPx(),
+                    topPadding + chartHeight - bottomLabel.size.height,
+                ),
+            )
+        }
+    }
+
+    // Glucose data points (drawn last so they're on top)
+    val dotRadius = 3.dp.toPx()
+    for (reading in readings) {
+        val ts = reading.timestamp.toEpochMilli()
+        if (ts < xMin || ts > xMax) continue
+
+        val x = leftPadding + chartWidth * (ts - xMin).toFloat() / (xMax - xMin).toFloat()
+        val clampedValue = reading.glucoseMgDl.coerceIn(yMin.toInt(), yMax.toInt())
+        val y = topPadding + chartHeight * (1f - (clampedValue - yMin) / yRange)
+        val color = glucoseColor(reading.glucoseMgDl)
+
+        drawCircle(
+            color = color,
+            radius = dotRadius,
+            center = Offset(x, y),
+        )
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.glycemicgpt.mobile.presentation.home
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,18 +11,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Battery0Bar
+import androidx.compose.material.icons.filled.Battery1Bar
+import androidx.compose.material.icons.filled.Battery3Bar
+import androidx.compose.material.icons.filled.Battery5Bar
+import androidx.compose.material.icons.filled.BatteryFull
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.BluetoothConnected
 import androidx.compose.material.icons.filled.BluetoothDisabled
 import androidx.compose.material.icons.filled.CloudDone
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.CloudSync
+import androidx.compose.material.icons.filled.Opacity
 import androidx.compose.material.icons.automirrored.filled.BluetoothSearching
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -38,15 +40,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
 import com.glycemicgpt.mobile.domain.model.ConnectionState
-import com.glycemicgpt.mobile.domain.model.ControlIqMode
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
 import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
 import com.glycemicgpt.mobile.service.SyncStatus
 import kotlinx.coroutines.delay
@@ -58,17 +57,16 @@ fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val connectionState by viewModel.connectionState.collectAsState()
+    val cgm by viewModel.cgm.collectAsState()
     val iob by viewModel.iob.collectAsState()
     val basalRate by viewModel.basalRate.collectAsState()
     val battery by viewModel.battery.collectAsState()
     val reservoir by viewModel.reservoir.collectAsState()
-    val cgm by viewModel.cgm.collectAsState()
     val syncStatus by viewModel.syncStatus.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
-
-    // Data refresh is handled by PumpPollingOrchestrator (staggered reads
-    // with initial delay). Manual refresh is available via pull-to-refresh.
-    // HomeViewModel observes Room, so data appears as the orchestrator writes it.
+    val selectedPeriod by viewModel.selectedPeriod.collectAsState()
+    val cgmHistory by viewModel.cgmHistory.collectAsState()
+    val iobHistory by viewModel.iobHistory.collectAsState()
 
     PullToRefreshBox(
         isRefreshing = isRefreshing,
@@ -82,110 +80,37 @@ fun HomeScreen(
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Connection status banner
+            // Connection + sync status
             ConnectionStatusBanner(connectionState)
-
             Spacer(modifier = Modifier.height(4.dp))
-
-            // Sync status banner
             SyncStatusBanner(syncStatus)
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            // IoB card
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                ),
-            ) {
-                Column(
-                    modifier = Modifier.padding(24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = "Insulin on Board",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = iob?.let { "%.2f".format(it.iob) } ?: "--",
-                        fontSize = 48.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.testTag("iob_value"),
-                    )
-                    Text(
-                        text = "units",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    iob?.let {
-                        Spacer(modifier = Modifier.height(4.dp))
-                        FreshnessLabel(it.timestamp)
-                    }
-                }
-            }
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Status cards row 1
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                StatusCard(
-                    title = "Basal Rate",
-                    value = basalRate?.let { "%.2f".format(it.rate) } ?: "--",
-                    unit = "u/hr",
-                    modifier = Modifier.weight(1f).testTag("basal_card"),
-                    timestamp = basalRate?.timestamp,
-                    badge = basalRate?.let {
-                        when (it.controlIqMode) {
-                            ControlIqMode.SLEEP -> "Sleep"
-                            ControlIqMode.EXERCISE -> "Exercise"
-                            ControlIqMode.STANDARD -> if (it.isAutomated) "Auto" else null
-                        }
-                    },
-                    badgeColor = when (basalRate?.controlIqMode) {
-                        ControlIqMode.SLEEP -> MaterialTheme.colorScheme.secondary
-                        ControlIqMode.EXERCISE -> GlucoseColors.High
-                        else -> MaterialTheme.colorScheme.primary
-                    },
-                )
-                StatusCard(
-                    title = "Reservoir",
-                    value = reservoir?.let { "%.0f".format(it.unitsRemaining) } ?: "--",
-                    unit = "units",
-                    modifier = Modifier.weight(1f).testTag("reservoir_card"),
-                    timestamp = reservoir?.timestamp,
-                )
-            }
+            // Glucose hero: large current BG + trend + IoB + Basal
+            GlucoseHero(
+                cgm = cgm,
+                iob = iob,
+                basalRate = basalRate,
+            )
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            // Status cards row 2
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                StatusCard(
-                    title = "Battery",
-                    value = battery?.let { "${it.percentage}" } ?: "--",
-                    unit = "%",
-                    modifier = Modifier.weight(1f).testTag("battery_card"),
-                    timestamp = battery?.timestamp,
-                )
-                StatusCard(
-                    title = "Last BG",
-                    value = cgm?.let { "${it.glucoseMgDl}" } ?: "--",
-                    unit = "mg/dL",
-                    modifier = Modifier.weight(1f).testTag("cgm_card"),
-                    timestamp = cgm?.timestamp,
-                    badge = cgm?.let { trendArrowSymbol(it.trendArrow) },
-                )
-            }
+            // Glucose trend chart with IoB overlay
+            GlucoseTrendChart(
+                readings = cgmHistory,
+                iobReadings = iobHistory,
+                selectedPeriod = selectedPeriod,
+                onPeriodSelected = { viewModel.onPeriodSelected(it) },
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Compact pump status row
+            PumpStatusRow(
+                battery = battery,
+                reservoir = reservoir,
+            )
 
             Spacer(modifier = Modifier.height(24.dp))
 
@@ -195,7 +120,7 @@ fun HomeScreen(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-            } else if (connectionState == ConnectionState.CONNECTED && iob == null) {
+            } else if (connectionState == ConnectionState.CONNECTED && cgm == null) {
                 Text(
                     text = "Loading pump data...",
                     style = MaterialTheme.typography.bodyMedium,
@@ -203,6 +128,59 @@ fun HomeScreen(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun PumpStatusRow(
+    battery: BatteryStatus?,
+    reservoir: ReservoirReading?,
+) {
+    val batteryIcon = when {
+        battery == null -> Icons.Default.Battery0Bar
+        battery.percentage >= 95 -> Icons.Default.BatteryFull
+        battery.percentage >= 70 -> Icons.Default.Battery5Bar
+        battery.percentage >= 40 -> Icons.Default.Battery3Bar
+        battery.percentage >= 15 -> Icons.Default.Battery1Bar
+        else -> Icons.Default.Battery0Bar
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Battery indicator
+        Icon(
+            imageVector = batteryIcon,
+            contentDescription = "Battery",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(14.dp),
+        )
+        Spacer(modifier = Modifier.width(3.dp))
+        Text(
+            text = battery?.let { "${it.percentage}%" } ?: "--%",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag("battery_card"),
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        // Reservoir indicator
+        Icon(
+            imageVector = Icons.Default.Opacity,
+            contentDescription = "Reservoir",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(14.dp),
+        )
+        Spacer(modifier = Modifier.width(3.dp))
+        Text(
+            text = reservoir?.let { "%.0fu".format(it.unitsRemaining) } ?: "--u",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag("reservoir_card"),
+        )
     }
 }
 
@@ -265,6 +243,14 @@ private fun ConnectionStatusBanner(state: ConnectionState) {
 
 @Composable
 private fun SyncStatusBanner(status: SyncStatus) {
+    var now by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(30_000)
+            now = System.currentTimeMillis()
+        }
+    }
+
     val (icon, text, color) = when {
         status.lastError != null -> Triple(
             Icons.Default.CloudOff,
@@ -277,7 +263,7 @@ private fun SyncStatusBanner(status: SyncStatus) {
             MaterialTheme.colorScheme.tertiary,
         )
         status.lastSyncAtMs > 0 -> {
-            val ago = (System.currentTimeMillis() - status.lastSyncAtMs) / 1000
+            val ago = (now - status.lastSyncAtMs) / 1000
             val label = when {
                 ago < 60 -> "just now"
                 ago < 3600 -> "${ago / 60}m ago"
@@ -317,92 +303,7 @@ private fun SyncStatusBanner(status: SyncStatus) {
 }
 
 @Composable
-private fun StatusCard(
-    title: String,
-    value: String,
-    unit: String,
-    modifier: Modifier = Modifier,
-    timestamp: Instant? = null,
-    badge: String? = null,
-    badgeColor: Color = MaterialTheme.colorScheme.primary,
-) {
-    Card(
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-        ),
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            // Title row with optional Control-IQ mode badge
-            if (badge != null) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Text(
-                        text = badge,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = badgeColor,
-                        modifier = Modifier
-                            .background(
-                                badgeColor.copy(alpha = 0.15f),
-                                RoundedCornerShape(4.dp),
-                            )
-                            .padding(horizontal = 6.dp, vertical = 2.dp),
-                    )
-                }
-            } else {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            Text(
-                text = value,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = unit,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
-            // Data freshness indicator
-            if (timestamp != null) {
-                Spacer(modifier = Modifier.height(4.dp))
-                FreshnessLabel(timestamp)
-            }
-        }
-    }
-}
-
-private fun trendArrowSymbol(trend: CgmTrend): String = when (trend) {
-    CgmTrend.DOUBLE_UP -> "\u21C8"
-    CgmTrend.SINGLE_UP -> "\u2191"
-    CgmTrend.FORTY_FIVE_UP -> "\u2197"
-    CgmTrend.FLAT -> "\u2192"
-    CgmTrend.FORTY_FIVE_DOWN -> "\u2198"
-    CgmTrend.SINGLE_DOWN -> "\u2193"
-    CgmTrend.DOUBLE_DOWN -> "\u21CA"
-    CgmTrend.UNKNOWN -> "?"
-}
-
-@Composable
-private fun FreshnessLabel(timestamp: Instant) {
-    // Re-compose every 30 seconds to keep "Xm ago" text up to date
+internal fun FreshnessLabel(timestamp: Instant) {
     var now by remember { mutableLongStateOf(System.currentTimeMillis()) }
     LaunchedEffect(Unit) {
         while (true) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -13,23 +13,21 @@ import com.glycemicgpt.mobile.domain.pump.PumpDriver
 import com.glycemicgpt.mobile.service.BackendSyncManager
 import com.glycemicgpt.mobile.service.PumpPollingOrchestrator
 import com.glycemicgpt.mobile.service.SyncStatus
-import kotlinx.coroutines.delay
-import timber.log.Timber
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.time.Instant
 import javax.inject.Inject
 
-/**
- * ViewModel for the Home screen.
- *
- * Observes the latest readings from the local Room database (populated by
- * PumpPollingOrchestrator). Also supports manual refresh via [refreshData].
- */
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val pumpDriver: PumpDriver,
@@ -39,6 +37,9 @@ class HomeViewModel @Inject constructor(
 
     val connectionState: StateFlow<ConnectionState> = pumpDriver.observeConnectionState()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ConnectionState.DISCONNECTED)
+
+    val cgm: StateFlow<CgmReading?> = repository.observeLatestCgm()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     val iob: StateFlow<IoBReading?> = repository.observeLatestIoB()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
@@ -52,13 +53,37 @@ class HomeViewModel @Inject constructor(
     val reservoir: StateFlow<ReservoirReading?> = repository.observeLatestReservoir()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
-    val cgm: StateFlow<CgmReading?> = repository.observeLatestCgm()
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
-
     val syncStatus: StateFlow<SyncStatus> = backendSyncManager.syncStatus
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    // -- Glucose trend chart state --------------------------------------------
+
+    private val _selectedPeriod = MutableStateFlow(ChartPeriod.THREE_HOURS)
+    val selectedPeriod: StateFlow<ChartPeriod> = _selectedPeriod.asStateFlow()
+
+    val cgmHistory: StateFlow<List<CgmReading>> = _selectedPeriod
+        .flatMapLatest { period ->
+            val since = Instant.ofEpochMilli(
+                System.currentTimeMillis() - period.hours * 3600_000L,
+            )
+            repository.observeCgmHistory(since)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val iobHistory: StateFlow<List<IoBReading>> = _selectedPeriod
+        .flatMapLatest { period ->
+            val since = Instant.ofEpochMilli(
+                System.currentTimeMillis() - period.hours * 3600_000L,
+            )
+            repository.observeIoBHistory(since)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun onPeriodSelected(period: ChartPeriod) {
+        _selectedPeriod.value = period
+    }
 
     /**
      * Manually trigger a pump data refresh. Reads are staggered sequentially


### PR DESCRIPTION
## Summary
- Replace standalone IoB/Basal/Battery/Reservoir status cards with integrated GlucoseHero composable showing current BG value, trend arrow, IoB, and basal rate as secondary metrics
- Add Canvas-based glucose trend chart with color-coded data points, target range band (70-180 mg/dL), IoB area overlay on secondary right Y-axis, and 3H/6H/12H/24H period selector chips
- Add compact PumpStatusRow with dynamic battery icon (scales with percentage) and reservoir indicator
- Add Room DAO reactive queries for CGM and IoB history with LIMIT clauses
- Accessibility semantics on GlucoseHero card and chart Canvas

## Test plan
- [x] `./gradlew assembleDebug` builds successfully
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes
- [x] Visual verification on Android emulator -- GlucoseHero, chart empty state, period selector, compact pump status row, bottom nav all render correctly
- [x] Adversarial code review completed and all findings addressed
- [x] Security review of staged diff -- clean, no secrets or vulnerabilities