### PR TITLE
fix: ignore false positive DEV_BUILD_NUMBER in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,9 @@
     "**/venv/**",
     "**/.venv/**"
   ],
+  // False positive: Renovate parses buildConfigField("int", "DEV_BUILD_NUMBER", "0")
+  // as a Maven dependency int:DEV_BUILD_NUMBER. Ignore it.
+  "ignoreDeps": ["int:DEV_BUILD_NUMBER"],
   // Timezone for scheduling
   "timezone": "America/Chicago",
   // Schedule for updates (weekdays during work hours)


### PR DESCRIPTION
## Summary
- Adds `int:DEV_BUILD_NUMBER` to `ignoreDeps` in Renovate config
- Renovate misparses `buildConfigField("int", "DEV_BUILD_NUMBER", "0")` as a Maven dependency, causing a `Failed to look up maven package` warning on every run

## Test plan
- [ ] Verify Renovate dashboard no longer shows the `int:DEV_BUILD_NUMBER` lookup error after next scheduled run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to suppress a false-positive alert, improving the stability of the development automation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->