### PR TITLE
fix(mobile): add R8 keep rules for wear release APK build

### DIFF
--- a/apps/mobile/app/proguard-rules.pro
+++ b/apps/mobile/app/proguard-rules.pro
@@ -41,6 +41,15 @@
 -keep class com.glycemicgpt.mobile.domain.pump.** { *; }
 -keep class com.glycemicgpt.mobile.domain.model.** { *; }
 
+# TwelveMonkeys ImageIO (transitive via webpdecoder)
+-dontwarn javax.imageio.**
+-dontwarn com.twelvemonkeys.imageio.**
+-dontwarn com.twelvemonkeys.common.**
+
+# AutoValue annotation processor references
+-dontwarn javax.lang.model.**
+-dontwarn javax.annotation.processing.**
+
 # Strip debug logs in release builds
 -assumenosideeffects class timber.log.Timber {
     public static void d(...);

--- a/apps/mobile/wear-device/proguard-rules.pro
+++ b/apps/mobile/wear-device/proguard-rules.pro
@@ -13,3 +13,19 @@
 
 # DWF Validator -- AAR ships no consumer ProGuard rules; keep public API + factory
 -keep class com.google.android.wearable.watchface.validator.client.** { *; }
+
+# TwelveMonkeys ImageIO (transitive via webpdecoder)
+# These reference javax.imageio SPI classes not available in Android SDK.
+-dontwarn javax.imageio.**
+-dontwarn com.twelvemonkeys.imageio.**
+-dontwarn com.twelvemonkeys.common.**
+
+# AutoValue annotation processor references (javax.lang.model is from tools.jar)
+-dontwarn javax.lang.model.**
+-dontwarn javax.annotation.processing.**
+
+# DOM/XML/XPath references from transitive dependencies
+-dontwarn org.w3c.dom.DOMImplementationSourceList
+-dontwarn org.xml.sax.driver
+-dontwarn org.eclipse.wst.**
+-dontwarn org.apache.xerces.**


### PR DESCRIPTION
## Summary

Fixes the wear-device release APK build that has been failing at R8 minification since the module was added. The phone app proguard rules are also updated for consistency.

## Problem

R8 minification fails with missing class errors for `javax.imageio.*`, `javax.lang.model.*`, and `org.eclipse.wst.*` classes. These are desktop Java classes referenced by transitive dependencies (TwelveMonkeys ImageIO via webpdecoder, AutoValue annotation processor, Apache Xerces) that don't exist in the Android runtime.

## Fix

Added `-dontwarn` rules to both `wear-device/proguard-rules.pro` and `app/proguard-rules.pro` for the missing Java SE classes. Verified both release APKs build successfully.

## Test plan

- [x] `./gradlew :wear-device:assembleRelease` -- BUILD SUCCESSFUL
- [x] `./gradlew :app:assembleRelease` -- BUILD SUCCESSFUL
- [ ] After promotion: v0.3.3 release has both phone AND wear APKs
- [ ] Install wear APK on physical watch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mobile app build configurations to suppress build warnings for transitive dependencies, improving build output clarity without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->