### PR TITLE
feat(wear): feature toggle sync phone -> watch via DataClient (Story 32.5)

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -1671,7 +1671,7 @@ private fun WatchFaceConfigCard(
             WatchToggleRow("Show Glucose Graph", config.showGraph) {
                 onConfigChange(config.copy(showGraph = it))
             }
-            WatchToggleRow("Show Alert Indicator", config.showAlert) {
+            WatchToggleRow("Alert Vibration", config.showAlert) {
                 onConfigChange(config.copy(showAlert = it))
             }
             WatchToggleRow("Show Seconds", config.showSeconds) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -29,6 +29,7 @@ import com.glycemicgpt.mobile.data.update.DownloadResult
 import com.glycemicgpt.mobile.data.update.UpdateCheckResult
 import com.glycemicgpt.mobile.wear.WatchFacePusher
 import com.glycemicgpt.mobile.wear.WearDataContract
+import com.glycemicgpt.mobile.wear.WearDataSender
 import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.Wearable
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -185,6 +186,7 @@ class SettingsViewModel @Inject constructor(
     private val alertNotificationManager: AlertNotificationManager,
     private val pluginRegistry: PluginRegistry,
     private val watchFacePusher: WatchFacePusher,
+    private val wearDataSender: WearDataSender,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -577,6 +579,10 @@ class SettingsViewModel @Inject constructor(
                 if (capInfo.nodes.isNotEmpty()) {
                     loadWatchDataTelemetry()
                 }
+                // Push current config to watch when connected
+                if (nearbyNode != null) {
+                    syncWatchFaceConfig(_uiState.value.watchFaceConfig)
+                }
             } catch (e: Exception) {
                 Timber.w(e, "Failed to check watch status")
                 _uiState.value = _uiState.value.copy(
@@ -709,7 +715,24 @@ class SettingsViewModel @Inject constructor(
         )
         _uiState.value = _uiState.value.copy(watchFaceConfig = validated)
         persistWatchFaceConfig(validated)
-        // TODO(Story 32.5): Sync config to watch via DataClient
+        syncWatchFaceConfig(validated)
+    }
+
+    private fun syncWatchFaceConfig(config: WatchFaceConfig) {
+        viewModelScope.launch {
+            try {
+                wearDataSender.sendWatchFaceConfig(
+                    showIoB = config.showIoB,
+                    showGraph = config.showGraph,
+                    showAlert = config.showAlert,
+                    showSeconds = config.showSeconds,
+                    graphRangeHours = config.graphRangeHours,
+                    theme = config.theme.contractKey,
+                )
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to sync watch face config")
+            }
+        }
     }
 
     private fun loadPersistedWatchFaceConfig(): WatchFaceConfig {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataContract.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataContract.kt
@@ -1,5 +1,7 @@
 package com.glycemicgpt.mobile.wear
 
+// MIRROR: This contract must stay in sync with
+// wear-device/src/main/java/com/glycemicgpt/weardevice/data/WearDataContract.kt
 object WearDataContract {
     // DataClient paths (persistent state sync)
     const val IOB_PATH = "/glycemicgpt/iob"
@@ -38,6 +40,17 @@ object WearDataContract {
 
     // Watch Face Push status paths (watch -> phone via MessageClient)
     const val WATCHFACE_PUSH_STATUS_PATH = "/glycemicgpt/watchface/status"
+
+    // Watch face config sync path (phone -> watch via DataClient)
+    const val CONFIG_PATH = "/glycemicgpt/watchface/config"
+
+    // Watch face config keys
+    const val KEY_CONFIG_SHOW_IOB = "cfg_show_iob"
+    const val KEY_CONFIG_SHOW_GRAPH = "cfg_show_graph"
+    const val KEY_CONFIG_SHOW_ALERT = "cfg_show_alert"
+    const val KEY_CONFIG_SHOW_SECONDS = "cfg_show_seconds"
+    const val KEY_CONFIG_GRAPH_RANGE_HOURS = "cfg_graph_range_h"
+    const val KEY_CONFIG_THEME = "cfg_theme"
 
     // CapabilityClient capabilities
     const val CHAT_RELAY_CAPABILITY = "glycemicgpt_chat_relay"

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataSender.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataSender.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.tasks.await
 import timber.log.Timber
 import javax.inject.Inject
@@ -74,5 +75,35 @@ class WearDataSender @Inject constructor(
 
     suspend fun clearAlert() {
         sendAlert(type = "none", bgValue = 0, timestampMs = System.currentTimeMillis(), message = "")
+    }
+
+    suspend fun sendWatchFaceConfig(
+        showIoB: Boolean,
+        showGraph: Boolean,
+        showAlert: Boolean,
+        showSeconds: Boolean,
+        graphRangeHours: Int,
+        theme: String,
+    ) {
+        try {
+            val request = PutDataMapRequest.create(WearDataContract.CONFIG_PATH).apply {
+                dataMap.putBoolean(WearDataContract.KEY_CONFIG_SHOW_IOB, showIoB)
+                dataMap.putBoolean(WearDataContract.KEY_CONFIG_SHOW_GRAPH, showGraph)
+                dataMap.putBoolean(WearDataContract.KEY_CONFIG_SHOW_ALERT, showAlert)
+                dataMap.putBoolean(WearDataContract.KEY_CONFIG_SHOW_SECONDS, showSeconds)
+                dataMap.putInt(WearDataContract.KEY_CONFIG_GRAPH_RANGE_HOURS, graphRangeHours)
+                dataMap.putString(WearDataContract.KEY_CONFIG_THEME, theme)
+                // Timestamp forces DataClient delivery even when config values are unchanged,
+                // preventing deduplication from swallowing re-syncs (e.g. on reconnect).
+                dataMap.putLong("_ts", System.currentTimeMillis())
+            }.asPutDataRequest().setUrgent()
+
+            dataClient.putDataItem(request).await()
+            Timber.d("Sent watch face config to watch: theme=%s, graph=%dh", theme, graphRangeHours)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to send watch face config to watch (no watch connected?)")
+        }
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -17,6 +17,7 @@ import com.glycemicgpt.mobile.data.update.DownloadResult
 import com.glycemicgpt.mobile.data.update.UpdateCheckResult
 import com.glycemicgpt.mobile.data.update.UpdateInfo
 import com.glycemicgpt.mobile.wear.WatchFacePusher
+import com.glycemicgpt.mobile.wear.WearDataSender
 import com.glycemicgpt.mobile.domain.plugin.DevicePlugin
 import com.glycemicgpt.mobile.domain.plugin.Plugin
 import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
@@ -99,6 +100,7 @@ class SettingsViewModelTest {
         every { runtimePlugins } returns MutableStateFlow<List<RuntimePluginInfo>>(emptyList())
     }
     private val watchFacePusher = mockk<WatchFacePusher>(relaxed = true)
+    private val wearDataSender = mockk<WearDataSender>(relaxed = true)
 
     @Before
     fun setup() {
@@ -111,7 +113,7 @@ class SettingsViewModelTest {
     }
 
     private fun createViewModel() =
-        SettingsViewModel(appContext, pumpCredentialStore, appSettingsStore, glucoseRangeStore, safetyLimitsStore, authRepository, appUpdateChecker, authManager, alertSoundStore, alertNotificationManager, pluginRegistry, watchFacePusher)
+        SettingsViewModel(appContext, pumpCredentialStore, appSettingsStore, glucoseRangeStore, safetyLimitsStore, authRepository, appUpdateChecker, authManager, alertSoundStore, alertNotificationManager, pluginRegistry, watchFacePusher, wearDataSender)
 
     @Test
     fun `loadState initializes from stores`() {
@@ -511,6 +513,51 @@ class SettingsViewModelTest {
         assertTrue(config.showSeconds)
         assertEquals(6, config.graphRangeHours)
         assertEquals(WatchFaceTheme.HighContrast, config.theme)
+    }
+
+    @Test
+    fun `updateWatchFaceConfig syncs to watch via WearDataSender`() = runTest {
+        val vm = createViewModel()
+        val config = WatchFaceConfig(
+            showIoB = false,
+            showGraph = true,
+            showAlert = false,
+            showSeconds = true,
+            graphRangeHours = 6,
+            theme = WatchFaceTheme.ClinicalBlue,
+        )
+
+        vm.updateWatchFaceConfig(config)
+
+        coVerify {
+            wearDataSender.sendWatchFaceConfig(
+                showIoB = false,
+                showGraph = true,
+                showAlert = false,
+                showSeconds = true,
+                graphRangeHours = 6,
+                theme = "clinical_blue",
+            )
+        }
+    }
+
+    @Test
+    fun `updateWatchFaceConfig sends theme contractKey not label`() = runTest {
+        val vm = createViewModel()
+        val config = WatchFaceConfig(theme = WatchFaceTheme.HighContrast)
+
+        vm.updateWatchFaceConfig(config)
+
+        coVerify {
+            wearDataSender.sendWatchFaceConfig(
+                showIoB = any(),
+                showGraph = any(),
+                showAlert = any(),
+                showSeconds = any(),
+                graphRangeHours = any(),
+                theme = "high_contrast",
+            )
+        }
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearDataContractTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearDataContractTest.kt
@@ -53,4 +53,19 @@ class WearDataContractTest {
         assertEquals("glycemicgpt_chat_relay", WearDataContract.CHAT_RELAY_CAPABILITY)
         assertEquals("glycemicgpt_watch_app", WearDataContract.WATCH_APP_CAPABILITY)
     }
+
+    @Test
+    fun `CONFIG_PATH matches expected value`() {
+        assertEquals("/glycemicgpt/watchface/config", WearDataContract.CONFIG_PATH)
+    }
+
+    @Test
+    fun `config keys are consistent`() {
+        assertEquals("cfg_show_iob", WearDataContract.KEY_CONFIG_SHOW_IOB)
+        assertEquals("cfg_show_graph", WearDataContract.KEY_CONFIG_SHOW_GRAPH)
+        assertEquals("cfg_show_alert", WearDataContract.KEY_CONFIG_SHOW_ALERT)
+        assertEquals("cfg_show_seconds", WearDataContract.KEY_CONFIG_SHOW_SECONDS)
+        assertEquals("cfg_graph_range_h", WearDataContract.KEY_CONFIG_GRAPH_RANGE_HOURS)
+        assertEquals("cfg_theme", WearDataContract.KEY_CONFIG_THEME)
+    }
 }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/IoBComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/IoBComplicationDataSource.kt
@@ -34,6 +34,9 @@ class IoBComplicationDataSource : SuspendingComplicationDataSourceService() {
     }
 
     override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData {
+        if (!WatchDataRepository.watchFaceConfig.value.showIoB) {
+            return NoDataComplicationData()
+        }
         val iobState = WatchDataRepository.iob.value
         val iobText = iobState?.let { "%.2f".format(it.iob) } ?: "--"
         val descriptionText = iobState?.let { "Insulin on Board: $iobText units" } ?: "No data"

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/GlycemicDataListenerService.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/GlycemicDataListenerService.kt
@@ -19,10 +19,32 @@ class GlycemicDataListenerService : WearableListenerService() {
     override fun onDataChanged(dataEvents: DataEventBuffer) {
         var iobUpdated = false
         var cgmUpdated = false
+        var configUpdated = false
 
-        dataEvents.forEach { event ->
-            if (event.type != DataEvent.TYPE_CHANGED) return@forEach
+        // Two-pass processing: config events first so that data/alert events
+        // see the latest showAlert / showIoB state within the same batch.
+        val changedEvents = dataEvents.filter { it.type == DataEvent.TYPE_CHANGED }
 
+        // Pass 1 -- config
+        changedEvents.forEach { event ->
+            val path = event.dataItem.uri.path ?: return@forEach
+            if (path != WearDataContract.CONFIG_PATH) return@forEach
+            val dataMap = DataMapItem.fromDataItem(event.dataItem).dataMap
+
+            WatchDataRepository.updateWatchFaceConfig(
+                showIoB = dataMap.getBoolean(WearDataContract.KEY_CONFIG_SHOW_IOB, true),
+                showGraph = dataMap.getBoolean(WearDataContract.KEY_CONFIG_SHOW_GRAPH, true),
+                showAlert = dataMap.getBoolean(WearDataContract.KEY_CONFIG_SHOW_ALERT, true),
+                showSeconds = dataMap.getBoolean(WearDataContract.KEY_CONFIG_SHOW_SECONDS, false),
+                graphRangeHours = dataMap.getInt(WearDataContract.KEY_CONFIG_GRAPH_RANGE_HOURS, 3),
+                theme = dataMap.getString(WearDataContract.KEY_CONFIG_THEME, "dark"),
+            )
+            configUpdated = true
+            Timber.d("Received watch face config from phone")
+        }
+
+        // Pass 2 -- data and alert events
+        changedEvents.forEach { event ->
             val path = event.dataItem.uri.path ?: return@forEach
             val dataMap = DataMapItem.fromDataItem(event.dataItem).dataMap
 
@@ -63,20 +85,27 @@ class GlycemicDataListenerService : WearableListenerService() {
 
                 WearDataContract.ALERT_PATH -> {
                     val alertType = dataMap.getString(WearDataContract.KEY_ALERT_TYPE, "none")
+                    val alertsEnabled = WatchDataRepository.watchFaceConfig.value.showAlert
+                    val rawBg = dataMap.getInt(WearDataContract.KEY_ALERT_BG_VALUE, 0)
+                    val bgValue = if (GlucoseDisplayUtils.isValidGlucose(rawBg)) rawBg else 0
                     WatchDataRepository.updateAlert(
                         type = alertType,
-                        bgValue = dataMap.getInt(WearDataContract.KEY_ALERT_BG_VALUE, 0),
+                        bgValue = bgValue,
                         timestampMs = dataMap.getLong(WearDataContract.KEY_ALERT_TIMESTAMP),
                         message = dataMap.getString(WearDataContract.KEY_ALERT_MESSAGE, ""),
                     )
-                    if (alertType != "none") {
+                    if (alertType != "none" && alertsEnabled) {
                         vibrateForAlert(alertType)
                     }
-                    Timber.d("Received alert from phone: %s", alertType)
+                    Timber.d("Received alert from phone: %s (vibrate=%b)", alertType, alertsEnabled)
                 }
             }
         }
 
+        if (configUpdated) {
+            // Config change may affect which complications are visible
+            requestComplicationUpdate(IoBComplicationDataSource::class.java)
+        }
         if (iobUpdated) {
             requestComplicationUpdate(IoBComplicationDataSource::class.java)
         }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WatchDataRepository.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WatchDataRepository.kt
@@ -28,6 +28,15 @@ object WatchDataRepository {
         val message: String,
     )
 
+    data class WatchFaceConfigState(
+        val showIoB: Boolean = true,
+        val showGraph: Boolean = true,
+        val showAlert: Boolean = true,
+        val showSeconds: Boolean = false,
+        val graphRangeHours: Int = 3,
+        val theme: String = "dark",
+    )
+
     private val _iob = MutableStateFlow<IoBState?>(null)
     val iob: StateFlow<IoBState?> = _iob.asStateFlow()
 
@@ -36,6 +45,9 @@ object WatchDataRepository {
 
     private val _alert = MutableStateFlow<AlertState?>(null)
     val alert: StateFlow<AlertState?> = _alert.asStateFlow()
+
+    private val _watchFaceConfig = MutableStateFlow(WatchFaceConfigState())
+    val watchFaceConfig: StateFlow<WatchFaceConfigState> = _watchFaceConfig.asStateFlow()
 
     fun updateIoB(iob: Float, timestampMs: Long) {
         _iob.value = IoBState(iob, timestampMs)
@@ -55,5 +67,26 @@ object WatchDataRepository {
 
     fun updateAlert(type: String, bgValue: Int, timestampMs: Long, message: String) {
         _alert.value = if (type == "none") null else AlertState(type, bgValue, timestampMs, message)
+    }
+
+    private val VALID_GRAPH_RANGES = setOf(1, 3, 6)
+    private val VALID_THEMES = setOf("dark", "clinical_blue", "high_contrast")
+
+    fun updateWatchFaceConfig(
+        showIoB: Boolean,
+        showGraph: Boolean,
+        showAlert: Boolean,
+        showSeconds: Boolean,
+        graphRangeHours: Int,
+        theme: String,
+    ) {
+        _watchFaceConfig.value = WatchFaceConfigState(
+            showIoB = showIoB,
+            showGraph = showGraph,
+            showAlert = showAlert,
+            showSeconds = showSeconds,
+            graphRangeHours = if (graphRangeHours in VALID_GRAPH_RANGES) graphRangeHours else 3,
+            theme = if (theme in VALID_THEMES) theme else "dark",
+        )
     }
 }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WearDataContract.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WearDataContract.kt
@@ -1,5 +1,7 @@
 package com.glycemicgpt.weardevice.data
 
+// MIRROR: This contract must stay in sync with
+// app/src/main/java/com/glycemicgpt/mobile/wear/WearDataContract.kt
 object WearDataContract {
     // DataClient paths (persistent state sync)
     const val IOB_PATH = "/glycemicgpt/iob"
@@ -38,6 +40,17 @@ object WearDataContract {
 
     // Watch Face Push status paths (watch -> phone via MessageClient)
     const val WATCHFACE_PUSH_STATUS_PATH = "/glycemicgpt/watchface/status"
+
+    // Watch face config sync path (phone -> watch via DataClient)
+    const val CONFIG_PATH = "/glycemicgpt/watchface/config"
+
+    // Watch face config keys
+    const val KEY_CONFIG_SHOW_IOB = "cfg_show_iob"
+    const val KEY_CONFIG_SHOW_GRAPH = "cfg_show_graph"
+    const val KEY_CONFIG_SHOW_ALERT = "cfg_show_alert"
+    const val KEY_CONFIG_SHOW_SECONDS = "cfg_show_seconds"
+    const val KEY_CONFIG_GRAPH_RANGE_HOURS = "cfg_graph_range_h"
+    const val KEY_CONFIG_THEME = "cfg_theme"
 
     // CapabilityClient capabilities
     const val CHAT_RELAY_CAPABILITY = "glycemicgpt_chat_relay"

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WatchDataRepositoryTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WatchDataRepositoryTest.kt
@@ -1,8 +1,10 @@
 package com.glycemicgpt.weardevice.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -16,6 +18,10 @@ class WatchDataRepositoryTest {
             low = 70, high = 180, urgentLow = 55, urgentHigh = 250,
         )
         WatchDataRepository.updateAlert(type = "none", bgValue = 0, timestampMs = 0L, message = "")
+        WatchDataRepository.updateWatchFaceConfig(
+            showIoB = true, showGraph = true, showAlert = true,
+            showSeconds = false, graphRangeHours = 3, theme = "dark",
+        )
     }
 
     @Test
@@ -124,5 +130,72 @@ class WatchDataRepositoryTest {
         val state = WatchDataRepository.alert.value
         assertEquals("urgent_low", state!!.type)
         assertEquals(50, state.bgValue)
+    }
+
+    @Test
+    fun `resetState sets expected watchFaceConfig`() {
+        val config = WatchDataRepository.watchFaceConfig.value
+        assertTrue(config.showIoB)
+        assertTrue(config.showGraph)
+        assertTrue(config.showAlert)
+        assertFalse(config.showSeconds)
+        assertEquals(3, config.graphRangeHours)
+        assertEquals("dark", config.theme)
+    }
+
+    @Test
+    fun `updateWatchFaceConfig sets correct values`() {
+        WatchDataRepository.updateWatchFaceConfig(
+            showIoB = false,
+            showGraph = false,
+            showAlert = false,
+            showSeconds = true,
+            graphRangeHours = 6,
+            theme = "clinical_blue",
+        )
+
+        val config = WatchDataRepository.watchFaceConfig.value
+        assertFalse(config.showIoB)
+        assertFalse(config.showGraph)
+        assertFalse(config.showAlert)
+        assertTrue(config.showSeconds)
+        assertEquals(6, config.graphRangeHours)
+        assertEquals("clinical_blue", config.theme)
+    }
+
+    @Test
+    fun `updateWatchFaceConfig overwrites previous config`() {
+        WatchDataRepository.updateWatchFaceConfig(
+            showIoB = false, showGraph = false, showAlert = false,
+            showSeconds = true, graphRangeHours = 1, theme = "high_contrast",
+        )
+        WatchDataRepository.updateWatchFaceConfig(
+            showIoB = true, showGraph = true, showAlert = true,
+            showSeconds = false, graphRangeHours = 6, theme = "dark",
+        )
+
+        val config = WatchDataRepository.watchFaceConfig.value
+        assertTrue(config.showIoB)
+        assertTrue(config.showGraph)
+        assertEquals(6, config.graphRangeHours)
+        assertEquals("dark", config.theme)
+    }
+
+    @Test
+    fun `updateWatchFaceConfig clamps invalid graphRangeHours to default`() {
+        WatchDataRepository.updateWatchFaceConfig(
+            showIoB = true, showGraph = true, showAlert = true,
+            showSeconds = false, graphRangeHours = 99, theme = "dark",
+        )
+        assertEquals(3, WatchDataRepository.watchFaceConfig.value.graphRangeHours)
+    }
+
+    @Test
+    fun `updateWatchFaceConfig falls back to dark for unknown theme`() {
+        WatchDataRepository.updateWatchFaceConfig(
+            showIoB = true, showGraph = true, showAlert = true,
+            showSeconds = false, graphRangeHours = 3, theme = "neon_green",
+        )
+        assertEquals("dark", WatchDataRepository.watchFaceConfig.value.theme)
     }
 }

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WearDataContractTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WearDataContractTest.kt
@@ -18,6 +18,7 @@ class WearDataContractTest {
             WearDataContract.ALERT_DISMISS_PATH,
             WearDataContract.WATCHFACE_PUSH_CHANNEL,
             WearDataContract.WATCHFACE_PUSH_STATUS_PATH,
+            WearDataContract.CONFIG_PATH,
         )
         paths.forEach { path ->
             assertTrue("Path '$path' should start with /glycemicgpt/", path.startsWith("/glycemicgpt/"))
@@ -49,5 +50,20 @@ class WearDataContractTest {
     fun `capability names are defined`() {
         assertEquals("glycemicgpt_chat_relay", WearDataContract.CHAT_RELAY_CAPABILITY)
         assertEquals("glycemicgpt_watch_app", WearDataContract.WATCH_APP_CAPABILITY)
+    }
+
+    @Test
+    fun `config path is defined`() {
+        assertEquals("/glycemicgpt/watchface/config", WearDataContract.CONFIG_PATH)
+    }
+
+    @Test
+    fun `config keys are defined`() {
+        assertEquals("cfg_show_iob", WearDataContract.KEY_CONFIG_SHOW_IOB)
+        assertEquals("cfg_show_graph", WearDataContract.KEY_CONFIG_SHOW_GRAPH)
+        assertEquals("cfg_show_alert", WearDataContract.KEY_CONFIG_SHOW_ALERT)
+        assertEquals("cfg_show_seconds", WearDataContract.KEY_CONFIG_SHOW_SECONDS)
+        assertEquals("cfg_graph_range_h", WearDataContract.KEY_CONFIG_GRAPH_RANGE_HOURS)
+        assertEquals("cfg_theme", WearDataContract.KEY_CONFIG_THEME)
     }
 }


### PR DESCRIPTION
## Summary

- Add CONFIG_PATH to WearDataContract (phone + watch) for syncing watch face configuration via DataClient persistent state
- Phone sends config (showIoB, showGraph, showAlert, showSeconds, graphRangeHours, theme) on toggle change and on watch reconnect
- Watch validates config values (graphRangeHours allowlist, theme allowlist), processes config events before data/alerts (two-pass), triggers complication refresh after config change
- IoBComplicationDataSource returns NoData when showIoB is disabled; alert vibration gated on showAlert config
- DataClient deduplication bypassed via timestamp field for reliable re-syncs
- CancellationException properly rethrown in WearDataSender
- Alert bgValue validated via GlucoseDisplayUtils before storing

## Test plan

- [x] 54 unit tests passing (phone + watch contracts, repository state, config validation, ViewModel sync)
- [x] Lint clean, build succeeds
- [x] E2E verified on physical Galaxy S24 Ultra + Galaxy Watch5 Pro (config sync confirmed via logcat)
- [x] Emulator visual verification of Watch settings section
- [x] Adversarial review completed, all findings addressed
- [x] CodeRabbit CLI review completed, all findings addressed
- [x] Security review passed clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watch face settings now automatically synchronize to connected wear devices when modified in the app

* **Improvements**
  * Enhanced configuration management for watch display (IOB, graph, alerts, theme, and graph range visibility)
  * Improved alert handling on watch device with better validation and vibration control

* **UI Changes**
  * Updated setting label from "Show Alert Indicator" to "Alert Vibration" for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->