### PR TITLE
fix(ci): include wear-device and watchface in version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,16 +199,23 @@ jobs:
           jq --arg v "$VERSION" '.version = $v' sidecar/package.json > /tmp/sidecar-pkg.json
           mv /tmp/sidecar-pkg.json sidecar/package.json
 
-          # 5. apps/mobile/app/build.gradle.kts
-          sed -i "s/val appVersionName = \"${CURRENT}\"/val appVersionName = \"${VERSION}\"/" \
-            apps/mobile/app/build.gradle.kts
+          # 5-7. apps/mobile/*/build.gradle.kts (app, wear-device, watchface)
+          for GRADLE_FILE in apps/mobile/app/build.gradle.kts \
+                            apps/mobile/wear-device/build.gradle.kts \
+                            apps/mobile/watchface/build.gradle.kts; do
+            sed -i "s/val appVersionName = \"${CURRENT}\"/val appVersionName = \"${VERSION}\"/" "$GRADLE_FILE"
+          done
 
           # Verify all files were updated
           grep -q "\"${VERSION}\"" .release-please-manifest.json || { echo "::error::Manifest not updated"; exit 1; }
           grep -q "^version = \"${VERSION}\"" apps/api/pyproject.toml || { echo "::error::pyproject.toml not updated"; exit 1; }
           grep -q "\"version\": \"${VERSION}\"" apps/web/package.json || { echo "::error::web package.json not updated"; exit 1; }
           grep -q "\"version\": \"${VERSION}\"" sidecar/package.json || { echo "::error::sidecar package.json not updated"; exit 1; }
-          grep -q "val appVersionName = \"${VERSION}\"" apps/mobile/app/build.gradle.kts || { echo "::error::build.gradle.kts not updated"; exit 1; }
+          for GRADLE_FILE in apps/mobile/app/build.gradle.kts \
+                            apps/mobile/wear-device/build.gradle.kts \
+                            apps/mobile/watchface/build.gradle.kts; do
+            grep -q "val appVersionName = \"${VERSION}\"" "$GRADLE_FILE" || { echo "::error::$GRADLE_FILE not updated"; exit 1; }
+          done
 
       - name: Update release-please changelog
         if: steps.bump.outputs.already_exists != 'true'
@@ -244,7 +251,9 @@ jobs:
             apps/api/pyproject.toml \
             apps/web/package.json \
             sidecar/package.json \
-            apps/mobile/app/build.gradle.kts
+            apps/mobile/app/build.gradle.kts \
+            apps/mobile/wear-device/build.gradle.kts \
+            apps/mobile/watchface/build.gradle.kts
 
           git commit -m "chore: release ${VERSION}"
 

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -132,8 +132,10 @@ jobs:
             # Version files: always take main's version (authoritative post-release)
             for f in .release-please-manifest.json apps/api/pyproject.toml \
                      apps/web/package.json sidecar/package.json \
-                     apps/mobile/app/build.gradle.kts CHANGELOG.md \
-                     .release-please-changelog.md; do
+                     apps/mobile/app/build.gradle.kts \
+                     apps/mobile/wear-device/build.gradle.kts \
+                     apps/mobile/watchface/build.gradle.kts \
+                     CHANGELOG.md .release-please-changelog.md; do
               if git diff --name-only --diff-filter=U 2>/dev/null | grep -q "^${f}$"; then
                 # Only overwrite if the file exists at the source commit
                 if git show "$COMMIT_SHA":"$f" > /dev/null 2>&1; then

--- a/apps/mobile/watchface/build.gradle.kts
+++ b/apps/mobile/watchface/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         minSdk = 33
         targetSdk = 35
 
-        val appVersionName = "0.1.99" // x-release-please-version
+        val appVersionName = "0.3.3" // x-release-please-version
         val parts = appVersionName.split(".")
         val major = parts.getOrElse(0) { "0" }.toInt()
         val minor = parts.getOrElse(1) { "0" }.toInt()

--- a/apps/mobile/wear-device/build.gradle.kts
+++ b/apps/mobile/wear-device/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 35
         targetSdk = 35
 
-        val appVersionName = "0.1.99" // x-release-please-version
+        val appVersionName = "0.3.3" // x-release-please-version
         val parts = appVersionName.split(".")
         val major = parts.getOrElse(0) { "0" }.toInt()
         val minor = parts.getOrElse(1) { "0" }.toInt()

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,9 @@
         "apps/api/pyproject.toml",
         "apps/web/package.json",
         "sidecar/package.json",
-        "apps/mobile/app/build.gradle.kts"
+        "apps/mobile/app/build.gradle.kts",
+        "apps/mobile/wear-device/build.gradle.kts",
+        "apps/mobile/watchface/build.gradle.kts"
       ]
     }
   },


### PR DESCRIPTION
## Summary

Adds wear-device and watchface `build.gradle.kts` files to release-please's `extra-files` list so they get version-bumped alongside the phone app on every release. Also updates the fallback release job and sync-main-to-develop conflict resolution to include these files.

## Problem

The wear-device and watchface modules were stuck at version `0.1.99` while the phone app was at `0.3.3`. This caused the phone app to detect a version mismatch and attempt to push an update to the watch, which failed with "Channel closed unexpectedly."

## Changes

- `release-please-config.json`: Added `apps/mobile/wear-device/build.gradle.kts` and `apps/mobile/watchface/build.gradle.kts` to extra-files
- `release.yml`: Updated fallback release to bump all 3 mobile gradle files
- `sync-main-to-develop.yml`: Updated conflict resolution file list
- `wear-device/build.gradle.kts`: Bumped from `0.1.99` to `0.3.3`
- `watchface/build.gradle.kts`: Bumped from `0.1.99` to `0.3.3`

## Test plan

- [ ] CI passes
- [ ] After promotion: all mobile modules show same version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated watchface and wear-device app versions to 0.3.3
  * Enhanced release automation workflow to manage version updates across all mobile application modules
  * Updated release configuration to include additional build files for consistent version management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->