### PR TITLE
ci(renovate): add log_level workflow_dispatch input for diagnostic runs

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,6 +10,16 @@ on:
       - ".github/renovate.json5"
       - ".github/workflows/renovate.yml"
   workflow_dispatch:
+    inputs:
+      log_level:
+        description: 'Renovate log level for this run (scheduled runs always use info)'
+        type: choice
+        required: false
+        default: info
+        options:
+          - info
+          - debug
+          - trace
 
 permissions:
   contents: write
@@ -36,5 +46,5 @@ jobs:
           configurationFile: .github/renovate.json5
           token: ${{ steps.generate-token.outputs.token }}
         env:
-          LOG_LEVEL: info
+          LOG_LEVEL: ${{ inputs.log_level || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## What

Adds a \`workflow_dispatch.inputs.log_level\` choice input to the Renovate workflow. Default stays \`info\`; manual triggers can opt up to \`debug\` or \`trace\` for diagnostic sessions.

## Why

When investigating the Renovate self-abort issue we hit during the recent CVE-cleanup cycle, we needed verbose per-package decision logs but had to use a throwaway branch to flip \`LOG_LEVEL\` temporarily. The throwaway branch trick worked but is friction we shouldn't repeat. Making the capability first-class lets future diagnostic sessions just run:

\`\`\`bash
gh workflow run renovate.yml -f log_level=debug
\`\`\`

## Behavior

| Trigger | LOG_LEVEL |
|---|---|
| Scheduled cron (\`0 */6 * * *\`) | \`info\` (unchanged; no log volume increase) |
| Push to main | \`info\` (unchanged) |
| \`workflow_dispatch\` (no input) | \`info\` (default) |
| \`workflow_dispatch\` with \`log_level=debug\` | \`debug\` |
| \`workflow_dispatch\` with \`log_level=trace\` | \`trace\` |

## Why this needs to land on main

The scheduled cron run uses the workflow file from the default branch (main). For the input to be available in scheduled-trigger contexts and for the GitHub Actions UI dropdown to render, the change needs to be on main. So this lands on develop first, then rides the next promotion to main.

## Risk

Near-zero. Default behavior is unchanged. Only adds opt-in capability.

## Test plan

- [x] YAML is valid (parsed by GitHub Actions runner)
- [ ] CI passes (no test changes; workflow file change only)
- [ ] After merge: confirm \`gh workflow run renovate.yml -f log_level=debug\` produces debug logs

## Bundling note

This PR is intentionally small and intended to land alongside [PR #535](https://github.com/GlycemicGPT/GlycemicGPT/pull/535)'s CVE fixes via [PR #537](https://github.com/GlycemicGPT/GlycemicGPT/pull/537) (the in-flight develop→main promotion). Once this merges to develop, #537 will pick it up in its diff automatically.