### PR TITLE
docs: clarify GitHub branch-counter artifact + fix flow diagram

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,11 +213,11 @@ npm test       # Run tests
 We use a **develop/main** branching model:
 
 ```
-feature branch --> squash merge --> develop --> rebase merge --> main
-                                      |                           |
-                                  dev builds                  stable releases
-                                  debug APKs                  signed APKs
-                                  Docker :dev                 Docker :latest
+feature branch --> squash merge --> develop --> merge --> main
+                                      |                     |
+                                  dev builds           stable releases
+                                  debug APKs           signed APKs
+                                  Docker :dev          Docker :latest
 ```
 
 ### Rules
@@ -225,6 +225,8 @@ feature branch --> squash merge --> develop --> rebase merge --> main
 - **`develop`** is the integration branch. **All contributor PRs target `develop`.**
 - **`main`** is the stable release branch. Do **not** target PRs to `main`.
 - Feature branches are created from `develop` and squash-merged back.
+
+> **Note on the GitHub branch counter:** GitHub's branch comparison may show `develop` as a number of commits *behind* `main`. This is a cosmetic SHA-graph artifact, not a content drift -- after a release-please version bump or automated changelog update on `main`, the `sync-main-to-develop` workflow cherry-picks those commits back to `develop` as new commits with new SHAs. GitHub compares SHAs, so the original `main`-side commits register as missing on `develop` even though the file content (version number, `CHANGELOG.md`) is identical. See [docs/branching-strategy.md](docs/branching-strategy.md) for the full release cycle.
 
 ### Creating a Feature Branch
 

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -7,6 +7,8 @@
 | `main` | Stable releases | Yes | Yes |
 | `develop` | Integration / dev testing | Yes | No |
 
+> **GitHub's "X commits behind main" counter on `develop` is non-substantive.** After each promotion, release-please bumps the version on `main` and the `sync-main-to-develop` workflow cherry-picks those commits back to `develop` as *new* commits with new SHAs. GitHub's counter compares SHAs, so the original `main`-side commits register as "missing" on `develop` even though the file content is identical. The two branches stay content-synced (same version, same `CHANGELOG.md`); only the commit graph drifts. Contributors should always target `develop` regardless of what the counter shows -- see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
 ## Full Release Cycle
 
 ```


### PR DESCRIPTION
## Summary

Two contributor-facing documentation clarifications that came out of a question about why `develop` displays as "12 commits behind `main`" on GitHub.

1. **Fix the Branching & Workflow ASCII diagram in `CONTRIBUTING.md`** -- it showed "rebase merge" as the `develop` → `main` step, but the actual workflow is merge-commit. Verified by inspecting promotion commits #446 through #507 on `origin/main`: all 2-parent merge commits. Diagram updated to "merge" (verb form) and column alignment retuned for the shorter word.

2. **Add a blockquote callout** in `CONTRIBUTING.md §Branching & Workflow §Rules` and in `docs/branching-strategy.md §Branch Model` explaining the GitHub branch-counter artifact. The `sync-main-to-develop` workflow cherry-picks release-please version bumps and automated changelog commits from `main` back to `develop` as new commits with new SHAs. GitHub's branch-comparison counter compares SHAs, so the original `main`-side commits register as "missing" on `develop` even though file content (version number, `CHANGELOG.md`) is identical.

## Why

Without the note, a new contributor lands on GitHub, sees "develop is 12 commits behind main," and reasonably infers one of: "develop is broken," "I should target main since it's more current," or "I should rebase my fork on main first." Two of those three are the wrong action. The existing Rules bullet says **"All contributor PRs target `develop`"** in bold — that tells them *what* to do. This note tells them *why* the counter looks wrong, so they trust the rule.

## Test plan

- [x] Markdown renders correctly on GitHub
- [x] Cross-links between CONTRIBUTING.md and docs/branching-strategy.md are bidirectional
- [x] Anchor fragments dropped from cross-links to avoid GitHub slug-generator ambiguity around emoji-prefixed headers
- [x] ASCII diagram column alignment verified in monospace
- [x] Adversarial review on the diff -- 15 findings raised, 9 fixed in this commit, 5 rejected (scope creep / handwave concerns), 1 auto-resolved by other fixes
- [x] Workflow accuracy: "After a release-please version bump or automated changelog update on `main`" matches the actual `sync-main-to-develop.yml:24-26` `if:` trigger

## Out of scope

- Rebase-conflict guidance for in-flight feature branches (different doc problem; the note here is scoped to the targeting question)
- Architectural discussion of why cherry-pick was chosen over ref-reset (lives in branching-strategy.md history if a contributor is curious; not surfaced in the new note to keep the contributor-facing message tight)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated branching strategy documentation clarifying merge approach for branch promotion workflow
  * Added explanation of GitHub's commit-behind counter behavior and branch content synchronization
  * Provided contributor guidance for targeting the correct branch during release processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->