### PR TITLE
feat: add time in range bar and move pump status into hero card

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
@@ -94,6 +94,13 @@ data class PumpHardwareInfo(
     val pumpFeatures: Map<String, Boolean>,
 )
 
+data class TimeInRangeData(
+    val lowPercent: Float,
+    val inRangePercent: Float,
+    val highPercent: Float,
+    val totalReadings: Int,
+)
+
 enum class ConnectionState {
     DISCONNECTED,
     SCANNING,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBar.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBar.kt
@@ -1,0 +1,279 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.glycemicgpt.mobile.domain.model.TimeInRangeData
+import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
+
+enum class TirPeriod(val label: String, val hours: Long) {
+    TWENTY_FOUR_HOURS("24H", 24),
+    THREE_DAYS("3D", 72),
+    SEVEN_DAYS("7D", 168),
+}
+
+private val TirLow = GlucoseColors.UrgentLow   // Red
+private val TirInRange = GlucoseColors.InRange  // Green
+private val TirHigh = GlucoseColors.High        // Yellow
+
+@Composable
+fun TimeInRangeBar(
+    data: TimeInRangeData?,
+    selectedPeriod: TirPeriod,
+    onPeriodSelected: (TirPeriod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val a11yDescription = if (data != null && data.totalReadings > 0) {
+        ("Time in range: %.0f%% low, %.0f%% in range, %.0f%% high, " +
+            "based on %d readings over %s").format(
+                data.lowPercent,
+                data.inRangePercent,
+                data.highPercent,
+                data.totalReadings,
+                selectedPeriod.label,
+            )
+    } else {
+        "Time in range: no glucose readings for this period"
+    }
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = a11yDescription }
+            .testTag("tir_bar"),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            // Header: title + quality label
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Time in Range",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                if (data != null && data.totalReadings > 0) {
+                    val (qualityLabel, qualityColor) = qualityAssessment(data.inRangePercent)
+                    Text(
+                        text = qualityLabel,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = qualityColor,
+                        modifier = Modifier.testTag("tir_quality_label"),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Period selector chips
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+            ) {
+                TirPeriod.entries.forEach { period ->
+                    FilterChip(
+                        selected = period == selectedPeriod,
+                        onClick = { onPeriodSelected(period) },
+                        label = {
+                            Text(
+                                text = period.label,
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                        },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                        modifier = Modifier.testTag("tir_period_chip_${period.label}"),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (data == null || data.totalReadings == 0) {
+                // Empty state
+                Text(
+                    text = "No glucose readings for this period",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                // Stacked horizontal bar
+                StackedBar(
+                    lowPercent = data.lowPercent,
+                    inRangePercent = data.inRangePercent,
+                    highPercent = data.highPercent,
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Legend row
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                ) {
+                    LegendEntry(color = TirLow, label = "Low", percent = data.lowPercent)
+                    LegendEntry(color = TirInRange, label = "In Range", percent = data.inRangePercent)
+                    LegendEntry(color = TirHigh, label = "High", percent = data.highPercent)
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Target range
+                Text(
+                    text = "Target: 70-180 mg/dL",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StackedBar(
+    lowPercent: Float,
+    inRangePercent: Float,
+    highPercent: Float,
+) {
+    val barHeight = 24.dp
+    val cornerRadius = 12.dp
+
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(barHeight)
+            .clip(RoundedCornerShape(cornerRadius)),
+    ) {
+        val totalWidth = size.width
+        val h = size.height
+        val cr = CornerRadius(cornerRadius.toPx())
+
+        // Background
+        drawRoundRect(
+            color = Color(0xFF334155), // slate-700
+            size = size,
+            cornerRadius = cr,
+        )
+
+        val total = lowPercent + inRangePercent + highPercent
+        if (total <= 0f) return@Canvas
+
+        val lowW = (lowPercent / total) * totalWidth
+        val inRangeW = (inRangePercent / total) * totalWidth
+        val highW = totalWidth - lowW - inRangeW // absorb rounding
+
+        var x = 0f
+
+        // Low segment
+        if (lowW > 0f) {
+            drawRect(
+                color = TirLow,
+                topLeft = Offset(x, 0f),
+                size = Size(lowW, h),
+            )
+            x += lowW
+        }
+
+        // In Range segment
+        if (inRangeW > 0f) {
+            drawRect(
+                color = TirInRange,
+                topLeft = Offset(x, 0f),
+                size = Size(inRangeW, h),
+            )
+            x += inRangeW
+        }
+
+        // High segment
+        if (highW > 0f) {
+            drawRect(
+                color = TirHigh,
+                topLeft = Offset(x, 0f),
+                size = Size(highW, h),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LegendEntry(
+    color: Color,
+    label: String,
+    percent: Float,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .background(color, CircleShape),
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = "$label: ${formatTirPercent(percent)}",
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+        )
+    }
+}
+
+internal fun qualityAssessment(inRangePercent: Float): Pair<String, Color> = when {
+    inRangePercent >= 70f -> "Excellent" to TirInRange
+    inRangePercent >= 50f -> "Good" to TirHigh
+    else -> "Needs Improvement" to TirLow
+}
+
+internal fun formatTirPercent(value: Float): String = when {
+    value <= 0f -> "0%"
+    value < 0.5f -> "<1%"
+    value >= 99.5f && value < 100f -> ">99%"
+    else -> "%.0f%%".format(value)
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBarTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBarTest.kt
@@ -1,0 +1,109 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import com.glycemicgpt.mobile.data.local.dao.TimeInRangeCounts
+import com.glycemicgpt.mobile.domain.model.TimeInRangeData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TimeInRangeBarTest {
+
+    // -- Percentage math via TimeInRangeCounts -> TimeInRangeData --------------
+
+    @Test
+    fun `zero readings produces all-zero percentages`() {
+        val counts = TimeInRangeCounts(total = 0, lowCount = 0, inRangeCount = 0, highCount = 0)
+        val data = counts.toTimeInRange()
+        assertEquals(0f, data.lowPercent, 0.001f)
+        assertEquals(0f, data.inRangePercent, 0.001f)
+        assertEquals(0f, data.highPercent, 0.001f)
+        assertEquals(0, data.totalReadings)
+    }
+
+    @Test
+    fun `100 percent in range`() {
+        val counts = TimeInRangeCounts(total = 200, lowCount = 0, inRangeCount = 200, highCount = 0)
+        val data = counts.toTimeInRange()
+        assertEquals(0f, data.lowPercent, 0.001f)
+        assertEquals(100f, data.inRangePercent, 0.001f)
+        assertEquals(0f, data.highPercent, 0.001f)
+    }
+
+    @Test
+    fun `mixed distribution`() {
+        val counts = TimeInRangeCounts(total = 100, lowCount = 10, inRangeCount = 70, highCount = 20)
+        val data = counts.toTimeInRange()
+        assertEquals(10f, data.lowPercent, 0.001f)
+        assertEquals(70f, data.inRangePercent, 0.001f)
+        assertEquals(20f, data.highPercent, 0.001f)
+        assertEquals(100, data.totalReadings)
+    }
+
+    @Test
+    fun `percentages sum to 100 for odd totals`() {
+        val counts = TimeInRangeCounts(total = 3, lowCount = 1, inRangeCount = 1, highCount = 1)
+        val data = counts.toTimeInRange()
+        val sum = data.lowPercent + data.inRangePercent + data.highPercent
+        assertEquals(100f, sum, 0.01f)
+    }
+
+    // -- Quality labels (calls real production function) -----------------------
+
+    @Test
+    fun `quality label is Excellent when inRange is 70 or above`() {
+        assertEquals("Excellent", qualityAssessment(70f).first)
+        assertEquals("Excellent", qualityAssessment(85f).first)
+        assertEquals("Excellent", qualityAssessment(100f).first)
+    }
+
+    @Test
+    fun `quality label is Good when inRange is 50 to 69`() {
+        assertEquals("Good", qualityAssessment(50f).first)
+        assertEquals("Good", qualityAssessment(69.9f).first)
+    }
+
+    @Test
+    fun `quality label is Needs Improvement below 50`() {
+        assertEquals("Needs Improvement", qualityAssessment(49f).first)
+        assertEquals("Needs Improvement", qualityAssessment(0f).first)
+    }
+
+    // -- Format percent (calls real production function) -----------------------
+
+    @Test
+    fun `formatTirPercent handles zero`() {
+        assertEquals("0%", formatTirPercent(0f))
+    }
+
+    @Test
+    fun `formatTirPercent handles small values`() {
+        assertEquals("<1%", formatTirPercent(0.3f))
+    }
+
+    @Test
+    fun `formatTirPercent handles near-100 values`() {
+        assertEquals(">99%", formatTirPercent(99.7f))
+    }
+
+    @Test
+    fun `formatTirPercent handles normal values`() {
+        assertEquals("50%", formatTirPercent(50f))
+        assertEquals("75%", formatTirPercent(75.3f))
+    }
+
+    @Test
+    fun `formatTirPercent handles exactly 100`() {
+        assertEquals("100%", formatTirPercent(100f))
+    }
+
+    // -- Helper: mirrors repository logic for percentage math tests -----------
+
+    private fun TimeInRangeCounts.toTimeInRange(): TimeInRangeData {
+        if (total == 0) return TimeInRangeData(0f, 0f, 0f, 0)
+        return TimeInRangeData(
+            lowPercent = lowCount * 100f / total,
+            inRangePercent = inRangeCount * 100f / total,
+            highPercent = highCount * 100f / total,
+            totalReadings = total,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add stacked Time in Range bar with 24H/3D/7D period selector, quality labels (Excellent/Good/Needs Improvement), Canvas-based visualization, and accessibility descriptions
- Move battery and reservoir metrics from standalone PumpStatusRow into GlucoseHero card alongside IoB and Basal on a single evenly-spaced row
- Replace verbose connection/sync status banners with compact icon-only ConnectionSyncRow
- Add Room aggregate query (CASE WHEN) for efficient TIR computation from cgm_readings table
- Improve GlucoseHero accessibility: contentDescription now includes all secondary metrics (IoB, Basal, Battery, Reservoir)

## Test plan
- [x] Unit tests: TimeInRangeBarTest (percentage math, quality labels, format edge cases), PumpDataRepositoryTest (TIR mapping), HomeViewModelTest (TIR state/period selection)
- [x] `./gradlew testDebugUnitTest` -- all pass
- [x] `./gradlew lintDebug` -- clean
- [x] `./gradlew assembleDebug` -- builds successfully
- [x] Emulator: verified empty state (no pump data), TIR period chips, connection row
- [x] Phone (real pump): verified TIR bar with real CGM data across all three periods (24H/3D/7D), hero card shows IoB + Basal + Battery + Reservoir on one row
- [x] Accessibility: screen reader label verified via element listing -- includes all metrics
- [x] Adversarial review completed, HIGH/MEDIUM findings addressed (hardcoded thresholds deferred to dynamic ranges story)
- [x] Security review of staged diff -- clean (no secrets, no vulnerabilities)