### PR TITLE
feat(wear): add complication tap actions for Alerts and AI Chat

### DIFF
--- a/apps/mobile/wear-device/src/main/AndroidManifest.xml
+++ b/apps/mobile/wear-device/src/main/AndroidManifest.xml
@@ -50,13 +50,13 @@
             </intent-filter>
         </service>
 
-        <!-- Alert dismiss activity (launched via explicit intent from within the app) -->
+        <!-- Alert dismiss activity (launched via complication tap PendingIntent or explicit intent) -->
         <activity
             android:name=".presentation.AlertsActivity"
             android:exported="false"
             android:theme="@android:style/Theme.DeviceDefault" />
 
-        <!-- AI chat activity (launched via explicit intent from within the app) -->
+        <!-- AI chat activity (launched via complication tap PendingIntent or explicit intent) -->
         <activity
             android:name=".presentation.ChatActivity"
             android:exported="false"

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/BgComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/BgComplicationDataSource.kt
@@ -1,5 +1,7 @@
 package com.glycemicgpt.weardevice.complications
 
+import android.app.PendingIntent
+import android.content.Intent
 import androidx.wear.watchface.complications.data.ComplicationData
 import androidx.wear.watchface.complications.data.ComplicationType
 import androidx.wear.watchface.complications.data.LongTextComplicationData
@@ -9,9 +11,27 @@ import androidx.wear.watchface.complications.data.ShortTextComplicationData
 import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
 import com.glycemicgpt.weardevice.data.WatchDataRepository
+import com.glycemicgpt.weardevice.presentation.AlertsActivity
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
 
 class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
+
+    private val tapPendingIntent by lazy {
+        val intent = Intent(this, AlertsActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra(EXTRA_SOURCE, SOURCE_BG)
+        }
+        PendingIntent.getActivity(
+            this, REQUEST_CODE_BG, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    companion object {
+        const val EXTRA_SOURCE = "complication_source"
+        const val SOURCE_BG = "bg"
+        private const val REQUEST_CODE_BG = 0
+    }
 
     override fun getPreviewData(type: ComplicationType): ComplicationData {
         val text = PlainComplicationText.Builder("120 \u2192").build()
@@ -51,10 +71,12 @@ class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
         val title = PlainComplicationText.Builder("BG").build()
         val description = PlainComplicationText.Builder(descriptionText).build()
 
+        val tap = tapPendingIntent
         return when (request.complicationType) {
             ComplicationType.SHORT_TEXT ->
                 ShortTextComplicationData.Builder(text = text, contentDescription = description)
                     .setTitle(title)
+                    .setTapAction(tap)
                     .build()
             ComplicationType.LONG_TEXT ->
                 LongTextComplicationData.Builder(
@@ -64,6 +86,7 @@ class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
                     contentDescription = description,
                 )
                     .setTitle(title)
+                    .setTapAction(tap)
                     .build()
             else -> NoDataComplicationData()
         }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/GraphComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/GraphComplicationDataSource.kt
@@ -1,5 +1,7 @@
 package com.glycemicgpt.weardevice.complications
 
+import android.app.PendingIntent
+import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
@@ -14,9 +16,21 @@ import android.graphics.drawable.Icon
 import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
 import com.glycemicgpt.weardevice.data.WatchDataRepository
+import com.glycemicgpt.weardevice.presentation.ChatActivity
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
 
 class GraphComplicationDataSource : SuspendingComplicationDataSourceService() {
+
+    private val tapPendingIntent by lazy {
+        val intent = Intent(this, ChatActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra(EXTRA_SOURCE, SOURCE_GRAPH)
+        }
+        PendingIntent.getActivity(
+            this, REQUEST_CODE_GRAPH, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
 
     companion object {
         private const val IMG_WIDTH = 400
@@ -25,6 +39,9 @@ class GraphComplicationDataSource : SuspendingComplicationDataSourceService() {
         private const val LINE_WIDTH = 3f
         private const val RANGE_LINE_WIDTH = 1f
         private const val MIN_READINGS = 3
+        const val EXTRA_SOURCE = "complication_source"
+        const val SOURCE_GRAPH = "graph"
+        private const val REQUEST_CODE_GRAPH = 2
     }
 
     override fun getPreviewData(type: ComplicationType): ComplicationData {
@@ -63,7 +80,7 @@ class GraphComplicationDataSource : SuspendingComplicationDataSourceService() {
             contentDescription = PlainComplicationText.Builder(
                 "Glucose trend: ${readings.size} readings over ${config.graphRangeHours}h"
             ).build(),
-        ).build()
+        ).setTapAction(tapPendingIntent).build()
     }
 
     private fun renderGraph(

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/IoBComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/IoBComplicationDataSource.kt
@@ -1,5 +1,7 @@
 package com.glycemicgpt.weardevice.complications
 
+import android.app.PendingIntent
+import android.content.Intent
 import androidx.wear.watchface.complications.data.ComplicationData
 import androidx.wear.watchface.complications.data.ComplicationType
 import androidx.wear.watchface.complications.data.LongTextComplicationData
@@ -9,8 +11,26 @@ import androidx.wear.watchface.complications.data.ShortTextComplicationData
 import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
 import com.glycemicgpt.weardevice.data.WatchDataRepository
+import com.glycemicgpt.weardevice.presentation.ChatActivity
 
 class IoBComplicationDataSource : SuspendingComplicationDataSourceService() {
+
+    private val tapPendingIntent by lazy {
+        val intent = Intent(this, ChatActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra(EXTRA_SOURCE, SOURCE_IOB)
+        }
+        PendingIntent.getActivity(
+            this, REQUEST_CODE_IOB, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    companion object {
+        const val EXTRA_SOURCE = "complication_source"
+        const val SOURCE_IOB = "iob"
+        private const val REQUEST_CODE_IOB = 1
+    }
 
     override fun getPreviewData(type: ComplicationType): ComplicationData {
         val text = PlainComplicationText.Builder("2.45").build()
@@ -45,10 +65,12 @@ class IoBComplicationDataSource : SuspendingComplicationDataSourceService() {
         val title = PlainComplicationText.Builder("IoB").build()
         val description = PlainComplicationText.Builder(descriptionText).build()
 
+        val tap = tapPendingIntent
         return when (request.complicationType) {
             ComplicationType.SHORT_TEXT ->
                 ShortTextComplicationData.Builder(text = text, contentDescription = description)
                     .setTitle(title)
+                    .setTapAction(tap)
                     .build()
             ComplicationType.LONG_TEXT ->
                 LongTextComplicationData.Builder(
@@ -56,6 +78,7 @@ class IoBComplicationDataSource : SuspendingComplicationDataSourceService() {
                     contentDescription = description,
                 )
                     .setTitle(title)
+                    .setTapAction(tap)
                     .build()
             else -> NoDataComplicationData()
         }


### PR DESCRIPTION
## Summary
- BG complication tap opens AlertsActivity (view glucose alerts/status)
- IoB complication tap opens ChatActivity (ask AI about insulin)
- Graph complication tap opens ChatActivity (ask AI about trends)
- PendingIntents cached as lazy properties, use FLAG_IMMUTABLE + FLAG_ACTIVITY_NEW_TASK
- Source extras included so target activities can tailor initial context
- Activities remain exported="false" (PendingIntents carry creating app identity)

## Test plan
- [x] ./gradlew testDebugUnitTest -- all pass
- [x] ./gradlew lintDebug -- clean
- [x] ./gradlew assembleDebug -- builds
- [x] Verified on physical watch (SM_R925U): BG tap -> AlertsActivity opens
- [x] Verified on physical watch: IoB tap -> ChatActivity opens with "Ask AI" screen
- [x] Verified tap actions work with exported="false" (PendingIntent carries app identity)
- [x] Adversarial review: 3 HIGH, 4 MEDIUM, 3 LOW -- all HIGH/MEDIUM addressed
- [x] Security review -- PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made watch complications interactive—users can now tap them for quick access to important features.
  * Blood glucose complication launches alerts when tapped.
  * Graph and insulin-on-board complications open chat when tapped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->