### PR TITLE
feat: add guided onboarding flow for mobile first-run experience

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
@@ -19,6 +19,12 @@ class AppSettingsStore @Inject constructor(
     private val prefs: SharedPreferences =
         context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
 
+    var onboardingComplete: Boolean
+        get() = prefs.getBoolean(KEY_ONBOARDING_COMPLETE, false)
+        set(value) {
+            prefs.edit().putBoolean(KEY_ONBOARDING_COMPLETE, value).apply()
+        }
+
     var backendSyncEnabled: Boolean
         get() = prefs.getBoolean(KEY_BACKEND_SYNC_ENABLED, true)
         set(value) {
@@ -42,6 +48,7 @@ class AppSettingsStore @Inject constructor(
         }
 
     companion object {
+        private const val KEY_ONBOARDING_COMPLETE = "onboarding_complete"
         private const val KEY_BACKEND_SYNC_ENABLED = "backend_sync_enabled"
         private const val KEY_DATA_RETENTION_DAYS = "data_retention_days"
         private const val KEY_DEVICE_TOKEN = "device_token"

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
@@ -1,0 +1,153 @@
+package com.glycemicgpt.mobile.data.repository
+
+import android.content.Context
+import com.glycemicgpt.mobile.BuildConfig
+import com.glycemicgpt.mobile.data.auth.AuthManager
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.LoginRequest
+import com.glycemicgpt.mobile.service.AlertStreamService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class LoginResult(
+    val success: Boolean,
+    val email: String? = null,
+    val error: String? = null,
+)
+
+@Singleton
+class AuthRepository @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    private val authTokenStore: AuthTokenStore,
+    private val glucoseRangeStore: GlucoseRangeStore,
+    private val api: GlycemicGptApi,
+    private val deviceRepository: DeviceRepository,
+    private val authManager: AuthManager,
+) {
+
+    suspend fun testConnection(): Result<String> {
+        return try {
+            val response = api.healthCheck()
+            if (response.isSuccessful) {
+                Result.success("Connected successfully")
+            } else {
+                Result.failure(Exception("Server responded with HTTP ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Connection test failed")
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Performs login and fires background tasks (device registration, glucose range fetch)
+     * on the provided [scope]. Callers should pass their ViewModel's scope so these
+     * fire-and-forget tasks are cancelled if the ViewModel is cleared.
+     */
+    suspend fun login(
+        baseUrl: String,
+        email: String,
+        password: String,
+        scope: CoroutineScope,
+    ): LoginResult {
+        if (baseUrl.isBlank()) {
+            return LoginResult(success = false, error = "Configure server URL first")
+        }
+        if (email.isBlank() || password.isBlank()) {
+            return LoginResult(success = false, error = "Email and password are required")
+        }
+        return try {
+            val response = api.login(LoginRequest(email = email, password = password))
+            if (response.isSuccessful) {
+                val body = response.body()
+                    ?: return LoginResult(success = false, error = "Login failed: empty response from server")
+
+                val expiresAtMs = System.currentTimeMillis() + (body.expiresIn * 1000L)
+                authTokenStore.saveCredentials(baseUrl, body.accessToken, expiresAtMs, body.user.email)
+                authTokenStore.saveRefreshToken(body.refreshToken)
+                authManager.onLoginSuccess(scope)
+
+                // Register device, fetch settings, and start alert stream
+                scope.launch {
+                    deviceRepository.registerDevice()
+                        .onFailure { e -> Timber.w(e, "Device registration failed") }
+                }
+                scope.launch { fetchGlucoseRange() }
+                AlertStreamService.start(appContext)
+
+                LoginResult(success = true, email = body.user.email)
+            } else {
+                LoginResult(
+                    success = false,
+                    error = when (response.code()) {
+                        401 -> "Invalid email or password"
+                        else -> "Login failed: HTTP ${response.code()}"
+                    },
+                )
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Login failed")
+            LoginResult(success = false, error = "Network error: ${e.message}")
+        }
+    }
+
+    fun logout(scope: CoroutineScope) {
+        AlertStreamService.stop(appContext)
+        scope.launch {
+            deviceRepository.unregisterDevice()
+                .onFailure { e -> Timber.w(e, "Device unregistration failed") }
+        }
+        authTokenStore.clearToken()
+        authManager.onLogout()
+    }
+
+    fun isValidUrl(url: String): Boolean {
+        val parsed = url.toHttpUrlOrNull() ?: return false
+        if (BuildConfig.DEBUG && parsed.scheme == "http") return true
+        return parsed.scheme == "https"
+    }
+
+    fun saveBaseUrl(url: String) {
+        authTokenStore.saveBaseUrl(url)
+    }
+
+    fun getBaseUrl(): String? = authTokenStore.getBaseUrl()
+
+    fun isLoggedIn(): Boolean = authTokenStore.isLoggedIn()
+
+    fun getUserEmail(): String? = authTokenStore.getUserEmail()
+
+    suspend fun reRegisterDevice() {
+        deviceRepository.registerDevice()
+            .onFailure { e -> Timber.w(e, "Device re-registration failed") }
+    }
+
+    suspend fun refreshGlucoseRange() {
+        fetchGlucoseRange()
+    }
+
+    private suspend fun fetchGlucoseRange() {
+        try {
+            val response = api.getGlucoseRange()
+            if (response.isSuccessful) {
+                response.body()?.let { range ->
+                    val ul = range.urgentLow.toInt()
+                    val lo = range.lowTarget.toInt()
+                    val hi = range.highTarget.toInt()
+                    val uh = range.urgentHigh.toInt()
+                    glucoseRangeStore.updateAll(ul, lo, hi, uh)
+                    Timber.d("Glucose range fetched: %d/%d/%d/%d", ul, lo, hi, uh)
+                }
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to fetch glucose range settings")
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/MainActivity.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/MainActivity.kt
@@ -4,18 +4,23 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.presentation.navigation.GlycemicGptNavHost
 import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject lateinit var appSettingsStore: AppSettingsStore
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             GlycemicGptTheme {
-                GlycemicGptNavHost()
+                GlycemicGptNavHost(appSettingsStore = appSettingsStore)
             }
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -24,8 +24,10 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -38,11 +40,13 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.glycemicgpt.mobile.data.auth.AuthState
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.presentation.alerts.AlertsScreen
 import com.glycemicgpt.mobile.presentation.chat.AiChatScreen
 import com.glycemicgpt.mobile.presentation.home.HomeScreen
 import com.glycemicgpt.mobile.BuildConfig
 import com.glycemicgpt.mobile.presentation.debug.BleDebugScreen
+import com.glycemicgpt.mobile.presentation.onboarding.OnboardingScreen
 import com.glycemicgpt.mobile.presentation.pairing.PairingScreen
 import com.glycemicgpt.mobile.presentation.settings.SettingsScreen
 import com.glycemicgpt.mobile.presentation.settings.SettingsViewModel
@@ -54,65 +58,95 @@ sealed class Screen(val route: String, val label: String, val icon: ImageVector)
     data object Settings : Screen("settings", "Settings", Icons.Default.Settings)
     data object Pairing : Screen("pairing", "Pairing", Icons.Default.Bluetooth)
     data object BleDebug : Screen("ble_debug", "BLE Debug", Icons.Default.BugReport)
+    data object Onboarding : Screen("onboarding", "Onboarding", Icons.Default.Home)
 }
 
 private val bottomNavItems = listOf(Screen.Home, Screen.AiChat, Screen.Alerts, Screen.Settings)
 
 @Composable
-fun GlycemicGptNavHost() {
+fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
     val settingsViewModel: SettingsViewModel = hiltViewModel()
     val authState by settingsViewModel.authState.collectAsState()
 
+    val startDestination = remember {
+        if (appSettingsStore.onboardingComplete) Screen.Home.route else Screen.Onboarding.route
+    }
+
+    val isOnboarding = currentDestination?.route == Screen.Onboarding.route
+
+    // Observe logout -> onboarding navigation event
+    LaunchedEffect(Unit) {
+        settingsViewModel.navigateToOnboarding.collect {
+            navController.navigate(Screen.Onboarding.route) {
+                popUpTo(0) { inclusive = true }
+            }
+        }
+    }
+
     Scaffold(
         bottomBar = {
-            NavigationBar {
-                bottomNavItems.forEach { screen ->
-                    NavigationBarItem(
-                        icon = { Icon(screen.icon, contentDescription = screen.label) },
-                        label = { Text(screen.label) },
-                        selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
-                        onClick = {
-                            navController.navigate(screen.route) {
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
+            if (!isOnboarding) {
+                NavigationBar {
+                    bottomNavItems.forEach { screen ->
+                        NavigationBarItem(
+                            icon = { Icon(screen.icon, contentDescription = screen.label) },
+                            label = { Text(screen.label) },
+                            selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
+                            onClick = {
+                                navController.navigate(screen.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
                                 }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        },
-                    )
+                            },
+                        )
+                    }
                 }
             }
         },
     ) { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
-            // Session expired banner
-            (authState as? AuthState.Expired)?.let { expired ->
-                SessionExpiredBanner(
-                    message = expired.message,
-                    onClick = {
-                        navController.navigate(Screen.Settings.route) {
-                            popUpTo(navController.graph.findStartDestination().id) {
-                                saveState = true
+            // Session expired banner (not shown during onboarding)
+            if (!isOnboarding) {
+                (authState as? AuthState.Expired)?.let { expired ->
+                    SessionExpiredBanner(
+                        message = expired.message,
+                        onClick = {
+                            navController.navigate(Screen.Settings.route) {
+                                popUpTo(navController.graph.findStartDestination().id) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
                             }
-                            launchSingleTop = true
-                        }
-                    },
-                )
+                        },
+                    )
+                }
             }
 
             NavHost(
                 navController = navController,
-                startDestination = Screen.Home.route,
+                startDestination = startDestination,
             ) {
+                composable(Screen.Onboarding.route) {
+                    OnboardingScreen(
+                        onOnboardingComplete = {
+                            navController.navigate(Screen.Home.route) {
+                                popUpTo(Screen.Onboarding.route) { inclusive = true }
+                            }
+                        },
+                    )
+                }
                 composable(Screen.Home.route) { HomeScreen() }
                 composable(Screen.AiChat.route) { AiChatScreen() }
                 composable(Screen.Alerts.route) { AlertsScreen() }
                 composable(Screen.Settings.route) {
                     SettingsScreen(
+                        settingsViewModel = settingsViewModel,
                         onNavigateToPairing = {
                             navController.navigate(Screen.Pairing.route)
                         },

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingScreen.kt
@@ -1,0 +1,656 @@
+package com.glycemicgpt.mobile.presentation.onboarding
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bluetooth
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.LocalHospital
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.Security
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.launch
+
+private const val PAGE_COUNT = 5
+private const val PAGE_WELCOME = 0
+private const val PAGE_FEATURES = 1
+private const val PAGE_DISCLAIMER = 2
+private const val PAGE_SERVER = 3
+private const val PAGE_LOGIN = 4
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun OnboardingScreen(
+    onOnboardingComplete: () -> Unit,
+    viewModel: OnboardingViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val pagerState = rememberPagerState(
+        initialPage = viewModel.getStartPage(),
+        pageCount = { PAGE_COUNT },
+    )
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(state.onboardingComplete) {
+        if (state.onboardingComplete) {
+            onOnboardingComplete()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.weight(1f),
+            userScrollEnabled = pagerState.currentPage < PAGE_SERVER,
+        ) { page ->
+            when (page) {
+                PAGE_WELCOME -> WelcomePage()
+                PAGE_FEATURES -> FeaturesPage()
+                PAGE_DISCLAIMER -> DisclaimerPage()
+                PAGE_SERVER -> ServerSetupPage(
+                    baseUrl = state.baseUrl,
+                    onUrlChange = viewModel::updateBaseUrl,
+                    isTestingConnection = state.isTestingConnection,
+                    connectionTestResult = state.connectionTestResult,
+                    connectionTestSuccess = state.connectionTestSuccess,
+                    onTestConnection = viewModel::testConnection,
+                )
+                PAGE_LOGIN -> LoginPage(
+                    email = state.email,
+                    onEmailChange = viewModel::updateEmail,
+                    password = state.password,
+                    onPasswordChange = viewModel::updatePassword,
+                    isLoggingIn = state.isLoggingIn,
+                    loginError = state.loginError,
+                    onLogin = viewModel::login,
+                )
+            }
+        }
+
+        // Bottom controls
+        OnboardingControls(
+            currentPage = pagerState.currentPage,
+            pageCount = PAGE_COUNT,
+            connectionTestSuccess = state.connectionTestSuccess,
+            onSkip = {
+                coroutineScope.launch { pagerState.animateScrollToPage(PAGE_SERVER) }
+            },
+            onBack = {
+                coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
+            },
+            onNext = {
+                coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
+            },
+        )
+    }
+}
+
+@Composable
+private fun OnboardingControls(
+    currentPage: Int,
+    pageCount: Int,
+    connectionTestSuccess: Boolean,
+    onSkip: () -> Unit,
+    onBack: () -> Unit,
+    onNext: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Page indicators
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(bottom = 16.dp),
+        ) {
+            repeat(pageCount) { index ->
+                Box(
+                    modifier = Modifier
+                        .size(if (index == currentPage) 10.dp else 8.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (index == currentPage) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.outlineVariant
+                            },
+                        )
+                        .testTag("page_indicator_$index"),
+                )
+            }
+        }
+
+        // Navigation buttons
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            when {
+                // Skip button on welcome pages 0-1
+                currentPage in PAGE_WELCOME..PAGE_FEATURES -> {
+                    TextButton(
+                        onClick = onSkip,
+                        modifier = Modifier.testTag("skip_button"),
+                    ) {
+                        Text("Skip")
+                    }
+                }
+                // Back button on server setup and login pages
+                currentPage in PAGE_SERVER..PAGE_LOGIN -> {
+                    TextButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag("back_button"),
+                    ) {
+                        Text("Back")
+                    }
+                }
+                else -> Spacer(modifier = Modifier.width(64.dp))
+            }
+
+            // Next button
+            when (currentPage) {
+                PAGE_DISCLAIMER -> {
+                    Button(
+                        onClick = onNext,
+                        modifier = Modifier.testTag("next_button"),
+                    ) {
+                        Text("I Understand")
+                    }
+                }
+                PAGE_SERVER -> {
+                    Button(
+                        onClick = onNext,
+                        enabled = connectionTestSuccess,
+                        modifier = Modifier.testTag("next_button"),
+                    ) {
+                        Text("Next")
+                    }
+                }
+                PAGE_LOGIN -> {
+                    // Login button is in the page itself
+                    Spacer(modifier = Modifier.width(64.dp))
+                }
+                else -> {
+                    Button(
+                        onClick = onNext,
+                        modifier = Modifier.testTag("next_button"),
+                    ) {
+                        Text("Next")
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -- Page Composables --
+
+@Composable
+private fun WelcomePage() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Favorite,
+            contentDescription = null,
+            modifier = Modifier.size(96.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "GlycemicGPT",
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "AI-powered diabetes management companion",
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            text = "Your on-call endo at home",
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun FeaturesPage() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            text = "What You Get",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        FeatureCard(
+            icon = Icons.Default.Bluetooth,
+            title = "Direct Pump Connection",
+            description = "Connect directly to your Tandem t:slim via BLE for real-time basal, bolus, IoB, reservoir, and battery data.",
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        FeatureCard(
+            icon = Icons.Default.Psychology,
+            title = "AI-Powered Analysis",
+            description = "Get daily briefs, meal analysis, and pattern recognition powered by your choice of AI provider.",
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        FeatureCard(
+            icon = Icons.Default.Notifications,
+            title = "Smart Alerts",
+            description = "Configurable glucose alerts with Telegram delivery and caregiver escalation.",
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        FeatureCard(
+            icon = Icons.Default.Lock,
+            title = "Self-Hosted Privacy",
+            description = "Your data stays on your infrastructure. No cloud dependency, full control.",
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun FeatureCard(icon: ImageVector, title: String, description: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(32.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DisclaimerPage() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Icon(
+            imageVector = Icons.Default.Warning,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.error,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = "Important Safety Information",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        DisclaimerCard(
+            icon = Icons.Default.Science,
+            title = "Experimental Software",
+            description = "This is alpha software under active development. It is functional but has not been broadly tested. Use at your own risk.",
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        DisclaimerCard(
+            icon = Icons.Default.Psychology,
+            title = "AI Limitations",
+            description = "AI can hallucinate, misinterpret data, and provide outdated or incorrect information. Never rely solely on AI suggestions.",
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        DisclaimerCard(
+            icon = Icons.Default.Shield,
+            title = "Not FDA Approved",
+            description = "This software is not approved by the FDA or any regulatory body for medical use. It is not a medical device.",
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        DisclaimerCard(
+            icon = Icons.Default.LocalHospital,
+            title = "Consult Your Healthcare Provider",
+            description = "Always consult with your endocrinologist before making changes to your diabetes management. Verify all AI suggestions with your care team.",
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun DisclaimerCard(icon: ImageVector, title: String, description: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f),
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+                tint = MaterialTheme.colorScheme.error,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ServerSetupPage(
+    baseUrl: String,
+    onUrlChange: (String) -> Unit,
+    isTestingConnection: Boolean,
+    connectionTestResult: String?,
+    connectionTestSuccess: Boolean,
+    onTestConnection: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(48.dp))
+
+        Icon(
+            imageVector = Icons.Default.Security,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Connect to Your Server",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Enter the URL of your self-hosted GlycemicGPT server.",
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        OutlinedTextField(
+            value = baseUrl,
+            onValueChange = onUrlChange,
+            label = { Text("Server URL") },
+            placeholder = { Text("https://your-server.com") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("onboarding_server_url"),
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        OutlinedButton(
+            onClick = onTestConnection,
+            enabled = !isTestingConnection && baseUrl.isNotBlank(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("onboarding_test_connection"),
+        ) {
+            if (isTestingConnection) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+            Text(if (isTestingConnection) "Testing..." else "Test Connection")
+        }
+
+        connectionTestResult?.let { result ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = result,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (connectionTestSuccess) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.error
+                },
+                textAlign = TextAlign.Center,
+                modifier = Modifier.testTag("onboarding_connection_result"),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoginPage(
+    email: String,
+    onEmailChange: (String) -> Unit,
+    password: String,
+    onPasswordChange: (String) -> Unit,
+    isLoggingIn: Boolean,
+    loginError: String?,
+    onLogin: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(48.dp))
+
+        Text(
+            text = "Sign In",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Sign in to your GlycemicGPT account to start monitoring.",
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = onEmailChange,
+            label = { Text("Email") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("onboarding_email"),
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = password,
+            onValueChange = onPasswordChange,
+            label = { Text("Password") },
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("onboarding_password"),
+        )
+
+        loginError?.let { error ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.testTag("onboarding_login_error"),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Button(
+            onClick = onLogin,
+            enabled = !isLoggingIn && email.isNotBlank() && password.isNotBlank(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("onboarding_sign_in"),
+        ) {
+            if (isLoggingIn) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    strokeWidth = 2.dp,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+            Text(if (isLoggingIn) "Signing in..." else "Sign In")
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,137 @@
+package com.glycemicgpt.mobile.presentation.onboarding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.repository.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class OnboardingUiState(
+    val baseUrl: String = "",
+    val isTestingConnection: Boolean = false,
+    val connectionTestResult: String? = null,
+    val connectionTestSuccess: Boolean = false,
+    val email: String = "",
+    val password: String = "",
+    val isLoggingIn: Boolean = false,
+    val loginError: String? = null,
+    val onboardingComplete: Boolean = false,
+)
+
+@HiltViewModel
+class OnboardingViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val appSettingsStore: AppSettingsStore,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(OnboardingUiState())
+    val uiState: StateFlow<OnboardingUiState> = _uiState.asStateFlow()
+
+    init {
+        // Pre-fill server URL if returning after logout
+        val savedUrl = authRepository.getBaseUrl()
+        if (!savedUrl.isNullOrBlank()) {
+            _uiState.value = _uiState.value.copy(baseUrl = savedUrl)
+        }
+    }
+
+    fun updateBaseUrl(url: String) {
+        _uiState.value = _uiState.value.copy(
+            baseUrl = url,
+            connectionTestResult = null,
+            connectionTestSuccess = false,
+        )
+    }
+
+    fun testConnection() {
+        val url = _uiState.value.baseUrl.trim()
+        if (url.isBlank()) {
+            _uiState.value = _uiState.value.copy(
+                connectionTestResult = "Enter a server URL first",
+                connectionTestSuccess = false,
+            )
+            return
+        }
+        if (!authRepository.isValidUrl(url)) {
+            _uiState.value = _uiState.value.copy(
+                connectionTestResult = "Invalid URL. HTTPS required.",
+                connectionTestSuccess = false,
+            )
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                isTestingConnection = true,
+                connectionTestResult = null,
+                connectionTestSuccess = false,
+            )
+            authRepository.saveBaseUrl(url)
+            val result = authRepository.testConnection()
+            result.onSuccess { message ->
+                _uiState.value = _uiState.value.copy(
+                    isTestingConnection = false,
+                    connectionTestResult = message,
+                    connectionTestSuccess = true,
+                )
+            }.onFailure { e ->
+                _uiState.value = _uiState.value.copy(
+                    isTestingConnection = false,
+                    connectionTestResult = "Connection failed: ${e.message}",
+                    connectionTestSuccess = false,
+                )
+            }
+        }
+    }
+
+    fun updateEmail(email: String) {
+        _uiState.value = _uiState.value.copy(email = email, loginError = null)
+    }
+
+    fun updatePassword(password: String) {
+        _uiState.value = _uiState.value.copy(password = password, loginError = null)
+    }
+
+    fun login() {
+        val state = _uiState.value
+        if (state.email.isBlank() || state.password.isBlank()) {
+            _uiState.value = state.copy(loginError = "Email and password are required")
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoggingIn = true, loginError = null)
+            val result = authRepository.login(
+                state.baseUrl.trim(),
+                state.email.trim(),
+                state.password,
+                viewModelScope,
+            )
+            if (result.success) {
+                appSettingsStore.onboardingComplete = true
+                _uiState.value = _uiState.value.copy(
+                    isLoggingIn = false,
+                    onboardingComplete = true,
+                    password = "",
+                )
+            } else {
+                _uiState.value = _uiState.value.copy(
+                    isLoggingIn = false,
+                    loginError = result.error,
+                    password = "",
+                )
+            }
+        }
+    }
+
+    /** Returns the starting page index: 0 for fresh install, 3 for returning after logout. */
+    fun getStartPage(): Int {
+        val savedUrl = authRepository.getBaseUrl()
+        return if (!savedUrl.isNullOrBlank()) 3 else 0
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -220,99 +220,39 @@ private fun AccountSection(
     onClearConnectionResult: () -> Unit,
     onClearLoginError: () -> Unit,
 ) {
-    var urlInput by remember(state.baseUrl) { mutableStateOf(state.baseUrl) }
-
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.Storage,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(24.dp),
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Text(
-                    text = "Server Connection",
-                    style = MaterialTheme.typography.titleSmall,
-                )
-            }
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            OutlinedTextField(
-                value = urlInput,
-                onValueChange = { urlInput = it },
-                label = { Text("Server URL") },
-                placeholder = { Text("https://your-server.com") },
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-                modifier = Modifier.fillMaxWidth().testTag("server_url_field"),
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                OutlinedButton(
-                    onClick = {
-                        onSaveUrl(urlInput)
-                        onTestConnection()
-                    },
-                    enabled = !state.isTestingConnection && urlInput.isNotBlank(),
-                    modifier = Modifier.weight(1f).testTag("test_connection_button"),
-                ) {
-                    if (state.isTestingConnection) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(16.dp),
-                            strokeWidth = 2.dp,
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                    }
-                    Text(if (state.isTestingConnection) "Testing..." else "Test Connection")
-                }
-            }
-
-            state.connectionTestResult?.let { result ->
-                Spacer(modifier = Modifier.height(4.dp))
-                val isSuccess = result.contains("successfully")
-                Text(
-                    text = result,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (isSuccess) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.error
-                    },
-                )
-            }
-
-            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
-
-            // Login / Auth section
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.Person,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(24.dp),
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Text(
-                    text = "Authentication",
-                    style = MaterialTheme.typography.titleSmall,
-                )
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
             if (state.isLoggedIn) {
+                // Logged-in view: read-only server info + sign out
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Storage,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Connected to",
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        if (state.baseUrl.isNotBlank()) {
+                            Text(
+                                text = state.baseUrl,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
@@ -348,6 +288,92 @@ private fun AccountSection(
                     }
                 }
             } else {
+                // Not logged in: full server URL + login form
+                var urlInput by remember(state.baseUrl) { mutableStateOf(state.baseUrl) }
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Storage,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = "Server Connection",
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                OutlinedTextField(
+                    value = urlInput,
+                    onValueChange = { urlInput = it },
+                    label = { Text("Server URL") },
+                    placeholder = { Text("https://your-server.com") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                    modifier = Modifier.fillMaxWidth().testTag("server_url_field"),
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = {
+                            onSaveUrl(urlInput)
+                            onTestConnection()
+                        },
+                        enabled = !state.isTestingConnection && urlInput.isNotBlank(),
+                        modifier = Modifier.weight(1f).testTag("test_connection_button"),
+                    ) {
+                        if (state.isTestingConnection) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Text(if (state.isTestingConnection) "Testing..." else "Test Connection")
+                    }
+                }
+
+                state.connectionTestResult?.let { result ->
+                    Spacer(modifier = Modifier.height(4.dp))
+                    val isSuccess = result.contains("successfully")
+                    Text(
+                        text = result,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (isSuccess) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.error
+                        },
+                    )
+                }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Person,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = "Authentication",
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
                 var email by remember { mutableStateOf("") }
                 var password by remember { mutableStateOf("") }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
@@ -1,0 +1,211 @@
+package com.glycemicgpt.mobile.data.repository
+
+import android.content.Context
+import com.glycemicgpt.mobile.data.auth.AuthManager
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.GlucoseRangeResponse
+import com.glycemicgpt.mobile.data.remote.dto.HealthResponse
+import com.glycemicgpt.mobile.data.remote.dto.LoginResponse
+import com.glycemicgpt.mobile.data.remote.dto.UserDto
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthRepositoryTest {
+
+    private val appContext = mockk<Context>(relaxed = true)
+    private val authTokenStore = mockk<AuthTokenStore>(relaxed = true) {
+        every { getBaseUrl() } returns "https://test.example.com"
+        every { isLoggedIn() } returns false
+        every { getUserEmail() } returns null
+    }
+    private val glucoseRangeStore = mockk<GlucoseRangeStore>(relaxed = true)
+    private val api = mockk<GlycemicGptApi>()
+    private val deviceRepository = mockk<DeviceRepository>(relaxed = true)
+    private val authManager = mockk<AuthManager>(relaxed = true)
+
+    private val repository = AuthRepository(
+        appContext, authTokenStore, glucoseRangeStore, api, deviceRepository, authManager,
+    )
+
+    private val testScope = TestScope(UnconfinedTestDispatcher())
+
+    @Test
+    fun `testConnection returns success on 200`() = runTest {
+        coEvery { api.healthCheck() } returns Response.success(HealthResponse(status = "ok"))
+
+        val result = repository.testConnection()
+
+        assertTrue(result.isSuccess)
+        assertEquals("Connected successfully", result.getOrNull())
+    }
+
+    @Test
+    fun `testConnection returns failure on HTTP error`() = runTest {
+        coEvery { api.healthCheck() } returns Response.error(500, "error".toResponseBody())
+
+        val result = repository.testConnection()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("500"))
+    }
+
+    @Test
+    fun `testConnection returns failure on network error`() = runTest {
+        coEvery { api.healthCheck() } throws java.io.IOException("No route to host")
+
+        val result = repository.testConnection()
+
+        assertTrue(result.isFailure)
+        assertEquals("No route to host", result.exceptionOrNull()!!.message)
+    }
+
+    @Test
+    fun `login saves credentials on success`() = runTest {
+        coEvery { api.login(any()) } returns Response.success(
+            LoginResponse(
+                accessToken = "jwt123",
+                refreshToken = "refresh123",
+                tokenType = "bearer",
+                expiresIn = 3600,
+                user = UserDto(id = "1", email = "user@test.com", role = "user"),
+            ),
+        )
+
+        val result = repository.login("https://test.example.com", "user@test.com", "pass", testScope)
+
+        assertTrue(result.success)
+        assertEquals("user@test.com", result.email)
+        assertNull(result.error)
+        verify { authTokenStore.saveCredentials(any(), "jwt123", any(), "user@test.com") }
+        verify { authTokenStore.saveRefreshToken("refresh123") }
+    }
+
+    @Test
+    fun `login notifies AuthManager on success`() = runTest {
+        coEvery { api.login(any()) } returns Response.success(
+            LoginResponse(
+                accessToken = "jwt123",
+                refreshToken = "refresh123",
+                tokenType = "bearer",
+                expiresIn = 3600,
+                user = UserDto(id = "1", email = "user@test.com", role = "user"),
+            ),
+        )
+
+        repository.login("https://test.example.com", "user@test.com", "pass", testScope)
+
+        verify { authManager.onLoginSuccess(any()) }
+    }
+
+    @Test
+    fun `login registers device and fetches glucose range`() = runTest {
+        coEvery { api.login(any()) } returns Response.success(
+            LoginResponse(
+                accessToken = "jwt123",
+                refreshToken = "refresh123",
+                tokenType = "bearer",
+                expiresIn = 3600,
+                user = UserDto(id = "1", email = "user@test.com", role = "user"),
+            ),
+        )
+        coEvery { api.getGlucoseRange() } returns Response.success(
+            GlucoseRangeResponse(urgentLow = 54f, lowTarget = 70f, highTarget = 180f, urgentHigh = 250f),
+        )
+
+        repository.login("https://test.example.com", "user@test.com", "pass", testScope)
+
+        coVerify { deviceRepository.registerDevice() }
+        coVerify { api.getGlucoseRange() }
+    }
+
+    @Test
+    fun `login returns error on 401`() = runTest {
+        coEvery { api.login(any()) } returns Response.error(401, "unauthorized".toResponseBody())
+
+        val result = repository.login("https://test.example.com", "user@test.com", "wrong", testScope)
+
+        assertFalse(result.success)
+        assertEquals("Invalid email or password", result.error)
+    }
+
+    @Test
+    fun `login returns error on empty response body`() = runTest {
+        coEvery { api.login(any()) } returns Response.success(null)
+
+        val result = repository.login("https://test.example.com", "user@test.com", "pass", testScope)
+
+        assertFalse(result.success)
+        assertEquals("Login failed: empty response from server", result.error)
+    }
+
+    @Test
+    fun `login returns error on network failure`() = runTest {
+        coEvery { api.login(any()) } throws java.io.IOException("timeout")
+
+        val result = repository.login("https://test.example.com", "user@test.com", "pass", testScope)
+
+        assertFalse(result.success)
+        assertTrue(result.error!!.contains("timeout"))
+    }
+
+    @Test
+    fun `login requires URL`() = runTest {
+        val result = repository.login("", "user@test.com", "pass", testScope)
+
+        assertFalse(result.success)
+        assertEquals("Configure server URL first", result.error)
+    }
+
+    @Test
+    fun `login requires email and password`() = runTest {
+        val result1 = repository.login("https://test.example.com", "", "pass", testScope)
+        assertFalse(result1.success)
+        assertEquals("Email and password are required", result1.error)
+
+        val result2 = repository.login("https://test.example.com", "user@test.com", "", testScope)
+        assertFalse(result2.success)
+        assertEquals("Email and password are required", result2.error)
+    }
+
+    @Test
+    fun `logout clears tokens and notifies AuthManager`() {
+        repository.logout(testScope)
+
+        verify { authTokenStore.clearToken() }
+        verify { authManager.onLogout() }
+    }
+
+    @Test
+    fun `logout unregisters device`() {
+        repository.logout(testScope)
+
+        coVerify { deviceRepository.unregisterDevice() }
+    }
+
+    @Test
+    fun `isValidUrl accepts HTTPS`() {
+        assertTrue(repository.isValidUrl("https://example.com"))
+    }
+
+    @Test
+    fun `isValidUrl rejects malformed URL`() {
+        assertFalse(repository.isValidUrl("not-a-url"))
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,207 @@
+package com.glycemicgpt.mobile.presentation.onboarding
+
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.repository.AuthRepository
+import com.glycemicgpt.mobile.data.repository.LoginResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnboardingViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val authRepository = mockk<AuthRepository>(relaxed = true) {
+        every { getBaseUrl() } returns null
+        every { isLoggedIn() } returns false
+    }
+    private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = OnboardingViewModel(authRepository, appSettingsStore)
+
+    @Test
+    fun `initial state has empty defaults`() {
+        val vm = createViewModel()
+        val state = vm.uiState.value
+
+        assertEquals("", state.baseUrl)
+        assertFalse(state.isTestingConnection)
+        assertNull(state.connectionTestResult)
+        assertFalse(state.connectionTestSuccess)
+        assertEquals("", state.email)
+        assertEquals("", state.password)
+        assertFalse(state.isLoggingIn)
+        assertNull(state.loginError)
+        assertFalse(state.onboardingComplete)
+    }
+
+    @Test
+    fun `pre-fills baseUrl from token store`() {
+        every { authRepository.getBaseUrl() } returns "https://saved.example.com"
+        val vm = createViewModel()
+
+        assertEquals("https://saved.example.com", vm.uiState.value.baseUrl)
+    }
+
+    @Test
+    fun `getStartPage returns 0 for fresh install`() {
+        every { authRepository.getBaseUrl() } returns null
+        val vm = createViewModel()
+
+        assertEquals(0, vm.getStartPage())
+    }
+
+    @Test
+    fun `getStartPage returns 3 for returning user`() {
+        every { authRepository.getBaseUrl() } returns "https://saved.example.com"
+        val vm = createViewModel()
+
+        assertEquals(3, vm.getStartPage())
+    }
+
+    @Test
+    fun `updateBaseUrl clears connection result`() {
+        val vm = createViewModel()
+        vm.updateBaseUrl("https://new.example.com")
+
+        assertEquals("https://new.example.com", vm.uiState.value.baseUrl)
+        assertNull(vm.uiState.value.connectionTestResult)
+        assertFalse(vm.uiState.value.connectionTestSuccess)
+    }
+
+    @Test
+    fun `testConnection success sets connectionTestSuccess`() = runTest {
+        every { authRepository.isValidUrl(any()) } returns true
+        coEvery { authRepository.testConnection() } returns Result.success("Connected successfully")
+        val vm = createViewModel()
+        vm.updateBaseUrl("https://test.example.com")
+
+        vm.testConnection()
+
+        assertTrue(vm.uiState.value.connectionTestSuccess)
+        assertEquals("Connected successfully", vm.uiState.value.connectionTestResult)
+        assertFalse(vm.uiState.value.isTestingConnection)
+    }
+
+    @Test
+    fun `testConnection failure clears connectionTestSuccess`() = runTest {
+        every { authRepository.isValidUrl(any()) } returns true
+        coEvery { authRepository.testConnection() } returns Result.failure(Exception("Connection refused"))
+        val vm = createViewModel()
+        vm.updateBaseUrl("https://test.example.com")
+
+        vm.testConnection()
+
+        assertFalse(vm.uiState.value.connectionTestSuccess)
+        assertTrue(vm.uiState.value.connectionTestResult!!.contains("Connection refused"))
+    }
+
+    @Test
+    fun `testConnection rejects blank URL`() {
+        val vm = createViewModel()
+        vm.testConnection()
+
+        assertEquals("Enter a server URL first", vm.uiState.value.connectionTestResult)
+        assertFalse(vm.uiState.value.connectionTestSuccess)
+    }
+
+    @Test
+    fun `testConnection rejects invalid URL`() {
+        every { authRepository.isValidUrl("not-a-url") } returns false
+        val vm = createViewModel()
+        vm.updateBaseUrl("not-a-url")
+
+        vm.testConnection()
+
+        assertEquals("Invalid URL. HTTPS required.", vm.uiState.value.connectionTestResult)
+        assertFalse(vm.uiState.value.connectionTestSuccess)
+    }
+
+    @Test
+    fun `login success sets onboardingComplete`() = runTest {
+        every { authRepository.isValidUrl(any()) } returns true
+        coEvery { authRepository.login(any(), any(), any(), any()) } returns LoginResult(
+            success = true, email = "user@test.com",
+        )
+        val vm = createViewModel()
+        vm.updateBaseUrl("https://test.example.com")
+        vm.updateEmail("user@test.com")
+        vm.updatePassword("password123")
+
+        vm.login()
+
+        assertTrue(vm.uiState.value.onboardingComplete)
+        assertFalse(vm.uiState.value.isLoggingIn)
+        assertNull(vm.uiState.value.loginError)
+        verify { appSettingsStore.onboardingComplete = true }
+    }
+
+    @Test
+    fun `login failure shows error`() = runTest {
+        coEvery { authRepository.login(any(), any(), any(), any()) } returns LoginResult(
+            success = false, error = "Invalid email or password",
+        )
+        val vm = createViewModel()
+        vm.updateBaseUrl("https://test.example.com")
+        vm.updateEmail("user@test.com")
+        vm.updatePassword("wrong")
+
+        vm.login()
+
+        assertFalse(vm.uiState.value.onboardingComplete)
+        assertEquals("Invalid email or password", vm.uiState.value.loginError)
+    }
+
+    @Test
+    fun `login requires email and password`() {
+        val vm = createViewModel()
+        vm.updateBaseUrl("https://test.example.com")
+
+        vm.login()
+
+        assertEquals("Email and password are required", vm.uiState.value.loginError)
+    }
+
+    @Test
+    fun `updateEmail clears login error`() {
+        val vm = createViewModel()
+        vm.login() // triggers error
+        assertEquals("Email and password are required", vm.uiState.value.loginError)
+
+        vm.updateEmail("test@example.com")
+        assertNull(vm.uiState.value.loginError)
+    }
+
+    @Test
+    fun `updatePassword clears login error`() {
+        val vm = createViewModel()
+        vm.login() // triggers error
+
+        vm.updatePassword("newpass")
+        assertNull(vm.uiState.value.loginError)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a 5-page guided onboarding flow (Welcome, Features, Safety Disclaimer, Server Setup, Login) that gates first-run access to the mobile app
- Extracts login/testConnection/logout logic from SettingsViewModel into a shared AuthRepository singleton used by both Onboarding and Settings
- Implements conditional navigation routing: fresh install shows onboarding, subsequent launches go straight to Home, logout returns to login page with server URL pre-filled

## Changes

### New files
- **AuthRepository** -- shared singleton for auth operations (login, logout, testConnection, URL validation)
- **OnboardingViewModel** -- manages pager state, connection testing, login flow, and onboarding completion
- **OnboardingScreen** -- 5-page HorizontalPager with page indicators, Skip/Back/Next controls, and safety disclaimer cards

### Modified files
- **AppSettingsStore** -- added `onboardingComplete` persistence flag
- **NavHost** -- conditional `startDestination`, shared SettingsViewModel, post-logout navigation via SharedFlow
- **SettingsViewModel** -- delegates to AuthRepository, observes auth state changes with `drop(1).distinctUntilChanged()`
- **SettingsScreen** -- simplified AccountSection when logged in (read-only server info + email badge + Sign Out)
- **MainActivity** -- removed splash delay

### Tests
- **AuthRepositoryTest** -- login, logout, testConnection, URL validation
- **OnboardingViewModelTest** -- initial state, pre-fill URL, getStartPage, connection test, login, error clearing
- **SettingsViewModelTest** -- updated for AuthRepository delegation

## Test plan

- [ ] Fresh install: uninstall app, reinstall -- should show onboarding, not home
- [ ] Swipe through welcome pages, verify content and page indicators
- [ ] Skip button on pages 0-1 jumps to server setup (page 3)
- [ ] Disclaimer page has no Skip -- user must see safety info
- [ ] Server setup: enter URL, Test Connection, Next enabled only on success
- [ ] Login: enter credentials, Sign In navigates to home screen
- [ ] Subsequent launch: kill app, reopen -- goes straight to home
- [ ] Logout: Settings > Sign Out navigates to onboarding page 3 with URL pre-filled
- [ ] Re-login: complete login, back to home
- [ ] Back button on pages 3-4 navigates to previous page
- [ ] Unit tests pass: `./gradlew testDebugUnitTest`
- [ ] Lint clean: `./gradlew lintDebug`
- [ ] Build succeeds: `./gradlew assembleDebug`