### PR TITLE
fix: bypass broken paths-filter for develop branch container builds

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -59,6 +59,7 @@ jobs:
     if: |
       github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
       needs.detect-changes.outputs.api == 'true'
     steps:
       - name: Checkout
@@ -115,6 +116,7 @@ jobs:
     if: |
       github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
       needs.detect-changes.outputs.web == 'true'
     steps:
       - name: Checkout
@@ -171,6 +173,7 @@ jobs:
     if: |
       github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
       needs.detect-changes.outputs.sidecar == 'true'
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Docker `:dev` tags have never been produced on the `develop` branch because `dorny/paths-filter` compares develop against `main` (default branch) to detect changed paths
- After every promotion merge (develop -> main via rebase merge, then develop recreated from main), both branches point to the same commit -- paths-filter finds zero diff and all build jobs are skipped
- Added a bypass condition for develop push events in all three build jobs (api, web, sidecar) since the top-level `paths:` trigger already gates which pushes run the workflow

## Root Cause

Workflow logs confirmed: `Changes will be detected between main and develop` / `Searching for merge-base main...develop`. With both branches at the same SHA, merge-base = HEAD = empty diff = all builds skipped.

## Test plan

- [ ] After merging, the next develop push that touches `apps/api/`, `apps/web/`, or `sidecar/` should produce `:dev` tagged images
- [ ] Verify `:dev` tags appear on `ghcr.io/jlengelbrecht/glycemicgpt-{api,web,sidecar}`
- [ ] Main branch builds should be unaffected (still uses paths-filter for selective builds)