### PR TITLE
fix(ai): use sidecar API key for subscription chat auth

### DIFF
--- a/apps/api/src/services/ai_client.py
+++ b/apps/api/src/services/ai_client.py
@@ -133,7 +133,7 @@ async def get_ai_client(
     if config.encrypted_api_key:
         api_key = decrypt_credential(config.encrypted_api_key)
     else:
-        api_key = "sidecar-managed"
+        api_key = settings.ai_sidecar_api_key or "sidecar-managed"
     model = config.model_name or DEFAULT_MODELS.get(config.provider_type, "")
 
     # For subscription types, auto-route through the managed sidecar


### PR DESCRIPTION
## Summary

Fixes subscription AI chat returning 502 because the API sends the wrong Bearer token to the sidecar.

Closes #504

## Problem

When no `encrypted_api_key` is stored (subscription providers use sidecar OAuth), the OpenAI SDK client was initialized with `api_key = "sidecar-managed"`, sending `Authorization: Bearer sidecar-managed` to the sidecar. The sidecar rejects this with 401 since it expects the `SIDECAR_API_KEY` token.

## Fix

One-line change in `apps/api/src/services/ai_client.py`: use `settings.ai_sidecar_api_key` (already populated from the `AI_SIDECAR_API_KEY` env var) instead of the placeholder string.

## Test plan

- [ ] Backend tests pass
- [ ] Configure Claude subscription via web UI, send chat message, verify response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key configuration handling with more flexible fallback options when certain API key settings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->