### PR TITLE
feat: navigation scaffold and detail page architecture (Story 31.1)

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/AlertHistoryScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/AlertHistoryScreen.kt
@@ -1,0 +1,28 @@
+package com.glycemicgpt.mobile.presentation.detail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun AlertHistoryScreen(onBack: () -> Unit) {
+    DetailScaffold(title = "Alert History", onBack = onBack) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "Alert history coming in Story 31.6",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/ChartDetailScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/ChartDetailScreen.kt
@@ -1,0 +1,29 @@
+package com.glycemicgpt.mobile.presentation.detail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ChartDetailScreen(onBack: () -> Unit) {
+    // Landscape orientation lock will be added in Story 31.3 when real chart content is implemented.
+    DetailScaffold(title = "Glucose Trend", onBack = onBack) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "Chart detail coming in Story 31.3",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/DashboardCard.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/DashboardCard.kt
@@ -1,0 +1,79 @@
+package com.glycemicgpt.mobile.presentation.detail
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DashboardCard(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("dashboard_card_${title.lowercase().replace(' ', '_')}")
+            .clickable(role = Role.Button, onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (icon != null) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = "View details",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            content()
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/DetailScaffold.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/DetailScaffold.kt
@@ -1,0 +1,44 @@
+package com.glycemicgpt.mobile.presentation.detail
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DetailScaffold(
+    title: String,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    Scaffold(
+        modifier = modifier.testTag(
+            "detail_scaffold_${title.lowercase().replace(' ', '_')}",
+        ),
+        topBar = {
+            TopAppBar(
+                title = { Text(text = title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        content(innerPadding)
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/InsulinDetailScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/InsulinDetailScreen.kt
@@ -1,0 +1,28 @@
+package com.glycemicgpt.mobile.presentation.detail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun InsulinDetailScreen(onBack: () -> Unit) {
+    DetailScaffold(title = "Insulin Summary", onBack = onBack) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "Insulin detail coming in Story 31.5",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/TirDetailScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/TirDetailScreen.kt
@@ -1,0 +1,28 @@
+package com.glycemicgpt.mobile.presentation.detail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun TirDetailScreen(onBack: () -> Unit) {
+    DetailScaffold(title = "Time in Range", onBack = onBack) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "TIR detail coming in Story 31.4",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -49,6 +49,10 @@ import java.time.Instant
 fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
     onPluginCardTap: (pluginId: String, cardId: String) -> Unit = { _, _ -> },
+    onNavigateToChartDetail: () -> Unit = {},
+    onNavigateToTirDetail: () -> Unit = {},
+    onNavigateToInsulinDetail: () -> Unit = {},
+    onNavigateToAlertHistory: () -> Unit = {},
 ) {
     val connectionState by viewModel.connectionState.collectAsState()
     val cgm by viewModel.cgm.collectAsState()
@@ -133,7 +137,6 @@ fun HomeScreen(
                     )
                 }
             }
-
 
             Spacer(modifier = Modifier.height(24.dp))
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -11,12 +11,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -50,6 +54,10 @@ import com.glycemicgpt.mobile.presentation.chat.AiChatScreen
 import com.glycemicgpt.mobile.presentation.home.HomeScreen
 import com.glycemicgpt.mobile.BuildConfig
 import com.glycemicgpt.mobile.presentation.debug.BleDebugScreen
+import com.glycemicgpt.mobile.presentation.detail.AlertHistoryScreen
+import com.glycemicgpt.mobile.presentation.detail.ChartDetailScreen
+import com.glycemicgpt.mobile.presentation.detail.InsulinDetailScreen
+import com.glycemicgpt.mobile.presentation.detail.TirDetailScreen
 import com.glycemicgpt.mobile.presentation.onboarding.OnboardingScreen
 import com.glycemicgpt.mobile.presentation.pairing.PairingScreen
 import com.glycemicgpt.mobile.presentation.plugin.PluginDetailScreen
@@ -65,9 +73,24 @@ sealed class Screen(val route: String, val label: String, val icon: ImageVector)
     data object BleDebug : Screen("ble_debug", "BLE Debug", Icons.Default.BugReport)
     data object Onboarding : Screen("onboarding", "Onboarding", Icons.Default.Home)
     data object PluginDetail : Screen("plugin_detail/{pluginId}/{cardId}", "Plugin Detail", Icons.Default.Settings)
+    data object ChartDetail : Screen("chart_detail", "Chart", Icons.AutoMirrored.Filled.ShowChart)
+    data object TirDetail : Screen("tir_detail", "Time in Range", Icons.Default.BarChart)
+    data object InsulinDetail : Screen("insulin_detail", "Insulin", Icons.Default.Science)
+    data object AlertHistory : Screen("alert_history", "Alert History", Icons.Default.History)
 }
 
 private val bottomNavItems = listOf(Screen.Home, Screen.AiChat, Screen.Alerts, Screen.Settings)
+
+// Routes that show their own TopAppBar + back button; bottom nav is hidden on these.
+private val spokeRoutes = setOf(
+    Screen.ChartDetail.route,
+    Screen.TirDetail.route,
+    Screen.InsulinDetail.route,
+    Screen.AlertHistory.route,
+    Screen.PluginDetail.route,
+    Screen.Pairing.route,
+    Screen.BleDebug.route,
+)
 
 @Composable
 fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthTokenStore) {
@@ -89,6 +112,7 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
     }
 
     val isOnboarding = currentDestination?.route == Screen.Onboarding.route
+    val showBottomNav = !isOnboarding && currentDestination?.route !in spokeRoutes
 
     // Observe logout -> onboarding navigation event
     LaunchedEffect(Unit) {
@@ -112,7 +136,7 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
 
     Scaffold(
         bottomBar = {
-            if (!isOnboarding) {
+            if (showBottomNav) {
                 NavigationBar {
                     bottomNavItems.forEach { screen ->
                         NavigationBarItem(
@@ -172,6 +196,10 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                                 "plugin_detail/${Uri.encode(pluginId)}/${Uri.encode(cardId)}",
                             )
                         },
+                        onNavigateToChartDetail = { navController.navigate(Screen.ChartDetail.route) },
+                        onNavigateToTirDetail = { navController.navigate(Screen.TirDetail.route) },
+                        onNavigateToInsulinDetail = { navController.navigate(Screen.InsulinDetail.route) },
+                        onNavigateToAlertHistory = { navController.navigate(Screen.AlertHistory.route) },
                     )
                 }
                 composable(Screen.AiChat.route) { AiChatScreen() }
@@ -213,6 +241,18 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                         cardId = cardId,
                         onBack = { navController.popBackStack() },
                     )
+                }
+                composable(Screen.ChartDetail.route) {
+                    ChartDetailScreen(onBack = { navController.popBackStack() })
+                }
+                composable(Screen.TirDetail.route) {
+                    TirDetailScreen(onBack = { navController.popBackStack() })
+                }
+                composable(Screen.InsulinDetail.route) {
+                    InsulinDetailScreen(onBack = { navController.popBackStack() })
+                }
+                composable(Screen.AlertHistory.route) {
+                    AlertHistoryScreen(onBack = { navController.popBackStack() })
                 }
             }
         }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/DetailRoutesTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/DetailRoutesTest.kt
@@ -1,0 +1,103 @@
+package com.glycemicgpt.mobile.presentation.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class DetailRoutesTest {
+
+    // Note: bottomNavItems is private in NavHost.kt. This list mirrors it for assertions.
+    // If bottomNavItems changes, update this list accordingly.
+    private val bottomNavRoutes = listOf(
+        Screen.Home.route,
+        Screen.AiChat.route,
+        Screen.Alerts.route,
+        Screen.Settings.route,
+    )
+
+    private val detailRoutes = listOf(
+        Screen.ChartDetail.route,
+        Screen.TirDetail.route,
+        Screen.InsulinDetail.route,
+        Screen.AlertHistory.route,
+    )
+
+    // -- Route strings -----------------------------------------------------------
+
+    @Test
+    fun `ChartDetail has correct route`() {
+        assertEquals("chart_detail", Screen.ChartDetail.route)
+    }
+
+    @Test
+    fun `TirDetail has correct route`() {
+        assertEquals("tir_detail", Screen.TirDetail.route)
+    }
+
+    @Test
+    fun `InsulinDetail has correct route`() {
+        assertEquals("insulin_detail", Screen.InsulinDetail.route)
+    }
+
+    @Test
+    fun `AlertHistory has correct route`() {
+        assertEquals("alert_history", Screen.AlertHistory.route)
+    }
+
+    // -- Not in bottom nav -------------------------------------------------------
+
+    @Test
+    fun `detail routes are not in bottom nav items`() {
+        detailRoutes.forEach { route ->
+            assertFalse(
+                "Detail route '$route' should not be in bottom nav",
+                bottomNavRoutes.contains(route),
+            )
+        }
+    }
+
+    // -- Uniqueness --------------------------------------------------------------
+
+    @Test
+    fun `all detail routes are unique`() {
+        assertEquals(
+            "Detail routes should be unique",
+            detailRoutes.size,
+            detailRoutes.toSet().size,
+        )
+    }
+
+    @Test
+    fun `detail routes do not collide with existing routes`() {
+        val existingRoutes = listOf(
+            Screen.Home.route,
+            Screen.AiChat.route,
+            Screen.Alerts.route,
+            Screen.Settings.route,
+            Screen.Pairing.route,
+            Screen.BleDebug.route,
+            Screen.Onboarding.route,
+            Screen.PluginDetail.route,
+        )
+        detailRoutes.forEach { detailRoute ->
+            existingRoutes.forEach { existing ->
+                assertNotEquals(
+                    "Detail route '$detailRoute' collides with '$existing'",
+                    existing,
+                    detailRoute,
+                )
+            }
+        }
+    }
+
+    // -- Labels ------------------------------------------------------------------
+
+    @Test
+    fun `detail screen labels are set`() {
+        assertEquals("Chart", Screen.ChartDetail.label)
+        assertEquals("Time in Range", Screen.TirDetail.label)
+        assertEquals("Insulin", Screen.InsulinDetail.label)
+        assertEquals("Alert History", Screen.AlertHistory.label)
+    }
+}


### PR DESCRIPTION
## Summary

- Add 4 new spoke routes (`ChartDetail`, `TirDetail`, `InsulinDetail`, `AlertHistory`) to the navigation graph as empty shell screens
- Create reusable `DetailScaffold` composable (TopAppBar + back navigation + content slot) matching existing `PluginDetailScreen` pattern
- Create reusable `DashboardCard` composable (tappable card with title, optional icon, chevron, content slot) for the future 2-column grid layout
- Wire navigation callbacks into `HomeScreen` with default-empty lambdas (no visual changes)
- Hide bottom navigation bar on spoke/detail routes (also retroactively fixes Pairing and BleDebug screens)
- Add `DetailRoutesTest` verifying route uniqueness, collision avoidance, and bottom-nav exclusion

## Test plan

- [x] `./gradlew testDebugUnitTest` passes (all modules)
- [x] `./gradlew lintDebug` passes clean
- [x] `./gradlew assembleDebug` builds successfully
- [x] Visual verification on emulator: home screen is identical to before
- [x] New routes are wired but not yet navigated to from UI (Story 31.2 adds tap targets)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new detail screens (Chart, Time in Range, Insulin, Alert History) accessible from the home screen with placeholder content for future implementation.
  * Introduced a new dashboard card component for improved navigation and UI consistency.
  * Enhanced app navigation to support routing to the new detail screens.

* **Tests**
  * Added comprehensive routing tests for the new detail screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->