### PR TITLE
ci: path-filter ci.yml component test/lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -126,6 +128,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -156,6 +160,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -187,6 +193,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -212,6 +220,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate token for glycemicgpt-ci
         id: ci-token
@@ -486,6 +495,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,59 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
+  # Path-filter PRs so we don't spin up VMs for components that didn't
+  # change. On push to main/develop the gated jobs always run -- skipping
+  # is PR-only.
+  #
+  # Each gateable job has `needs: detect-changes` + a fail-open `if:`:
+  #   if: needs.detect-changes.result != 'success'
+  #       || needs.detect-changes.outputs.<flag> == 'true'
+  #       || github.event_name == 'push'
+  #
+  # When the `if:` evaluates false, GitHub reports the job as "skipped"
+  # and that DOES satisfy the required-status-check rule on develop.
+  # However, if `detect-changes` itself FAILS (network blip, paths-filter
+  # transient bug, runner hiccup), dependent jobs would otherwise be
+  # skipped with reason "dependent job failed", which GitHub treats as
+  # a FAILURE for required-check purposes -- blocking every PR. The
+  # `needs.detect-changes.result != 'success'` clause fail-opens that
+  # path: a flaky detect-changes degrades to "run the job," not "block
+  # the PR."
+  detect-changes:
+    name: Detect Component Changes
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      web: ${{ steps.filter.outputs.web }}
+      sidecar: ${{ steps.filter.outputs.sidecar }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          # Mirrors the path semantics in security-scan.yml so contributors
+          # only have one mental model. Anything inside apps/api/** triggers
+          # backend; anything inside apps/web/** triggers frontend; etc.
+          # Tests and lockfiles are co-located under those trees so no
+          # extra patterns are needed.
+          filters: |
+            api:
+              - 'apps/api/**'
+            web:
+              - 'apps/web/**'
+            sidecar:
+              - 'sidecar/**'
+
   test-backend:
     name: Backend Tests
+    needs: detect-changes
+    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.api == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
 
     services:
@@ -65,6 +115,8 @@ jobs:
 
   test-frontend:
     name: Frontend Tests
+    needs: detect-changes
+    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.web == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
 
     defaults:
@@ -93,6 +145,8 @@ jobs:
 
   lint-backend:
     name: Backend Lint
+    needs: detect-changes
+    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.api == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
 
     defaults:
@@ -122,6 +176,8 @@ jobs:
 
   lint-frontend:
     name: Frontend Lint
+    needs: detect-changes
+    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.web == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
 
     defaults:
@@ -419,6 +475,8 @@ jobs:
 
   test-sidecar:
     name: Sidecar Tests
+    needs: detect-changes
+    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.sidecar == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
 
     defaults:


### PR DESCRIPTION
## Summary

Phase 1 of the Renovate auto-merge plan. Adds a `detect-changes` job to `ci.yml` and gates the 5 component-specific jobs (Backend Tests, Backend Lint, Frontend Tests, Frontend Lint, Sidecar Tests) on the relevant filter output. `check-attribution` is intentionally not gated -- it inspects commit messages.

A Renovate PR that touches only `.github/workflows/*.yml` (e.g. PR #543, the SHA-pin conversion) currently spins up VMs for all 5 jobs -- about **7 minutes of runner time per PR for no useful work**. With this gate, those jobs report \"skipped\" and the runner time is reclaimed.

## Required-check semantics (the load-bearing part)

This needs careful reasoning because `ci.yml`'s 6 jobs are all required status checks on `develop`'s ruleset.

- When a job's **own `if:`** evaluates false, GitHub reports it as \"skipped\". That **does** satisfy a required status check.
- When a `needs:` **dependency fails**, dependent jobs are skipped with reason \"dependent job failed\", which GitHub treats as a **FAILURE** for required-check purposes -- which would block every PR.

The fail-open clause `needs.detect-changes.result != 'success'` in each gated job's `if:` prevents the second case: if `detect-changes` flakes for any transient reason, the dependent job runs unconditionally and reports its own real result instead of cascading to a transitive failure.

This was caught in adversarial review before push -- the original draft had a simpler `if:` expression that would have blocked PRs on any `detect-changes` flake.

Push events to main/develop always run all jobs unconditionally (`|| github.event_name == 'push'`), so protected-branch coverage is preserved end-to-end.

## What did NOT change

- `docker-integration.yml` -- already has workflow-level path filters and is not a required check.
- `security-scan.yml`, `android.yml`, `dependency-scan.yml` -- already use the gate-job pattern.
- Required-check names on develop's ruleset -- verified each name still matches exactly (Backend Tests, Backend Lint, Frontend Tests, Frontend Lint, Sidecar Tests, Attribution Check).

## Test plan

- [x] YAML parses cleanly.
- [x] All required-check job names on develop's ruleset match the diff exactly.
- [x] Fail-open clause prevents transitive `needs:`-failure from blocking PRs.
- [x] Push events to main/develop bypass the gate (full coverage on protected branches).
- [ ] CI on this PR confirms detect-changes runs successfully and the 5 jobs report green/skipped as expected.
- [ ] Once merged, verify on the next Renovate PR that the gated jobs actually skip when not relevant.

## Follow-ups (not blocking)

- Eventually move to the gate-job pattern (matches `security-scan.yml` etc.) so `detect-changes` failures produce a single clean failure signal on a `ci-gate` job rather than fanning out to 5 fail-open expressions. This is a ruleset change (rename required checks), so it's a bigger lift -- deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration with improved permissions and optimized job dependencies to streamline the testing and linting workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->