### PR TITLE
fix(ci): gate fallback release on deployable code changes

### DIFF
--- a/.github/PROMOTION_PR_TEMPLATE.md
+++ b/.github/PROMOTION_PR_TEMPLATE.md
@@ -25,19 +25,22 @@ Commit types in this promotion determine the version bump:
 | `fix:` | PATCH (0.3.0 -> 0.3.1) | Bug fix, CI fix (`fix(ci): ...`) |
 | `feat:` | MINOR (0.3.0 -> 0.4.0) | New user-facing feature |
 | `feat!:` / `BREAKING CHANGE:` | MINOR (while pre-1.0; MAJOR after 1.0) | Breaking API change |
-| `chore:`, `ci:`, `docs:`, etc. | Fallback PATCH | Non-user-facing (auto patch) |
+| `chore:`, `ci:`, `docs:`, etc. | Fallback PATCH (if deployable code changed) | Non-user-facing |
 
-If all commits are non-releasable types (`chore:`, `ci:`, `docs:`, `test:`, `style:`, `build:`),
-the release workflow automatically creates a patch release. Every promotion produces a versioned
-release -- no manual intervention required.
+If all commits are non-releasable types but **deployable code paths changed** (`apps/api/`, `apps/web/`,
+`apps/mobile/`, `sidecar/`, `plugins/`, `docker-compose*`, `Dockerfile*`), a fallback patch release
+is created automatically.
+If only docs/governance/CI files changed, **no release is created** -- no version bump, no container
+builds, no APKs. This avoids unnecessary noise for downstream users.
 
 ### Post-merge steps
 
-1. Release-please analyzes commits and either:
-   - Creates a version bump PR (if `feat:`/`fix:` commits exist) -- glycemicgpt-merge auto-merges it
-   - Does nothing (if only `chore:`/`ci:`/`docs:` commits) -- the fallback job creates a patch release automatically
-2. Verify stable container images are published with new version tag
-3. Verify signed release APK is uploaded to the GitHub release
-4. Version sync happens automatically -- the `sync-main-to-develop` workflow
-   cherry-picks the version bump back to develop via PR. Verify it completed
+1. Release-please analyzes commits and one of three outcomes occurs:
+   - **Code + releasable commits**: Release-please creates a version bump PR -- glycemicgpt-merge auto-merges it
+   - **Code + non-releasable commits only**: The fallback job detects deployable changes and creates a patch release automatically
+   - **Docs/governance only (no deployable code)**: No release is created -- no version bump, no container builds, no APKs
+2. If a release was created: verify stable container images are published with new version tag
+3. If a release was created: verify signed release APK is uploaded to the GitHub release
+4. Version sync happens automatically (only when a release is created) -- the `sync-main-to-develop`
+   workflow cherry-picks the version bump back to develop via PR. Verify it completed
    in the [Actions tab](../../actions/workflows/sync-main-to-develop.yml).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,18 +66,61 @@ jobs:
             echo "No PR number found"
           fi
 
-  # Fallback: when a promotion merge has no releasable conventional commits
-  # (only chore/ci/docs/test), release-please skips. This job creates a
-  # patch release so every promotion produces versioned container images
-  # for Renovate-managed k8s deployments.
-  fallback-release:
-    name: Fallback Patch Release
+  # Detect whether the promotion contains changes to deployable code paths.
+  # Doc-only promotions (README, GOVERNANCE, CODEOWNERS, docs/) should NOT
+  # trigger versioned releases, container builds, or APK builds.
+  detect-deployable-changes:
+    name: Check for Deployable Changes
     runs-on: ubuntu-latest
     needs: release-please
     if: >-
       needs.release-please.outputs.release_created != 'true' &&
       needs.release-please.outputs.pr == '' &&
       contains(github.event.head_commit.message, 'promote develop to main')
+    outputs:
+      has_deployable_changes: ${{ steps.check.outputs.has_deployable_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect deployable file changes
+        id: check
+        env:
+          MERGE_SHA: ${{ github.sha }}
+        run: |
+          # Compare promotion merge to its first parent (main before merge)
+          CHANGED=$(git diff --name-only "${MERGE_SHA}^1" "$MERGE_SHA")
+          echo "Changed files in promotion:"
+          printf '%s\n' "$CHANGED"
+
+          # Deployable paths: application code, containers, plugins
+          PATTERN='^(apps/api/|apps/web/|apps/mobile/|sidecar/|plugins/|docker-compose|Dockerfile)'
+          MATCHED=$(printf '%s\n' "$CHANGED" | grep -E "$PATTERN" || true)
+
+          if [ -n "$MATCHED" ]; then
+            echo "has_deployable_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Deployable files that triggered release:"
+            printf '%s\n' "$MATCHED"
+          else
+            echo "has_deployable_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No deployable changes -- skipping fallback release"
+          fi
+
+  # Fallback: when a promotion merge has no releasable conventional commits
+  # (only chore/ci/docs/test) BUT contains deployable code changes,
+  # release-please skips. This job creates a patch release so every
+  # code-changing promotion produces versioned container images for
+  # Renovate-managed k8s deployments.
+  fallback-release:
+    name: Fallback Patch Release
+    runs-on: ubuntu-latest
+    needs: [release-please, detect-deployable-changes]
+    if: >-
+      needs.release-please.outputs.release_created != 'true' &&
+      needs.release-please.outputs.pr == '' &&
+      contains(github.event.head_commit.message, 'promote develop to main') &&
+      needs.detect-deployable-changes.outputs.has_deployable_changes == 'true'
     outputs:
       release_created: ${{ steps.create-release.outputs.release_created || steps.existing-release.outputs.release_created }}
       tag_name: ${{ steps.bump.outputs.tag_name }}

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -83,15 +83,18 @@ GlycemicGPT uses [Conventional Commits](https://www.conventionalcommits.org/) wi
 1. Developers use conventional commit prefixes on PRs merged to `develop`
 2. On promotion (develop -> main), release-please analyzes commits since the last release
 3. The highest-priority commit type determines the bump: `feat!:` > `feat:` > `fix:`
-4. If no releasable commits exist (only `chore:`/`ci:`/`docs:`/etc.), a **fallback patch release** is created automatically
+4. If no releasable commits exist (only `chore:`/`ci:`/`docs:`/etc.) but deployable code changed, a **fallback patch release** is created automatically
+5. If no releasable commits exist AND no deployable code changed (doc-only promotion), **no release is created** -- no version bump, no container builds, no APKs
 
-Every promotion to main produces a versioned release. This ensures container images are always tagged with semver versions for Renovate-managed deployments.
+Promotions with deployable code changes always produce a versioned release. Doc-only promotions (README, GOVERNANCE, CODEOWNERS, docs/) do not create releases, avoiding unnecessary noise for downstream Renovate users.
+
+**Deployable paths:** `apps/api/`, `apps/web/`, `apps/mobile/`, `sidecar/`, `plugins/`, `docker-compose*`, `Dockerfile*`. Changes outside these paths (docs, governance, CI workflows, assets) do not trigger releases.
 
 ### Choosing the right commit type
 
 - **`feat:`** -- use only for new user-facing functionality. A CI improvement is NOT a feature.
 - **`fix:`** -- use for bug fixes in any area, including CI/infrastructure (`fix(ci): ...`).
-- **`chore:`/`ci:`/`docs:`** -- use for non-user-facing changes. These still produce a patch release via the fallback mechanism.
+- **`chore:`/`ci:`/`docs:`** -- use for non-user-facing changes. These produce a patch release only if deployable code paths are affected.
 
 ## Release Channels
 


### PR DESCRIPTION
## Summary

Gates the fallback patch release to only fire when a promotion contains deployable code changes. Doc-only promotions (README, GOVERNANCE, CODEOWNERS, docs/) no longer trigger unnecessary version bumps, container builds, or APK builds.

## Problem

Every promotion to main triggered a versioned release -- even for doc-only changes. This wasted CI, created misleading versions, and generated Renovate noise for downstream users who received update PRs for container images with zero code changes.

## Solution

Added a `detect-deployable-changes` job to `release.yml` that diffs the promotion merge against its parent to check if any deployable paths changed:

- `apps/api/`, `apps/web/`, `apps/mobile/`, `sidecar/`, `plugins/`, `docker-compose*`, `Dockerfile*`

If only non-deployable files changed (docs, governance, CI workflows, assets), the fallback is skipped entirely. Release-please's native behavior is unaffected -- `feat:`/`fix:` commits still trigger releases regardless of path.

| Scenario | Release created? |
|----------|:---:|
| Promotion with `feat:`/`fix:` commits | Yes (release-please) |
| Promotion with `chore:` + code changes | Yes (fallback) |
| Promotion with only docs/governance | No |
| Mixed promotion (docs + code) | Yes (fallback) |

## Test plan

- [ ] CI passes
- [ ] Future: promote with only doc changes -> verify no release created
- [ ] Future: promote with code changes -> verify release created as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated versioning rules to differentiate deployable code changes from documentation-only updates. Documentation-only promotions no longer trigger version bumps or release builds.

* **Chores**
  * Enhanced release automation to intelligently detect deployable code changes and optimize when release artifacts are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->