### PR TITLE
fix: use dynamic glucose thresholds in Time in Range pipeline

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
@@ -109,14 +109,14 @@ interface PumpDao {
         """
         SELECT
             COUNT(*) AS total,
-            SUM(CASE WHEN glucoseMgDl < 70 THEN 1 ELSE 0 END) AS lowCount,
-            SUM(CASE WHEN glucoseMgDl >= 70 AND glucoseMgDl <= 180 THEN 1 ELSE 0 END) AS inRangeCount,
-            SUM(CASE WHEN glucoseMgDl > 180 THEN 1 ELSE 0 END) AS highCount
+            SUM(CASE WHEN glucoseMgDl < :low THEN 1 ELSE 0 END) AS lowCount,
+            SUM(CASE WHEN glucoseMgDl >= :low AND glucoseMgDl <= :high THEN 1 ELSE 0 END) AS inRangeCount,
+            SUM(CASE WHEN glucoseMgDl > :high THEN 1 ELSE 0 END) AS highCount
         FROM cgm_readings
         WHERE timestampMs >= :sinceMs
         """,
     )
-    fun observeTimeInRangeCounts(sinceMs: Long): Flow<TimeInRangeCounts>
+    fun observeTimeInRangeCounts(sinceMs: Long, low: Int, high: Int): Flow<TimeInRangeCounts>
 
     // -- Transactional cleanup ------------------------------------------------
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/PumpDataRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/PumpDataRepository.kt
@@ -158,8 +158,8 @@ class PumpDataRepository @Inject constructor(
 
     // -- Time in Range --------------------------------------------------------
 
-    fun observeTimeInRange(since: Instant): Flow<TimeInRangeData> =
-        pumpDao.observeTimeInRangeCounts(since.toEpochMilli()).map { it.toTimeInRange() }
+    fun observeTimeInRange(since: Instant, low: Int, high: Int): Flow<TimeInRangeData> =
+        pumpDao.observeTimeInRangeCounts(since.toEpochMilli(), low, high).map { it.toTimeInRange() }
 
     // -- Cleanup --------------------------------------------------------------
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -112,6 +112,7 @@ fun HomeScreen(
                 data = timeInRange,
                 selectedPeriod = selectedTirPeriod,
                 onPeriodSelected = { viewModel.onTirPeriodSelected(it) },
+                thresholds = thresholds,
             )
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBar.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBar.kt
@@ -52,14 +52,18 @@ fun TimeInRangeBar(
     data: TimeInRangeData?,
     selectedPeriod: TirPeriod,
     onPeriodSelected: (TirPeriod) -> Unit,
+    thresholds: GlucoseThresholds = GlucoseThresholds(),
     modifier: Modifier = Modifier,
 ) {
     val a11yDescription = if (data != null && data.totalReadings > 0) {
         ("Time in range: %.0f%% low, %.0f%% in range, %.0f%% high, " +
+            "target %d to %d mg/dL, " +
             "based on %d readings over %s").format(
                 data.lowPercent,
                 data.inRangePercent,
                 data.highPercent,
+                thresholds.low,
+                thresholds.high,
                 data.totalReadings,
                 selectedPeriod.label,
             )
@@ -156,20 +160,22 @@ fun TimeInRangeBar(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                 ) {
-                    LegendEntry(color = TirLow, label = "Low", percent = data.lowPercent)
-                    LegendEntry(color = TirInRange, label = "In Range", percent = data.inRangePercent)
-                    LegendEntry(color = TirHigh, label = "High", percent = data.highPercent)
+                    LegendEntry(color = TirLow, label = "<${thresholds.low}", percent = data.lowPercent)
+                    LegendEntry(color = TirInRange, label = "${thresholds.low}-${thresholds.high}", percent = data.inRangePercent)
+                    LegendEntry(color = TirHigh, label = ">${thresholds.high}", percent = data.highPercent)
                 }
 
                 Spacer(modifier = Modifier.height(8.dp))
 
                 // Target range
                 Text(
-                    text = "Target: 70-180 mg/dL",
+                    text = "Target: ${thresholds.low}-${thresholds.high} mg/dL",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("tir_target_range"),
                 )
             }
         }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBarTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBarTest.kt
@@ -95,6 +95,30 @@ class TimeInRangeBarTest {
         assertEquals("100%", formatTirPercent(100f))
     }
 
+    // -- Dynamic target range label -------------------------------------------
+
+    @Test
+    fun `target range label uses default thresholds`() {
+        val thresholds = GlucoseThresholds()
+        val label = "Target: ${thresholds.low}-${thresholds.high} mg/dL"
+        assertEquals("Target: 70-180 mg/dL", label)
+    }
+
+    @Test
+    fun `target range label uses custom thresholds`() {
+        val thresholds = GlucoseThresholds(urgentLow = 60, low = 90, high = 230, urgentHigh = 330)
+        val label = "Target: ${thresholds.low}-${thresholds.high} mg/dL"
+        assertEquals("Target: 90-230 mg/dL", label)
+    }
+
+    @Test
+    fun `legend labels reflect custom thresholds`() {
+        val thresholds = GlucoseThresholds(urgentLow = 60, low = 90, high = 230, urgentHigh = 330)
+        assertEquals("<90", "<${thresholds.low}")
+        assertEquals("90-230", "${thresholds.low}-${thresholds.high}")
+        assertEquals(">230", ">${thresholds.high}")
+    }
+
     // -- Helper: mirrors repository logic for percentage math tests -----------
 
     private fun TimeInRangeCounts.toTimeInRange(): TimeInRangeData {


### PR DESCRIPTION
## Summary
- Threads dynamic glucose thresholds from backend settings through the entire TIR pipeline (DAO -> Repository -> ViewModel -> UI)
- PumpDao SQL query now uses parameterized `:low`/`:high` instead of hardcoded 70/180
- ViewModel uses `combine(period, thresholds) + flatMapLatest` so TIR recomputes when thresholds change
- TimeInRangeBar shows dynamic target range label and legend labels with actual threshold values
- Adds `low >= high` validation to reject inverted thresholds from backend
- Skips unnecessary Flow re-subscriptions when thresholds haven't actually changed
- Improves accessibility: target range included in TalkBack contentDescription
- Adds `testTag("tir_target_range")` for UI testing

## Test plan
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Lint clean (`./gradlew lintDebug`)
- [x] Build succeeds (`./gradlew assembleDebug`)
- [x] Emulator: empty state renders correctly
- [x] Phone: TIR bar shows "Target: 90-230 mg/dL" matching backend settings
- [x] Phone: Legend shows `<90`, `90-230`, `>230` labels
- [x] Adversarial review completed and all findings addressed
- [x] Security review of staged diff -- clean