### PR TITLE
fix(security): suppress false positive exported_activity on launcher (Closes #399)

### DIFF
--- a/apps/mobile/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/app/src/main/AndroidManifest.xml
@@ -57,8 +57,11 @@
         tools:targetApi="35">
 
         <!-- nosemgrep: java.android.security.exported_activity.exported_activity
-             False positive: MAIN/LAUNCHER activity must be exported (required since API 31).
-             No incoming intent data is processed; auth is required before sensitive data is shown. -->
+             Intentional: MAIN/LAUNCHER activity must be exported (required since API 31).
+             Safe because: no incoming intent data/extras are processed, auth is enforced
+             in GlycemicGptNavHost before any sensitive data is shown.
+             RE-EVALUATE THIS SUPPRESSION if deep-link handling, intent extras, or
+             custom URI schemes are added to this activity in the future. -->
         <activity
             android:name=".presentation.MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary

Suppresses Semgrep false positive `exported_activity` on MainActivity.

## Why this is a false positive

- `MAIN`/`LAUNCHER` activities **must** have `exported="true"` since Android API 31. Setting it to `false` prevents the app from installing.
- `MainActivity` does not process incoming intent data, extras, or URIs. It sets up the Compose UI tree.
- Authentication is required before any sensitive data is shown. Launching externally = tapping the app icon.
- The Semgrep rule is a broad heuristic that flags all exported activities without distinguishing launcher activities.

## Test plan

- [ ] Security scan passes (finding suppressed via nosemgrep)
- [ ] Issue #399 auto-closes on merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an inline annotation to satisfy code quality checks and document that the app's main launcher activity is intentionally exported. No runtime behavior, configuration, or user-facing functionality was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->