### PR TITLE
docs: plugin architecture guide and medical disclaimer (Phase 5)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -51,6 +51,12 @@ reviews:
       instructions: >
         Apply when PR modifies Bluetooth Low Energy code under
         apps/mobile/**/ble/**
+    - label: "plugin-api"
+      instructions: >
+        Apply when PR modifies files under apps/mobile/pump-driver-api/
+    - label: "plugin-driver"
+      instructions: >
+        Apply when PR modifies files under apps/mobile/tandem-pump-driver/
 
   path_filters:
     - "!**/*.png"
@@ -141,6 +147,37 @@ reviews:
         - Medical safety: glucose values must be validated (range 20-500 mg/dL),
           insulin doses must have hard caps, no auto-bolus without explicit user
           confirmation.
+
+    - path: "apps/mobile/pump-driver-api/**/*.kt"
+      instructions: |
+        Plugin API module defining interfaces and domain models for all plugins.
+
+        Critical review points:
+        - Interface stability: changes here affect all plugins. Avoid breaking changes.
+        - No implementation leakage: this module must not import from :app or any
+          plugin module. Only stdlib, AndroidX, and kotlinx dependencies allowed.
+        - API version compatibility: if interfaces change, PLUGIN_API_VERSION must
+          be incremented in PluginMetadata.kt.
+        - Safety contract KDoc: all capability methods that accept SafetyLimits
+          must document the filtering/rejection behavior in KDoc.
+        - PluginCapabilityInterface marker: all new capability interfaces must
+          extend this marker.
+
+    - path: "apps/mobile/tandem-pump-driver/**/*.kt"
+      instructions: |
+        Tandem t:slim X2 plugin implementation (reference plugin for the architecture).
+
+        Critical review points:
+        - Delegation patterns: capability classes (TandemGlucoseSource, TandemInsulinSource,
+          TandemPumpStatus) should be thin wrappers delegating to BLE components.
+        - No :app imports: this module depends on :pump-driver-api and the BLE layer.
+          Allowed import namespaces: .domain., .ble., .plugin. (its own classes).
+          Any import from .data., .ui., .service., or other :app namespaces is a violation.
+        - Safety limit passing: all methods receiving SafetyLimits must forward them
+          to the underlying BLE driver/parser. Never use default SafetyLimits().
+        - Lifecycle implementation: onActivated() should auto-reconnect, onDeactivated()
+          should disconnect, shutdown() should fully release resources.
+        - Plugin metadata: apiVersion must match PLUGIN_API_VERSION.
 
     - path: "apps/mobile/**/ble/**"
       instructions: |
@@ -322,6 +359,7 @@ knowledge_base:
     filePatterns:
       - "CLAUDE.md"
       - "docs/branching-strategy.md"
+      - "docs/plugin-architecture.md"
   learnings:
     scope: "local"
   issues:

--- a/MEDICAL-DISCLAIMER.md
+++ b/MEDICAL-DISCLAIMER.md
@@ -1,0 +1,87 @@
+# Medical Disclaimer
+
+## Regulatory Status
+
+This software has **not** been cleared, approved, or certified by any regulatory authority worldwide, including but not limited to:
+
+- The U.S. Food and Drug Administration (FDA)
+- EU Notified Bodies (no CE marking under MDR 2017/745)
+- Health Canada
+- Australia's Therapeutic Goods Administration (TGA)
+- Any equivalent national regulatory authority
+
+## Not a Medical Device
+
+**This software is NOT a medical device.** It is experimental open-source software provided for educational and informational purposes only. No individual, organization, or entity associated with this project is the "manufacturer" of a medical device under any regulatory framework.
+
+GlycemicGPT does not control any medical devices. It reads data from insulin pumps and continuous glucose monitors (CGMs), displays that data, and provides AI-generated text suggestions. These suggestions are not medical advice and must not be treated as such.
+
+## Health Data Processing
+
+This software processes health data including:
+
+- Continuous glucose monitor (CGM) readings
+- Insulin pump telemetry (basal rates, bolus history, insulin on board)
+- Pump hardware status (battery, reservoir levels)
+- User-configured therapy parameters (target glucose ranges, insulin ratios)
+
+Users are responsible for understanding the privacy and security implications of their deployment. The self-hosted architecture means users control where their data resides.
+
+When using the BYOAI (Bring Your Own AI) feature, glucose data context is sent to the configured AI provider (Anthropic, OpenAI, Ollama, or a self-hosted endpoint). Users should review their AI provider's data handling policies.
+
+## AI Limitations
+
+AI-generated suggestions in this software are produced by large language models (LLMs) that are known to:
+
+- **Hallucinate** -- generate plausible-sounding but incorrect information
+- **Misinterpret data** -- draw incorrect conclusions from glucose readings
+- **Provide outdated information** -- not reflect the latest medical guidelines
+- **Lack context** -- not understand your complete medical history, comorbidities, or current medications
+
+All AI-generated content in this software is labeled as suggestions, not medical advice. Never act on AI suggestions without consulting your healthcare team.
+
+## Critical Warnings
+
+1. **Do not replace professional medical care.** Always consult with your endocrinologist, diabetes educator, or healthcare provider before making any changes to your diabetes management.
+
+2. **Verify all suggestions.** Any insulin dosing, carb ratio, or correction factor suggestions must be verified with your healthcare team before use.
+
+3. **Use extreme caution.** Incorrect diabetes management can result in severe hypoglycemia, diabetic ketoacidosis (DKA), or other life-threatening conditions.
+
+4. **If you experience a diabetes emergency, contact your healthcare provider or emergency services immediately.** Do not rely on this software for emergency medical guidance.
+
+## Future Pump Control Features
+
+Pump control capabilities (insulin delivery commands) are not included in pre-built releases of this software. If such features are implemented in the future:
+
+- They will be available only by building from source code
+- They will require explicit user opt-in and acknowledgment of risks
+- They will be subject to additional safety validation pipelines
+- Users who build from source assume full responsibility as the "manufacturer" of their personal build
+
+## LIMITATION OF LIABILITY
+
+THE AUTHORS, CONTRIBUTORS, AND MAINTAINERS OF THIS SOFTWARE PROVIDE IT "AS IS" WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
+
+IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS, OR MAINTAINERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+THIS INCLUDES BUT IS NOT LIMITED TO ANY DAMAGES, INJURIES, OR ADVERSE HEALTH OUTCOMES RESULTING FROM THE USE OF THIS SOFTWARE. BY USING GLYCEMICGPT, YOU ACKNOWLEDGE THAT:
+
+- You are using this software entirely at your own risk
+- You will not rely solely on AI-generated suggestions for medical decisions
+- You understand that AI can and will make errors
+- You will maintain regular care with qualified healthcare professionals
+- You accept full responsibility for any decisions made based on this software's output
+- No individual or entity associated with this project is liable for medical outcomes
+
+## License Warranty Disclaimer
+
+This software is licensed under the GNU General Public License v3.0 (GPL-3.0). Per Sections 15-17 of the GPL-3.0:
+
+- **Section 15:** THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.
+- **Section 16:** IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES.
+- **Section 17:** If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program.
+
+See the [LICENSE](LICENSE) file for the complete GPL-3.0 text.
+
+**Jurisdictional note:** Limitation of liability clauses for personal injury may be unenforceable in some jurisdictions, including under EU consumer protection law, UK consumer rights legislation, and Australian consumer law. The build-from-source distribution model, where the individual user is the "manufacturer" of their personal build, is the primary risk mitigation strategy. This disclaimer does not constitute legal advice.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ GlycemicGPT bridges the gap between diabetes device data and actionable AI-power
 | Dexcom G7 | CGM | Cloud API |
 | Tandem t:slim X2 | Insulin Pump | BLE (direct) + Cloud API |
 
-> Support for additional pumps and CGMs is planned for future releases. The architecture is designed to be extensible -- see [CONTRIBUTING.md](CONTRIBUTING.md) if you'd like to help add support for your device.
+> Support for additional pumps and CGMs is planned for future releases. The mobile app uses a [capability-based plugin architecture](docs/plugin-architecture.md) designed for extensibility -- see [CONTRIBUTING.md](CONTRIBUTING.md) if you'd like to help add support for your device.
 
 **What it does:**
 
@@ -105,6 +105,7 @@ Services will be available at:
 | Backend | FastAPI, Python 3.12 |
 | Mobile | Kotlin, Jetpack Compose, BLE |
 | Wear OS | Kotlin, Wear Compose, Watch Face |
+| Plugin System | Extensible device support via [plugin architecture](docs/plugin-architecture.md) |
 | AI Sidecar | TypeScript, Express, multi-provider proxy |
 | Database | PostgreSQL 16, SQLAlchemy 2.0 |
 | Cache | Redis 7 |
@@ -139,6 +140,8 @@ This project is licensed under the **GNU General Public License v3.0 (GPL-3.0)**
 ---
 
 ## Disclaimer
+
+> See [MEDICAL-DISCLAIMER.md](MEDICAL-DISCLAIMER.md) for the complete medical and regulatory disclaimer.
 
 > **USE AT YOUR OWN RISK**
 

--- a/docs/docker-integration-testing.md
+++ b/docs/docker-integration-testing.md
@@ -1,7 +1,5 @@
 # Docker Integration Testing
 
-Story 13.2: Docker Container Integration Testing
-
 ## Overview
 
 The Docker integration test verifies the full GlycemicGPT stack works correctly when deployed as Docker containers. It builds all services, waits for health checks, exercises the full API through the container network, and validates cross-service connectivity.

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1,0 +1,702 @@
+# Plugin Architecture
+
+Developer guide for building GlycemicGPT mobile plugins.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Getting Started](#getting-started)
+- [Plugin Interfaces](#plugin-interfaces)
+- [Capabilities](#capabilities)
+- [Declarative UI](#declarative-ui)
+- [Event Bus](#event-bus)
+- [DI Registration](#di-registration)
+- [Safety Invariants](#safety-invariants)
+- [Reference Implementation](#reference-implementation)
+- [API Versioning](#api-versioning)
+- [ProGuard Rules](#proguard-rules)
+
+---
+
+## Overview
+
+GlycemicGPT's mobile app uses a three-layer plugin architecture:
+
+```
++---------------------------------------------------+
+|                  Platform (:app)                   |
+|  PluginRegistry, UI renderers, safety enforcement  |
++---------------------------------------------------+
+|              Plugin API (:pump-driver-api)          |
+|  Plugin, DevicePlugin, capabilities, event bus,    |
+|  declarative UI types, domain models               |
++---------------------------------------------------+
+|                    Plugins                          |
+|  :tandem-pump-driver, future: :omnipod-driver, etc |
++---------------------------------------------------+
+```
+
+**Platform** (`:app` module) -- Owns the `PluginRegistry`, core UI (GlucoseHero, TrendChart, TimeInRange), safety limit enforcement, and plugin lifecycle management. Plugins never import from this module.
+
+**Plugin API** (`:pump-driver-api` module) -- Defines all interfaces, capability contracts, event types, declarative UI descriptors, and domain models. Both the platform and plugins depend on this module.
+
+**Plugins** (e.g., `:tandem-pump-driver`) -- Implement one or more capability interfaces. Each plugin is a separate Gradle module that depends only on `:pump-driver-api`. Discovered at compile time via Hilt multibindings.
+
+### Design Principles
+
+- **Capability-based**: Plugins declare what they can do (`GLUCOSE_SOURCE`, `INSULIN_SOURCE`, etc.), not what they are. The platform routes data and enforces mutual exclusion based on capabilities.
+- **Safety-first**: Safety limits are owned by the platform, synced from the backend, and passed to plugins as read-only constraints. Plugins cannot override or bypass them.
+- **Compile-time discovery**: Plugins are discovered via Hilt `@IntoSet` multibindings. No reflection, no classpath scanning, no runtime loading (yet).
+- **Declarative UI**: Plugins describe their settings and dashboard cards using descriptor types. The platform renders them using Material 3 components.
+
+---
+
+## Getting Started
+
+### Gradle Module Setup
+
+Create a new Gradle module under `apps/mobile/`:
+
+```
+apps/mobile/
+  your-plugin/
+    build.gradle.kts
+    src/main/kotlin/com/glycemicgpt/mobile/plugin/...
+```
+
+Your `build.gradle.kts` should depend on `:pump-driver-api`:
+
+```kotlin
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.dagger.hilt.android")
+    id("com.google.devtools.ksp")
+}
+
+dependencies {
+    implementation(project(":pump-driver-api"))
+
+    // Use versions from the project's version catalog (libs.versions.toml)
+    // or match the versions used in :tandem-pump-driver/build.gradle.kts
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
+}
+```
+
+> **Note:** Always reference the project's version catalog (`gradle/libs.versions.toml`) for dependency versions. The `:tandem-pump-driver/build.gradle.kts` is the canonical example. Do not hardcode version strings.
+
+Then add the module to `apps/mobile/settings.gradle.kts`:
+
+```kotlin
+include(":your-plugin")
+```
+
+And add it as a dependency in `:app`:
+
+```kotlin
+// apps/mobile/app/build.gradle.kts
+dependencies {
+    implementation(project(":your-plugin"))
+}
+```
+
+### Minimum Viable Plugin
+
+A plugin needs three things:
+
+1. A class implementing `Plugin` (or `DevicePlugin` for hardware)
+2. A `PluginFactory` to create instances
+3. A Hilt module binding the factory into the `Set<PluginFactory>`
+
+---
+
+## Plugin Interfaces
+
+### Plugin (base)
+
+All plugins implement the `Plugin` interface:
+
+```kotlin
+interface Plugin {
+    val metadata: PluginMetadata
+    val capabilities: Set<PluginCapability>
+
+    fun initialize(context: PluginContext)
+    fun shutdown()
+    fun onActivated()
+    fun onDeactivated()
+    fun settingsDescriptor(): PluginSettingsDescriptor
+    fun observeDashboardCards(): Flow<List<DashboardCardDescriptor>>
+    fun <T : PluginCapabilityInterface> getCapability(type: KClass<T>): T?
+}
+```
+
+**Lifecycle methods:**
+
+| Method | When Called | Purpose |
+|--------|-----------|---------|
+| `initialize(context)` | Once, after creation | Set up resources. `PluginContext` provides Android context, settings store, credential provider, event bus, safety limits. |
+| `shutdown()` | When plugin is being destroyed | Release all resources. Disconnect hardware, cancel coroutines. |
+| `onActivated()` | User selects this plugin as active | Start operations. For device plugins, this is where auto-reconnect should trigger. |
+| `onDeactivated()` | Another plugin replaces this one, or user deactivates | Stop operations. Disconnect hardware, but don't clear stored credentials. |
+
+### DevicePlugin (hardware)
+
+For plugins that connect to physical devices (pumps, CGMs, BGMs):
+
+```kotlin
+interface DevicePlugin : Plugin {
+    fun observeConnectionState(): StateFlow<ConnectionState>
+    fun connect(address: String, config: Map<String, String> = emptyMap())
+    fun disconnect()
+    fun scan(): Flow<DiscoveredDevice>
+}
+```
+
+`ConnectionState` values: `DISCONNECTED`, `SCANNING`, `CONNECTING`, `AUTHENTICATING`, `AUTH_FAILED`, `CONNECTED`, `RECONNECTING`.
+
+Connection requirements:
+- `connect()` must enforce a reasonable timeout (typically 30 seconds)
+- `disconnect()` must be safe to call even if not connected (no-op)
+- `scan()` returns a Flow that completes when scanning ends; cancel collection to stop early
+
+### PluginFactory
+
+Each plugin provides a factory for the platform to create instances:
+
+```kotlin
+interface PluginFactory {
+    val metadata: PluginMetadata
+    fun create(context: PluginContext): Plugin
+}
+```
+
+`metadata` is available before the plugin is instantiated, allowing the platform to display plugin information in the UI without creating plugin instances.
+
+### PluginMetadata
+
+```kotlin
+data class PluginMetadata(
+    val id: String,           // Reverse-domain unique ID, e.g. "com.glycemicgpt.tandem"
+    val name: String,         // Human-readable, e.g. "Tandem t:slim X2"
+    val version: String,      // Semantic version, e.g. "1.0.0"
+    val apiVersion: Int,      // Must match PLUGIN_API_VERSION
+    val description: String,  // Short description
+    val author: String,       // Author name
+    val iconResName: String?, // Optional drawable resource name
+)
+```
+
+Plugin IDs must match the pattern `^[a-zA-Z][a-zA-Z0-9._-]{1,127}$` (reverse-domain style).
+
+### PluginContext
+
+Provided by the platform during `initialize()`:
+
+```kotlin
+class PluginContext(
+    val androidContext: Context,
+    val pluginId: String,
+    val settingsStore: PluginSettingsStore,
+    val credentialProvider: PumpCredentialProvider,
+    val debugLogger: DebugLogger,
+    val eventBus: PluginEventBus,
+    val safetyLimits: StateFlow<SafetyLimits>,
+    val apiVersion: Int,
+)
+```
+
+- **`settingsStore`**: Per-plugin key-value persistence (scoped to plugin ID). For general settings only -- use `credentialProvider` for sensitive credentials.
+- **`credentialProvider`**: Encrypted storage for pairing credentials and session data.
+- **`safetyLimits`**: Read-only `StateFlow` of current safety limits. Updated by the platform when backend settings change.
+- **`eventBus`**: Cross-plugin communication channel.
+
+**Security note**: `androidContext` exposes the full application `Context`. This is acceptable for compile-time plugins in the monorepo but must be replaced with a restricted interface before any runtime-loaded (third-party) plugin support is introduced.
+
+### Settings Store Behavior
+
+`PluginSettingsStore` provides immediate, synchronous persistence (backed by `SharedPreferences`). Key behaviors:
+
+- **Writes are immediate** -- `putString()`, `putBoolean()`, etc. persist synchronously.
+- **Data survives deactivation** -- settings are preserved when a plugin is deactivated and restored when reactivated.
+- **Data survives app updates** -- settings persist across APK upgrades.
+- **Data is scoped by plugin ID** -- each plugin has its own isolated namespace.
+- **Uninstall clears all data** -- Android clears SharedPreferences when the app is uninstalled.
+
+For sensitive credentials (pairing codes, session tokens), use `credentialProvider` instead, which uses `EncryptedSharedPreferences`.
+
+### Threading Contract
+
+Plugin lifecycle methods (`initialize`, `shutdown`, `onActivated`, `onDeactivated`) are called on the main thread by `PluginRegistry`. The registry serializes activation/deactivation calls via an internal lock, so these methods will not be called concurrently for the same plugin. However:
+
+- Capability methods (`getIoB()`, `observeReadings()`, etc.) may be called from background coroutine dispatchers.
+- `observeDashboardCards()` and `settingsDescriptor()` may be called from the UI thread.
+- If your plugin maintains mutable state accessed by both lifecycle and capability methods, use appropriate synchronization.
+
+### Error Handling
+
+If a lifecycle method throws an exception:
+
+- **`initialize()` throws**: Plugin is skipped entirely -- it will not appear in the available plugins list. An error is logged.
+- **`onActivated()` throws**: Activation fails and the plugin remains inactive. An error is logged and `Result.failure` is returned to the caller.
+- **`onDeactivated()` throws**: The exception is caught and logged, but deactivation continues -- the plugin is removed from the active set regardless.
+- **`shutdown()` throws**: Not currently called by the registry (plugins are garbage collected). Future versions may add explicit shutdown.
+
+---
+
+## Capabilities
+
+Plugins declare their capabilities as a `Set<PluginCapability>`. The platform uses these to enforce mutual exclusion and route data.
+
+### Capability Table
+
+| Capability | Interface | Cardinality | Description |
+|-----------|-----------|-------------|-------------|
+| `GLUCOSE_SOURCE` | `GlucoseSource` | Max 1 active | CGM/glucose readings (CGMs, pumps with CGM stream) |
+| `INSULIN_SOURCE` | `InsulinSource` | Max 1 active | IoB, basal rate, bolus history (read-only) |
+| `PUMP_STATUS` | `PumpStatus` | Max 1 active | Battery, reservoir, hardware info, history logs (read-only) |
+| `PUMP_CONTROL` | *(deferred)* | Max 1 active | Insulin delivery (future, build-from-source only) |
+| `BGM_SOURCE` | `BgmSource` | Multiple allowed | Fingerstick blood glucose readings |
+| `CALIBRATION_TARGET` | `CalibrationTarget` | Max 1 active | Accepts calibration from BGM readings |
+| `DATA_SYNC` | *(not yet defined)* | Multiple allowed | Syncs data to external services (Nightscout, Tidepool). No capability interface exists yet -- this capability is reserved for future use and is not currently implementable. |
+
+**Mutual exclusion**: For single-instance capabilities, activating a new plugin automatically deactivates the previous one for that capability. The platform activates the new plugin first (so the slot is never empty), then deactivates the old one.
+
+### Implementing Capability Interfaces
+
+Return capability instances from `getCapability()`:
+
+```kotlin
+override fun <T : PluginCapabilityInterface> getCapability(type: KClass<T>): T? =
+    when (type) {
+        GlucoseSource::class -> myGlucoseSource as? T
+        InsulinSource::class -> myInsulinSource as? T
+        else -> null
+    }
+```
+
+Convenience extension functions are provided for common access patterns:
+
+```kotlin
+val glucose: GlucoseSource? = plugin.asGlucoseSource()
+val insulin: InsulinSource? = plugin.asInsulinSource()
+val pump: PumpStatus? = plugin.asPumpStatus()
+val bgm: BgmSource? = plugin.asBgmSource()
+val cal: CalibrationTarget? = plugin.asCalibrationTarget()
+```
+
+### GlucoseSource
+
+```kotlin
+interface GlucoseSource : PluginCapabilityInterface {
+    fun observeReadings(): Flow<CgmReading>
+    suspend fun getCurrentReading(): Result<CgmReading>
+}
+```
+
+`CgmReading` values are validated: `glucoseMgDl` must be in 20..500.
+
+### InsulinSource
+
+```kotlin
+interface InsulinSource : PluginCapabilityInterface {
+    suspend fun getIoB(): Result<IoBReading>
+    suspend fun getBasalRate(): Result<BasalReading>
+    suspend fun getBolusHistory(since: Instant, limits: SafetyLimits): Result<List<BolusEvent>>
+}
+```
+
+`getBolusHistory()` receives `SafetyLimits`. **Convention:** implementations should reject bolus events whose dose exceeds `limits.maxBolusDoseMilliunits`. This is not enforced by the interface itself but is a required safety contract -- the platform and existing tests expect out-of-range values to be dropped, not returned.
+
+### PumpStatus
+
+```kotlin
+interface PumpStatus : PluginCapabilityInterface {
+    suspend fun getBatteryStatus(): Result<BatteryStatus>
+    suspend fun getReservoirLevel(): Result<ReservoirReading>
+    suspend fun getPumpSettings(): Result<PumpSettings>
+    suspend fun getPumpHardwareInfo(): Result<PumpHardwareInfo>
+    suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>>
+    fun extractCgmFromHistoryLogs(records: List<HistoryLogRecord>, limits: SafetyLimits): List<CgmReading>
+    fun extractBolusesFromHistoryLogs(records: List<HistoryLogRecord>, limits: SafetyLimits): List<BolusEvent>
+    fun extractBasalFromHistoryLogs(records: List<HistoryLogRecord>, limits: SafetyLimits): List<BasalReading>
+    fun unpair()
+    fun autoReconnectIfPaired()
+}
+```
+
+All `extract*` methods receive `SafetyLimits` and must drop out-of-range values (never clamp).
+
+### BgmSource
+
+```kotlin
+interface BgmSource : PluginCapabilityInterface {
+    fun observeReadings(): Flow<BgmReading>
+    suspend fun getLatestReading(): Result<BgmReading>
+}
+```
+
+### CalibrationTarget
+
+```kotlin
+interface CalibrationTarget : PluginCapabilityInterface {
+    suspend fun calibrate(bgValueMgDl: Int, timestamp: Instant): Result<Unit>
+    suspend fun getCalibrationStatus(): Result<CalibrationStatus>
+}
+```
+
+The platform validates `bgValueMgDl` against absolute glucose bounds (20..500) before forwarding. Plugins may enforce tighter device-specific limits.
+
+---
+
+## Declarative UI
+
+Plugins describe their UI using descriptor types. The platform renders them.
+
+### Settings Descriptors
+
+`PluginSettingsDescriptor` contains sections, each with a list of `SettingDescriptor` items:
+
+```kotlin
+PluginSettingsDescriptor(
+    sections = listOf(
+        PluginSettingsSection(
+            title = "Connection",
+            items = listOf(
+                SettingDescriptor.InfoText(key = "status", text = "Connected"),
+                SettingDescriptor.ActionButton(key = "unpair", label = "Unpair", style = ButtonStyle.DESTRUCTIVE),
+            ),
+        ),
+    ),
+)
+```
+
+Available setting types:
+
+| Type | Purpose | Key Properties |
+|------|---------|----------------|
+| `TextInput` | Text field | `label`, `hint`, `sensitive` (masks input) |
+| `Toggle` | On/off switch | `label`, `description` |
+| `Slider` | Numeric range | `label`, `min`, `max`, `step`, `unit` |
+| `Dropdown` | Selection from options | `label`, `options: List<DropdownOption>` |
+| `ActionButton` | Clickable button | `label`, `style` (DEFAULT, PRIMARY, DESTRUCTIVE) |
+| `InfoText` | Read-only display | `text` |
+
+Setting keys must match `^[a-zA-Z][a-zA-Z0-9_.-]{0,127}$` and be unique within a descriptor.
+
+### Dashboard Card Descriptors
+
+Plugins contribute dashboard cards via `observeDashboardCards()`:
+
+```kotlin
+override fun observeDashboardCards(): Flow<List<DashboardCardDescriptor>> = flow {
+    emit(listOf(
+        DashboardCardDescriptor(
+            id = "my-card",
+            title = "My Plugin Status",
+            priority = 100,  // Lower = higher on dashboard
+            elements = listOf(
+                CardElement.LargeValue(value = "120", unit = "mg/dL", color = UiColor.SUCCESS),
+                CardElement.Label(text = "Last reading 2 min ago", style = LabelStyle.CAPTION),
+            ),
+        ),
+    ))
+}
+```
+
+Available card elements:
+
+| Element | Purpose |
+|---------|---------|
+| `LargeValue` | Primary metric display with optional unit and color |
+| `Label` | Text with style (TITLE, SUBTITLE, BODY, CAPTION) |
+| `StatusBadge` | Colored status indicator |
+| `ProgressBar` | Progress indicator with label |
+| `IconValue` | Icon + value + label |
+| `SparkLine` | Mini line chart from a list of floats |
+| `Row` | Horizontal layout container |
+| `Column` | Vertical layout container |
+| `Spacer` | Vertical spacing (configurable height) |
+
+Colors: `DEFAULT`, `SUCCESS`, `WARNING`, `ERROR`, `INFO`, `MUTED`.
+
+Icons: `BLUETOOTH`, `BATTERY`, `RESERVOIR`, `INSULIN`, `GLUCOSE`, `HEART_RATE`, `SYNC`, `WARNING`, `CHECK`, `CLOCK`, `SETTINGS`, `SIGNAL`, `THERMOMETER`.
+
+---
+
+## Event Bus
+
+The `PluginEventBus` enables cross-plugin communication without direct coupling.
+
+### Publishing Events
+
+```kotlin
+// Inside your plugin (context is the PluginContext from initialize())
+context.eventBus.publish(
+    PluginEvent.NewBgmReading(
+        pluginId = metadata.id,
+        reading = bgmReading,
+    )
+)
+```
+
+### Subscribing to Events
+
+```kotlin
+// Using reified type parameter
+context.eventBus.subscribe<PluginEvent.NewBgmReading>()
+    .collect { event ->
+        // Handle BGM reading from another plugin
+    }
+```
+
+### Event Types
+
+| Event | Published By | Purpose |
+|-------|-------------|---------|
+| `NewGlucoseReading` | Glucose source plugins | New CGM reading available |
+| `NewBgmReading` | BGM source plugins | New fingerstick reading available |
+| `InsulinDelivered` | Insulin source plugins | Bolus delivery event |
+| `DeviceConnected` | Device plugins | Hardware connected |
+| `DeviceDisconnected` | Device plugins | Hardware disconnected |
+| `CalibrationRequested` | BGM plugins | Requesting CGM calibration (value validated: 20..500) |
+| `CalibrationCompleted` | Calibration target plugins | Calibration result |
+| `SafetyLimitsChanged` | **Platform only** | Safety limits updated from backend |
+
+### Platform-Only Events
+
+`SafetyLimitsChanged` can only be published by the platform. If a plugin attempts to publish a platform-only event, the event bus rejects it. Plugins should observe safety limits via `PluginContext.safetyLimits` (a `StateFlow<SafetyLimits>`) rather than subscribing to this event.
+
+### Calibration Flow Example
+
+A typical BGM-to-CGM calibration flow:
+
+1. BGM plugin receives fingerstick reading from meter
+2. BGM plugin publishes `NewBgmReading` event
+3. BGM plugin publishes `CalibrationRequested` with the BG value
+4. CGM plugin (subscribed to `CalibrationRequested`) sends calibration to the CGM device
+5. CGM plugin publishes `CalibrationCompleted` with success/failure
+6. BGM plugin (subscribed to `CalibrationCompleted`) updates its UI
+
+---
+
+## DI Registration
+
+Plugins are discovered via Hilt `@IntoSet` multibindings. Each plugin module provides a Hilt module that binds its factory:
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MyPumpModule {
+
+    @Binds
+    @IntoSet
+    abstract fun bindMyFactory(impl: MyPluginFactory): PluginFactory
+}
+```
+
+The factory class uses `@Inject` and `@Singleton`:
+
+```kotlin
+@Singleton
+class MyPluginFactory @Inject constructor(
+    private val myDriver: MyDriver,
+    // ... other dependencies
+) : PluginFactory {
+
+    override val metadata = PluginMetadata(
+        id = "com.glycemicgpt.my-device",
+        name = "My Device",
+        version = "1.0.0",
+        apiVersion = PLUGIN_API_VERSION,
+        description = "My custom device plugin",
+        author = "My Name",
+    )
+
+    override fun create(context: PluginContext): Plugin {
+        return MyDevicePlugin(myDriver)
+    }
+}
+```
+
+The platform's `PluginRegistry` receives `Set<PluginFactory>` via constructor injection and creates all plugins at startup.
+
+---
+
+## Safety Invariants
+
+### Platform-Enforced Limits
+
+Safety limits are defined by `SafetyLimits` with absolute bounds that cannot be bypassed:
+
+| Field | Absolute Bound | Default | Source |
+|-------|---------------|---------|--------|
+| `minGlucoseMgDl` | 20 | 20 | CGM sensor floor |
+| `maxGlucoseMgDl` | 500 | 500 | CGM sensor ceiling |
+| `maxBasalRateMilliunits` | 15,000 (15 u/hr) | 15,000 | Current hardware max (Tandem) |
+| `maxBolusDoseMilliunits` | 25,000 (25 u) | 25,000 | Current hardware max (Tandem) |
+
+> **Note:** The absolute bounds are currently based on Tandem t:slim X2 hardware limits. Future plugins for other pump hardware (OmniPod, Medtronic) may require revisiting these constants if those devices have different physical limits.
+
+User-configured limits (from the backend) narrow these ranges but can never widen them. The `SafetyLimits.safeOf()` factory clamps values to absolute bounds instead of throwing.
+
+### Plugin Responsibilities
+
+- **Read `safetyLimits` from `PluginContext`**: These are the current limits, updated by the platform.
+- **Drop out-of-range values**: When extracting data (CGM readings, bolus events, basal rates), drop values outside the limits. Never clamp.
+- **Pass limits to extraction methods**: `extractCgmFromHistoryLogs()`, `extractBolusesFromHistoryLogs()`, and `extractBasalFromHistoryLogs()` all receive `SafetyLimits` as a parameter.
+- **Do not publish `SafetyLimitsChanged`**: This is a platform-only event.
+
+### PUMP_CONTROL Capability
+
+The `PUMP_CONTROL` capability is defined in the enum but **deferred** -- no control features exist in the app. Pump control plugins are handled differently from monitoring plugins:
+
+- **Never compiled by CI/CD** -- pump control source code lives in the repo as reference implementations only, not as Gradle modules
+- **Never shipped in pre-built APKs** -- no GitHub Release artifact will ever contain a pump control plugin
+- **User-built only** -- end users who want pump control must compile the plugin themselves and load it via the app's custom plugin loader. By doing so, they accept manufacturer responsibility (see [MEDICAL-DISCLAIMER.md](../MEDICAL-DISCLAIMER.md))
+- Must use platform `SafetyLimits` (max bolus, max basal, glucose range) -- these cannot be bypassed
+- Must require explicit user confirmation with biometric authentication for every delivery command
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md#device-control-plugins) for the full contribution model.
+
+---
+
+## Reference Implementation
+
+The Tandem plugin (`:tandem-pump-driver`) serves as the reference implementation.
+
+### Module Structure
+
+```
+apps/mobile/tandem-pump-driver/
+  src/main/kotlin/com/glycemicgpt/mobile/
+    plugin/
+      TandemDevicePlugin.kt      # Main plugin class
+      TandemPluginFactory.kt     # Factory for Hilt registration
+      TandemGlucoseSource.kt     # GLUCOSE_SOURCE capability
+      TandemInsulinSource.kt     # INSULIN_SOURCE capability
+      TandemPumpStatus.kt        # PUMP_STATUS capability
+    di/
+      TandemPumpModule.kt        # Hilt @IntoSet binding
+```
+
+### TandemDevicePlugin
+
+The main plugin class implements `DevicePlugin` and declares three capabilities:
+
+```kotlin
+class TandemDevicePlugin(
+    private val connectionManager: BleConnectionManager,
+    private val bleDriver: TandemBleDriver,
+    private val scanner: BleScanner,
+    private val historyParser: TandemHistoryLogParser,
+) : DevicePlugin {
+
+    override val capabilities = setOf(
+        PluginCapability.GLUCOSE_SOURCE,
+        PluginCapability.INSULIN_SOURCE,
+        PluginCapability.PUMP_STATUS,
+    )
+
+    // Capability delegates -- thin wrappers around BLE components
+    private val glucoseSource = TandemGlucoseSource(bleDriver)
+    private val insulinSource = TandemInsulinSource(bleDriver)
+    private val pumpStatus = TandemPumpStatus(bleDriver, historyParser, connectionManager)
+
+    override fun <T : PluginCapabilityInterface> getCapability(type: KClass<T>): T? =
+        when (type) {
+            GlucoseSource::class -> glucoseSource as? T
+            InsulinSource::class -> insulinSource as? T
+            PumpStatus::class -> pumpStatus as? T
+            else -> null
+        }
+    // ...
+}
+```
+
+### Capability Delegates
+
+Each capability is a thin wrapper that delegates to the existing BLE components:
+
+```kotlin
+class TandemGlucoseSource(
+    private val bleDriver: TandemBleDriver,
+) : GlucoseSource {
+    override fun observeReadings(): Flow<CgmReading> = flow {
+        while (true) {
+            bleDriver.getCgmStatus().onSuccess { emit(it) }
+            delay(60_000L)
+        }
+    }
+
+    override suspend fun getCurrentReading(): Result<CgmReading> =
+        bleDriver.getCgmStatus()
+}
+```
+
+This pattern keeps plugin code simple: the complexity lives in the BLE layer, and the plugin just adapts it to the capability interface.
+
+### DI Binding
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TandemPumpModule {
+
+    @Binds
+    @IntoSet
+    abstract fun bindTandemFactory(impl: TandemPluginFactory): PluginFactory
+}
+```
+
+---
+
+## API Versioning
+
+### PLUGIN_API_VERSION
+
+The constant `PLUGIN_API_VERSION` (currently `1`) is declared in `PluginMetadata.kt`. Each `PluginMetadata` includes the `apiVersion` the plugin was built against.
+
+### Version Check Behavior
+
+During `PluginRegistry.initialize()`, each factory's `metadata.apiVersion` is checked against the platform's `PLUGIN_API_VERSION`:
+
+- **Match**: Plugin is created and registered normally.
+- **Mismatch**: Plugin is **skipped with a warning** log. It does not crash the app.
+
+```
+W/PluginRegistry: Plugin com.example.foo has API version 2, expected 1 -- skipping
+```
+
+This allows the platform to evolve without breaking older plugins at runtime. Plugins should be recompiled against the new API version when it changes.
+
+### When the Version Changes
+
+Increment `PLUGIN_API_VERSION` when making breaking changes to:
+- `Plugin` or `DevicePlugin` interface methods
+- Capability interfaces (`GlucoseSource`, `InsulinSource`, etc.)
+- `PluginContext` constructor parameters
+- `PluginEvent` sealed class variants
+- `SettingDescriptor` or `CardElement` sealed class variants
+
+Non-breaking additions (new optional fields, new event types) do not require a version bump.
+
+---
+
+## ProGuard Rules
+
+Plugin API interfaces and domain models must be kept for capability reflection. The following rules are included in `:app`'s `proguard-rules.pro`:
+
+```proguard
+# Plugin API interfaces and domain models (needed for capability reflection)
+-keep class com.glycemicgpt.mobile.domain.plugin.** { *; }
+-keep class com.glycemicgpt.mobile.domain.pump.** { *; }
+-keep class com.glycemicgpt.mobile.domain.model.** { *; }
+```
+
+If your plugin module introduces new classes that are accessed via reflection or `KClass` references, add corresponding keep rules in your module's ProGuard configuration.

--- a/docs/real-data-pipeline-verification.md
+++ b/docs/real-data-pipeline-verification.md
@@ -1,7 +1,5 @@
 # Real Data Pipeline Verification
 
-Story 13.3: Real Data Pipeline Verification
-
 ## Overview
 
 This document describes how to verify the complete GlycemicGPT data pipeline with real Dexcom G7 and Tandem t:connect data. The verification script exercises every stage from credential configuration through data ingestion, dashboard display, and AI analysis.

--- a/docs/testing-checklist.md
+++ b/docs/testing-checklist.md
@@ -1,7 +1,5 @@
 # GlycemicGPT Local Dev Server Testing Checklist
 
-Story 13.1: Local Dev Server Testing Checklist
-
 ## Prerequisites
 
 1. **Docker and Docker Compose** installed
@@ -221,6 +219,6 @@ For each settings page with a Save button:
 - Run migrations on the test database first
 
 ### Settings Save button stays disabled
-- This was fixed in Story 10.1 / 12.4
+- This was fixed in a previous release
 - If it persists, check browser console for API errors
 - Verify the backend endpoint returns expected schema

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,8 +1,5 @@
 # GlycemicGPT Kubernetes Deployment
 
-Story 1.4: Kubernetes Deployment Manifests
-Story 1.5: Structured Logging & Backup Configuration
-
 This directory contains Kubernetes manifests for deploying GlycemicGPT to a Kubernetes cluster.
 
 ## Prerequisites
@@ -26,7 +23,7 @@ k8s/
 │   ├── api.yaml             # FastAPI backend
 │   ├── web.yaml             # Next.js frontend
 │   ├── ingress.yaml         # Ingress for external access
-│   ├── backup-cronjob.yaml  # Database backup CronJob (Story 1.5)
+│   ├── backup-cronjob.yaml  # Database backup CronJob
 │   └── nodeport-services.yaml # Alternative: NodePort access
 └── overlays/
     ├── dev/                 # Development overlay
@@ -189,7 +186,7 @@ annotations:
   cert-manager.io/cluster-issuer: letsencrypt-prod
 ```
 
-## Structured Logging (Story 1.5)
+## Structured Logging
 
 GlycemicGPT uses structured JSON logging with correlation IDs for request tracing.
 
@@ -229,7 +226,7 @@ kubectl logs -n glycemicgpt -l app.kubernetes.io/component=api | jq .
 kubectl logs -n glycemicgpt -l app.kubernetes.io/component=api | jq 'select(.correlation_id == "your-id")'
 ```
 
-## Database Backups (Story 1.5)
+## Database Backups
 
 Automated PostgreSQL backups run via Kubernetes CronJob.
 


### PR DESCRIPTION
## Summary

- Add comprehensive Plugin Architecture Guide (`docs/plugin-architecture.md`) covering the three-layer model, capability interfaces, declarative UI, event bus, DI registration, safety invariants, and Tandem reference implementation
- Add consolidated `MEDICAL-DISCLAIMER.md` with regulatory status, AI limitations, liability terms, and GPL-3.0 warranty disclaimer
- Update `README.md` with plugin system in architecture table and link to medical disclaimer
- Update `CONTRIBUTING.md` with three-module project structure, Plugin Development section, ToC entry, and safety limits note
- Update `.coderabbit.yaml` with path instructions for `:pump-driver-api` and `:tandem-pump-driver`, new labels (`plugin-api`, `plugin-driver`), and knowledge base reference

## Context

This is Phase 5 of the plugin architecture work (Story 24.5). Phases 1-4 are merged (PRs #279, #281, #282, #289). This PR is docs-only -- no code changes.

## Test plan

- [ ] All internal cross-references resolve (links between docs)
- [ ] `.coderabbit.yaml` validates against schema
- [ ] No secrets or credentials in documentation
- [ ] CI passes (no code changes to break)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Plugin Architecture guide (capability-based model, plugin types, lifecycle, safety invariants, APIs, examples).
  * Expanded CONTRIBUTING with Plugin Development workflow, two-tier plugin model, and explicit SafetyLimits enforcement and governance.
  * Added MEDICAL-DISCLAIMER.md covering regulatory status, risks, data handling, and build-from-source guidance.
  * Updated README and various docs with plugin navigation and minor editorial cleanups.

* **Chores**
  * Repository config and docs navigation updated to support the new plugin content and review workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->