### PR TITLE
fix: align Renovate config with develop-first branching strategy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,12 +4,13 @@
     "config:recommended",
     "docker:enableMajor",
     ":dependencyDashboard",
-    ":semanticCommits",
-    ":automergeDigest"
+    ":semanticCommits"
   ],
   // Target develop as the integration branch -- all dependency
   // updates land here first so we can test before promoting to main.
   "baseBranches": ["develop"],
+  // Squash-merge auto-merged PRs for clean commit history on develop
+  "automergeStrategy": "squash",
   // Branch naming
   "branchPrefix": "renovate/",
   // Commit message format (semantic commits)


### PR DESCRIPTION
## Summary

- Switch Renovate `automergeType` from `branch` to `pr` so auto-merges work with branch protection rules on `develop` (PRs and status checks required)
- Auto-merge patch and minor updates for **all** dependencies into `develop`, not just devDependencies -- develop is the testing ground before promoting to main
- Remove redundant trusted-packages rule (all minors now auto-merge via the main rule)
- Remove `:automergeBranch` preset (incompatible with branch protection)
- Major updates still require manual review

Closed 5 stale Renovate PRs (#262-#266) that were incorrectly targeting `main` due to `develop` being temporarily deleted during a promotion merge.

## Test plan

- [ ] Verify Renovate recreates dependency PRs targeting `develop`
- [ ] Verify auto-merge triggers after CI passes on patch/minor PRs
- [ ] Verify major update PRs are NOT auto-merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched automerge workflow to use pull-request-based automerge for patch and minor dependency updates (squash strategy).
  * Digest and lockfile maintenance now use PR-based automerge.
  * Major updates now require manual review and testing before merging.
  * Removed automatic merging for trusted minor dev dependencies to improve quality control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->