### PR TITLE
feat: add develop/main branching strategy with dev release channels

### DIFF
--- a/.github/PROMOTION_PR_TEMPLATE.md
+++ b/.github/PROMOTION_PR_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Promotion: develop -> main
+
+> **IMPORTANT:** Merge this PR with **"Rebase and merge"**, NOT "Squash and merge".
+> Rebase merge preserves individual commits so release-please generates a granular CHANGELOG.
+
+### Pre-merge checklist
+
+- [ ] CI passes on develop
+- [ ] Dev Docker images smoke-tested (`ghcr.io/.../glycemicgpt-*:dev`)
+- [ ] Dev APK tested on device (from `dev-latest` release)
+- [ ] No known regressions
+
+### Notable changes since last promotion
+
+<!-- List significant changes included in this promotion -->
+
+-
+
+### Post-merge steps
+
+1. Wait for release-please to create a version bump PR on main
+2. homebot auto-merges it (or merge manually)
+3. Verify stable container images are published with new version tag
+4. Verify signed release APK is uploaded to the GitHub release
+5. Sync develop with the version bump:
+   ```bash
+   git fetch origin && git checkout develop && git rebase origin/main
+   # Temporarily disable non_fast_forward rule on develop ruleset, then:
+   git push origin develop --force-with-lease
+   # Re-enable the rule immediately after
+   ```

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,8 @@
     ":automergeDigest",
     ":automergeBranch"
   ],
+  // Target develop as the integration branch
+  "baseBranches": ["develop"],
   // Branch naming
   "branchPrefix": "renovate/",
   // Commit message format (semantic commits)

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,7 @@ name: Android
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths: ['apps/mobile/**']
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -2,7 +2,7 @@ name: Auto Label PRs
 
 on:
   pull_request_target:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, reopened, edited]
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, reopened]
 
 concurrency:
@@ -156,10 +156,11 @@ jobs:
 
       - name: Check for prohibited Co-Authored-By lines
         run: |
-          if git log --format="%B" origin/main..HEAD 2>/dev/null | grep -qiE '^Co-Authored-By:.*(claude|anthropic|noreply@anthropic)'; then
+          BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
+          if git log --format="%B" "origin/${BASE_REF}..HEAD" 2>/dev/null | grep -qiE '^Co-Authored-By:.*(claude|anthropic|noreply@anthropic)'; then
             echo "ERROR: Found prohibited Co-Authored-By attribution in commit messages."
             echo "The following commits contain AI tool attribution:"
-            git log --format="%h %s" origin/main..HEAD | while read -r hash rest; do
+            git log --format="%h %s" "origin/${BASE_REF}..HEAD" | while read -r hash rest; do
               if git log -1 --format="%B" "$hash" | grep -qiE '^Co-Authored-By:.*(claude|anthropic|noreply@anthropic)'; then
                 echo "  - $hash $rest"
               fi

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -2,7 +2,7 @@ name: Build and Push Container Images
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'apps/api/**'
       - 'apps/web/**'
@@ -84,6 +84,7 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}-api
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=sha-
@@ -139,6 +140,7 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}-web
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=sha-
@@ -194,6 +196,7 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}-sidecar
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=sha-

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: false
-          ignore-versions: '^(latest|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
+          ignore-versions: '^(latest|dev|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
 
   cleanup-web:
     name: Cleanup Web Images
@@ -33,7 +33,7 @@ jobs:
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: false
-          ignore-versions: '^(latest|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
+          ignore-versions: '^(latest|dev|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
 
   cleanup-sidecar:
     name: Cleanup Sidecar Images
@@ -46,7 +46,7 @@ jobs:
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: false
-          ignore-versions: '^(latest|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
+          ignore-versions: '^(latest|dev|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
 
   cleanup-untagged:
     name: Cleanup Untagged Images

--- a/.github/workflows/dev-pre-release.yml
+++ b/.github/workflows/dev-pre-release.yml
@@ -1,0 +1,93 @@
+name: Dev Pre-Release
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'apps/mobile/**'
+      - '.github/workflows/dev-pre-release.yml'
+
+concurrency:
+  group: dev-pre-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build-debug-apk:
+    name: Build Debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build debug APK
+        working-directory: apps/mobile
+        run: ./gradlew assembleDebug -PdevBuildNumber=${{ github.run_number }}
+
+      - name: Extract version
+        id: version
+        working-directory: apps/mobile
+        run: |
+          VERSION=$(grep 'val appVersionName' app/build.gradle.kts | sed 's/.*"\(.*\)".*/\1/')
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Extracted version '$VERSION' does not look like semver"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Rename APKs
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          RUN="${{ github.run_number }}"
+          PHONE_SRC="apps/mobile/app/build/outputs/apk/debug/app-debug.apk"
+          WEAR_SRC="apps/mobile/wear/build/outputs/apk/debug/wear-debug.apk"
+
+          mkdir -p dist
+          if [ -f "$PHONE_SRC" ]; then
+            cp "$PHONE_SRC" "dist/GlycemicGPT-${VERSION}-dev.${RUN}-debug.apk"
+          fi
+          if [ -f "$WEAR_SRC" ]; then
+            cp "$WEAR_SRC" "dist/GlycemicGPT-Wear-${VERSION}-dev.${RUN}-debug.apk"
+          fi
+
+          # Verify at least one APK was produced
+          if ! ls dist/*.apk >/dev/null 2>&1; then
+            echo "ERROR: No APK files found in dist/"
+            exit 1
+          fi
+
+      - name: Publish dev-latest pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          RUN="${{ github.run_number }}"
+          COMMIT="${{ github.sha }}"
+          SHORT_SHA="${COMMIT:0:7}"
+
+          # Delete existing release+tag, then immediately recreate (single step to reduce window)
+          gh release delete dev-latest --yes --cleanup-tag 2>/dev/null || true
+          gh release create dev-latest \
+            --title "Dev Build ${VERSION}-dev.${RUN}" \
+            --notes "Development build from \`develop\` branch.
+
+          **Version:** ${VERSION}-dev.${RUN}
+          **Commit:** ${SHORT_SHA}
+          **Branch:** develop
+
+          > This is an unstable development build. Use the [latest stable release](/releases/latest) for production use." \
+            --prerelease \
+            --target develop \
+            dist/*.apk

--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -2,7 +2,7 @@ name: Docker Integration Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'apps/api/**'
       - 'apps/web/**'
@@ -12,7 +12,7 @@ on:
       - 'scripts/docker-integration-test.sh'
       - '.github/workflows/docker-integration.yml'
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'apps/api/**'
       - 'apps/web/**'

--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -44,6 +44,9 @@ android {
             isDebuggable = true
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
+            buildConfigField("String", "UPDATE_CHANNEL", "\"dev\"")
+            val devBuildNumber = (project.findProperty("devBuildNumber") as? String)?.toIntOrNull() ?: 0
+            buildConfigField("int", "DEV_BUILD_NUMBER", devBuildNumber.toString())
         }
         release {
             isMinifyEnabled = true
@@ -58,6 +61,7 @@ android {
             } else {
                 signingConfigs.getByName("debug")
             }
+            buildConfigField("String", "UPDATE_CHANNEL", "\"stable\"")
         }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
@@ -104,4 +104,43 @@ class AppUpdateCheckerTest {
     fun `sanitizeFileName preserves valid name`() {
         assertEquals("GlycemicGPT-0.1.81-release.apk", AppUpdateChecker.sanitizeFileName("GlycemicGPT-0.1.81-release.apk"))
     }
+
+    // parseDevRunNumber tests
+
+    @Test
+    fun `parseDevRunNumber extracts run number from dev APK name`() {
+        assertEquals(42, AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.1.95-dev.42-debug.apk"))
+    }
+
+    @Test
+    fun `parseDevRunNumber extracts large run number`() {
+        assertEquals(1234, AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.2.0-dev.1234-debug.apk"))
+    }
+
+    @Test
+    fun `parseDevRunNumber returns 0 for stable APK name`() {
+        assertEquals(0, AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.1.95-release.apk"))
+    }
+
+    @Test
+    fun `parseDevRunNumber returns 0 for non-matching string`() {
+        assertEquals(0, AppUpdateChecker.parseDevRunNumber("base.apk"))
+    }
+
+    @Test
+    fun `parseDevRunNumber returns 0 for empty string`() {
+        assertEquals(0, AppUpdateChecker.parseDevRunNumber(""))
+    }
+
+    @Test
+    fun `parseDevRunNumber newer run number is greater`() {
+        val older = AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.1.95-dev.10-debug.apk")
+        val newer = AppUpdateChecker.parseDevRunNumber("GlycemicGPT-0.1.95-dev.11-debug.apk")
+        assertTrue(newer > older)
+    }
+
+    @Test
+    fun `parseDevRunNumber rejects loose match without hyphens`() {
+        assertEquals(0, AppUpdateChecker.parseDevRunNumber("some-devtools.5thing.apk"))
+    }
 }

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -1,0 +1,95 @@
+# Branching Strategy
+
+## Branch Model
+
+| Branch | Purpose | Protected | Default |
+|--------|---------|-----------|---------|
+| `main` | Stable releases | Yes | Yes |
+| `develop` | Integration / dev testing | Yes | No |
+
+## Full Release Cycle
+
+```
+1. Create feature branch from develop
+2. Open PR targeting develop, CI runs
+3. Squash-merge to develop
+4. (Automated) Dev Docker images tagged "dev", debug APK published as dev-latest pre-release
+5. Repeat 1-4 for more features, test dev builds
+6. When ready for stable release: create promotion PR (develop -> main)
+7. CI runs on the promotion PR
+8. Merge with "Rebase and merge" (individual commits land on main)
+9. (Automated) release-please creates version bump PR on main
+10. (Automated) homebot auto-merges the version bump PR
+11. (Automated) GitHub Release created, signed APK uploaded, Docker images tagged with version + "latest"
+12. Sync develop: rebase onto main to pick up version bump
+```
+
+## Feature Branch Workflow
+
+1. Create a feature branch from `develop`:
+   ```bash
+   git checkout develop && git pull
+   git checkout -b feat/my-feature
+   ```
+2. Push and create a PR targeting `develop`.
+3. CI runs on the PR. **Squash-merge** when approved.
+
+## Promotion (develop -> main)
+
+A "promotion PR" is a regular pull request that moves tested code from develop to main:
+
+```bash
+gh pr create --base main --head develop \
+  --title "chore: promote develop to main" \
+  --body-file .github/PROMOTION_PR_TEMPLATE.md
+```
+
+**IMPORTANT: Use "Rebase and merge", not "Squash and merge".** Rebase merge preserves each feature as an individual commit on main. This is critical for the CHANGELOG -- release-please needs to see each `feat:` and `fix:` commit separately to generate granular changelog entries. Squash merge would collapse everything into one unhelpful entry.
+
+After the promotion PR merges:
+- **release-please** sees the individual commits and creates a version bump PR
+- homebot auto-merges the version bump PR
+- A GitHub Release is created with signed APKs and versioned Docker images
+
+### Post-release develop sync
+
+The version bump commit exists on main but not develop. Sync them:
+
+```bash
+git fetch origin
+git checkout develop
+git rebase origin/main
+```
+
+To push: temporarily disable the `non_fast_forward` rule on the develop ruleset, then:
+```bash
+git push origin develop --force-with-lease
+```
+Re-enable the rule immediately after.
+
+## Release Channels
+
+### Stable (main)
+
+- **Docker images:** Tagged `latest` and semver (`1.2.3`, `1.2`)
+- **Mobile APKs:** Signed release APKs uploaded to GitHub Releases
+- **Update check:** Release builds fetch `/releases/latest`
+
+### Dev (develop)
+
+- **Docker images:** Tagged `dev` (overwritten on each push to develop)
+- **Mobile APKs:** Debug APKs uploaded to a rolling `dev-latest` pre-release
+- **Update check:** Debug builds fetch `/releases/tags/dev-latest`
+
+The `/releases/latest` API endpoint automatically excludes pre-releases, so `dev-latest` never interferes with stable update checks.
+
+## What Stays the Same
+
+- **release-please** config and workflow: no changes, still watches main
+- **CHANGELOG.md** format: unchanged, generated from individual commits on main
+- **release.yml**: still triggers on main push, builds signed APKs
+- **CI**: all workflows run on both branches, PRs can target either
+
+## Renovate
+
+Dependency update PRs target `develop` via the `baseBranches` config. They flow to main through the promotion process.


### PR DESCRIPTION
## Summary

- All CI workflows now trigger on both `main` and `develop` branches
- Docker container images get `dev` tag from develop pushes, `latest` from main
- New `dev-pre-release.yml` workflow builds debug APKs and publishes rolling `dev-latest` pre-release
- Mobile app update checker is channel-aware via `BuildConfig.UPDATE_CHANNEL`
- Renovate retargeted to `develop` via `baseBranches` config
- Attribution check uses dynamic base ref instead of hardcoded `origin/main`
- Promotion PR template and branching strategy docs explain the full release cycle

## Key design decisions

- **`main` stays as default branch** (visitors see stable code)
- **Rebase merge for promotion PRs** (preserves individual commits so release-please generates granular CHANGELOG)
- **Squash merge for feature PRs** to develop (clean single commit per feature)
- **No changes to release-please, release.yml, or CHANGELOG format**

## Test plan

- [x] Mobile unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Mobile lint passes (`./gradlew lintDebug`)
- [x] Debug APK builds and installs (`./gradlew assembleDebug`)
- [x] Visual verification on emulator
- [x] Adversarial code review completed, all HIGH/MEDIUM findings fixed
- [x] Security review passed clean
- [ ] CI passes on this PR

## Post-merge steps

1. Create develop branch ruleset via API
2. Re-enable main branch ruleset