### PR TITLE
feat: dynamic glucose thresholds -- all four configurable from backend

### DIFF
--- a/apps/api/migrations/versions/035_add_urgent_glucose_thresholds.py
+++ b/apps/api/migrations/versions/035_add_urgent_glucose_thresholds.py
@@ -1,0 +1,42 @@
+"""Add urgent_low and urgent_high columns to target_glucose_ranges.
+
+Extends the target glucose range settings to support all four
+configurable thresholds: urgent_low, low_target, high_target, urgent_high.
+
+Revision ID: 035_add_urgent_glucose_thresholds
+Revises: 034_add_tandem_pumper_id
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "035_urgent_glucose_thresh"
+down_revision = "034_add_tandem_pumper_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "target_glucose_ranges",
+        sa.Column(
+            "urgent_low",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("55.0"),
+        ),
+    )
+    op.add_column(
+        "target_glucose_ranges",
+        sa.Column(
+            "urgent_high",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("250.0"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("target_glucose_ranges", "urgent_high")
+    op.drop_column("target_glucose_ranges", "urgent_low")

--- a/apps/api/src/models/target_glucose_range.py
+++ b/apps/api/src/models/target_glucose_range.py
@@ -35,6 +35,12 @@ class TargetGlucoseRange(Base, TimestampMixin):
         index=True,
     )
 
+    urgent_low: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=55.0,
+    )
+
     low_target: Mapped[float] = mapped_column(
         Float,
         nullable=False,
@@ -47,10 +53,18 @@ class TargetGlucoseRange(Base, TimestampMixin):
         default=180.0,
     )
 
+    urgent_high: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=250.0,
+    )
+
     user = relationship("User", back_populates="target_glucose_range")
 
     def __repr__(self) -> str:
         return (
             f"<TargetGlucoseRange(user_id={self.user_id}, "
-            f"range={self.low_target}-{self.high_target})>"
+            f"urgent_low={self.urgent_low}, "
+            f"range={self.low_target}-{self.high_target}, "
+            f"urgent_high={self.urgent_high})>"
         )

--- a/apps/api/src/routers/settings.py
+++ b/apps/api/src/routers/settings.py
@@ -196,7 +196,8 @@ async def get_target_glucose_range(
 ) -> TargetGlucoseRangeResponse:
     """Get the current user's target glucose range.
 
-    Returns defaults (70-180 mg/dL) if no range has been configured yet.
+    Returns all four thresholds (urgent_low, low_target, high_target,
+    urgent_high). Creates defaults if no range has been configured yet.
     """
     target_range = await get_or_create_range(user.id, db)
     return TargetGlucoseRangeResponse.model_validate(target_range)
@@ -214,8 +215,9 @@ async def patch_target_glucose_range(
 ) -> TargetGlucoseRangeResponse:
     """Update the current user's target glucose range.
 
-    Only provided fields are updated. Validates that
-    low_target < high_target after merge with existing values.
+    Only provided fields are updated. Validates ordering:
+    urgent_low < low_target < high_target < urgent_high
+    after merge with existing values.
     """
     try:
         target_range = await update_range(user.id, body, db)

--- a/apps/api/src/schemas/target_glucose_range.py
+++ b/apps/api/src/schemas/target_glucose_range.py
@@ -1,4 +1,4 @@
-"""Story 9.1: Target glucose range schemas."""
+"""Target glucose range schemas."""
 
 import uuid
 from datetime import datetime
@@ -12,18 +12,26 @@ class TargetGlucoseRangeResponse(BaseModel):
     model_config = {"from_attributes": True}
 
     id: uuid.UUID
+    urgent_low: float
     low_target: float
     high_target: float
+    urgent_high: float
     updated_at: datetime
 
 
 class TargetGlucoseRangeUpdate(BaseModel):
     """Request schema for updating target glucose range.
 
-    Both fields are optional — only provided fields are updated.
-    Validates that low_target < high_target when both are provided.
+    All fields are optional -- only provided fields are updated.
+    Validates ordering: urgent_low < low_target < high_target < urgent_high.
     """
 
+    urgent_low: float | None = Field(
+        default=None,
+        ge=30.0,
+        le=70.0,
+        description="Urgent low threshold (mg/dL). Range: 30-70.",
+    )
     low_target: float | None = Field(
         default=None,
         ge=40.0,
@@ -36,22 +44,32 @@ class TargetGlucoseRangeUpdate(BaseModel):
         le=400.0,
         description="High target threshold (mg/dL). Range: 80-400.",
     )
+    urgent_high: float | None = Field(
+        default=None,
+        ge=200.0,
+        le=500.0,
+        description="Urgent high threshold (mg/dL). Range: 200-500.",
+    )
 
     @model_validator(mode="after")
     def validate_target_ordering(self) -> "TargetGlucoseRangeUpdate":
-        """Ensure low_target < high_target when both are provided."""
-        if (
-            self.low_target is not None
-            and self.high_target is not None
-            and self.low_target >= self.high_target
-        ):
-            msg = "low_target must be less than high_target"
-            raise ValueError(msg)
+        """Validate ordering of any provided thresholds."""
+        pairs = [
+            (self.urgent_low, self.low_target, "urgent_low", "low_target"),
+            (self.low_target, self.high_target, "low_target", "high_target"),
+            (self.high_target, self.urgent_high, "high_target", "urgent_high"),
+        ]
+        for lower, upper, lower_name, upper_name in pairs:
+            if lower is not None and upper is not None and lower >= upper:
+                msg = f"{lower_name} must be less than {upper_name}"
+                raise ValueError(msg)
         return self
 
 
 class TargetGlucoseRangeDefaults(BaseModel):
     """Default target glucose range values for reference."""
 
+    urgent_low: float = 55.0
     low_target: float = 70.0
     high_target: float = 180.0
+    urgent_high: float = 250.0

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -588,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "glycemicgpt-api"
-version = "0.1.84"
+version = "0.1.95"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/GlucoseRangeStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/GlucoseRangeStore.kt
@@ -1,0 +1,77 @@
+package com.glycemicgpt.mobile.data.local
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persists the user's configured glucose range thresholds locally.
+ *
+ * Values are fetched from the backend on connect and cached here.
+ * The app always uses whatever was last received from the backend.
+ */
+@Singleton
+class GlucoseRangeStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("glucose_range", Context.MODE_PRIVATE)
+
+    var urgentLow: Int
+        get() = prefs.getInt(KEY_URGENT_LOW, DEFAULT_URGENT_LOW)
+        set(value) { prefs.edit().putInt(KEY_URGENT_LOW, value).apply() }
+
+    var low: Int
+        get() = prefs.getInt(KEY_LOW, DEFAULT_LOW)
+        set(value) { prefs.edit().putInt(KEY_LOW, value).apply() }
+
+    var high: Int
+        get() = prefs.getInt(KEY_HIGH, DEFAULT_HIGH)
+        set(value) { prefs.edit().putInt(KEY_HIGH, value).apply() }
+
+    var urgentHigh: Int
+        get() = prefs.getInt(KEY_URGENT_HIGH, DEFAULT_URGENT_HIGH)
+        set(value) { prefs.edit().putInt(KEY_URGENT_HIGH, value).apply() }
+
+    /** Timestamp of the last successful fetch from the backend. */
+    var lastFetchedMs: Long
+        get() = prefs.getLong(KEY_LAST_FETCHED, 0L)
+        set(value) { prefs.edit().putLong(KEY_LAST_FETCHED, value).apply() }
+
+    /**
+     * Atomically update all four thresholds plus the fetch timestamp in a
+     * single SharedPreferences transaction. Prevents inconsistent state if
+     * the app is killed mid-write.
+     */
+    fun updateAll(urgentLow: Int, low: Int, high: Int, urgentHigh: Int) {
+        prefs.edit()
+            .putInt(KEY_URGENT_LOW, urgentLow)
+            .putInt(KEY_LOW, low)
+            .putInt(KEY_HIGH, high)
+            .putInt(KEY_URGENT_HIGH, urgentHigh)
+            .putLong(KEY_LAST_FETCHED, System.currentTimeMillis())
+            .apply()
+    }
+
+    /** Returns true if the cached values are older than the given max age. */
+    fun isStale(maxAgeMs: Long = STALE_THRESHOLD_MS): Boolean {
+        val age = System.currentTimeMillis() - lastFetchedMs
+        return age > maxAgeMs
+    }
+
+    companion object {
+        const val DEFAULT_URGENT_LOW = 55
+        const val DEFAULT_LOW = 70
+        const val DEFAULT_HIGH = 180
+        const val DEFAULT_URGENT_HIGH = 250
+        const val STALE_THRESHOLD_MS = 3_600_000L // 1 hour
+
+        private const val KEY_URGENT_LOW = "urgent_low"
+        private const val KEY_LOW = "low"
+        private const val KEY_HIGH = "high"
+        private const val KEY_URGENT_HIGH = "urgent_high"
+        private const val KEY_LAST_FETCHED = "last_fetched_ms"
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -7,6 +7,7 @@ import com.glycemicgpt.mobile.data.remote.dto.ChatRequest
 import com.glycemicgpt.mobile.data.remote.dto.ChatResponse
 import com.glycemicgpt.mobile.data.remote.dto.DeviceRegistrationRequest
 import com.glycemicgpt.mobile.data.remote.dto.DeviceRegistrationResponse
+import com.glycemicgpt.mobile.data.remote.dto.GlucoseRangeResponse
 import com.glycemicgpt.mobile.data.remote.dto.HealthResponse
 import com.glycemicgpt.mobile.data.remote.dto.LoginRequest
 import com.glycemicgpt.mobile.data.remote.dto.LoginResponse
@@ -56,4 +57,8 @@ interface GlycemicGptApi {
 
     @POST("/api/v1/alerts/{alertId}/acknowledge")
     suspend fun acknowledgeAlert(@Path("alertId") alertId: String): Response<AcknowledgeResponse>
+
+    // Glucose range settings
+    @GET("/api/settings/target-glucose-range")
+    suspend fun getGlucoseRange(): Response<GlucoseRangeResponse>
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
@@ -104,3 +104,11 @@ data class AiProviderStatusResponse(
     @Json(name = "provider_type") val providerType: String,
     val status: String,
 )
+
+@JsonClass(generateAdapter = true)
+data class GlucoseRangeResponse(
+    @Json(name = "urgent_low") val urgentLow: Float,
+    @Json(name = "low_target") val lowTarget: Float,
+    @Json(name = "high_target") val highTarget: Float,
+    @Json(name = "urgent_high") val urgentHigh: Float,
+)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseHero.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseHero.kt
@@ -29,18 +29,32 @@ import com.glycemicgpt.mobile.domain.model.ControlIqMode
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
 
-object GlucoseThresholds {
-    const val URGENT_LOW = 55
-    const val LOW = 70
-    const val HIGH = 180
-    const val URGENT_HIGH = 250
+/**
+ * Glucose threshold container. Defaults match the backend's default settings.
+ * Use [GlucoseRangeStore] values at runtime for dynamic thresholds.
+ */
+data class GlucoseThresholds(
+    val urgentLow: Int = DEFAULT_URGENT_LOW,
+    val low: Int = DEFAULT_LOW,
+    val high: Int = DEFAULT_HIGH,
+    val urgentHigh: Int = DEFAULT_URGENT_HIGH,
+) {
+    companion object {
+        const val DEFAULT_URGENT_LOW = 55
+        const val DEFAULT_LOW = 70
+        const val DEFAULT_HIGH = 180
+        const val DEFAULT_URGENT_HIGH = 250
+    }
 }
 
-fun glucoseColor(mgDl: Int): Color = when {
-    mgDl < GlucoseThresholds.URGENT_LOW -> GlucoseColors.UrgentLow
-    mgDl < GlucoseThresholds.LOW -> GlucoseColors.Low
-    mgDl <= GlucoseThresholds.HIGH -> GlucoseColors.InRange
-    mgDl <= GlucoseThresholds.URGENT_HIGH -> GlucoseColors.High
+fun glucoseColor(
+    mgDl: Int,
+    thresholds: GlucoseThresholds = GlucoseThresholds(),
+): Color = when {
+    mgDl <= thresholds.urgentLow -> GlucoseColors.UrgentLow
+    mgDl <= thresholds.low -> GlucoseColors.Low
+    mgDl < thresholds.high -> GlucoseColors.InRange
+    mgDl < thresholds.urgentHigh -> GlucoseColors.High
     else -> GlucoseColors.UrgentHigh
 }
 
@@ -60,6 +74,7 @@ fun GlucoseHero(
     cgm: CgmReading?,
     iob: IoBReading?,
     basalRate: BasalReading?,
+    thresholds: GlucoseThresholds = GlucoseThresholds(),
     modifier: Modifier = Modifier,
 ) {
     val a11yDescription = if (cgm != null) {
@@ -84,7 +99,7 @@ fun GlucoseHero(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             if (cgm != null) {
-                val color = glucoseColor(cgm.glucoseMgDl)
+                val color = glucoseColor(cgm.glucoseMgDl, thresholds)
 
                 // Primary: large glucose value + trend arrow
                 Row(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -69,6 +69,7 @@ fun HomeScreen(
     val iobHistory by viewModel.iobHistory.collectAsState()
     val basalHistory by viewModel.basalHistory.collectAsState()
     val bolusHistory by viewModel.bolusHistory.collectAsState()
+    val thresholds = viewModel.glucoseThresholds
 
     PullToRefreshBox(
         isRefreshing = isRefreshing,
@@ -94,6 +95,7 @@ fun HomeScreen(
                 cgm = cgm,
                 iob = iob,
                 basalRate = basalRate,
+                thresholds = thresholds,
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -106,6 +108,7 @@ fun HomeScreen(
                 bolusEvents = bolusHistory,
                 selectedPeriod = selectedPeriod,
                 onPeriodSelected = { viewModel.onPeriodSelected(it) },
+                thresholds = thresholds,
             )
 
             Spacer(modifier = Modifier.height(12.dp))

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -2,6 +2,7 @@ package com.glycemicgpt.mobile.presentation.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.repository.PumpDataRepository
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BatteryStatus
@@ -34,6 +35,7 @@ class HomeViewModel @Inject constructor(
     private val pumpDriver: PumpDriver,
     private val repository: PumpDataRepository,
     private val backendSyncManager: BackendSyncManager,
+    private val glucoseRangeStore: GlucoseRangeStore,
 ) : ViewModel() {
 
     val connectionState: StateFlow<ConnectionState> = pumpDriver.observeConnectionState()
@@ -55,6 +57,15 @@ class HomeViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     val syncStatus: StateFlow<SyncStatus> = backendSyncManager.syncStatus
+
+    /** Dynamic glucose thresholds from backend settings (cached locally). */
+    val glucoseThresholds: GlucoseThresholds
+        get() = GlucoseThresholds(
+            urgentLow = glucoseRangeStore.urgentLow,
+            low = glucoseRangeStore.low,
+            high = glucoseRangeStore.high,
+            urgentHigh = glucoseRangeStore.urgentHigh,
+        )
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -6,6 +6,7 @@ import com.glycemicgpt.mobile.data.auth.AuthManager
 import com.glycemicgpt.mobile.data.auth.AuthState
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpCredentialStore
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.dto.HealthResponse
@@ -65,6 +66,9 @@ class SettingsViewModelTest {
     }
     private val api = mockk<GlycemicGptApi>()
     private val deviceRepository = mockk<DeviceRepository>(relaxed = true)
+    private val glucoseRangeStore = mockk<GlucoseRangeStore>(relaxed = true) {
+        every { isStale(any()) } returns false
+    }
     private val appUpdateChecker = mockk<AppUpdateChecker>()
     private val authManager = mockk<AuthManager>(relaxed = true) {
         every { authState } returns MutableStateFlow(AuthState.Unauthenticated)
@@ -81,7 +85,7 @@ class SettingsViewModelTest {
     }
 
     private fun createViewModel() =
-        SettingsViewModel(appContext, authTokenStore, pumpCredentialStore, appSettingsStore, api, deviceRepository, appUpdateChecker, authManager)
+        SettingsViewModel(appContext, authTokenStore, pumpCredentialStore, appSettingsStore, glucoseRangeStore, api, deviceRepository, appUpdateChecker, authManager)
 
     @Test
     fun `loadState initializes from stores`() {

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -15,3 +15,8 @@ export {
 } from "./use-glucose-stream";
 
 export { useCurrentUser } from "./use-current-user";
+
+export {
+  useGlucoseRange,
+  type GlucoseThresholds,
+} from "./use-glucose-range";

--- a/apps/web/src/hooks/use-glucose-range.ts
+++ b/apps/web/src/hooks/use-glucose-range.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { getTargetGlucoseRange } from "@/lib/api";
+
+export interface GlucoseThresholds {
+  urgentLow: number;
+  low: number;
+  high: number;
+  urgentHigh: number;
+}
+
+const DEFAULT_THRESHOLDS: GlucoseThresholds = {
+  urgentLow: 55,
+  low: 70,
+  high: 180,
+  urgentHigh: 250,
+};
+
+/**
+ * Fetches the user's glucose range thresholds from the backend.
+ * Returns defaults until the fetch completes or on error.
+ */
+export function useGlucoseRange(): GlucoseThresholds {
+  const [thresholds, setThresholds] =
+    useState<GlucoseThresholds>(DEFAULT_THRESHOLDS);
+
+  const fetchRange = useCallback(async () => {
+    try {
+      const data = await getTargetGlucoseRange();
+      setThresholds({
+        urgentLow: data.urgent_low,
+        low: data.low_target,
+        high: data.high_target,
+        urgentHigh: data.urgent_high,
+      });
+    } catch {
+      // Keep defaults on error
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRange();
+  }, [fetchRange]);
+
+  return thresholds;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1307,19 +1307,25 @@ export async function getCaregiverGlucoseHistory(
  */
 export interface TargetGlucoseRangeResponse {
   id: string;
+  urgent_low: number;
   low_target: number;
   high_target: number;
+  urgent_high: number;
   updated_at: string;
 }
 
 export interface TargetGlucoseRangeUpdate {
+  urgent_low?: number;
   low_target?: number;
   high_target?: number;
+  urgent_high?: number;
 }
 
 export interface TargetGlucoseRangeDefaults {
+  urgent_low: number;
   low_target: number;
   high_target: number;
+  urgent_high: number;
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,8 @@ services:
     build:
       context: ./apps/web
       dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: http://localhost:8000
     restart: unless-stopped
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
- Extends target glucose range API with `urgent_low` and `urgent_high` columns (Alembic migration, Pydantic validation, service-layer ordering checks)
- Web: new `useGlucoseRange` hook, dynamic thresholds in dashboard/charts/hero, all 4 inputs on settings page with live preview
- Mobile: `GlucoseRangeStore` with atomic SharedPreferences writes, auto-fetch on login/stale, dynamic thresholds in GlucoseHero, GlucoseTrendChart, PumpPollingOrchestrator alerts
- Aligned alert/color boundary operators so threshold values consistently trigger alerts and matching colors
- Fixed Docker web build to pass `NEXT_PUBLIC_API_URL` as build arg (was only set as runtime env)

## Test plan
- [x] Backend: 40/40 pytest tests pass (including new cross-field validation tests)
- [x] Mobile: `testDebugUnitTest` (62 tasks), `lintDebug`, `assembleDebug` all pass
- [x] Web: login works, dashboard shows dynamic thresholds (70-180 target), glucose range settings page renders all 4 inputs
- [x] Adversarial review completed, fixes applied (atomic writes, boundary alignment)
- [x] Security review of staged diff -- no secrets or vulnerabilities