### PR TITLE
ci(security): GitHub Actions supply-chain hygiene

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,12 @@
     "config:recommended",
     "docker:enableMajor",
     ":dependencyDashboard",
-    ":semanticCommits"
+    ":semanticCommits",
+    // Pin GitHub Actions to commit SHAs (preserves trailing
+    // "# vX.Y.Z" comment for human readability). Defends against
+    // mutable-tag re-pointing attacks (e.g., tj-actions/changed-files,
+    // reviewdog 2025 incidents). Renovate keeps the SHAs current.
+    "helpers:pinGitHubActionDigests"
   ],
   // Target develop as the integration branch -- all dependency
   // updates land here first so we can test before promoting to main.

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,7 +24,7 @@ jobs:
       should_build: ${{ steps.filter.outputs.android }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |
@@ -52,7 +52,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
       - name: Run unit tests
         working-directory: apps/mobile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -109,7 +109,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Detect changed paths
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             api:
@@ -74,13 +74,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.IMAGE_PREFIX }}-api
           tags: |
@@ -99,7 +99,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push API image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./apps/api
           file: ./apps/api/Dockerfile
@@ -131,13 +131,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -145,7 +145,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.IMAGE_PREFIX }}-web
           tags: |
@@ -156,7 +156,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push Web image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./apps/web
           file: ./apps/web/Dockerfile
@@ -188,13 +188,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -202,7 +202,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.IMAGE_PREFIX }}-sidecar
           tags: |
@@ -213,7 +213,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push Sidecar image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./sidecar
           file: ./sidecar/Dockerfile

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -25,7 +25,7 @@ jobs:
       should_scan: ${{ steps.filter.outputs.deps }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |

--- a/.github/workflows/dev-pre-release.yml
+++ b/.github/workflows/dev-pre-release.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
       - name: Decode debug keystore
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           config-file: release-please-config.json
@@ -341,7 +341,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
       - name: Decode signing keystore
         env:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Renovate
-        uses: renovatebot/github-action@v44.0.2
+        uses: renovatebot/github-action@c5fdc9f98fdf9e9bb16b5760f7e560256eb79326 # v44.0.2
         with:
           configurationFile: .github/renovate.json5
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/security-full-suite.yml
+++ b/.github/workflows/security-full-suite.yml
@@ -312,7 +312,7 @@ jobs:
         run: |
           docker run --rm --network="host" \
             -v "$(pwd)/scripts/security:/zap/wrk/:rw" \
-            ghcr.io/zaproxy/zaproxy:stable \
+            ghcr.io/zaproxy/zaproxy@sha256:707fc6b9fd8327ba48bb7b49d0c5732c179b045dab9c99f8b95410627dff4a00 \
             zap.sh -cmd -autorun /zap/wrk/zap-api-plan.resolved.yaml || true
 
       - name: Evaluate ZAP API results
@@ -324,7 +324,7 @@ jobs:
         run: |
           docker run --rm --network="host" \
             -v "$(pwd)/scripts/security:/zap/wrk/:rw" \
-            ghcr.io/zaproxy/zaproxy:stable \
+            ghcr.io/zaproxy/zaproxy@sha256:707fc6b9fd8327ba48bb7b49d0c5732c179b045dab9c99f8b95410627dff4a00 \
             zap.sh -cmd -autorun /zap/wrk/zap-web-plan.resolved.yaml || true
 
       - name: Evaluate ZAP Web results
@@ -339,7 +339,7 @@ jobs:
         run: |
           docker run --rm --network="host" \
             -v "$(pwd)/scripts/security:/zap/wrk/:rw" \
-            ghcr.io/zaproxy/zaproxy:stable \
+            ghcr.io/zaproxy/zaproxy@sha256:707fc6b9fd8327ba48bb7b49d0c5732c179b045dab9c99f8b95410627dff4a00 \
             zap.sh -cmd -autorun /zap/wrk/zap-unauth-api-plan.yaml || true
 
       - name: Evaluate ZAP Unauthenticated API results
@@ -353,7 +353,7 @@ jobs:
         run: |
           docker run --rm --network="host" \
             -v "$(pwd)/scripts/security:/zap/wrk/:rw" \
-            ghcr.io/zaproxy/zaproxy:stable \
+            ghcr.io/zaproxy/zaproxy@sha256:707fc6b9fd8327ba48bb7b49d0c5732c179b045dab9c99f8b95410627dff4a00 \
             zap.sh -cmd -autorun /zap/wrk/zap-unauth-web-plan.yaml || true
 
       - name: Evaluate ZAP Unauthenticated Web results

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -37,7 +37,7 @@ jobs:
       any_security_relevant: ${{ steps.derived.outputs.any_security_relevant }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |
@@ -557,7 +557,7 @@ jobs:
         run: |
           docker run --rm --network="host" \
             -v "$(pwd)/scripts/security:/zap/wrk/:rw" \
-            ghcr.io/zaproxy/zaproxy:stable \
+            ghcr.io/zaproxy/zaproxy@sha256:707fc6b9fd8327ba48bb7b49d0c5732c179b045dab9c99f8b95410627dff4a00 \
             zap.sh -cmd -autorun /zap/wrk/zap-api-plan.resolved.yaml || true
 
       - name: Evaluate ZAP API results
@@ -574,7 +574,7 @@ jobs:
         run: |
           docker run --rm --network="host" \
             -v "$(pwd)/scripts/security:/zap/wrk/:rw" \
-            ghcr.io/zaproxy/zaproxy:stable \
+            ghcr.io/zaproxy/zaproxy@sha256:707fc6b9fd8327ba48bb7b49d0c5732c179b045dab9c99f8b95410627dff4a00 \
             zap.sh -cmd -autorun /zap/wrk/zap-web-plan.resolved.yaml || true
 
       - name: Evaluate ZAP Web results
@@ -590,7 +590,7 @@ jobs:
         run: |
           docker run --rm --network="host" \
             -v "$(pwd)/scripts/security:/zap/wrk/:rw" \
-            ghcr.io/zaproxy/zaproxy:stable \
+            ghcr.io/zaproxy/zaproxy@sha256:707fc6b9fd8327ba48bb7b49d0c5732c179b045dab9c99f8b95410627dff4a00 \
             zap.sh -cmd -autorun /zap/wrk/zap-unauth-api-plan.yaml || true
 
       - name: Evaluate ZAP Unauthenticated API results
@@ -604,7 +604,7 @@ jobs:
         run: |
           docker run --rm --network="host" \
             -v "$(pwd)/scripts/security:/zap/wrk/:rw" \
-            ghcr.io/zaproxy/zaproxy:stable \
+            ghcr.io/zaproxy/zaproxy@sha256:707fc6b9fd8327ba48bb7b49d0c5732c179b045dab9c99f8b95410627dff4a00 \
             zap.sh -cmd -autorun /zap/wrk/zap-unauth-web-plan.yaml || true
 
       - name: Evaluate ZAP Unauthenticated Web results

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,93 @@
+name: Workflow Lint
+
+# Static analysis of GitHub Actions workflow files using zizmor.
+# Defends against compromised/misconfigured workflows that could leak
+# CI secrets (the same class of attack as the tj-actions/changed-files
+# and reviewdog 2025 incidents).
+#
+# zizmor catches:
+#   - Untrusted input flowing into shell commands (template injection)
+#   - Excessive permissions: grants
+#   - Dangerous pull_request_target patterns (fork code execution)
+#   - Cache poisoning patterns
+#   - Self-hosted runner risks
+#   - Action references that evaluate at runtime
+#
+# ROLLOUT STATUS: ADVISORY (does not fail builds).
+# zizmor surfaces findings on the existing workflow corpus that need to
+# be triaged in follow-up PRs (template injection, excessive permissions,
+# cache poisoning, missing persist-credentials: false). Once the baseline
+# is clean, this gate will be tightened to fail on errors, then warnings,
+# then registered as a required status check on develop. Tracking issue
+# will be filed once this PR lands.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Workflow Lint Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install zizmor
+        run: pip install zizmor==1.5.2
+
+      - name: Run zizmor (advisory)
+        # ADVISORY MODE: does not fail the build. We collect findings,
+        # post a summary, and upload SARIF for review. Tighten to a
+        # failing gate once baseline findings are triaged.
+        run: |
+          set +e
+          zizmor --persona=auditor --format sarif .github/workflows/ > zizmor.sarif
+          ZIZMOR_EXIT=$?
+          # Always also print the human-readable output so it shows in run logs
+          zizmor --persona=auditor .github/workflows/ || true
+          echo "::notice::zizmor exited with $ZIZMOR_EXIT (advisory mode -- not failing build)"
+          # Summary counts for visibility
+          if [ -s zizmor.sarif ]; then
+            python3 -c "
+          import json
+          with open('zizmor.sarif') as f:
+              data = json.load(f)
+          counts = {}
+          for run in data.get('runs', []):
+              for r in run.get('results', []):
+                  level = r.get('level', 'unknown')
+                  counts[level] = counts.get(level, 0) + 1
+          for level, n in sorted(counts.items()):
+              print(f'::notice::zizmor {level}: {n}')
+          " || true
+          fi
+          exit 0
+
+      - name: Upload SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zizmor-sarif
+          path: zizmor.sarif
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -46,6 +46,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # No git-push needed -- zizmor only reads files. Disabling
+          # token persistence reduces exposure when the step's external
+          # tooling (pip + zizmor) runs.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Phase 3 of the Renovate auto-merge plan. Defends against the tj-actions/changed-files / reviewdog 2025 attack class (mutable-tag re-pointing on third-party actions). Brings two of the three intended controls online; the third (OSV-on-workflows) is dropped after verifying OSV-Scanner v2.3.3 has no GitHub Actions extractor.

## What's in

**SHA-pinned every third-party action** (10 distinct, 26 occurrences). Tags can be moved by maintainers (or anyone who compromises a maintainer's account); SHAs cannot. Full mapping is in the commit message. ZAP image (`ghcr.io/zaproxy/zaproxy:stable`) also pinned to its sha256 digest.

**`helpers:pinGitHubActionDigests`** added to `.github/renovate.json5`. Renovate now keeps third-party SHAs current automatically and will produce a follow-up PR converting first-party `actions/*` to SHA pins on its next run.

**`workflow-lint.yml`** runs zizmor in **advisory mode**. Surfaces findings on the existing corpus (16 errors / 47 warnings / 81 help) that need triage in follow-up PRs -- template injection, excessive permissions, cache poisoning, missing `persist-credentials: false`. Will be tightened to a failing required check once baseline is clean.

## What's NOT in (and why)

- **OSV-Scanner over workflow files.** Originally planned; OSV-Scanner v2.3.3 has no GitHub Actions extractor (verified locally). The `dependency-scan.yml` filter change has been reverted -- the path expansion would have triggered the scan but extracted nothing. CVE alerting on actions still exists via Renovate / Dependabot vulnerability alerts (a separate pipeline from OSV-Scanner).
- **First-party `actions/*` SHA pinning.** Left to Renovate's automated conversion PR via the new `pinGitHubActionDigests` preset. Avoids bundling a large mechanical change into this PR.
- **Doc updates to `docs/dev/security-testing.md`.** That file is being edited in PR #540 (still open); the GitHub Actions Supply-Chain Hygiene section needs to be updated there to reflect what actually shipped (OSV control withdrawn, SHA-pin + zizmor advisory landed).

## Adversarial review fixes applied before push

- **HIGH** -- ZAP digest pin originally embedded `# zaproxy:stable \\` inside a `run: |` block, which made `#` start a shell comment that consumed the `\` line continuation. Would have silently broken all 8 ZAP scans (containers exited before invoking `zap.sh`). Trailing comment removed; the digest is self-documenting via the audit trail.
- **MEDIUM** -- `gradle/actions/setup-gradle@v4.4.3` initially pinned to the tag-object SHA (`48b5f213...`) instead of the commit SHA (`ed408507...`). Replaced across all three workflow references.
- **MEDIUM** -- Dropped the OSV-on-workflows path filter (see above).
- **MEDIUM** -- Removed comments referencing `docs/dev/security-testing.md` sections that don't exist on develop yet (live in PR #540).

## Test plan

- [x] All 10 changed workflow files parse as valid YAML.
- [x] All third-party actions SHA-pinned (verified zero remain at tag pins).
- [x] All 10 SHAs verified against `gh api repos/{owner}/{repo}/git/ref/tags/{tag}` -- 9 commit SHAs, 1 tag-object that was corrected to a commit SHA.
- [x] ZAP digest verified as a multi-arch OCI index (works on `ubuntu-latest` x86_64 runners).
- [x] zizmor runs locally and produces SARIF; no syntax errors.
- [x] Shell continuation in ZAP `run:` blocks parses correctly post-fix (verified via inline AST check).
- [ ] CI run on this PR confirms ZAP scans actually fire (pre-fix, this would have silently no-op'd).
- [ ] Renovate's next run produces the expected first-party SHA conversion PR.

## Follow-ups

- Update PR #540's audit doc to reflect the OSV-on-workflows control withdrawal and the zizmor advisory rollout.
- Triage zizmor findings in batches: template-injection (2 -- real bugs) -> excessive-permissions errors (11) -> cache-poisoning (3) -> artipacked warnings (33).
- Once baseline is clean, tighten `Workflow Lint Gate` to fail on errors and register as required status check on develop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Pinned GitHub Actions across all workflows to specific commit digests for enhanced security and reproducibility, replacing floating version tags.
  * Updated Renovate configuration to automatically maintain pinned GitHub Action digests.

* **New Features**
  * Added automated workflow linting to detect and report potential security issues in CI/CD configurations, with findings logged and archived for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->