### PR TITLE
fix: close CODEOWNERS self-review loophole, align with governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,24 +10,31 @@
 # Default: maintainers team reviews everything
 * @GlycemicGPT/maintainers
 
-# Governance & project policy: project lead only
-# These files define how the project is run. Only the project lead
-# can approve changes to prevent unilateral governance modifications.
-/.github/CODEOWNERS @jlengelbrecht
-/GOVERNANCE.md @jlengelbrecht
-/CONTRIBUTING.md @jlengelbrecht
-/LICENSE @jlengelbrecht
+# Governance & project policy: project lead explicitly requested
+# These files define how the project is run. The project lead is
+# listed individually so they always appear in the review request.
+# The maintainers team is co-listed so review is always requested
+# even when the project lead authors the PR (GitHub skips self-review
+# for sole code owners). Note: CODEOWNERS ensures the request, not
+# that a specific person approves -- that is enforced by process
+# (see GOVERNANCE.md).
+/.github/CODEOWNERS @jlengelbrecht @GlycemicGPT/maintainers
+/GOVERNANCE.md @jlengelbrecht @GlycemicGPT/maintainers
+/CONTRIBUTING.md @jlengelbrecht @GlycemicGPT/maintainers
+/LICENSE @jlengelbrecht @GlycemicGPT/maintainers
 
-# Security infrastructure: project lead only
-# Security scan configuration and workflows affect what gets flagged
-# and what gets suppressed. Changes require project lead review.
-/scripts/security/ @jlengelbrecht
-/.github/workflows/security-scan.yml @jlengelbrecht
-/.github/workflows/security-full-suite.yml @jlengelbrecht
+# Security infrastructure: project lead explicitly requested
+# Security scan configuration, workflows, and documentation affect
+# what gets flagged and what gets suppressed. Project lead review
+# expected (enforced by process, not CODEOWNERS).
+/scripts/security/ @jlengelbrecht @GlycemicGPT/maintainers
+/.github/workflows/security-scan.yml @jlengelbrecht @GlycemicGPT/maintainers
+/.github/workflows/security-full-suite.yml @jlengelbrecht @GlycemicGPT/maintainers
+/docs/security-testing.md @jlengelbrecht @GlycemicGPT/maintainers
 
-# Release & CI configuration: project lead only
-/.github/workflows/release.yml @jlengelbrecht
-/.github/renovate.json5 @jlengelbrecht
+# Release & CI configuration: project lead explicitly requested
+/.github/workflows/release.yml @jlengelbrecht @GlycemicGPT/maintainers
+/.github/renovate.json5 @jlengelbrecht @GlycemicGPT/maintainers
 
 # Component ownership -- ready for future committer teams.
 # Uncomment and update when component-specific teams are created.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -198,7 +198,7 @@ The repository enforces these protections via org-level rulesets that apply to a
 - Squash merge only
 - 10 required status checks (CI, security scan, linting, etc.)
 - No force push, no deletion
-- Bypass: org admins + glycemicgpt-renovate (for automated dependency updates)
+- Bypass: org admins + glycemicgpt-merge (for automated sync PRs). glycemicgpt-renovate bypass pending manual ruleset update.
 
 ### Why project lead approval is required on `main`
 
@@ -214,7 +214,9 @@ This is not bureaucracy -- it's the checkpoint between "code that works" and "co
 
 Code owners are defined in [`.github/CODEOWNERS`](.github/CODEOWNERS). When a PR touches files owned by a specific team or person, GitHub automatically requests their review.
 
-The `@GlycemicGPT/maintainers` team owns all files by default. Governance files, security infrastructure, and release configuration are owned by the project lead individually -- this ensures these critical files cannot be changed without the project lead's explicit approval, even if the maintainers team grows.
+The `@GlycemicGPT/maintainers` team owns all files by default. Governance files, security infrastructure, and release configuration list the project lead individually alongside the maintainers team. The project lead's individual listing ensures they are always explicitly requested as a reviewer on external PRs. The team co-listing ensures review is still requested when the project lead authors the PR -- GitHub skips review requests for sole code owners who are also the PR author, so the team serves as a fallback to maintain audit trail.
+
+> **Note:** CODEOWNERS controls who is *requested* for review, not who *must* approve. The requirement that the project lead personally reviews governance, security, and release changes is enforced by process (this document), not by GitHub's code owner mechanism. Any code owner approval satisfies the branch protection check.
 
 As the project grows, component-specific committer teams will be added:
 


### PR DESCRIPTION
## Summary

Closes the CODEOWNERS enforcement gap where PRs authored by the project lead had zero reviewers requested on critical files.

## Problem

All 9 specific CODEOWNERS rules listed only `@jlengelbrecht`. GitHub skips review requests when the PR author is the sole code owner. This meant PRs touching governance, security, release, and license files could merge without any review being requested -- violating the governance promise that "these critical files cannot be changed without the project lead's explicit approval."

## Fix

- **CODEOWNERS**: Add `@GlycemicGPT/maintainers` as co-owner on all 9 specific rules. The project lead is still listed first (always requested for external PRs). The team ensures review is requested even when the project lead authors the PR.
- **CODEOWNERS**: Add missing protection for `/docs/security-testing.md` (referenced in GOVERNANCE.md as security policy source)
- **GOVERNANCE.md**: Update Code Ownership section to explain the dual-owner pattern
- **GOVERNANCE.md**: Fix develop bypass actor documentation (glycemicgpt-merge was missing, only glycemicgpt-renovate was listed)

## Manual actions needed after merge

1. **Develop ruleset**: Add glycemicgpt-renovate (ID 3227479) as bypass actor (currently only glycemicgpt-merge is listed)
2. **Maintainers team permission**: Verify if `pull` is intentional or should be `Maintain` (GOVERNANCE.md says Maintain)

## Test plan

- [ ] CI passes
- [ ] After merge: next PR touching `release.yml` shows `@GlycemicGPT/maintainers` as requested reviewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CODEOWNERS to add team-based co-ownership (project lead + maintainers) for governance, security, and release/CI files, and added a co-owned rule for docs/security-testing.md.

* **Documentation**
  * Clarified governance docs: branch protection bypasses adjusted for automation, and CODEOWNERS vs. mandatory personal review semantics explained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->