### PR TITLE
ci: phase 5 -- enable Renovate auto-merge via label-driven workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -104,36 +104,130 @@
   ],
   // Package rules
   "packageRules": [
-    // Auto-merge patch and minor updates into develop via PR.
-    // Branch protection requires PRs, so automergeType must be "pr".
-    // develop is the testing ground -- we verify before promoting to main.
+    // ====================================================================
+    // Auto-merge contract -- the per-category rationale lives in the
+    // "Dependency Auto-Merge Coverage" section of docs/dev/security-testing.md
+    // (currently in PR #540, not yet on develop -- the contract is
+    // expected to land before this PR is enabled in production).
+    //
+    // Renovate adds the "automerge" label to PRs that match a tier rule
+    // below. The .github/workflows/auto-merge-renovate.yml workflow reads
+    // the label and uses glycemicgpt-merge (a bypass actor on develop) to
+    // call `gh pr merge --auto --squash`. Required status checks still
+    // gate the actual merge -- the bypass only skips the CODEOWNERS
+    // approval requirement, not the security/test gates.
+    //
+    // Default-deny: a PR without the "automerge" label sits for human
+    // review. The tier rules below are the explicit allow-list.
+    // ====================================================================
+
+    // Tier A -- always auto-merge (digest pins, lockfile maintenance).
+    // Behavior change is bounded by what already passed the full
+    // required-check suite.
+    //
+    // CRITICAL: Tier A digest does NOT include github-actions. Renovate's
+    // pinGitHubActionDigests preset emits a `digest` updateType when a
+    // tag is re-pointed upstream. The tj-actions/changed-files and
+    // reviewdog 2025 incidents were exactly tag-re-pointing attacks --
+    // auto-merging those digest PRs would defeat the SHA-pinning
+    // defense. github-actions stays Tier D (manual) until the
+    // Workflow Lint Gate is tightened (#542).
     {
-      "description": "Auto-merge patch and minor updates",
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "pr",
-      "matchPackageNames": ["*"]
-    },
-    // Auto-merge digest updates (container images)
-    {
-      "description": "Auto-merge digest updates",
+      "description": "Tier A: auto-merge label for container/lockfile/regex digests",
+      "matchManagers": ["docker-compose", "dockerfile", "regex"],
       "matchUpdateTypes": ["digest"],
-      "automerge": true,
-      "automergeType": "pr"
+      "addLabels": ["automerge"]
     },
-    // Auto-merge lockfile maintenance
     {
-      "description": "Auto-merge lockfile maintenance",
+      "description": "Tier A: auto-merge label for lockfile maintenance",
       "matchUpdateTypes": ["lockFileMaintenance"],
-      "automerge": true,
-      "automergeType": "pr"
+      "addLabels": ["automerge"]
     },
-    // Require manual review for major updates (can be breaking)
+
+    // Tier B -- auto-merge label for patch+minor across covered managers.
+    // Excludes github-actions (until the Workflow Lint Gate is tightened
+    // from advisory to required -- tracked in #542). Excludes regex
+    // manager (vendored Swagger/Redoc -- patch only, separate rule below).
     {
-      "description": "Require manual review for major updates",
+      "description": "Tier B: auto-merge label for platform deps patch+minor",
+      "matchManagers": [
+        "pep621",
+        "npm",
+        "gradle",
+        "gradle-wrapper",
+        "docker-compose",
+        "dockerfile"
+      ],
+      "matchUpdateTypes": ["patch", "minor"],
+      "addLabels": ["automerge"]
+    },
+
+    // Tier B (regex) -- vendored Swagger/Redoc patch only. Renovate
+    // already requires the SHA-256 hash to be refreshed in the same PR.
+    {
+      "description": "Tier B: auto-merge label for vendored docs (regex manager)",
+      "matchManagers": ["regex"],
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["automerge"]
+    },
+
+    // Tier C override -- web markdown renderer minors require human
+    // review (XSS-relevant per the audit doc). Patches still auto-merge
+    // because the broader npm rule above matches them. This rule uses
+    // `labels:` (replaces) instead of `addLabels:` (accumulates) to
+    // strip any "automerge" label set by an earlier rule.
+    {
+      "description": "Tier C override: web markdown renderer minors stay manual; patches still auto-merge via Tier B",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "react-markdown",
+        "remark-gfm",
+        "remark-*",
+        "rehype-*"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "labels": ["dependencies", "needs-review"]
+    },
+
+    // Tier D -- major version bumps always manual (can be breaking).
+    // Uses labels: (replaces) so the "automerge" label from earlier
+    // rules is stripped. Major bumps are matched by matchUpdateTypes
+    // separately from the patch+minor rules above, so this only
+    // applies to major-typed PRs.
+    {
+      "description": "Tier D: major updates always manual",
       "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "labels": ["dependencies", "major"]
+      "labels": ["dependencies", "major", "needs-review"]
+    },
+
+    // Tier D override -- mobile crypto stays manual on every update
+    // type until a SQLCipher round-trip + EncryptedSharedPreferences
+    // contract test lands (audit doc gap). Two rules so the
+    // "security-sensitive" label survives major bumps too -- placed
+    // AFTER the major rule above so last-wins on labels keeps the
+    // security-sensitive flag visible in either case. labels: replaces,
+    // which is what strips any "automerge" label set by Tier B.
+    {
+      "description": "Tier D override: mobile crypto patch+minor (no auto-merge until SQLCipher round-trip test)",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": [
+        "org.bouncycastle:bcprov-jdk18on",
+        "net.zetetic:sqlcipher-android",
+        "androidx.security:security-crypto"
+      ],
+      "matchUpdateTypes": ["patch", "minor"],
+      "labels": ["dependencies", "needs-review", "security-sensitive"]
+    },
+    {
+      "description": "Tier D override: mobile crypto major (preserves security-sensitive flag)",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": [
+        "org.bouncycastle:bcprov-jdk18on",
+        "net.zetetic:sqlcipher-android",
+        "androidx.security:security-crypto"
+      ],
+      "matchUpdateTypes": ["major"],
+      "labels": ["dependencies", "major", "needs-review", "security-sensitive"]
     },
     // Group Python dependencies
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -164,9 +164,18 @@
 
     // Tier B (regex) -- vendored Swagger/Redoc patch only. Renovate
     // already requires the SHA-256 hash to be refreshed in the same PR.
+    //
+    // CRITICAL: matchPackageNames scopes this to ONLY swagger-ui-dist
+    // and redoc. The regex manager also covers the `go install` version
+    // pin manager (in customManagers above) which catches CI security
+    // tools like osv-scanner and nuclei. Those should NOT auto-merge
+    // silently because they run with full repo access during CI -- a
+    // compromised tool version would have a much larger blast radius
+    // than a vendored frontend doc viewer.
     {
-      "description": "Tier B: auto-merge label for vendored docs (regex manager)",
+      "description": "Tier B: auto-merge label for vendored docs (regex manager, scoped)",
       "matchManagers": ["regex"],
+      "matchPackageNames": ["swagger-ui-dist", "redoc"],
       "matchUpdateTypes": ["patch"],
       "addLabels": ["automerge"]
     },

--- a/.github/workflows/auto-merge-renovate.yml
+++ b/.github/workflows/auto-merge-renovate.yml
@@ -17,8 +17,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
-permissions:
-  contents: read
+# Empty permissions -- this job uses glycemicgpt-merge's app token for
+# the merge call; GITHUB_TOKEN is never used and there is no checkout.
+permissions: {}
 
 concurrency:
   # One auto-merge attempt per PR at a time. Auto-merge state is
@@ -58,6 +59,11 @@ jobs:
         # against the new HEAD before merging.
         env:
           GH_TOKEN: ${{ steps.merge-token.outputs.token }}
+          # GH_REPO is required because this workflow does not check
+          # out the repo (no git context for `gh` to infer from).
+          # Without GH_REPO, `gh pr merge` errors with "no GitHub repo
+          # selected" -- and the auto-merge silently never fires.
+          GH_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           gh pr merge --auto --squash "$PR"

--- a/.github/workflows/auto-merge-renovate.yml
+++ b/.github/workflows/auto-merge-renovate.yml
@@ -51,6 +51,43 @@ jobs:
           app-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
 
+      - name: Verify Renovate PR only touches dep-manifest files
+        # Defense in depth against a compromised Renovate App. The hard
+        # `if:` above guarantees the PR was opened by Renovate, but does
+        # not constrain WHAT Renovate could have put in the PR. A
+        # compromised Renovate could in principle slip arbitrary code or
+        # workflow changes alongside a "dep bump" -- the bot-author
+        # check would still pass.
+        #
+        # This step refuses to auto-merge when the PR touches any file
+        # outside the allowlist of paths Renovate is legitimately
+        # supposed to modify (lockfiles, manifests, Dockerfiles,
+        # workflow `uses:` pins, etc.). Anything else falls through to
+        # human review.
+        #
+        # If Renovate ever needs to touch a path not listed here (e.g.,
+        # a new ecosystem with a new lockfile location), extend the
+        # allowlist in the same PR that adds the manager to
+        # .github/renovate.json5.
+        env:
+          GH_TOKEN: ${{ steps.merge-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          ALLOWED='^(apps/api/(uv\.lock|pyproject\.toml)|apps/web/package(-lock)?\.json|sidecar/package(-lock)?\.json|apps/mobile/(gradle/(libs\.versions\.toml|wrapper/gradle-wrapper\.properties)|.*build\.gradle\.kts)|plugins/.*build\.gradle\.kts|scripts/security/requirements\.txt|.*[Dd]ockerfile.*|docker-compose.*\.ya?ml|\.github/workflows/.*\.ya?ml|osv-scanner\.toml|\.github/renovate\.json5)$'
+          UNEXPECTED=$(gh pr diff "$PR" --name-only | grep -vE "$ALLOWED" || true)
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Renovate PR touches files outside the dep-manifest allowlist; refusing to auto-merge"
+            echo "Unexpected files:"
+            echo "$UNEXPECTED" | sed 's/^/  - /'
+            echo ""
+            echo "If this is a legitimate Renovate pattern not covered by the"
+            echo "allowlist, extend the ALLOWED regex in this workflow."
+            echo "Otherwise, treat this PR as suspicious and review manually."
+            exit 1
+          fi
+          echo "::notice::all changed files are within the Renovate dep-manifest allowlist"
+
       - name: Enable auto-merge
         # `--auto` queues the merge; GitHub waits for required status
         # checks to pass before processing. If checks fail, the PR

--- a/.github/workflows/auto-merge-renovate.yml
+++ b/.github/workflows/auto-merge-renovate.yml
@@ -1,0 +1,64 @@
+name: Auto-merge Renovate PRs
+
+# Reads the "automerge" label set by Renovate (per the tier rules in
+# .github/renovate.json5) and enables GitHub auto-merge using
+# glycemicgpt-merge -- a bypass actor on develop's ruleset. Required
+# status checks still gate the actual merge; the bypass only skips
+# the CODEOWNERS approval requirement.
+#
+# See docs/dev/security-testing.md "Dependency Auto-Merge Coverage"
+# for the contract this enforces.
+
+on:
+  # Note: `labeled` is intentionally NOT included. Renovate sets the
+  # "automerge" label at PR creation time (captured by `opened`), so
+  # `labeled` is unnecessary -- and it would let any user with triage
+  # permission bypass the review gate by labeling a Renovate PR.
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  # One auto-merge attempt per PR at a time. Auto-merge state is
+  # idempotent (re-enabling is a no-op), so let in-flight runs finish
+  # rather than cancelling them mid-execution.
+  group: auto-merge-renovate-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for Renovate PR
+    # Hard guards:
+    #   1. PR author is glycemicgpt-renovate (cannot be impersonated).
+    #   2. PR carries the automerge label (set by Renovate's tier rules).
+    #   3. PR targets develop -- glycemicgpt-merge is also a bypass actor
+    #      on main, so this guard prevents an accidental main-target
+    #      auto-merge if Renovate's baseBranches config ever changes.
+    if: |
+      github.event.pull_request.user.login == 'glycemicgpt-renovate[bot]'
+      && contains(github.event.pull_request.labels.*.name, 'automerge')
+      && github.event.pull_request.base.ref == 'develop'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Generate token for glycemicgpt-merge
+        id: merge-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge
+        # `--auto` queues the merge; GitHub waits for required status
+        # checks to pass before processing. If checks fail, the PR
+        # sits with auto-merge enabled but no merge fires. If new
+        # commits arrive on the PR branch, GitHub re-evaluates checks
+        # against the new HEAD before merging.
+        env:
+          GH_TOKEN: ${{ steps.merge-token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr merge --auto --squash "$PR"
+          echo "::notice::auto-merge enabled for PR #$PR"


### PR DESCRIPTION
## Summary

The actual auto-merge feature this whole multi-phase plan has been building toward. Two changes that operate together to auto-merge safe dependency updates while keeping risky categories manual.

## How it works

1. **`.github/renovate.json5`** -- replaced the existing `automerge: true` wildcard rules (which never actually fired because Renovate isn't a bypass actor on develop) with label-driven tier rules. Renovate adds the `automerge` label to PRs that match a tier rule.

2. **`.github/workflows/auto-merge-renovate.yml`** -- reads the label, mints `glycemicgpt-merge` token, calls `gh pr merge --auto --squash`. `glycemicgpt-merge` is a bypass actor on develop's ruleset so the merge bypasses CODEOWNERS approval. **Required status checks still gate the actual merge** -- `--auto` queues the merge to fire when checks pass; it does not bypass them.

## Tier matrix

| Tier | Trigger | Updates | Auto-merge label? |
|---|---|---|---|
| **A** | Container/lockfile/regex digests | digest | yes |
| **A** | Lockfile maintenance | lockFileMaintenance | yes |
| **B** | pep621, npm, gradle, gradle-wrapper, docker-compose, dockerfile | patch + minor | yes |
| **B regex** | Vendored Swagger/Redoc | patch | yes |
| **C override** | Web markdown renderers (`react-markdown`, `remark-gfm`, `remark-*`, `rehype-*`) | minor | **no** (patch still auto-merges via Tier B) |
| **D override** | Mobile crypto (`bouncycastle`, `sqlcipher-android`, `security-crypto`) | any | **no** |
| **D** | Any major bump | major | **no** |
| **(implicit) D** | github-actions (any update type) | any | **no** until #542 |

## Adversarial review fixes applied before push

- **HIGH**: Tier A originally auto-merged github-actions `digest` updates, which would have defeated the SHA-pinning supply-chain defense. Renovate's `pinGitHubActionDigests` preset emits a `digest` updateType when a tag is re-pointed upstream -- exactly the tj-actions/changed-files attack pattern. Tier A now scopes digest auto-merge to `docker-compose`, `dockerfile`, `regex` managers only.
- **MEDIUM**: Triage-permission users could label any Renovate PR `automerge` and bypass review via the `labeled` event trigger. Dropped `labeled` -- Renovate sets the label at PR creation, captured by `opened`.
- **MEDIUM**: Mobile crypto major bumps lost the `security-sensitive` label due to last-rule-wins on `labels:`. Split the override into per-update-type rules placed AFTER the major rule so the security flag survives across all update types.
- **MEDIUM**: Doc reference pointed at a section that lives in unmerged PR #540. Updated comment to be honest about that.
- **LOW**: Added `base.ref == 'develop'` guard as defense-in-depth against a future config change re-pointing Renovate at main.
- **LOW**: `concurrency.cancel-in-progress` flipped to `false` since auto-merge state is idempotent.

## Test plan

- [x] `renovate-config-validator`: Config validated successfully.
- [x] zizmor on `auto-merge-renovate.yml`: 0 findings.
- [x] All package coordinates verified against `apps/mobile/gradle/libs.versions.toml`.
- [x] PR author identifier verified against recent Renovate PRs (`glycemicgpt-renovate[bot]`).
- [x] `gh pr merge --squash` verified against develop ruleset's `allowed_merge_methods: [\"squash\"]`.
- [x] No secret patterns in the diff.
- [ ] Once merged, observe the next Renovate PR -- it should be auto-labeled per the tier rules.
- [ ] Once a labeled Renovate PR is observed, verify the auto-merge workflow fires on `opened`, succeeds in token generation, and `--auto` is registered.
- [ ] Verify that a PR which fails CI does NOT auto-merge (queued waits indefinitely).
- [ ] Verify that github-actions PRs (e.g., a future Renovate-driven action bump) do NOT get the automerge label.

## Dependencies

- PR #540 (audit doc) should ideally land before or alongside this PR, since the doc is the contract that justifies the tier rules. The contract is referenced in renovate.json5 comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored dependency update automation with a tiered labeling system to provide granular control over auto-merge behavior for different update types and risk levels.
  * Added automated merge workflow that routes dependency updates based on labels while integrating with required status checks to ensure code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->