### PR TITLE
ci: phase 4 -- group Renovate PRs by family

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -222,6 +222,80 @@
         "androidx.wear.*:*"
       ],
       "groupName": "AndroidX Wear OS"
+    },
+    // Group GitHub built-in actions (actions/*).
+    // Owned by GitHub itself, lower individual blast radius. Bundle them
+    // into one PR per cycle so the dashboard isn't flooded with one PR
+    // per action when monthly bumps land.
+    {
+      "description": "Group GitHub built-in actions",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["actions/*"],
+      "groupName": "GitHub Actions"
+    },
+    // Group Docker GitHub Actions (docker/*).
+    // The Docker actions (build-push, login, metadata, setup-buildx,
+    // setup-qemu) are co-released and almost always bumped together.
+    {
+      "description": "Group Docker GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["docker/*"],
+      "groupName": "Docker Actions"
+    },
+    // Group all other third-party CI actions (gradle, dorny, astral-sh,
+    // googleapis, renovatebot) into one PR per cycle. Each is SHA-pinned
+    // (PR #541 / #543) so even when this group bundles multiple updates
+    // the per-action audit is straightforward. When adding a new vendor
+    // action to the workflows, extend this list so it doesn't fall
+    // through to a one-PR-per-action ungrouped state.
+    {
+      "description": "Group third-party CI actions",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "gradle/*",
+        "dorny/*",
+        "astral-sh/*",
+        "googleapis/*",
+        "renovatebot/*"
+      ],
+      "groupName": "Third-party CI actions"
+    },
+    // Group web markdown renderers. react-markdown + remark-gfm are
+    // typically co-versioned and the rendering surface is the same
+    // (XSS-relevant per the audit doc -- see docs/dev/security-testing.md
+    // dependency auto-merge coverage table).
+    {
+      "description": "Group web markdown renderers",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "react-markdown",
+        "remark-gfm",
+        "remark-*",
+        "rehype-*"
+      ],
+      "groupName": "Web markdown renderers"
+    },
+    // Group Python data-source SDKs. These vendor-API clients are
+    // unrelated codebases but share the same risk profile (read-only
+    // vendor data; covered by api=true SAST/DAST per the audit doc).
+    // Bundling reduces dashboard noise without coupling unrelated
+    // upgrade decisions, since each row in the bundle is reviewed
+    // independently in the same PR.
+    //
+    // Rule order is load-bearing: this rule MUST stay below the
+    // "Python dependencies" catch-all (matchManagers: pep621) above.
+    // Renovate uses last-rule-wins on groupName -- if this rule moves
+    // above, these SDKs would be re-absorbed into "Python dependencies".
+    {
+      "description": "Group Python data-source SDKs",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": [
+        "pydexcom",
+        "tconnectsync",
+        "apscheduler",
+        "fastembed"
+      ],
+      "groupName": "Python data-source SDKs"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Phase 4 of the Renovate auto-merge plan. Five new `packageRules` with `groupName` so the dependency dashboard collapses individual PRs into family-bundled PRs.

| Group | Manager | Packages |
|---|---|---|
| GitHub Actions | github-actions | `actions/*` |
| Docker Actions | github-actions | `docker/*` |
| Third-party CI actions | github-actions | `gradle/*`, `dorny/*`, `astral-sh/*`, `googleapis/*`, `renovatebot/*` |
| Web markdown renderers | npm | `react-markdown`, `remark-gfm`, `remark-*`, `rehype-*` |
| Python data-source SDKs | pep621 | `pydexcom`, `tconnectsync`, `apscheduler`, `fastembed` |

The rules only set `groupName` -- auto-merge / major-update behavior inherits from the existing wildcard rules (last-wins per field). Manager scoping prevents cross-manager collisions.

## Adversarial review fixes applied before push

- **MEDIUM**: `reviewdog/*` was originally in the third-party CI group but no workflow uses it. Removed as dead config that would rot.
- **MEDIUM**: The Python data-source SDKs rule order is load-bearing -- it must stay below the \"Python dependencies\" catch-all so it isn't re-absorbed by last-rule-wins on groupName. Inline comment added so a future reorder doesn't break this silently.

## What did NOT change

- Auto-merge tier definitions (Phase 5)
- Per-tier scheduling (intentionally deferred -- can revisit if dashboard cadence feels wrong in practice)
- Existing groups (TypeScript types, ESLint, Testing libraries, AGP+Wrapper, AndroidX Hilt/Core+Compose/Room/WearOS) remain unchanged

## Test plan

- [x] `renovate-config-validator`: \"Config validated successfully\"
- [x] All package patterns verified against the actual workflow files and dep manifests; no coverage holes among current consumers.
- [x] No cross-manager collisions (github-actions vs gradle vs npm vs pep621 are disjoint package universes).
- [x] No secret patterns in the diff.
- [ ] Once merged, observe the next Renovate run -- dashboard should collapse the 9 individual `actions/*` items, 5 individual `docker/*` items, etc. into the new groups.

## Follow-ups

- Per-tier scheduling (Tier A daily, Tier C/D Monday-only) was in the original Phase 4 plan but is deferred -- the global schedule + the existing `lockFileMaintenance` Monday schedule already do most of what we need.
- Phase 5 (auto-merge enable) is next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update organization through enhanced grouping rules that consolidate updates for GitHub Actions, Docker container actions, CI automation tools, web markdown rendering packages, and Python data-source SDKs. This enables more efficient development workflows, streamlined pull requests, and better tracking of related dependency changes across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->