### PR TITLE
feat: backfill CGM chart gaps from BLE history logs

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/connection/BleConnectionManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/ble/connection/BleConnectionManager.kt
@@ -136,6 +136,11 @@ class BleConnectionManager @Inject constructor(
     // Pending status read requests: txId -> deferred response cargo
     private val pendingRequests = ConcurrentHashMap<Int, CompletableDeferred<ByteArray>>()
 
+    // FFF8 history log stream: collects notifications after opcode 60 request
+    private val historyLogAssembler = PacketAssembler()
+    @Volatile
+    private var historyLogDeferred: CompletableDeferred<ByteArray>? = null
+
     // Handshake timeout: fail if authentication doesn't complete within this window.
     // JPAKE has 5 round trips; 30s is generous even on slow BLE connections.
     private var authTimeoutJob: Job? = null
@@ -198,6 +203,8 @@ class BleConnectionManager @Inject constructor(
         assemblers.clear()
         statusAssemblers.clear()
         cancelPendingRequests()
+        // Cancel any pending history log stream request from previous connection
+        cancelHistoryLogDeferred()
 
         Timber.d("Connecting to pump: %s", address)
         val newGatt = device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
@@ -226,6 +233,7 @@ class BleConnectionManager @Inject constructor(
         operationQueue.clear()
         operationInFlight.set(false)
         cancelPendingRequests()
+        cancelHistoryLogDeferred()
         synchronized(gattLock) {
             gatt?.let {
                 Timber.d("Disconnecting from pump")
@@ -245,6 +253,15 @@ class BleConnectionManager @Inject constructor(
             val entry = iter.next()
             iter.remove()
             entry.value.cancel()
+        }
+    }
+
+    /** Cancel any pending history log stream request and reset the assembler. */
+    private fun cancelHistoryLogDeferred() {
+        historyLogDeferred?.cancel()
+        historyLogDeferred = null
+        synchronized(historyLogAssembler) {
+            historyLogAssembler.reset()
         }
     }
 
@@ -360,6 +377,68 @@ class BleConnectionManager @Inject constructor(
         } finally {
             // Always clean up -- whether completed, timed out, or cancelled
             pendingRequests.remove(id, deferred)
+        }
+    }
+
+    /**
+     * Send an opcode 60 (HistoryLogRequest) on FFF6 and collect the response
+     * that arrives on FFF8 (HISTORY_LOG_UUID).
+     *
+     * The pump responds with a 2-byte ACK on FFF6 and streams actual records
+     * on FFF8. This method ignores the FFF6 ACK and waits for the FFF8 data.
+     *
+     * @param cargo 5-byte opcode 60 cargo (uint32 LE startSeq + byte count)
+     * @param timeoutMs max time to wait for FFF8 response
+     * @return the FFF8 response cargo bytes
+     */
+    suspend fun requestHistoryLogStream(
+        cargo: ByteArray,
+        timeoutMs: Long = TandemProtocol.HISTORY_LOG_TIMEOUT_MS,
+    ): ByteArray {
+        if (_connectionState.value != ConnectionState.CONNECTED) {
+            throw IllegalStateException("Not connected to pump")
+        }
+
+        val deferred = CompletableDeferred<ByteArray>()
+        // Reset assembler and set deferred atomically so FFF8 notifications
+        // can't feed stale data or find a null deferred in between.
+        synchronized(historyLogAssembler) {
+            historyLogAssembler.reset()
+            historyLogDeferred = deferred
+        }
+
+        // Send opcode 60 on FFF6. The FFF6 response is a 2-byte ACK which
+        // sendStatusRequest will return. We ignore it.
+        val id = nextTxId()
+        val ackDeferred = CompletableDeferred<ByteArray>()
+        pendingRequests.put(id, ackDeferred)?.cancel()
+
+        Timber.d("BLE_RAW TX opcode=0x%02x txId=%d cargoLen=%d (history log request)",
+            TandemProtocol.OPCODE_HISTORY_LOG_REQ, id, cargo.size)
+        debugStore.add(BleDebugStore.Entry(
+            timestamp = Instant.now(),
+            direction = BleDebugStore.Direction.TX,
+            opcode = TandemProtocol.OPCODE_HISTORY_LOG_REQ,
+            opcodeName = TandemProtocol.opcodeName(TandemProtocol.OPCODE_HISTORY_LOG_REQ),
+            txId = id,
+            cargoHex = cargo.toHexString(),
+            cargoSize = cargo.size,
+        ))
+
+        val chunks = Packetize.encode(
+            TandemProtocol.OPCODE_HISTORY_LOG_REQ, id, cargo,
+            TandemProtocol.CHUNK_SIZE_SHORT,
+        )
+        enqueueWrite(TandemProtocol.CURRENT_STATUS_UUID, chunks)
+
+        return try {
+            // Wait for FFF8 response (ignore FFF6 ACK)
+            withTimeout(timeoutMs) {
+                deferred.await()
+            }
+        } finally {
+            historyLogDeferred = null
+            pendingRequests.remove(id, ackDeferred)
         }
     }
 
@@ -885,12 +964,36 @@ class BleConnectionManager @Inject constructor(
     }
 
     /**
-     * Log FFF8 (HISTORY_LOG_UUID) notifications for debugging. The FFF8
-     * streaming protocol (opcode 0x81, flow control, record format) needs
-     * further reverse-engineering before we can parse records from it.
+     * Handle FFF8 (HISTORY_LOG_UUID) notifications.
+     *
+     * After an opcode 60 request is sent on FFF6, the pump sends history
+     * log records as packetized messages on FFF8. Uses the same PacketAssembler
+     * + Packetize.parseHeader flow as status responses, completing the
+     * [historyLogDeferred] when a full message arrives.
      */
     private fun handleHistoryLogNotification(data: ByteArray) {
         Timber.d("BLE_RAW RX_HIST len=%d hex=%s", data.size, data.toHexString())
+
+        val deferred = historyLogDeferred ?: return
+
+        val raw: ByteArray
+        synchronized(historyLogAssembler) {
+            if (!historyLogAssembler.feed(data)) return
+            raw = historyLogAssembler.assemble()
+            historyLogAssembler.reset()
+        }
+
+        val parsed = Packetize.parseHeader(raw)
+        if (parsed != null) {
+            val (opcode, _, cargo) = parsed
+            Timber.d("BLE_RAW RX_HIST_PARSED opcode=0x%02x cargoLen=%d hex=%s",
+                opcode, cargo.size, cargo.toHexString())
+            deferred.complete(cargo)
+        } else {
+            // Deliver raw assembled bytes if parseHeader fails (different framing)
+            Timber.d("BLE_RAW RX_HIST_RAW len=%d hex=%s", raw.size, raw.toHexString())
+            deferred.complete(raw)
+        }
     }
 
     private fun startAuthentication() {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
@@ -28,7 +28,7 @@ import com.glycemicgpt.mobile.data.local.entity.SyncQueueEntity
         CgmReadingEntity::class,
         AlertEntity::class,
     ],
-    version = 6,
+    version = 7,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/PumpDao.kt
@@ -94,6 +94,9 @@ interface PumpDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertCgm(reading: CgmReadingEntity)
 
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertCgmBatch(readings: List<CgmReadingEntity>)
+
     @Query("SELECT * FROM cgm_readings ORDER BY timestampMs DESC LIMIT 1")
     fun observeLatestCgm(): Flow<CgmReadingEntity?>
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/PumpEntities.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/PumpEntities.kt
@@ -64,7 +64,7 @@ data class ReservoirReadingEntity(
 
 @Entity(
     tableName = "cgm_readings",
-    indices = [Index(value = ["timestampMs"])],
+    indices = [Index(value = ["timestampMs"], unique = true)],
 )
 data class CgmReadingEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/PumpDataRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/PumpDataRepository.kt
@@ -148,6 +148,19 @@ class PumpDataRepository @Inject constructor(
         )
     }
 
+    suspend fun saveCgmBatch(readings: List<CgmReading>) {
+        if (readings.isEmpty()) return
+        pumpDao.insertCgmBatch(
+            readings.map {
+                CgmReadingEntity(
+                    glucoseMgDl = it.glucoseMgDl,
+                    trendArrow = it.trendArrow.name,
+                    timestampMs = it.timestamp.toEpochMilli(),
+                )
+            },
+        )
+    }
+
     fun observeLatestCgm(): Flow<CgmReading?> =
         pumpDao.observeLatestCgm().map { it?.toDomain() }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
@@ -2,6 +2,8 @@ package com.glycemicgpt.mobile.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.glycemicgpt.mobile.data.local.AppDatabase
 import com.glycemicgpt.mobile.data.local.dao.AlertDao
 import com.glycemicgpt.mobile.data.local.dao.PumpDao
@@ -18,10 +20,28 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
 
+    /** Migration 6->7: make cgm_readings.timestampMs index unique for dedup. */
+    private val MIGRATION_6_7 = object : Migration(6, 7) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // Drop the old non-unique index and create a unique one.
+            // Remove duplicate timestamps first (keep the row with the highest id).
+            db.execSQL(
+                """DELETE FROM cgm_readings WHERE id NOT IN (
+                    SELECT MAX(id) FROM cgm_readings GROUP BY timestampMs
+                )""",
+            )
+            db.execSQL("DROP INDEX IF EXISTS index_cgm_readings_timestampMs")
+            db.execSQL(
+                "CREATE UNIQUE INDEX IF NOT EXISTS index_cgm_readings_timestampMs ON cgm_readings(timestampMs)",
+            )
+        }
+    }
+
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "glycemicgpt.db")
+            .addMigrations(MIGRATION_6_7)
             .fallbackToDestructiveMigration()
             .build()
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/ble/connection/HistoryLogCargoTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/ble/connection/HistoryLogCargoTest.kt
@@ -1,0 +1,59 @@
+package com.glycemicgpt.mobile.ble.connection
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class HistoryLogCargoTest {
+
+    @Test
+    fun `buildHistoryLogCargo encodes correct 5-byte format`() {
+        val cargo = TandemBleDriver.buildHistoryLogCargo(startSequence = 1000, count = 20)
+        assertEquals(5, cargo.size)
+
+        val buf = ByteBuffer.wrap(cargo).order(ByteOrder.LITTLE_ENDIAN)
+        assertEquals(1000, buf.int)
+        assertEquals(20, cargo[4].toInt() and 0xFF)
+    }
+
+    @Test
+    fun `buildHistoryLogCargo with sequence zero`() {
+        val cargo = TandemBleDriver.buildHistoryLogCargo(startSequence = 0, count = 1)
+        assertEquals(5, cargo.size)
+
+        val buf = ByteBuffer.wrap(cargo).order(ByteOrder.LITTLE_ENDIAN)
+        assertEquals(0, buf.int)
+        assertEquals(1, cargo[4].toInt() and 0xFF)
+    }
+
+    @Test
+    fun `buildHistoryLogCargo with large sequence number`() {
+        val cargo = TandemBleDriver.buildHistoryLogCargo(startSequence = Int.MAX_VALUE, count = 10)
+        assertEquals(5, cargo.size)
+
+        val buf = ByteBuffer.wrap(cargo).order(ByteOrder.LITTLE_ENDIAN)
+        assertEquals(Int.MAX_VALUE, buf.int)
+        assertEquals(10, cargo[4].toInt() and 0xFF)
+    }
+
+    @Test
+    fun `buildHistoryLogCargo clamps count to 255`() {
+        val cargo = TandemBleDriver.buildHistoryLogCargo(startSequence = 100, count = 300)
+        assertEquals(255, cargo[4].toInt() and 0xFF)
+    }
+
+    @Test
+    fun `buildHistoryLogCargo clamps count minimum to 1`() {
+        val cargo = TandemBleDriver.buildHistoryLogCargo(startSequence = 100, count = 0)
+        assertEquals(1, cargo[4].toInt() and 0xFF)
+    }
+
+    @Test
+    fun `buildHistoryLogCargo encodes little-endian sequence`() {
+        // Sequence 0x04030201 should be stored as [01, 02, 03, 04] in LE
+        val cargo = TandemBleDriver.buildHistoryLogCargo(startSequence = 0x04030201, count = 5)
+        assertArrayEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05), cargo)
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/ble/messages/CgmHistoryParserTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/ble/messages/CgmHistoryParserTest.kt
@@ -1,0 +1,327 @@
+package com.glycemicgpt.mobile.ble.messages
+
+import android.util.Base64
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class CgmHistoryParserTest {
+
+    @Before
+    fun setUp() {
+        // Mock Android's Base64 since it's not available in unit tests
+        mockkStatic(Base64::class)
+        every { Base64.encodeToString(any(), any()) } answers {
+            java.util.Base64.getEncoder().encodeToString(firstArg<ByteArray>())
+        }
+        every { Base64.decode(any<String>(), any()) } answers {
+            java.util.Base64.getDecoder().decode(firstArg<String>())
+        }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Base64::class)
+    }
+
+    /**
+     * Build an 18-byte raw history log record (opcode 61 format):
+     *   seq(4) + eventTypeId(2) + pumpTimeSec(4) + payload(8)
+     */
+    private fun buildRawRecord18(
+        seq: Int,
+        eventTypeId: Int,
+        pumpTimeSec: Long,
+        payload: ByteArray,
+    ): ByteArray {
+        val buf = ByteBuffer.allocate(18).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(seq)
+        buf.putShort(eventTypeId.toShort())
+        buf.putInt(pumpTimeSec.toInt())
+        buf.put(payload.copyOf(8)) // pad/truncate to 8 bytes
+        return buf.array()
+    }
+
+    /**
+     * Build a 26-byte raw history log record (FFF8 stream format):
+     *   seq(4) + pumpTimeSec(4) + eventTypeId(2) + data(16)
+     */
+    private fun buildStreamRecord(
+        seq: Int,
+        pumpTimeSec: Long,
+        eventTypeId: Int,
+        data: ByteArray = ByteArray(16),
+    ): ByteArray {
+        val buf = ByteBuffer.allocate(26).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(seq)
+        buf.putInt(pumpTimeSec.toInt())
+        buf.putShort(eventTypeId.toShort())
+        buf.put(data.copyOf(16)) // pad/truncate to 16 bytes
+        return buf.array()
+    }
+
+    private fun buildCgmPayload(glucoseMgDl: Int): ByteArray {
+        val payload = ByteArray(8)
+        val buf = ByteBuffer.wrap(payload, 0, 2).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putShort(glucoseMgDl.toShort())
+        return payload
+    }
+
+    private fun buildCgmData16(glucoseMgDl: Int): ByteArray {
+        val data = ByteArray(16)
+        val buf = ByteBuffer.wrap(data, 0, 2).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putShort(glucoseMgDl.toShort())
+        return data
+    }
+
+    private fun toHistoryLogRecord(raw: ByteArray, seq: Int, eventTypeId: Int, pumpTimeSec: Long): HistoryLogRecord {
+        val b64 = java.util.Base64.getEncoder().encodeToString(raw)
+        return HistoryLogRecord(
+            sequenceNumber = seq,
+            rawBytesB64 = b64,
+            eventTypeId = eventTypeId,
+            pumpTimeSeconds = pumpTimeSec,
+        )
+    }
+
+    // -- parseCgmEventPayload tests -------------------------------------------
+
+    @Test
+    fun `parseCgmEventPayload returns reading for valid glucose`() {
+        val payload = buildCgmPayload(120)
+        val result = StatusResponseParser.parseCgmEventPayload(payload, 500_000_000L)
+        assertNotNull(result)
+        assertEquals(120, result!!.glucoseMgDl)
+        assertEquals(CgmTrend.UNKNOWN, result.trendArrow)
+    }
+
+    @Test
+    fun `parseCgmEventPayload returns null for zero glucose`() {
+        val payload = buildCgmPayload(0)
+        val result = StatusResponseParser.parseCgmEventPayload(payload, 500_000_000L)
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseCgmEventPayload returns null for glucose above 500`() {
+        val payload = buildCgmPayload(501)
+        val result = StatusResponseParser.parseCgmEventPayload(payload, 500_000_000L)
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseCgmEventPayload returns reading for boundary glucose 1`() {
+        val payload = buildCgmPayload(1)
+        val result = StatusResponseParser.parseCgmEventPayload(payload, 500_000_000L)
+        assertNotNull(result)
+        assertEquals(1, result!!.glucoseMgDl)
+    }
+
+    @Test
+    fun `parseCgmEventPayload returns reading for boundary glucose 500`() {
+        val payload = buildCgmPayload(500)
+        val result = StatusResponseParser.parseCgmEventPayload(payload, 500_000_000L)
+        assertNotNull(result)
+        assertEquals(500, result!!.glucoseMgDl)
+    }
+
+    @Test
+    fun `parseCgmEventPayload returns null for short payload`() {
+        val result = StatusResponseParser.parseCgmEventPayload(ByteArray(1), 500_000_000L)
+        assertNull(result)
+    }
+
+    // -- extractCgmFromHistoryLogs tests (18-byte format) ---------------------
+
+    @Test
+    fun `extractCgmFromHistoryLogs filters only event type 16 from 18-byte records`() {
+        val pumpTime = 500_000_000L
+        val cgmPayload = buildCgmPayload(150)
+        val nonCgmPayload = ByteArray(8) // event type 20 (bolus)
+
+        val cgmRaw = buildRawRecord18(100, 16, pumpTime, cgmPayload)
+        val nonCgmRaw = buildRawRecord18(101, 20, pumpTime, nonCgmPayload)
+
+        val records = listOf(
+            toHistoryLogRecord(cgmRaw, 100, 16, pumpTime),
+            toHistoryLogRecord(nonCgmRaw, 101, 20, pumpTime),
+        )
+
+        val result = StatusResponseParser.extractCgmFromHistoryLogs(records)
+        assertEquals(1, result.size)
+        assertEquals(150, result[0].glucoseMgDl)
+    }
+
+    @Test
+    fun `extractCgmFromHistoryLogs returns empty for no CGM events`() {
+        val pumpTime = 500_000_000L
+        val raw = buildRawRecord18(100, 280, pumpTime, ByteArray(8))
+        val records = listOf(toHistoryLogRecord(raw, 100, 280, pumpTime))
+
+        val result = StatusResponseParser.extractCgmFromHistoryLogs(records)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `extractCgmFromHistoryLogs returns sorted by timestamp`() {
+        val earlyTime = 500_000_000L
+        val lateTime = 500_000_300L // 5 minutes later
+
+        val early = buildRawRecord18(100, 16, earlyTime, buildCgmPayload(100))
+        val late = buildRawRecord18(101, 16, lateTime, buildCgmPayload(110))
+
+        // Insert in reverse order
+        val records = listOf(
+            toHistoryLogRecord(late, 101, 16, lateTime),
+            toHistoryLogRecord(early, 100, 16, earlyTime),
+        )
+
+        val result = StatusResponseParser.extractCgmFromHistoryLogs(records)
+        assertEquals(2, result.size)
+        assertTrue(result[0].timestamp.isBefore(result[1].timestamp))
+        assertEquals(100, result[0].glucoseMgDl)
+        assertEquals(110, result[1].glucoseMgDl)
+    }
+
+    @Test
+    fun `extractCgmFromHistoryLogs skips invalid glucose in CGM events`() {
+        val pumpTime = 500_000_000L
+        val validRaw = buildRawRecord18(100, 16, pumpTime, buildCgmPayload(120))
+        val invalidRaw = buildRawRecord18(101, 16, pumpTime, buildCgmPayload(0))
+
+        val records = listOf(
+            toHistoryLogRecord(validRaw, 100, 16, pumpTime),
+            toHistoryLogRecord(invalidRaw, 101, 16, pumpTime),
+        )
+
+        val result = StatusResponseParser.extractCgmFromHistoryLogs(records)
+        assertEquals(1, result.size)
+        assertEquals(120, result[0].glucoseMgDl)
+    }
+
+    // -- extractCgmFromHistoryLogs tests (26-byte stream format) --------------
+
+    @Test
+    fun `extractCgmFromHistoryLogs handles 26-byte stream records`() {
+        val pumpTime = 500_000_000L
+        val streamRaw = buildStreamRecord(100, pumpTime, 16, buildCgmData16(180))
+
+        val records = listOf(toHistoryLogRecord(streamRaw, 100, 16, pumpTime))
+        val result = StatusResponseParser.extractCgmFromHistoryLogs(records)
+        assertEquals(1, result.size)
+        assertEquals(180, result[0].glucoseMgDl)
+    }
+
+    @Test
+    fun `extractCgmFromHistoryLogs handles mixed 18 and 26-byte records`() {
+        val pumpTime = 500_000_000L
+        val record18 = buildRawRecord18(100, 16, pumpTime, buildCgmPayload(120))
+        val record26 = buildStreamRecord(101, pumpTime + 300, 16, buildCgmData16(150))
+
+        val records = listOf(
+            toHistoryLogRecord(record18, 100, 16, pumpTime),
+            toHistoryLogRecord(record26, 101, 16, pumpTime + 300),
+        )
+
+        val result = StatusResponseParser.extractCgmFromHistoryLogs(records)
+        assertEquals(2, result.size)
+        assertEquals(120, result[0].glucoseMgDl)
+        assertEquals(150, result[1].glucoseMgDl)
+    }
+
+    // -- parseHistoryLogStreamCargo tests -------------------------------------
+
+    @Test
+    fun `parseHistoryLogStreamCargo parses single 26-byte record without header`() {
+        val record = buildStreamRecord(1000, 500_000_000L, 16, buildCgmData16(140))
+        // Cargo = just the 26-byte record (no header)
+        val result = StatusResponseParser.parseHistoryLogStreamCargo(record, sinceSequence = 999)
+        assertEquals(1, result.size)
+        assertEquals(1000, result[0].sequenceNumber)
+        assertEquals(16, result[0].eventTypeId)
+    }
+
+    @Test
+    fun `parseHistoryLogStreamCargo parses single record with 2-byte header`() {
+        val record = buildStreamRecord(1000, 500_000_000L, 280, ByteArray(16))
+        // Cargo = 2-byte header + 26-byte record
+        val cargo = ByteArray(2 + 26)
+        cargo[0] = 1 // record count
+        cargo[1] = 0 // flags
+        System.arraycopy(record, 0, cargo, 2, 26)
+
+        val result = StatusResponseParser.parseHistoryLogStreamCargo(cargo, sinceSequence = 999)
+        assertEquals(1, result.size)
+        assertEquals(1000, result[0].sequenceNumber)
+        assertEquals(280, result[0].eventTypeId)
+    }
+
+    @Test
+    fun `parseHistoryLogStreamCargo parses multiple records with header`() {
+        val record1 = buildStreamRecord(1000, 500_000_000L, 16, buildCgmData16(120))
+        val record2 = buildStreamRecord(1001, 500_000_300L, 280, ByteArray(16))
+        // Cargo = 2-byte header + 2 x 26-byte records
+        val cargo = ByteArray(2 + 52)
+        cargo[0] = 2 // record count
+        System.arraycopy(record1, 0, cargo, 2, 26)
+        System.arraycopy(record2, 0, cargo, 28, 26)
+
+        val result = StatusResponseParser.parseHistoryLogStreamCargo(cargo, sinceSequence = 999)
+        assertEquals(2, result.size)
+        assertEquals(1000, result[0].sequenceNumber)
+        assertEquals(1001, result[1].sequenceNumber)
+    }
+
+    @Test
+    fun `parseHistoryLogStreamCargo filters by sinceSequence`() {
+        val record = buildStreamRecord(1000, 500_000_000L, 16, buildCgmData16(120))
+        val result = StatusResponseParser.parseHistoryLogStreamCargo(record, sinceSequence = 1000)
+        // seq 1000 is NOT > sinceSequence 1000, so filtered out
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `parseHistoryLogStreamCargo returns empty for too-short cargo`() {
+        val result = StatusResponseParser.parseHistoryLogStreamCargo(ByteArray(10), sinceSequence = 0)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `parseHistoryLogStreamCargo falls back to 18-byte format`() {
+        // Build a valid 18-byte record
+        val record = buildRawRecord18(500, 16, 500_000_000L, buildCgmPayload(100))
+        val result = StatusResponseParser.parseHistoryLogStreamCargo(record, sinceSequence = 499)
+        assertEquals(1, result.size)
+        assertEquals(500, result[0].sequenceNumber)
+    }
+
+    @Test
+    fun `parseHistoryLogStreamCargo preserves full 26-byte rawBytesB64`() {
+        val data = buildCgmData16(200)
+        val record = buildStreamRecord(1000, 500_000_000L, 16, data)
+        val result = StatusResponseParser.parseHistoryLogStreamCargo(record, sinceSequence = 999)
+        assertEquals(1, result.size)
+        // Decode the stored base64 and verify it's the full 26 bytes
+        val decoded = java.util.Base64.getDecoder().decode(result[0].rawBytesB64)
+        assertEquals(26, decoded.size)
+    }
+
+    @Test
+    fun `parseHistoryLogStreamCargo rejects records with invalid event types`() {
+        // Build a record with an impossibly high event type (> MAX_KNOWN_EVENT_TYPE)
+        val record = buildStreamRecord(1000, 500_000_000L, 60000, ByteArray(16))
+        val result = StatusResponseParser.parseHistoryLogStreamCargo(record, sinceSequence = 999)
+        assertTrue(result.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

- Implements opcode 60 (HistoryLogRequest) fetch loop in TandemBleDriver to download history log records from the Tandem pump via FFF8 streaming
- Extracts CGM readings (event type 16) from history logs and batch-inserts them into the local database with IGNORE dedup strategy
- Fills glucose chart gaps that occur when the phone disconnects from the pump (BLE out of range) and later reconnects
- Adds proper Room schema migration (v6->v7) with unique index on cgm_readings.timestampMs for dedup
- Handles both 26-byte FFF8 stream format and 18-byte opcode 61 format with sanity checks on parsed records

## Changes

- **BleConnectionManager**: Added FFF8 history log stream handling (PacketAssembler, CompletableDeferred, requestHistoryLogStream), thread-safe cleanup on connect/disconnect
- **TandemBleDriver**: Replaced getHistoryLogs() stub with batched fetch loop using requestHistoryLogStream(), time-capped at 15s to keep poll loop responsive
- **StatusResponseParser**: Added parseHistoryLogStreamCargo() for 26-byte records, parseCgmEventPayload(), extractCgmFromHistoryLogs() with dual format support
- **PumpDao/PumpDataRepository**: Added insertCgmBatch(IGNORE) and saveCgmBatch() for batch CGM backfill
- **PumpPollingOrchestrator**: Wired CGM extraction into pollHistoryLogs() after raw record save
- **DatabaseModule**: Added MIGRATION_6_7 (dedup + unique index on timestampMs)
- **AppDatabase**: Version 6 -> 7

## Test plan

- [x] Unit tests pass (352 tests, 0 failures) -- CgmHistoryParserTest, HistoryLogCargoTest, PumpPollingOrchestratorTest updated
- [x] Lint clean (lintDebug)
- [x] Build succeeds (assembleDebug)
- [x] Emulator: app launches without Room migration crash
- [x] Adversarial code review: all HIGH/MEDIUM findings addressed
- [x] Security review: clean (no secrets or vulnerabilities)
- [ ] Phone: connect to pump, verify Timber logs show "Backfilled N CGM readings from history logs"
- [ ] Phone: disconnect pump, wait 10+ min, reconnect, verify chart gap fills in