### PR TITLE
chore: tune CodeRabbit config to reduce review noise

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,11 +2,9 @@
 
 language: "en-US"
 tone_instructions: >
-  Be direct, technically precise, and concise. Focus on correctness, security,
-  and safety. Only comment on issues that affect correctness, security, performance,
-  or maintainability. Do not comment on style preferences, naming conventions, or
-  formatting unless they introduce ambiguity or bugs. Do not suggest refactors
-  unless the current code has a clear defect.
+  Be direct and precise. Focus on correctness, security, safety, performance,
+  and maintainability. Ignore style, naming, and formatting unless they cause
+  ambiguity or defects. Suggest refactors only for clear defects.
 early_access: false
 enable_free_tier: true
 


### PR DESCRIPTION
## Summary

- Switch review profile from `assertive` to `chill` -- suppresses trivial nitpick findings while keeping bug, security, and meaningful refactoring feedback
- Enable `request_changes_workflow` so the 3 custom pre-merge checks (No Hardcoded Secrets, Medical Safety, BLE Protocol Safety) actually block merging instead of being advisory
- Lower `auto_pause_after_reviewed_commits` from 5 to 3 to prevent runaway incremental review cycles on active PRs
- Disable `finishing_touches` (auto-generated docstring and unit test PRs) -- we manage these ourselves
- Strengthen `tone_instructions` to explicitly focus on correctness and security, discouraging style-only and speculative refactor comments

## Context

We were caught in a loop: push fixes, CodeRabbit finds more things, fix those, push, find more. The `assertive` profile surfaces everything including trivial style nitpicks, and each incremental review can surface new findings in surrounding context. The `chill` profile eliminates the nitpick category while keeping all meaningful catches.

## Test plan

- [ ] Merge this PR to develop (config only takes effect from default branch)
- [ ] Open a subsequent PR and verify: fewer trivial findings, no nitpick-category comments
- [ ] Verify pre-merge checks show as blocking (request changes) for security/safety failures
- [ ] Verify auto-pause kicks in after 3 incremental reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Many new review configuration options: title placeholders, review/commit/fail statuses, collapse walkthroughs, changed-file summaries, sequence diagrams, effort estimates, linked issues/PRs, suggested/auto-applied labels, suggested/auto-assigned reviewers, AI prompts, in-progress fortune/poem, abort-on-close, and cache control.

* **Chores**
  * Tone guidance made more prescriptive; review profile set to "chill" and request-changes workflow enabled; auto-review pause shortened (5→3); finishing touches for docstrings and unit tests disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->