### PR TITLE
feat: add develop/main branching strategy with dev release channels

### DIFF
--- a/.github/PROMOTION_PR_TEMPLATE.md
+++ b/.github/PROMOTION_PR_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Promotion: develop -> main
+
+### Pre-merge checklist
+
+- [ ] CI passes on develop
+- [ ] Dev Docker images smoke-tested (`ghcr.io/.../glycemicgpt-*:dev`)
+- [ ] Dev APK tested on device (from `dev-latest` release)
+- [ ] No known regressions
+
+### Notable changes since last promotion
+
+<!-- List significant changes included in this promotion -->
+
+-
+
+### Post-merge steps
+
+1. Wait for release-please to create a version bump PR on main
+2. Merge the release-please PR (auto-merges if configured)
+3. Verify stable container images are published with new version tag
+4. Verify signed release APK is uploaded to the GitHub release
+5. Rebase develop onto main (squash-merge creates divergence):
+   ```bash
+   git fetch origin && git checkout develop && git rebase origin/main
+   # Force push required -- temporarily disable branch protection on develop first
+   git push origin develop --force-with-lease
+   ```

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,8 @@
     ":automergeDigest",
     ":automergeBranch"
   ],
+  // Target develop as the integration branch
+  "baseBranches": ["develop"],
   // Branch naming
   "branchPrefix": "renovate/",
   // Commit message format (semantic commits)

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,7 @@ name: Android
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths: ['apps/mobile/**']
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -2,7 +2,7 @@ name: Auto Label PRs
 
 on:
   pull_request_target:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, reopened, edited]
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, reopened]
 
 concurrency:
@@ -156,10 +156,11 @@ jobs:
 
       - name: Check for prohibited Co-Authored-By lines
         run: |
-          if git log --format="%B" origin/main..HEAD 2>/dev/null | grep -qiE '^Co-Authored-By:.*(claude|anthropic|noreply@anthropic)'; then
+          BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
+          if git log --format="%B" "origin/${BASE_REF}..HEAD" 2>/dev/null | grep -qiE '^Co-Authored-By:.*(claude|anthropic|noreply@anthropic)'; then
             echo "ERROR: Found prohibited Co-Authored-By attribution in commit messages."
             echo "The following commits contain AI tool attribution:"
-            git log --format="%h %s" origin/main..HEAD | while read -r hash rest; do
+            git log --format="%h %s" "origin/${BASE_REF}..HEAD" | while read -r hash rest; do
               if git log -1 --format="%B" "$hash" | grep -qiE '^Co-Authored-By:.*(claude|anthropic|noreply@anthropic)'; then
                 echo "  - $hash $rest"
               fi

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -2,7 +2,7 @@ name: Build and Push Container Images
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'apps/api/**'
       - 'apps/web/**'
@@ -84,6 +84,7 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}-api
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=sha-
@@ -139,6 +140,7 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}-web
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=sha-
@@ -194,6 +196,7 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}-sidecar
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=sha-

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: false
-          ignore-versions: '^(latest|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
+          ignore-versions: '^(latest|dev|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
 
   cleanup-web:
     name: Cleanup Web Images
@@ -33,7 +33,7 @@ jobs:
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: false
-          ignore-versions: '^(latest|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
+          ignore-versions: '^(latest|dev|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
 
   cleanup-sidecar:
     name: Cleanup Sidecar Images
@@ -46,7 +46,7 @@ jobs:
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: false
-          ignore-versions: '^(latest|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
+          ignore-versions: '^(latest|dev|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
 
   cleanup-untagged:
     name: Cleanup Untagged Images

--- a/.github/workflows/dev-pre-release.yml
+++ b/.github/workflows/dev-pre-release.yml
@@ -1,0 +1,93 @@
+name: Dev Pre-Release
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'apps/mobile/**'
+      - '.github/workflows/dev-pre-release.yml'
+
+concurrency:
+  group: dev-pre-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build-debug-apk:
+    name: Build Debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build debug APK
+        working-directory: apps/mobile
+        run: ./gradlew assembleDebug -PdevBuildNumber=${{ github.run_number }}
+
+      - name: Extract version
+        id: version
+        working-directory: apps/mobile
+        run: |
+          VERSION=$(grep 'val appVersionName' app/build.gradle.kts | sed 's/.*"\(.*\)".*/\1/')
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Extracted version '$VERSION' does not look like semver"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Rename APKs
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          RUN="${{ github.run_number }}"
+          PHONE_SRC="apps/mobile/app/build/outputs/apk/debug/app-debug.apk"
+          WEAR_SRC="apps/mobile/wear/build/outputs/apk/debug/wear-debug.apk"
+
+          mkdir -p dist
+          if [ -f "$PHONE_SRC" ]; then
+            cp "$PHONE_SRC" "dist/GlycemicGPT-${VERSION}-dev.${RUN}-debug.apk"
+          fi
+          if [ -f "$WEAR_SRC" ]; then
+            cp "$WEAR_SRC" "dist/GlycemicGPT-Wear-${VERSION}-dev.${RUN}-debug.apk"
+          fi
+
+          # Verify at least one APK was produced
+          if ! ls dist/*.apk >/dev/null 2>&1; then
+            echo "ERROR: No APK files found in dist/"
+            exit 1
+          fi
+
+      - name: Publish dev-latest pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          RUN="${{ github.run_number }}"
+          COMMIT="${{ github.sha }}"
+          SHORT_SHA="${COMMIT:0:7}"
+
+          # Delete existing release+tag, then immediately recreate (single step to reduce window)
+          gh release delete dev-latest --yes --cleanup-tag 2>/dev/null || true
+          gh release create dev-latest \
+            --title "Dev Build ${VERSION}-dev.${RUN}" \
+            --notes "Development build from \`develop\` branch.
+
+          **Version:** ${VERSION}-dev.${RUN}
+          **Commit:** ${SHORT_SHA}
+          **Branch:** develop
+
+          > This is an unstable development build. Use the [latest stable release](/releases/latest) for production use." \
+            --prerelease \
+            --target develop \
+            dist/*.apk

--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -2,7 +2,7 @@ name: Docker Integration Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'apps/api/**'
       - 'apps/web/**'
@@ -12,7 +12,7 @@ on:
       - 'scripts/docker-integration-test.sh'
       - '.github/workflows/docker-integration.yml'
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'apps/api/**'
       - 'apps/web/**'

--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -44,6 +44,9 @@ android {
             isDebuggable = true
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
+            buildConfigField("String", "UPDATE_CHANNEL", "\"dev\"")
+            val devBuildNumber = (project.findProperty("devBuildNumber") as? String)?.toIntOrNull() ?: 0
+            buildConfigField("int", "DEV_BUILD_NUMBER", devBuildNumber.toString())
         }
         release {
             isMinifyEnabled = true
@@ -58,6 +61,7 @@ android {
             } else {
                 signingConfigs.getByName("debug")
             }
+            buildConfigField("String", "UPDATE_CHANNEL", "\"stable\"")
         }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
@@ -104,4 +104,43 @@ class AppUpdateCheckerTest {
     fun `sanitizeFileName preserves valid name`() {
         assertEquals("GlycemicGPT-0.1.81-release.apk", AppUpdateChecker.sanitizeFileName("GlycemicGPT-0.1.81-release.apk"))
     }
+
+    // parseDevRunNumber tests
+
+    @Test
+    fun `parseDevRunNumber extracts run number from dev APK name`() {
+        assertEquals(42, AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.1.95-dev.42-debug.apk"))
+    }
+
+    @Test
+    fun `parseDevRunNumber extracts large run number`() {
+        assertEquals(1234, AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.2.0-dev.1234-debug.apk"))
+    }
+
+    @Test
+    fun `parseDevRunNumber returns 0 for stable APK name`() {
+        assertEquals(0, AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.1.95-release.apk"))
+    }
+
+    @Test
+    fun `parseDevRunNumber returns 0 for non-matching string`() {
+        assertEquals(0, AppUpdateChecker.parseDevRunNumber("base.apk"))
+    }
+
+    @Test
+    fun `parseDevRunNumber returns 0 for empty string`() {
+        assertEquals(0, AppUpdateChecker.parseDevRunNumber(""))
+    }
+
+    @Test
+    fun `parseDevRunNumber newer run number is greater`() {
+        val older = AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.1.95-dev.10-debug.apk")
+        val newer = AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.1.95-dev.11-debug.apk")
+        assertTrue(newer > older)
+    }
+
+    @Test
+    fun `parseDevRunNumber rejects loose match without hyphens`() {
+        assertEquals(0, AppUpdateChecker.parseDevRunNumber("some-devtools.5thing.apk"))
+    }
 }

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -1,0 +1,72 @@
+# Branching Strategy
+
+## Branch Model
+
+| Branch | Purpose | Protected | Default |
+|--------|---------|-----------|---------|
+| `main` | Stable releases | Yes | No |
+| `develop` | Integration / next release | Yes | Yes |
+
+> **Setup required:** The GitHub default branch must be changed from `main` to `develop` and branch protection rules applied to `develop` before this model is active.
+
+## Feature Branch Workflow
+
+1. Create a feature branch from `develop`:
+   ```bash
+   git checkout develop && git pull
+   git checkout -b feat/my-feature
+   ```
+2. Push and create a PR targeting `develop`.
+3. CI runs on the PR. Squash-merge when approved.
+
+## Promotion (develop -> main)
+
+When develop is ready for a stable release:
+
+```bash
+gh pr create --base main --head develop \
+  --title "chore: promote develop to main" \
+  --body-file .github/PROMOTION_PR_TEMPLATE.md
+```
+
+After the promotion PR merges:
+- **release-please** creates a version bump PR on main
+- Merging that PR triggers the stable release (changelog, GitHub release, signed APKs, Docker images tagged with semver + `latest`)
+
+### Post-promotion rebase
+
+Squash-merge creates divergence between develop and main. Rebase develop onto main after promotion:
+
+```bash
+git fetch origin
+git checkout develop
+git rebase origin/main
+# Force push required -- temporarily disable branch protection on develop first
+git push origin develop --force-with-lease
+```
+
+> **Note:** Branch protection on `develop` blocks force pushes. Temporarily disable protection before this step, then re-enable it immediately after.
+
+## Release Channels
+
+### Stable (main)
+
+- **Docker images:** Tagged `latest` and semver (`1.2.3`, `1.2`)
+- **Mobile APKs:** Signed release APKs uploaded to GitHub Releases
+- **Update check:** App fetches `/releases/latest` (release builds)
+
+### Dev (develop)
+
+- **Docker images:** Tagged `dev` (overwritten on each push to develop)
+- **Mobile APKs:** Debug APKs uploaded to a rolling `dev-latest` pre-release
+- **Update check:** App fetches `/releases/tags/dev-latest` (debug builds)
+
+The `/releases/latest` API endpoint automatically excludes pre-releases, so `dev-latest` never interferes with stable update checks.
+
+## CI Triggers
+
+All CI workflows (lint, test, build, Docker integration) run on both `main` and `develop` branches. PRs can target either branch.
+
+## Renovate
+
+Dependency update PRs target `develop` via the `baseBranches` config. They flow to main through the promotion process.


### PR DESCRIPTION
## Summary

- All CI workflows (ci, android, docker-integration, container-build, container-cleanup, auto-label) now trigger on both `main` and `develop` branches
- Docker container images get a `dev` tag when built from `develop` pushes, `latest` from `main`
- New `dev-pre-release.yml` workflow builds debug APKs on develop push and publishes a rolling `dev-latest` GitHub pre-release
- Mobile app update checker is channel-aware via `BuildConfig.UPDATE_CHANNEL`: release builds check `/releases/latest`, debug builds check `/releases/tags/dev-latest`
- Dev version comparison uses `BuildConfig.DEV_BUILD_NUMBER` (injected by CI via `-PdevBuildNumber`) instead of APK filename parsing
- Renovate retargeted to `develop` via `baseBranches` config
- Attribution check in CI now uses dynamic base ref instead of hardcoded `origin/main`
- Added promotion PR template and branching strategy documentation

## Pre-requisites (manual, before merging)

1. Force-update `develop` to match `main` (requires temporarily disabling branch protection on develop)
2. Change GitHub default branch from `main` to `develop`
3. Add branch protection rules to `develop`

## Test plan

- [x] Mobile unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Mobile lint passes (`./gradlew lintDebug`)
- [x] Debug APK builds and installs (`./gradlew assembleDebug`)
- [x] Visual verification on emulator (home screen, settings, about section)
- [x] Adversarial code review completed, all HIGH/MEDIUM findings fixed
- [x] Security review of staged diff passed clean
- [ ] CI passes on this PR
- [ ] After merge + branch setup: verify dev-pre-release workflow creates dev-latest release
- [ ] After merge + branch setup: verify container images get `dev` tag on develop push