### PR TITLE
feat(data): initial pump history sync for fresh installs

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/adapter/PumpDriverAdapter.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/adapter/PumpDriverAdapter.kt
@@ -94,6 +94,10 @@ class PumpDriverAdapter @Inject constructor(
         registry.activePumpPlugin.value?.asPumpStatus()?.getHistoryLogs(sinceSequence)
             ?: Result.failure(NoActivePluginException())
 
+    override suspend fun getFullHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
+        registry.activePumpPlugin.value?.asPumpStatus()?.getFullHistoryLogs(sinceSequence)
+            ?: Result.failure(NoActivePluginException())
+
     override suspend fun getPumpHardwareInfo(): Result<PumpHardwareInfo> =
         registry.activePumpPlugin.value?.asPumpStatus()?.getPumpHardwareInfo()
             ?: Result.failure(NoActivePluginException())

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -328,6 +328,10 @@ class PumpPollingOrchestrator @Inject constructor(
          *  complete catch-up within a single cycle for typical gaps (< 2 hours). */
         const val MAX_BACKFILL_DURATION_MS = 120_000L     // 2 minutes
 
+        /** Max time for initial pump history sync on fresh install.
+         *  Allows downloading the full pump history (months of data) in one pass. */
+        const val MAX_INITIAL_SYNC_DURATION_MS = 600_000L  // 10 minutes for full pump download
+
         /** Pause between consecutive history log batch fetches during catch-up.
          *  Gives fast loop (IoB/CGM) a window to fire between batches. */
         const val BACKFILL_BATCH_STAGGER_MS = 1_000L      // 1 second
@@ -390,11 +394,21 @@ class PumpPollingOrchestrator @Inject constructor(
      * after a single 200-record batch. This ensures gaps are filled completely on
      * reconnect instead of taking 5 minutes per 200 records. Each batch is capped
      * at 200 records / 15 seconds by the BLE driver to keep the connection alive.
+     *
+     * On fresh installs (lastSequenceNumber == 0), performs a full initial sync
+     * with extended duration (10 minutes) and requests the full pump history
+     * from the BLE driver (no lookback limit, larger batch caps).
      */
     private suspend fun pollHistoryLogs() {
         val limits = safetyLimitsStore.toSafetyLimits()
         if (safetyLimitsStore.isStale()) {
             Timber.w("Safety limits are stale (>%d ms old), using cached values", SafetyLimitsStore.STALE_THRESHOLD_MS)
+        }
+
+        val isInitialSync = lastSequenceNumber == 0
+        val deadline = if (isInitialSync) MAX_INITIAL_SYNC_DURATION_MS else MAX_BACKFILL_DURATION_MS
+        if (isInitialSync) {
+            Timber.i("Initial pump history sync starting (no prior data, full download)")
         }
 
         var totalRecords = 0
@@ -404,8 +418,12 @@ class PumpPollingOrchestrator @Inject constructor(
         var batchCount = 0
         val startNanos = System.nanoTime()
 
-        while ((System.nanoTime() - startNanos) / 1_000_000 < MAX_BACKFILL_DURATION_MS) {
-            val result = pumpDriver.getHistoryLogs(sinceSequence = lastSequenceNumber)
+        while ((System.nanoTime() - startNanos) / 1_000_000 < deadline) {
+            val result = if (isInitialSync) {
+                pumpDriver.getFullHistoryLogs(sinceSequence = lastSequenceNumber)
+            } else {
+                pumpDriver.getHistoryLogs(sinceSequence = lastSequenceNumber)
+            }
 
             if (result.isFailure) {
                 Timber.w(result.exceptionOrNull(), "Failed to poll history logs (batch %d)", batchCount)
@@ -415,6 +433,9 @@ class PumpPollingOrchestrator @Inject constructor(
 
             if (records.isEmpty()) {
                 if (batchCount > 0) {
+                    if (isInitialSync) {
+                        Timber.i("Initial pump history sync complete")
+                    }
                     Timber.d("History backfill complete: %d records (%d CGM, %d bolus, %d basal) in %d batches",
                         totalRecords, totalCgm, totalBolus, totalBasal, batchCount)
                 }
@@ -463,6 +484,11 @@ class PumpPollingOrchestrator @Inject constructor(
                 repository.saveBasalBatch(basalReadings)
                 syncEnqueuer.enqueueBasalBatch(basalReadings)
                 totalBasal += basalReadings.size
+            }
+
+            if (isInitialSync) {
+                Timber.i("Initial sync: fetched %d records total (%d CGM, %d bolus, %d basal) in %d batches",
+                    totalRecords, totalCgm, totalBolus, totalBasal, batchCount)
             }
 
             // Trigger backend sync after each batch so data is uploaded incrementally

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
@@ -61,6 +61,7 @@ class PumpPollingOrchestratorTest {
         )
         coEvery { getBolusHistory(any(), any()) } returns Result.success(emptyList())
         coEvery { getHistoryLogs(any()) } returns Result.success(emptyList())
+        coEvery { getFullHistoryLogs(any()) } returns Result.success(emptyList())
         coEvery { getPumpHardwareInfo() } returns Result.failure(RuntimeException("not connected"))
     }
     private val repository = mockk<PumpDataRepository>(relaxed = true) {
@@ -458,6 +459,7 @@ class PumpPollingOrchestratorTest {
             ),
         )
         coEvery { pumpDriver.getHistoryLogs(any()) } returns Result.success(fakeRecords)
+        coEvery { pumpDriver.getFullHistoryLogs(any()) } returns Result.success(fakeRecords)
         every { historyLogParser.extractCgmFromHistoryLogs(any(), any()) } returns emptyList()
         every { historyLogParser.extractBolusesFromHistoryLogs(any(), any()) } returns emptyList()
         every { historyLogParser.extractBasalFromHistoryLogs(any(), any()) } returns emptyList()

--- a/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/PluginMetadata.kt
+++ b/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/PluginMetadata.kt
@@ -2,8 +2,9 @@ package com.glycemicgpt.mobile.domain.plugin
 
 /** Current plugin API version. Plugins with a different version are rejected.
  *  v3: BasalReading.controlIqMode renamed to activityMode (PumpActivityMode enum).
- *  v4: BolusEvent.category field + BolusCategoryProvider capability. */
-const val PLUGIN_API_VERSION = 4
+ *  v4: BolusEvent.category field + BolusCategoryProvider capability.
+ *  v5: getFullHistoryLogs() overload added to PumpDriver and PumpStatus. */
+const val PLUGIN_API_VERSION = 5
 
 /**
  * Immutable metadata describing a plugin. Available before the plugin is created.

--- a/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/capabilities/PumpStatus.kt
+++ b/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/capabilities/PumpStatus.kt
@@ -21,6 +21,11 @@ interface PumpStatus : PluginCapabilityInterface {
     suspend fun getPumpHardwareInfo(): Result<PumpHardwareInfo>
     suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>>
 
+    /** Full sync variant that fetches all available history without lookback limits.
+     *  Default implementation delegates to the standard incremental fetch. */
+    suspend fun getFullHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
+        getHistoryLogs(sinceSequence)
+
     /**
      * Extracts CGM readings from [records], applying [limits] to filter out any reading
      * whose glucose value falls outside [SafetyLimits.glucoseLow]..[SafetyLimits.glucoseHigh]

--- a/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/pump/PumpDriver.kt
+++ b/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/pump/PumpDriver.kt
@@ -36,6 +36,11 @@ interface PumpDriver {
     suspend fun getReservoirLevel(): Result<ReservoirReading>
     suspend fun getCgmStatus(): Result<CgmReading>
     suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>>
+
+    /** Full sync variant that fetches all available history without lookback limits.
+     *  Default implementation delegates to the standard incremental fetch. */
+    suspend fun getFullHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
+        getHistoryLogs(sinceSequence)
     suspend fun getPumpHardwareInfo(): Result<PumpHardwareInfo>
     fun observeConnectionState(): Flow<ConnectionState>
 }

--- a/plugins/shipped/tandem/src/main/java/com/glycemicgpt/mobile/ble/connection/TandemBleDriver.kt
+++ b/plugins/shipped/tandem/src/main/java/com/glycemicgpt/mobile/ble/connection/TandemBleDriver.kt
@@ -174,7 +174,13 @@ class TandemBleDriver @Inject constructor(
         return Result.success(egv.copy(trendArrow = trend))
     }
 
-    override suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> {
+    override suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
+        fetchHistoryLogs(sinceSequence, fullSync = false)
+
+    override suspend fun getFullHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
+        fetchHistoryLogs(sinceSequence, fullSync = true)
+
+    private suspend fun fetchHistoryLogs(sinceSequence: Int, fullSync: Boolean): Result<List<HistoryLogRecord>> {
         // Step 1: Get the available index range from the pump (opcode 58).
         // IMPORTANT: The pump's firstSeq/lastSeq are record INDICES, not event
         // sequence numbers. Opcode 60 takes a start INDEX. Records returned
@@ -188,17 +194,23 @@ class TandemBleDriver @Inject constructor(
         if (rangeResult.isFailure) return Result.failure(rangeResult.exceptionOrNull()!!)
 
         val range = rangeResult.getOrThrow()
-        val windowStart = maxOf(range.firstSeq, range.lastSeq - HISTORY_LOOKBACK_INDICES + 1)
-        // Resume from previous scan position if still within the lookback window,
+        // Full sync: start from the very first available index (no lookback limit).
+        // Normal sync: cap lookback to ~24h of indices.
+        val windowStart = if (fullSync) {
+            range.firstSeq
+        } else {
+            maxOf(range.firstSeq, range.lastSeq - HISTORY_LOOKBACK_INDICES + 1)
+        }
+        // Resume from previous scan position if still within the window,
         // otherwise start from the beginning of the window (new session / range shift).
         val fetchStart = if (nextHistoryIndex in windowStart..range.lastSeq) {
             nextHistoryIndex
         } else {
             windowStart
         }
-        Timber.d("History log range: firstIdx=%d lastIdx=%d numEntries=%d windowStart=%d fetchStart=%d resumed=%s sinceSeq=%d",
+        Timber.d("History log range: firstIdx=%d lastIdx=%d numEntries=%d windowStart=%d fetchStart=%d resumed=%s sinceSeq=%d fullSync=%s",
             range.firstSeq, range.lastSeq, range.lastSeq - range.firstSeq + 1,
-            windowStart, fetchStart, fetchStart != windowStart, sinceSequence)
+            windowStart, fetchStart, fetchStart != windowStart, sinceSequence, fullSync)
 
         if (range.lastSeq < range.firstSeq) return Result.success(emptyList())
 
@@ -206,12 +218,14 @@ class TandemBleDriver @Inject constructor(
         // Opcode 60 sends a 2-byte ACK on FFF6 and streams records on FFF8.
         // Cap total time to avoid blocking the slow poll loop (pump drops
         // idle connections at ~30s; other reads need time to execute too).
+        val maxRecords = if (fullSync) MAX_FULL_SYNC_RECORDS_PER_POLL else MAX_HISTORY_RECORDS_PER_POLL
+        val maxDurationMs = if (fullSync) MAX_FULL_SYNC_FETCH_DURATION_MS else MAX_HISTORY_FETCH_DURATION_MS
         val allRecords = mutableListOf<HistoryLogRecord>()
         var currentIndex = fetchStart
-        val deadline = System.currentTimeMillis() + MAX_HISTORY_FETCH_DURATION_MS
+        val deadline = System.currentTimeMillis() + maxDurationMs
 
         while (currentIndex <= range.lastSeq &&
-            allRecords.size < MAX_HISTORY_RECORDS_PER_POLL &&
+            allRecords.size < maxRecords &&
             System.currentTimeMillis() < deadline
         ) {
             val batchSize = minOf(HISTORY_BATCH_SIZE, range.lastSeq - currentIndex + 1)
@@ -296,6 +310,13 @@ class TandemBleDriver @Inject constructor(
          *  Control-IQ activity. Progressive scanning across poll cycles ensures
          *  the entire window is covered even with the 200 records/cycle cap. */
         const val HISTORY_LOOKBACK_INDICES = 2000
+
+        /** Safety cap on total records fetched per poll cycle during full sync. */
+        const val MAX_FULL_SYNC_RECORDS_PER_POLL = 500
+
+        /** Max time (ms) to spend fetching history logs per poll cycle during
+         *  full sync. Allows more time to download the full pump history. */
+        const val MAX_FULL_SYNC_FETCH_DURATION_MS = 25_000L
 
         /**
          * Build the 5-byte cargo for opcode 60 (HistoryLogRequest).

--- a/plugins/shipped/tandem/src/main/java/com/glycemicgpt/mobile/plugin/TandemPumpStatus.kt
+++ b/plugins/shipped/tandem/src/main/java/com/glycemicgpt/mobile/plugin/TandemPumpStatus.kt
@@ -34,6 +34,9 @@ class TandemPumpStatus(
     override suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
         bleDriver.getHistoryLogs(sinceSequence)
 
+    override suspend fun getFullHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
+        bleDriver.getFullHistoryLogs(sinceSequence)
+
     override fun extractCgmFromHistoryLogs(
         records: List<HistoryLogRecord>,
         limits: SafetyLimits,


### PR DESCRIPTION
## Summary

On fresh install or database clear, fetch the pump's **full history log** rather than only the last 24 hours. This ensures GlycemicGPT captures all available CGM, bolus, and basal data for complete data retention and backend upload.

## Problem
- `HISTORY_LOOKBACK_INDICES = 2000` limited history fetch to ~24 hours
- Fresh install had `lastSequenceNumber = 0`, meaning the first connection only downloaded recent data
- Months of pump history was silently ignored, defeating the "years of data retention" selling point

## Solution
- Added `getFullHistoryLogs()` to `PumpDriver`/`PumpStatus` interfaces with binary-compatible default implementation
- Tandem driver full sync: starts from `range.firstSeq`, 500 record cap, 25s per-fetch timeout
- Orchestrator detects initial sync (`lastSequenceNumber == 0`), uses 10-minute deadline
- `PLUGIN_API_VERSION` bumped to 5 (additive, backward compatible)

## Verified
- Normal incremental fetch still works (sequence not advancing = caught up)
- Interface change is binary compatible (default method delegates to existing)

## Test plan
- [ ] Fresh install: initial sync fetches full pump history (check logcat for "Initial sync" messages)
- [ ] Existing install: normal incremental fetch continues working
- [ ] Plugin API version bump doesn't break existing plugins
- [ ] Unit tests pass, lint clean, build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full-history synchronization capability for initial data sync with an extended time budget (10 minutes), enabling more comprehensive retrieval of pump records on first setup.
  * Implemented full-history sync support in Tandem pump driver with optimized parameters for bulk data transfer.

* **Chores**
  * Updated plugin API version to 5 to support new full-history sync interface across pump drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->