### PR TITLE
fix(ci): idempotent fallback release on workflow rerun

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       needs.release-please.outputs.pr == '' &&
       contains(github.event.head_commit.message, 'promote develop to main')
     outputs:
-      release_created: ${{ steps.create-release.outputs.release_created }}
+      release_created: ${{ steps.create-release.outputs.release_created || steps.existing-release.outputs.release_created }}
       tag_name: ${{ steps.bump.outputs.tag_name }}
       version: ${{ steps.bump.outputs.version }}
 
@@ -106,7 +106,10 @@ jobs:
       - name: Calculate next patch version
         id: bump
         run: |
-          CURRENT=$(jq -r '.["."]' .release-please-manifest.json)
+          # Read from the triggering commit SHA (immutable across workflow reruns).
+          # This prevents computing a different version on rerun after the first
+          # run already bumped the manifest on main.
+          CURRENT=$(git show ${{ github.sha }}:.release-please-manifest.json | jq -r '.["."]')
           if [ -z "$CURRENT" ] || [ "$CURRENT" = "null" ]; then
             echo "::error::Could not read current version from manifest"
             exit 1
@@ -117,18 +120,23 @@ jobs:
           VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
           TAG="v${VERSION}"
 
-          # Safety: verify tag does not already exist
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "::error::Tag $TAG already exists. Skipping fallback release."
-            exit 1
-          fi
-
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag_name=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Fallback: bumping $CURRENT -> $VERSION (tag: $TAG)"
+
+          # Idempotency: if this tag already exists (workflow rerun after
+          # successful first run), skip version bump but still set outputs
+          # so downstream jobs can re-run against the existing release.
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists (workflow rerun). Skipping version bump."
+            echo "already_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_exists=false" >> "$GITHUB_OUTPUT"
+            echo "Fallback: bumping $CURRENT -> $VERSION (tag: $TAG)"
+          fi
 
       - name: Update version files
+        if: steps.bump.outputs.already_exists != 'true'
         env:
           CURRENT: ${{ steps.bump.outputs.current }}
           VERSION: ${{ steps.bump.outputs.version }}
@@ -160,6 +168,7 @@ jobs:
           grep -q "val appVersionName = \"${VERSION}\"" apps/mobile/app/build.gradle.kts || { echo "::error::build.gradle.kts not updated"; exit 1; }
 
       - name: Update release-please changelog
+        if: steps.bump.outputs.already_exists != 'true'
         env:
           VERSION: ${{ steps.bump.outputs.version }}
           CURRENT: ${{ steps.bump.outputs.current }}
@@ -181,6 +190,7 @@ jobs:
           mv /tmp/updated-rp-changelog.md .release-please-changelog.md
 
       - name: Commit, tag, and push
+        if: steps.bump.outputs.already_exists != 'true'
         env:
           VERSION: ${{ steps.bump.outputs.version }}
           TAG: ${{ steps.bump.outputs.tag_name }}
@@ -208,6 +218,7 @@ jobs:
 
       - name: Create GitHub Release
         id: create-release
+        if: steps.bump.outputs.already_exists != 'true'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           VERSION: ${{ steps.bump.outputs.version }}
@@ -224,6 +235,24 @@ jobs:
 
           echo "release_created=true" >> "$GITHUB_OUTPUT"
           echo "Created fallback GitHub Release $TAG"
+
+      # On rerun when release already exists, still signal success
+      # so downstream jobs (APK build, release body) can re-run.
+      - name: Signal existing release on rerun
+        id: existing-release
+        if: steps.bump.outputs.already_exists == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          # Verify the GitHub Release (not just the tag) exists.
+          # A prior run could have pushed the tag but failed before gh release create.
+          if gh release view "${{ steps.bump.outputs.tag_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "release_created=true" >> "$GITHUB_OUTPUT"
+            echo "Rerun: release ${{ steps.bump.outputs.tag_name }} already exists"
+          else
+            echo "::error::Tag exists but GitHub Release ${{ steps.bump.outputs.tag_name }} does not"
+            exit 1
+          fi
 
   release-android-apk:
     name: Build & Upload Release APK
@@ -324,7 +353,7 @@ jobs:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
           TAG="${{ steps.version-info.outputs.tag_name }}"
-          gh release upload "$TAG" GlycemicGPT-*-release.apk --repo ${{ github.repository }}
+          gh release upload "$TAG" GlycemicGPT-*-release.apk --repo ${{ github.repository }} --clobber
 
       - name: Upload APK as workflow artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes a rerun safety issue in the fallback release job (from PR #481) identified by CodeRabbit on promotion PR #482.

## Problem

On workflow rerun after a successful fallback release, the job would read the already-bumped manifest from main HEAD and compute a different version (e.g., 0.3.2 instead of 0.3.1), causing either a spurious double version bump or a confusing tag-exists failure.

## Fix

- **Anchor version read to triggering SHA**: `git show ${{ github.sha }}:.release-please-manifest.json` reads from the immutable promotion merge commit
- **Graceful idempotency**: When the computed tag already exists (rerun after success), skip all mutation steps but signal `release_created=true` so downstream jobs can re-run

## Test plan

- [ ] CI passes
- [ ] After merge: close PR #482, create new promotion PR to pick up this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability: version detection is stable across reruns and release steps become idempotent when a tag already exists.
  * Reruns now detect existing GitHub Releases so downstream jobs behave correctly.
  * APK uploads overwrite existing release assets during reruns to ensure uploads succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->