### PR TITLE
feat: automated DAST and auth flow penetration testing (story 28.11)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,151 @@
+name: Security Scan (DAST)
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'sidecar/**'
+      - 'docker-compose.yml'
+      - 'docker-compose.test.yml'
+      - 'scripts/security/**'
+      - '.github/workflows/security-scan.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'sidecar/**'
+      - 'docker-compose.yml'
+      - 'docker-compose.test.yml'
+      - 'scripts/security/**'
+      - '.github/workflows/security-scan.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  security-scan:
+    name: DAST & Auth Penetration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install test dependencies
+        run: pip install -r scripts/security/requirements.txt
+
+      - name: Install nuclei
+        run: |
+          go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.7
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Build & start Docker test stack
+        env:
+          COMPOSE_PROJECT_NAME: glycemicgpt-test
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.test.yml up --build -d
+
+      - name: Wait for services to be healthy
+        env:
+          COMPOSE_PROJECT_NAME: glycemicgpt-test
+        run: |
+          API_HEALTHY=false
+          echo "Waiting for API health..."
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:8001/health > /dev/null 2>&1; then
+              echo "API healthy after ${i}s"
+              API_HEALTHY=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$API_HEALTHY" != "true" ]; then
+            echo "FATAL: API not healthy after 90s"
+            docker compose -f docker-compose.yml -f docker-compose.test.yml logs api --tail=50
+            exit 1
+          fi
+
+          WEB_HEALTHY=false
+          echo "Waiting for Web health..."
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:3001 > /dev/null 2>&1; then
+              echo "Web healthy after ${i}s"
+              WEB_HEALTHY=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$WEB_HEALTHY" != "true" ]; then
+            echo "FATAL: Web not healthy after 90s"
+            docker compose -f docker-compose.yml -f docker-compose.test.yml logs web --tail=50
+            exit 1
+          fi
+
+      - name: Run auth flow tests
+        env:
+          API_URL: http://localhost:8001
+          WEB_URL: http://localhost:3001
+          COMPOSE_PROJECT_NAME: glycemicgpt-test
+        run: |
+          # Read the test SECRET_KEY from the running API container
+          TEST_SECRET_KEY=$(docker compose -f docker-compose.yml -f docker-compose.test.yml exec -T api printenv SECRET_KEY) || {
+            echo "FATAL: Could not read SECRET_KEY from API container"
+            docker compose -f docker-compose.yml -f docker-compose.test.yml ps
+            exit 1
+          }
+          export TEST_SECRET_KEY
+          python scripts/security/test-auth-flows.py
+
+      - name: Run API fuzzer
+        env:
+          API_URL: http://localhost:8001
+          COMPOSE_PROJECT_NAME: glycemicgpt-test
+        run: python scripts/security/fuzz-api.py
+
+      - name: Run DAST scanner
+        env:
+          API_URL: http://localhost:8001
+          WEB_URL: http://localhost:3001
+        run: ./scripts/security/run-dast.sh
+
+      - name: Upload scan results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-scan-results
+          path: scripts/security/results/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Show container logs on failure
+        if: failure()
+        env:
+          COMPOSE_PROJECT_NAME: glycemicgpt-test
+        run: |
+          echo "=== API Logs ==="
+          docker compose -f docker-compose.yml -f docker-compose.test.yml logs api --tail=100
+          echo ""
+          echo "=== Web Logs ==="
+          docker compose -f docker-compose.yml -f docker-compose.test.yml logs web --tail=50
+
+      - name: Tear down Docker stack
+        if: always()
+        env:
+          COMPOSE_PROJECT_NAME: glycemicgpt-test
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.test.yml down -v --remove-orphans

--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,9 @@ _bmad/
 .claude/
 CLAUDE.md
 
+# Security testing
+scripts/security/results/
+scripts/security/.venv/
+
 # Stray files from package managers
 =*

--- a/scripts/security/fuzz-api.py
+++ b/scripts/security/fuzz-api.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Story 28.11: OpenAPI-driven endpoint fuzzer.
+
+Fetches /openapi.json from the live API, iterates endpoints, and sends
+malicious payloads.  Asserts that no endpoint returns HTTP 500.
+
+Usage:
+    API_URL=http://localhost:8001 python fuzz-api.py
+"""
+
+import os
+import re
+import sys
+import uuid
+
+import httpx
+
+API_URL = os.environ.get("API_URL", "http://localhost:8001")
+
+# Endpoints to skip (docs, health, SSE streams)
+SKIP_PREFIXES = ("/docs", "/openapi.json", "/redoc", "/health")
+SKIP_SUFFIXES = ("/stream",)
+
+# Regex to find {param} placeholders in paths
+PATH_PARAM_RE = re.compile(r"\{[^}]+\}")
+
+# Fuzz payloads by category
+PAYLOADS: dict[str, list[str]] = {
+    "sql_injection": [
+        "' OR 1=1--",
+        "'; DROP TABLE users;--",
+        "1; SELECT * FROM information_schema.tables--",
+        "' UNION SELECT NULL,NULL,NULL--",
+    ],
+    "xss": [
+        "<script>alert(1)</script>",
+        '<img onerror=alert(1) src="">',
+        "javascript:alert(1)",
+        '"><svg onload=alert(1)>',
+    ],
+    "path_traversal": [
+        "../../../../etc/passwd",
+        "..%2F..%2F..%2F..%2Fetc%2Fpasswd",
+        "....//....//etc/passwd",
+        "/etc/shadow",
+    ],
+    "oversized": [
+        "A" * 10_000,
+    ],
+    "type_confusion": [
+        "not-a-uuid",
+        "99999999",
+        "-1",
+        "true",
+        "null",
+        '{"nested": "object"}',
+    ],
+    "empty": [
+        "",
+    ],
+}
+
+TOTAL_REQUESTS = 0
+ERROR_500_COUNT = 0
+CONNECT_ERROR_COUNT = 0
+ENDPOINTS_TESTED = 0
+MAX_CONSECUTIVE_CONNECT_ERRORS = 10
+
+
+def setup_session(client: httpx.Client) -> bool:
+    """Register + login a throwaway user, storing cookies on the client.
+
+    Returns True if login succeeded (cookies are set on the client).
+    """
+    email = f"fuzz_{uuid.uuid4().hex[:10]}@example.com"
+    password = os.environ.get("TEST_PASSWORD", f"Fuzz-{uuid.uuid4().hex[:8]}!")
+
+    client.post(
+        f"{API_URL}/api/auth/register",
+        json={"email": email, "password": password},
+    )
+    resp = client.post(
+        f"{API_URL}/api/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    has_session = any(
+        c.name == "glycemicgpt_session" for c in client.cookies.jar
+    )
+    if not has_session and resp.status_code == 200:
+        # Fallback: parse Set-Cookie header manually
+        for sc in resp.headers.get_list("set-cookie"):
+            if "glycemicgpt_session=" in sc:
+                val = sc.split("glycemicgpt_session=")[1].split(";")[0]
+                client.cookies.set("glycemicgpt_session", val)
+                has_session = True
+                break
+
+    return has_session
+
+
+def should_skip(path: str) -> bool:
+    """Check if an endpoint should be skipped."""
+    for prefix in SKIP_PREFIXES:
+        if path.startswith(prefix):
+            return True
+    for suffix in SKIP_SUFFIXES:
+        if path.endswith(suffix):
+            return True
+    return False
+
+
+def resolve_path_params(path: str, payload: str) -> str:
+    """Replace {param} placeholders in the path with the fuzz payload."""
+    return PATH_PARAM_RE.sub(payload, path)
+
+
+def make_fuzz_body(payload: str, schema: dict | None) -> dict:
+    """Build a JSON body using the payload for all string fields."""
+    if not schema:
+        return {"data": payload}
+
+    # Try to populate fields from schema properties
+    properties = schema.get("properties", {})
+    if not properties:
+        return {"data": payload}
+
+    body: dict = {}
+    for field_name, field_info in properties.items():
+        field_type = field_info.get("type", "string")
+        if field_type == "string":
+            body[field_name] = payload
+        elif field_type == "integer":
+            body[field_name] = payload  # Type confusion is intentional
+        elif field_type == "boolean":
+            body[field_name] = payload
+        elif field_type == "number":
+            body[field_name] = payload
+        else:
+            body[field_name] = payload
+    return body
+
+
+def resolve_ref(ref: str, openapi: dict) -> dict:
+    """Resolve a $ref pointer like '#/components/schemas/Foo'."""
+    parts = ref.lstrip("#/").split("/")
+    node = openapi
+    for part in parts:
+        node = node.get(part, {})
+    return node
+
+
+def get_request_schema(operation: dict, openapi: dict) -> dict | None:
+    """Extract the JSON request body schema from an operation."""
+    request_body = operation.get("requestBody", {})
+    content = request_body.get("content", {})
+    json_content = content.get("application/json", {})
+    schema = json_content.get("schema", {})
+
+    if "$ref" in schema:
+        return resolve_ref(schema["$ref"], openapi)
+    return schema if schema else None
+
+
+def has_path_params(path: str) -> bool:
+    """Check if a path has {param} placeholders."""
+    return bool(PATH_PARAM_RE.search(path))
+
+
+def fuzz_endpoint(
+    client: httpx.Client,
+    method: str,
+    path: str,
+    schema: dict | None,
+) -> bool:
+    """Send all payload categories against a single endpoint.
+
+    Returns False if too many consecutive connection errors occurred
+    (possible server crash).
+    """
+    global TOTAL_REQUESTS, ERROR_500_COUNT, CONNECT_ERROR_COUNT
+
+    headers = {}
+    csrf_token = ""
+    for cookie in client.cookies.jar:
+        if cookie.name == "csrf_token":
+            csrf_token = cookie.value
+            break
+    if csrf_token and method.upper() in ("POST", "PUT", "PATCH", "DELETE"):
+        headers["X-CSRF-Token"] = csrf_token
+
+    consecutive_connect_errors = 0
+
+    for category, payloads in PAYLOADS.items():
+        for payload in payloads:
+            TOTAL_REQUESTS += 1
+
+            # Substitute path parameters with fuzz payload
+            resolved_path = resolve_path_params(path, payload) if has_path_params(path) else path
+
+            try:
+                if method.upper() in ("GET", "HEAD", "OPTIONS"):
+                    resp = client.request(
+                        method,
+                        f"{API_URL}{resolved_path}",
+                        params={"q": payload, "id": payload},
+                        headers=headers,
+                        timeout=10,
+                    )
+                else:
+                    body = make_fuzz_body(payload, schema)
+                    resp = client.request(
+                        method,
+                        f"{API_URL}{resolved_path}",
+                        json=body,
+                        headers=headers,
+                        timeout=10,
+                    )
+
+                consecutive_connect_errors = 0  # Reset on success
+
+                if resp.status_code == 500:
+                    ERROR_500_COUNT += 1
+                    print(
+                        f"  [500] {method.upper()} {resolved_path} "
+                        f"({category}): {payload[:60]}"
+                    )
+                elif resp.status_code == 429:
+                    # Rate limited -- stop hitting this endpoint
+                    return True
+
+            except httpx.TimeoutException:
+                pass  # Timeouts are acceptable (e.g. SSE endpoints)
+            except httpx.ConnectError:
+                consecutive_connect_errors += 1
+                CONNECT_ERROR_COUNT += 1
+                if consecutive_connect_errors >= MAX_CONSECUTIVE_CONNECT_ERRORS:
+                    print(
+                        f"  [WARN] {MAX_CONSECUTIVE_CONNECT_ERRORS} consecutive "
+                        f"connection errors on {method.upper()} {path} -- "
+                        f"server may have crashed"
+                    )
+                    return False
+
+    return True
+
+
+def main() -> int:
+    global ENDPOINTS_TESTED
+
+    print("=== OpenAPI Endpoint Fuzzer ===")
+    print(f"API: {API_URL}")
+    print()
+
+    with httpx.Client(timeout=10) as client:
+        # Fetch OpenAPI spec
+        print("Fetching /openapi.json ...")
+        resp = client.get(f"{API_URL}/openapi.json")
+        if resp.status_code != 200:
+            print(f"Failed to fetch OpenAPI spec: {resp.status_code}")
+            return 1
+
+        openapi = resp.json()
+        paths = openapi.get("paths", {})
+        print(f"Found {len(paths)} paths")
+        print()
+
+        # Get authenticated session
+        print("Creating test session ...")
+        if not setup_session(client):
+            print("WARNING: Could not get session cookie; "
+                  "some endpoints may return 401")
+        print()
+
+        # Fuzz each endpoint
+        server_alive = True
+        for path, methods in paths.items():
+            if should_skip(path):
+                continue
+            if not server_alive:
+                break
+
+            for method, operation in methods.items():
+                if method.lower() not in ("get", "post", "put", "patch", "delete"):
+                    continue
+                if not isinstance(operation, dict):
+                    continue
+
+                ENDPOINTS_TESTED += 1
+                schema = get_request_schema(operation, openapi)
+                summary = operation.get("summary", "")
+                print(f"  Fuzzing {method.upper()} {path} ({summary})")
+                server_alive = fuzz_endpoint(client, method, path, schema)
+                if not server_alive:
+                    print("  Aborting fuzz run due to server connectivity issues")
+                    break
+
+    print()
+    print(f"Endpoints tested: {ENDPOINTS_TESTED}")
+    print(f"Total requests: {TOTAL_REQUESTS}")
+    print(f"500 errors: {ERROR_500_COUNT}")
+    if CONNECT_ERROR_COUNT > 0:
+        print(f"Connection errors: {CONNECT_ERROR_COUNT}")
+
+    if ERROR_500_COUNT > 0 or not server_alive:
+        print()
+        if not server_alive:
+            print("FAIL: Server became unreachable during fuzzing")
+        else:
+            print("FAIL: Server returned 500 errors on fuzzed input")
+        return 1
+
+    print()
+    print("PASS: No 500 errors detected")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/security/requirements.txt
+++ b/scripts/security/requirements.txt
@@ -1,0 +1,2 @@
+httpx>=0.26.0,<1.0
+python-jose[cryptography]>=3.4.0,<4.0

--- a/scripts/security/run-dast.sh
+++ b/scripts/security/run-dast.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Story 28.11: DAST scanner wrapper using nuclei.
+#
+# Runs nuclei against the live Docker stack with curated templates.
+# Skips gracefully if nuclei is not installed.
+#
+# Usage:
+#   API_URL=http://localhost:8001 WEB_URL=http://localhost:3001 ./run-dast.sh
+#
+# Environment variables:
+#   API_URL   - Backend API URL (default: http://localhost:8001)
+#   WEB_URL   - Web frontend URL (default: http://localhost:3001)
+#   SEVERITY  - Minimum severity (default: medium,high,critical)
+set -euo pipefail
+
+API_URL="${API_URL:-http://localhost:8001}"
+WEB_URL="${WEB_URL:-http://localhost:3001}"
+SEVERITY="${SEVERITY:-medium,high,critical}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULTS_DIR="${SCRIPT_DIR}/results"
+
+echo "=== DAST Scanner (nuclei) ==="
+echo "API: ${API_URL}  |  Web: ${WEB_URL}"
+echo ""
+
+# Check if nuclei is installed
+if ! command -v nuclei &>/dev/null; then
+    echo "nuclei is not installed -- skipping DAST scan."
+    echo "Install: go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest"
+    echo ""
+    echo "SKIP: nuclei not available (exit 0)"
+    exit 0
+fi
+
+# Ensure results directory exists
+mkdir -p "${RESULTS_DIR}"
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUTPUT_FILE="${RESULTS_DIR}/nuclei-${TIMESTAMP}.json"
+
+echo "Running nuclei scan (severity: ${SEVERITY}) ..."
+echo ""
+
+# Build target list
+TARGETS_FILE=$(mktemp)
+trap 'rm -f "${TARGETS_FILE}"' EXIT
+echo "${API_URL}" >> "${TARGETS_FILE}"
+echo "${WEB_URL}" >> "${TARGETS_FILE}"
+
+# Run nuclei with curated templates, capturing its exit code
+NUCLEI_EXIT=0
+nuclei \
+    -l "${TARGETS_FILE}" \
+    -t http/misconfiguration/ \
+    -t http/exposures/ \
+    -t http/vulnerabilities/ \
+    -exclude-templates http/fuzzing/ \
+    -exclude-templates http/takeovers/ \
+    -severity "${SEVERITY}" \
+    -json-export "${OUTPUT_FILE}" \
+    -silent \
+    -no-color \
+    -timeout 10 \
+    -retries 1 \
+    -rate-limit 50 \
+    || NUCLEI_EXIT=$?
+
+# Clean up temp file
+rm -f "${TARGETS_FILE}"
+
+echo ""
+
+# Count findings by severity
+if [ -f "${OUTPUT_FILE}" ] && [ -s "${OUTPUT_FILE}" ]; then
+    TOTAL=$(wc -l < "${OUTPUT_FILE}")
+    HIGH_CRIT=$(grep -cE '"severity":"(high|critical)"' "${OUTPUT_FILE}" || true)
+
+    echo "Results saved to: ${OUTPUT_FILE}"
+    echo "Total findings: ${TOTAL}"
+    echo "High/Critical: ${HIGH_CRIT}"
+
+    if [ "${HIGH_CRIT}" -gt 0 ]; then
+        echo ""
+        echo "FAIL: High/critical findings detected"
+        echo "Review: cat ${OUTPUT_FILE} | python3 -m json.tool"
+        exit 1
+    fi
+else
+    if [ "${NUCLEI_EXIT}" -ne 0 ]; then
+        echo "FAIL: nuclei execution failed (exit ${NUCLEI_EXIT}) with no results"
+        exit 1
+    fi
+    echo "No findings (clean scan)"
+fi
+
+echo ""
+echo "PASS: No high/critical findings"
+exit 0

--- a/scripts/security/test-auth-flows.py
+++ b/scripts/security/test-auth-flows.py
@@ -1,0 +1,712 @@
+#!/usr/bin/env python3
+"""Story 28.11: Automated auth flow & security penetration tests.
+
+Runs 15 security tests against a live Docker stack to verify that
+rate limiting, token handling, CSRF, CORS, security headers, and
+input validation all work correctly at the HTTP level.
+
+Usage:
+    API_URL=http://localhost:8001 WEB_URL=http://localhost:3001 python test-auth-flows.py
+"""
+
+import base64
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+
+import httpx
+from jose import jwt
+
+API_URL = os.environ.get("API_URL", "http://localhost:8001")
+WEB_URL = os.environ.get("WEB_URL", "http://localhost:3001")
+# Test secret key must be supplied via env var (matches docker-compose.test.yml)
+TEST_SECRET_KEY = os.environ.get("TEST_SECRET_KEY", "")
+JWT_ALGORITHM = "HS256"
+# Compose project name for redis-cli access
+COMPOSE_PROJECT = os.environ.get("COMPOSE_PROJECT_NAME", "glycemicgpt-test")
+
+PASS_COUNT = 0
+FAIL_COUNT = 0
+SKIP_COUNT = 0
+
+
+def log_pass(name: str) -> None:
+    global PASS_COUNT
+    PASS_COUNT += 1
+    print(f"  [PASS] {name}")
+
+
+def log_fail(name: str, reason: str = "") -> None:
+    global FAIL_COUNT
+    FAIL_COUNT += 1
+    detail = f" -- {reason}" if reason else ""
+    print(f"  [FAIL] {name}{detail}")
+
+
+def log_skip(name: str, reason: str) -> None:
+    global SKIP_COUNT
+    SKIP_COUNT += 1
+    print(f"  [SKIP] {name} -- {reason}")
+
+
+def unique_email() -> str:
+    return f"sectest_{uuid.uuid4().hex[:12]}@example.com"
+
+
+TEST_PASSWORD = os.environ.get(
+    "TEST_PASSWORD", f"SecTest-{uuid.uuid4().hex[:8]}!"
+)
+
+
+def register_user(client: httpx.Client, email: str) -> int:
+    """Register a test user and return the status code."""
+    resp = client.post(
+        f"{API_URL}/api/auth/register",
+        json={"email": email, "password": TEST_PASSWORD},
+    )
+    return resp.status_code
+
+
+def login_user(client: httpx.Client, email: str) -> httpx.Response:
+    """Web login and return the response (cookies are stored in client)."""
+    return client.post(
+        f"{API_URL}/api/auth/login",
+        json={"email": email, "password": TEST_PASSWORD},
+    )
+
+
+def get_csrf_token(client: httpx.Client) -> str:
+    """Extract CSRF token from the client's cookie jar."""
+    for cookie in client.cookies.jar:
+        if cookie.name == "csrf_token":
+            return cookie.value
+    return ""
+
+
+def flush_rate_limits() -> None:
+    """Flush Redis DB 0 so rate limit counters reset for the next test group.
+
+    Uses FLUSHDB (single database) rather than FLUSHALL to avoid nuking
+    other Redis databases if they exist.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "docker", "compose",
+                "-f", "docker-compose.yml",
+                "-f", "docker-compose.test.yml",
+                "exec", "-T", "redis", "redis-cli", "FLUSHDB",
+            ],
+            capture_output=True,
+            timeout=5,
+            env={**os.environ, "COMPOSE_PROJECT_NAME": COMPOSE_PROJECT},
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            print(f"  [WARN] Redis FLUSHDB failed (rc={result.returncode}): {stderr}")
+    except Exception as exc:
+        print(f"  [WARN] Redis FLUSHDB unavailable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Rate limit on /api/auth/login
+# ---------------------------------------------------------------------------
+def test_rate_limit_login() -> None:
+    name = "Rate limit: login"
+    got_429 = False
+    with httpx.Client(timeout=10) as client:
+        for _ in range(12):
+            resp = client.post(
+                f"{API_URL}/api/auth/login",
+                json={"email": "nobody@example.com", "password": "wrong"},
+            )
+            if resp.status_code == 429:
+                got_429 = True
+                break
+    if got_429:
+        log_pass(name)
+    else:
+        log_fail(name, "no 429 after 12 rapid requests")
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Rate limit on /api/auth/mobile/login
+# ---------------------------------------------------------------------------
+def test_rate_limit_mobile_login() -> None:
+    name = "Rate limit: mobile login"
+    got_429 = False
+    with httpx.Client(timeout=10) as client:
+        for _ in range(12):
+            resp = client.post(
+                f"{API_URL}/api/auth/mobile/login",
+                json={"email": "nobody@example.com", "password": "wrong"},
+            )
+            if resp.status_code == 429:
+                got_429 = True
+                break
+    if got_429:
+        log_pass(name)
+    else:
+        log_fail(name, "no 429 after 12 rapid requests")
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Rate limit on /api/auth/mobile/refresh
+# ---------------------------------------------------------------------------
+def test_rate_limit_refresh() -> None:
+    name = "Rate limit: mobile refresh"
+    got_429 = False
+    with httpx.Client(timeout=10) as client:
+        for _ in range(32):
+            resp = client.post(
+                f"{API_URL}/api/auth/mobile/refresh",
+                json={"refresh_token": "bogus"},
+            )
+            if resp.status_code == 429:
+                got_429 = True
+                break
+    if got_429:
+        log_pass(name)
+    else:
+        log_fail(name, "no 429 after 32 rapid requests")
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Token tampering -- wrong signing key
+# ---------------------------------------------------------------------------
+def test_token_tampering_wrong_key() -> None:
+    name = "Token tampering: wrong key"
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "email": "hacker@example.com",
+        "role": "diabetic",
+        "exp": int(time.time()) + 3600,
+        "iat": int(time.time()),
+        "type": "access",
+        "jti": str(uuid.uuid4()),
+    }
+    token = jwt.encode(payload, "wrong-secret", algorithm=JWT_ALGORITHM)
+    with httpx.Client(timeout=10) as client:
+        resp = client.get(
+            f"{API_URL}/api/auth/me",
+            cookies={"glycemicgpt_session": token},
+        )
+    if resp.status_code == 401:
+        log_pass(name)
+    else:
+        log_fail(name, f"expected 401, got {resp.status_code}")
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Token tampering -- algorithm confusion (HS384 + alg:none)
+# ---------------------------------------------------------------------------
+def test_token_tampering_alg_confusion() -> None:
+    name = "Token tampering: alg confusion"
+    errors = []
+
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "email": "hacker@example.com",
+        "role": "diabetic",
+        "exp": int(time.time()) + 3600,
+        "iat": int(time.time()),
+        "type": "access",
+        "jti": str(uuid.uuid4()),
+    }
+
+    # Sub-test A: HS384 with wrong key (different algorithm than expected HS256)
+    token_384 = jwt.encode(payload, "wrong-secret", algorithm="HS384")
+    with httpx.Client(timeout=10) as client:
+        resp = client.get(
+            f"{API_URL}/api/auth/me",
+            cookies={"glycemicgpt_session": token_384},
+        )
+    if resp.status_code != 401:
+        errors.append(f"HS384: expected 401, got {resp.status_code}")
+
+    # Sub-test B: alg:none attack -- craft an unsigned JWT
+    # Header: {"alg": "none", "typ": "JWT"}, payload, empty signature
+    header_b64 = base64.urlsafe_b64encode(
+        json.dumps({"alg": "none", "typ": "JWT"}).encode()
+    ).rstrip(b"=").decode()
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps(payload).encode()
+    ).rstrip(b"=").decode()
+    token_none = f"{header_b64}.{payload_b64}."
+
+    with httpx.Client(timeout=10) as client:
+        resp = client.get(
+            f"{API_URL}/api/auth/me",
+            cookies={"glycemicgpt_session": token_none},
+        )
+    if resp.status_code != 401:
+        errors.append(f"alg:none: expected 401, got {resp.status_code}")
+
+    if errors:
+        log_fail(name, "; ".join(errors))
+    else:
+        log_pass(name)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Cookie flags
+# ---------------------------------------------------------------------------
+def test_cookie_flags() -> None:
+    name = "Cookie flags"
+    email = unique_email()
+    with httpx.Client(timeout=10) as client:
+        register_user(client, email)
+        resp = login_user(client, email)
+
+    # Inspect raw Set-Cookie headers
+    set_cookies = resp.headers.get_list("set-cookie")
+    session_cookie_header = ""
+    csrf_cookie_header = ""
+    for sc in set_cookies:
+        lower = sc.lower()
+        if "glycemicgpt_session" in lower:
+            session_cookie_header = lower
+        elif "csrf_token" in lower:
+            csrf_cookie_header = lower
+
+    errors = []
+    if not session_cookie_header:
+        errors.append("no glycemicgpt_session cookie set")
+    else:
+        if "httponly" not in session_cookie_header:
+            errors.append("session cookie missing HttpOnly")
+        if "samesite=lax" not in session_cookie_header:
+            errors.append("session cookie missing SameSite=Lax")
+        if "path=/" not in session_cookie_header:
+            errors.append("session cookie missing Path=/")
+
+    if csrf_cookie_header:
+        if "httponly" in csrf_cookie_header:
+            errors.append("csrf_token cookie should NOT have HttpOnly")
+    # csrf_token may not be set if the client already had one; not an error
+    # NOTE: Secure flag not checked here because test env uses COOKIE_SECURE=false.
+    # Production enforces Secure=true via the default config (config.py line 48).
+
+    if errors:
+        log_fail(name, "; ".join(errors))
+    else:
+        log_pass(name)
+
+
+# ---------------------------------------------------------------------------
+# Test 7: CSRF -- missing token
+# ---------------------------------------------------------------------------
+def test_csrf_missing_token() -> None:
+    name = "CSRF: missing token"
+    email = unique_email()
+    with httpx.Client(timeout=10) as client:
+        register_user(client, email)
+        login_user(client, email)
+
+        # Get the session cookie but don't send CSRF header
+        session_val = None
+        for cookie in client.cookies.jar:
+            if cookie.name == "glycemicgpt_session":
+                session_val = cookie.value
+                break
+
+        if not session_val:
+            log_fail(name, "no session cookie after login")
+            return
+
+    # Use a fresh client with only the session cookie (no csrf_token cookie)
+    with httpx.Client(timeout=10) as client2:
+        resp = client2.post(
+            f"{API_URL}/api/auth/logout",
+            cookies={"glycemicgpt_session": session_val},
+        )
+    if resp.status_code == 403:
+        log_pass(name)
+    else:
+        log_fail(name, f"expected 403, got {resp.status_code}")
+
+
+# ---------------------------------------------------------------------------
+# Test 8: CSRF -- wrong token
+# ---------------------------------------------------------------------------
+def test_csrf_wrong_token() -> None:
+    name = "CSRF: wrong token"
+    email = unique_email()
+    with httpx.Client(timeout=10) as client:
+        register_user(client, email)
+        login_user(client, email)
+
+        session_val = None
+        csrf_val = None
+        for cookie in client.cookies.jar:
+            if cookie.name == "glycemicgpt_session":
+                session_val = cookie.value
+            elif cookie.name == "csrf_token":
+                csrf_val = cookie.value
+
+        if not session_val:
+            log_fail(name, "no session cookie after login")
+            return
+
+    # Send a deliberately wrong CSRF token
+    with httpx.Client(timeout=10) as client2:
+        resp = client2.post(
+            f"{API_URL}/api/auth/logout",
+            cookies={
+                "glycemicgpt_session": session_val,
+                "csrf_token": csrf_val or "placeholder",
+            },
+            headers={"X-CSRF-Token": "completely-wrong-token"},
+        )
+    if resp.status_code == 403:
+        log_pass(name)
+    else:
+        log_fail(name, f"expected 403, got {resp.status_code}")
+
+
+# ---------------------------------------------------------------------------
+# Test 9: CORS -- reject evil origin
+# ---------------------------------------------------------------------------
+def test_cors_reject_evil_origin() -> None:
+    name = "CORS: reject evil origin"
+    errors = []
+    evil_origin = "http://evil.example.com"
+
+    with httpx.Client(timeout=10) as client:
+        # Preflight check
+        resp_preflight = client.options(
+            f"{API_URL}/api/auth/login",
+            headers={
+                "Origin": evil_origin,
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        acao = resp_preflight.headers.get("access-control-allow-origin", "")
+        if "evil.example.com" in acao:
+            errors.append(f"preflight reflected evil origin: {acao}")
+
+        # Actual POST with evil origin
+        resp_post = client.post(
+            f"{API_URL}/api/auth/login",
+            json={"email": "x@x.com", "password": "x"},
+            headers={"Origin": evil_origin},
+        )
+        acao_post = resp_post.headers.get("access-control-allow-origin", "")
+        if "evil.example.com" in acao_post:
+            errors.append(f"POST reflected evil origin: {acao_post}")
+
+        acac = resp_post.headers.get("access-control-allow-credentials", "")
+        if acac.lower() == "true" and acao_post == "*":
+            errors.append("credentials + wildcard origin is dangerous")
+
+    if errors:
+        log_fail(name, "; ".join(errors))
+    else:
+        log_pass(name)
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Security headers on web frontend
+# ---------------------------------------------------------------------------
+def test_security_headers() -> None:
+    name = "Security headers (web)"
+    with httpx.Client(timeout=10, follow_redirects=True) as client:
+        resp = client.get(WEB_URL)
+
+    errors = []
+    headers = resp.headers
+
+    xfo = headers.get("x-frame-options", "").upper()
+    if xfo != "DENY":
+        errors.append(f"X-Frame-Options: expected DENY, got '{xfo}'")
+
+    xcto = headers.get("x-content-type-options", "").lower()
+    if xcto != "nosniff":
+        errors.append(f"X-Content-Type-Options: expected nosniff, got '{xcto}'")
+
+    hsts = headers.get("strict-transport-security", "")
+    if "max-age=" not in hsts:
+        errors.append(f"HSTS missing or invalid: '{hsts}'")
+
+    csp = headers.get("content-security-policy", "")
+    if "frame-ancestors 'none'" not in csp:
+        errors.append(f"CSP missing frame-ancestors 'none': '{csp[:80]}'")
+
+    if errors:
+        log_fail(name, "; ".join(errors))
+    else:
+        log_pass(name)
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Token blacklist -- logout then reuse
+# ---------------------------------------------------------------------------
+def test_token_blacklist_logout_reuse() -> None:
+    name = "Token blacklist: logout reuse"
+    email = unique_email()
+    with httpx.Client(timeout=10) as client:
+        register_user(client, email)
+        login_user(client, email)
+
+        session_val = None
+        csrf_val = None
+        for cookie in client.cookies.jar:
+            if cookie.name == "glycemicgpt_session":
+                session_val = cookie.value
+            elif cookie.name == "csrf_token":
+                csrf_val = cookie.value
+
+        if not session_val or not csrf_val:
+            log_fail(name, "no session or csrf cookie after login")
+            return
+
+        # Logout with valid CSRF
+        client.post(
+            f"{API_URL}/api/auth/logout",
+            headers={"X-CSRF-Token": csrf_val},
+        )
+
+    # Reuse the old session cookie
+    with httpx.Client(timeout=10) as client2:
+        resp = client2.get(
+            f"{API_URL}/api/auth/me",
+            cookies={"glycemicgpt_session": session_val},
+        )
+    if resp.status_code == 401:
+        log_pass(name)
+    else:
+        log_fail(name, f"expected 401, got {resp.status_code}")
+
+
+# ---------------------------------------------------------------------------
+# Test 12: Refresh token replay
+# ---------------------------------------------------------------------------
+def test_refresh_token_replay() -> None:
+    name = "Refresh token replay"
+    email = unique_email()
+    with httpx.Client(timeout=10) as client:
+        register_user(client, email)
+
+        # Mobile login to get refresh token
+        resp = client.post(
+            f"{API_URL}/api/auth/mobile/login",
+            json={"email": email, "password": TEST_PASSWORD},
+        )
+        if resp.status_code != 200:
+            log_fail(name, f"mobile login failed: {resp.status_code}")
+            return
+
+        data = resp.json()
+        refresh_token = data["refresh_token"]
+
+        # First refresh -- should succeed
+        resp1 = client.post(
+            f"{API_URL}/api/auth/mobile/refresh",
+            json={"refresh_token": refresh_token},
+        )
+        if resp1.status_code != 200:
+            log_fail(name, f"first refresh failed: {resp1.status_code}")
+            return
+
+        # Replay the same refresh token -- should fail
+        resp2 = client.post(
+            f"{API_URL}/api/auth/mobile/refresh",
+            json={"refresh_token": refresh_token},
+        )
+    if resp2.status_code == 401:
+        log_pass(name)
+    else:
+        log_fail(name, f"expected 401 on replay, got {resp2.status_code}")
+
+
+# ---------------------------------------------------------------------------
+# Test 13: Password change invalidates session
+# ---------------------------------------------------------------------------
+def test_password_change_invalidates_session() -> None:
+    name = "Password change invalidates session"
+    email = unique_email()
+    new_password = f"NewSec-{uuid.uuid4().hex[:8]}!"
+    with httpx.Client(timeout=10) as client:
+        register_user(client, email)
+        login_user(client, email)
+
+        session_val = None
+        csrf_val = None
+        for cookie in client.cookies.jar:
+            if cookie.name == "glycemicgpt_session":
+                session_val = cookie.value
+            elif cookie.name == "csrf_token":
+                csrf_val = cookie.value
+
+        if not session_val or not csrf_val:
+            log_fail(name, "no session or csrf cookie after login")
+            return
+
+        # Change password
+        resp = client.post(
+            f"{API_URL}/api/auth/change-password",
+            json={
+                "current_password": TEST_PASSWORD,
+                "new_password": new_password,
+            },
+            headers={"X-CSRF-Token": csrf_val},
+        )
+        if resp.status_code != 200:
+            log_fail(name, f"change-password returned {resp.status_code}")
+            return
+
+    # Reuse the old session cookie
+    with httpx.Client(timeout=10) as client2:
+        resp = client2.get(
+            f"{API_URL}/api/auth/me",
+            cookies={"glycemicgpt_session": session_val},
+        )
+    if resp.status_code == 401:
+        log_pass(name)
+    else:
+        log_fail(name, f"expected 401, got {resp.status_code}")
+
+
+# ---------------------------------------------------------------------------
+# Test 14: Email enumeration prevention
+# ---------------------------------------------------------------------------
+def test_email_enumeration_prevention() -> None:
+    name = "Email enumeration prevention"
+    email = unique_email()
+    errors = []
+
+    with httpx.Client(timeout=10) as client:
+        # Part A: Registration -- duplicate should use generic message
+        client.post(
+            f"{API_URL}/api/auth/register",
+            json={"email": email, "password": TEST_PASSWORD},
+        )
+        resp_dup = client.post(
+            f"{API_URL}/api/auth/register",
+            json={"email": email, "password": TEST_PASSWORD},
+        )
+        detail = resp_dup.json().get("detail", "").lower()
+        if "already" in detail or "exists" in detail or "taken" in detail:
+            errors.append(f"register leaks email: '{resp_dup.json().get('detail')}'")
+
+        # Part B: Login -- existing vs nonexistent email should return same
+        # error message (prevents enumeration via login endpoint)
+        resp_valid_email = client.post(
+            f"{API_URL}/api/auth/login",
+            json={"email": email, "password": "WrongPass999!"},
+        )
+        resp_fake_email = client.post(
+            f"{API_URL}/api/auth/login",
+            json={"email": unique_email(), "password": "WrongPass999!"},
+        )
+        msg_valid = resp_valid_email.json().get("detail", "")
+        msg_fake = resp_fake_email.json().get("detail", "")
+        if msg_valid != msg_fake:
+            errors.append(
+                f"login error differs: existing='{msg_valid}' vs "
+                f"nonexistent='{msg_fake}'"
+            )
+
+    if errors:
+        log_fail(name, "; ".join(errors))
+    else:
+        log_pass(name)
+
+
+# ---------------------------------------------------------------------------
+# Test 15: Expired token rejection
+# ---------------------------------------------------------------------------
+def test_expired_token_rejection() -> None:
+    name = "Expired token rejection"
+    if not TEST_SECRET_KEY:
+        log_skip(name, "TEST_SECRET_KEY env var not set; cannot forge token")
+        return
+
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "email": "expired@example.com",
+        "role": "diabetic",
+        "exp": int(time.time()) - 3600,  # expired 1 hour ago
+        "iat": int(time.time()) - 7200,
+        "type": "access",
+        "jti": str(uuid.uuid4()),
+    }
+    token = jwt.encode(payload, TEST_SECRET_KEY, algorithm=JWT_ALGORITHM)
+    with httpx.Client(timeout=10) as client:
+        resp = client.get(
+            f"{API_URL}/api/auth/me",
+            cookies={"glycemicgpt_session": token},
+        )
+    if resp.status_code == 401:
+        log_pass(name)
+    else:
+        log_fail(name, f"expected 401, got {resp.status_code}")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+# Tests that require login (run first, before rate limits are exhausted)
+AUTH_TESTS = [
+    test_token_tampering_wrong_key,
+    test_token_tampering_alg_confusion,
+    test_cookie_flags,
+    test_csrf_missing_token,
+    test_csrf_wrong_token,
+    test_cors_reject_evil_origin,
+    test_security_headers,
+    test_token_blacklist_logout_reuse,
+    test_refresh_token_replay,
+    test_password_change_invalidates_session,
+    test_email_enumeration_prevention,
+    test_expired_token_rejection,
+]
+
+# Rate limit tests (run last -- they intentionally exhaust quotas)
+RATE_LIMIT_TESTS = [
+    test_rate_limit_login,
+    test_rate_limit_mobile_login,
+    test_rate_limit_refresh,
+]
+
+ALL_TESTS = AUTH_TESTS + RATE_LIMIT_TESTS
+
+
+def main() -> int:
+    print(f"=== Auth Flow & Security Tests ({len(ALL_TESTS)} tests) ===")
+    print(f"API: {API_URL}  |  Web: {WEB_URL}")
+    print()
+
+    # Flush rate limits to start clean
+    flush_rate_limits()
+
+    print("--- Auth & security tests ---")
+    for test_fn in AUTH_TESTS:
+        try:
+            test_fn()
+        except Exception as exc:
+            log_fail(test_fn.__name__, f"exception: {exc}")
+
+    # Flush again before rate limit tests
+    flush_rate_limits()
+
+    print()
+    print("--- Rate limit tests ---")
+    for test_fn in RATE_LIMIT_TESTS:
+        try:
+            test_fn()
+        except Exception as exc:
+            log_fail(test_fn.__name__, f"exception: {exc}")
+
+    print()
+    skip_msg = f", {SKIP_COUNT} skipped" if SKIP_COUNT else ""
+    print(f"Results: {PASS_COUNT} passed, {FAIL_COUNT} failed{skip_msg}")
+
+    return 1 if FAIL_COUNT > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add 15 automated auth flow penetration tests (`scripts/security/test-auth-flows.py`) covering rate limiting, JWT tampering (including `alg:none`), cookie flags, CSRF validation, CORS enforcement, security headers, token blacklisting, refresh token replay, password change session invalidation, email enumeration prevention, and expired token rejection
- Add OpenAPI-driven endpoint fuzzer (`scripts/security/fuzz-api.py`) that discovers all API endpoints from `/openapi.json`, substitutes fuzz payloads into path parameters and request bodies, and asserts no 500 errors -- tested 114 endpoints with 2,280 requests
- Add nuclei DAST scanner wrapper (`scripts/security/run-dast.sh`) with graceful skip when nuclei is not installed
- Add CI workflow (`.github/workflows/security-scan.yml`) with Docker test stack management, health check timeouts with failure detection, artifact upload for scan results, and pinned nuclei version

## Test plan

- [x] `docker compose -f docker-compose.yml -f docker-compose.test.yml up --build -d` -- stack starts cleanly
- [x] `python scripts/security/test-auth-flows.py` -- all 15 tests pass
- [x] `python scripts/security/fuzz-api.py` -- 0 of 2,280 requests returned 500
- [x] `./scripts/security/run-dast.sh` -- graceful skip (nuclei not installed)
- [x] Stack teardown -- `docker compose down -v` cleans up
- [x] Adversarial code review -- all HIGH/MEDIUM findings addressed
- [x] Security review of staged diff -- no secrets or vulnerabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated security testing: API fuzzing, authentication-flow validation, and DAST scanning.
  * Integrated security tests into CI to run on relevant branch pushes and pull requests (manual trigger supported).
  * Test runs collect logs and scan results as archived artifacts for post-scan review and retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->