### PR TITLE
fix: use shared debug keystore for CI dev builds

### DIFF
--- a/.github/workflows/dev-pre-release.yml
+++ b/.github/workflows/dev-pre-release.yml
@@ -32,9 +32,26 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Decode debug keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          if [ -n "$KEYSTORE_BASE64" ]; then
+            echo "$KEYSTORE_BASE64" | base64 -d > /tmp/debug-keystore.jks
+            chmod 600 /tmp/debug-keystore.jks
+            echo "DEBUG_KEYSTORE_FILE=/tmp/debug-keystore.jks" >> "$GITHUB_ENV"
+          else
+            echo "::error::DEBUG_KEYSTORE_BASE64 secret is not set. Refusing to publish a dev APK with ephemeral signing."
+            exit 1
+          fi
+
       - name: Build debug APK
         working-directory: apps/mobile
         run: ./gradlew assembleDebug -PdevBuildNumber=${{ github.run_number }}
+        env:
+          DEBUG_KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
+          DEBUG_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
+          DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
 
       - name: Extract version
         id: version
@@ -91,3 +108,7 @@ jobs:
             --prerelease \
             --target develop \
             dist/*.apk
+
+      - name: Clean up keystore
+        if: always()
+        run: rm -f /tmp/debug-keystore.jks

--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -28,6 +28,25 @@ android {
     }
 
     signingConfigs {
+        // Shared debug keystore for consistent signatures across CI and local
+        // builds.  When the env var is absent (local dev), Gradle falls back to
+        // the default ~/.android/debug.keystore automatically.
+        val debugKsFile = System.getenv("DEBUG_KEYSTORE_FILE")?.takeIf { it.isNotBlank() }
+        if (debugKsFile != null) {
+            getByName("debug") {
+                storeFile = file(debugKsFile)
+                storePassword = requireNotNull(System.getenv("DEBUG_KEYSTORE_PASSWORD")) {
+                    "DEBUG_KEYSTORE_PASSWORD must be set when DEBUG_KEYSTORE_FILE is provided"
+                }
+                keyAlias = requireNotNull(System.getenv("DEBUG_KEY_ALIAS")) {
+                    "DEBUG_KEY_ALIAS must be set when DEBUG_KEYSTORE_FILE is provided"
+                }
+                keyPassword = requireNotNull(System.getenv("DEBUG_KEY_PASSWORD")) {
+                    "DEBUG_KEY_PASSWORD must be set when DEBUG_KEYSTORE_FILE is provided"
+                }
+            }
+        }
+
         create("release") {
             val ksFile = System.getenv("RELEASE_KEYSTORE_FILE")
             if (ksFile != null) {

--- a/apps/mobile/wear/build.gradle.kts
+++ b/apps/mobile/wear/build.gradle.kts
@@ -28,6 +28,25 @@ android {
     }
 
     signingConfigs {
+        // Shared debug keystore for consistent signatures across CI and local
+        // builds.  When the env var is absent (local dev), Gradle falls back to
+        // the default ~/.android/debug.keystore automatically.
+        val debugKsFile = System.getenv("DEBUG_KEYSTORE_FILE")?.takeIf { it.isNotBlank() }
+        if (debugKsFile != null) {
+            getByName("debug") {
+                storeFile = file(debugKsFile)
+                storePassword = requireNotNull(System.getenv("DEBUG_KEYSTORE_PASSWORD")) {
+                    "DEBUG_KEYSTORE_PASSWORD must be set when DEBUG_KEYSTORE_FILE is provided"
+                }
+                keyAlias = requireNotNull(System.getenv("DEBUG_KEY_ALIAS")) {
+                    "DEBUG_KEY_ALIAS must be set when DEBUG_KEYSTORE_FILE is provided"
+                }
+                keyPassword = requireNotNull(System.getenv("DEBUG_KEY_PASSWORD")) {
+                    "DEBUG_KEY_PASSWORD must be set when DEBUG_KEYSTORE_FILE is provided"
+                }
+            }
+        }
+
         create("release") {
             val ksFile = System.getenv("RELEASE_KEYSTORE_FILE")
             if (ksFile != null) {


### PR DESCRIPTION
## Summary

- Dev-channel debug APKs were signed with ephemeral per-runner debug keystores, causing "package conflicts with an existing package" errors when the auto-update mechanism tried to install a new build over a previous one (different signing key, same package name)
- Added a shared debug keystore stored as GitHub Actions secrets (`DEBUG_KEYSTORE_BASE64`, `DEBUG_KEYSTORE_PASSWORD`, `DEBUG_KEY_ALIAS`, `DEBUG_KEY_PASSWORD`) -- all secrets are already configured
- Both phone and Wear OS modules load the shared keystore via env vars when present, falling back to the default `~/.android/debug.keystore` for local development
- CI workflow decodes the keystore before building, sets restrictive file permissions, and cleans up after the job
- Gradle configs use `requireNotNull` guards to fail fast if companion env vars are missing
- CONTRIBUTING.md updated with debug signing explanation and keystore rotation instructions

## Test plan

- [x] `./gradlew assembleDebug` builds successfully (local dev fallback path)
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes
- [x] CI must pass on this PR (validates the workflow syntax and Gradle config)
- [ ] After merging, verify `dev-pre-release` workflow succeeds and the published APK installs over a previous dev build without conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now decodes and uses a shared debug keystore for pre-release builds, passes keystore credentials to the build, and securely cleans up after the build to enable consistent debug APK signing.

* **Documentation**
  * Updated contributor docs with guidance on Dev-channel debug APK signing, CI vs local build behavior, and a keystore rotation procedure for maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->