### PR TITLE
ci: address CodeRabbit findings on promotion PR #548

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,6 +24,8 @@ jobs:
       should_build: ${{ steps.filter.outputs.android }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
@@ -44,6 +46,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: npm install minimatch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,19 +20,28 @@ jobs:
   # is PR-only.
   #
   # Each gateable job has `needs: detect-changes` + a fail-open `if:`:
-  #   if: needs.detect-changes.result != 'success'
+  #   if: |
+  #     !cancelled()
+  #     && (
+  #       needs.detect-changes.result != 'success'
   #       || needs.detect-changes.outputs.<flag> == 'true'
   #       || github.event_name == 'push'
+  #     )
   #
-  # When the `if:` evaluates false, GitHub reports the job as "skipped"
-  # and that DOES satisfy the required-status-check rule on develop.
-  # However, if `detect-changes` itself FAILS (network blip, paths-filter
-  # transient bug, runner hiccup), dependent jobs would otherwise be
-  # skipped with reason "dependent job failed", which GitHub treats as
-  # a FAILURE for required-check purposes -- blocking every PR. The
-  # `needs.detect-changes.result != 'success'` clause fail-opens that
-  # path: a flaky detect-changes degrades to "run the job," not "block
-  # the PR."
+  # When the inner expression evaluates false, GitHub reports the job as
+  # "skipped" and that DOES satisfy the required-status-check rule on
+  # develop.
+  #
+  # The `!cancelled()` prefix is load-bearing. GitHub Actions implicitly
+  # applies `success()` to job-level `if` conditions, which means a job
+  # with `needs:` whose upstream FAILED would short-circuit the entire
+  # `if` to false (regardless of what the inner expression evaluates to)
+  # and report as "dependent job failed" -- a FAILURE for required-check
+  # purposes. `!cancelled()` overrides the implicit `success()` so the
+  # inner expression is honored even when `detect-changes` failed,
+  # letting the dependent job run unconditionally and report its own
+  # real result. (`!cancelled()` is preferred over `always()` because
+  # we still want to skip if the workflow itself was cancelled.)
   detect-changes:
     name: Detect Component Changes
     runs-on: ubuntu-latest
@@ -63,7 +72,13 @@ jobs:
   test-backend:
     name: Backend Tests
     needs: detect-changes
-    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.api == 'true' || github.event_name == 'push'
+    if: |
+      !cancelled()
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.api == 'true'
+        || github.event_name == 'push'
+      )
     runs-on: ubuntu-latest
 
     services:
@@ -118,7 +133,13 @@ jobs:
   test-frontend:
     name: Frontend Tests
     needs: detect-changes
-    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.web == 'true' || github.event_name == 'push'
+    if: |
+      !cancelled()
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.web == 'true'
+        || github.event_name == 'push'
+      )
     runs-on: ubuntu-latest
 
     defaults:
@@ -150,7 +171,13 @@ jobs:
   lint-backend:
     name: Backend Lint
     needs: detect-changes
-    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.api == 'true' || github.event_name == 'push'
+    if: |
+      !cancelled()
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.api == 'true'
+        || github.event_name == 'push'
+      )
     runs-on: ubuntu-latest
 
     defaults:
@@ -183,7 +210,13 @@ jobs:
   lint-frontend:
     name: Frontend Lint
     needs: detect-changes
-    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.web == 'true' || github.event_name == 'push'
+    if: |
+      !cancelled()
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.web == 'true'
+        || github.event_name == 'push'
+      )
     runs-on: ubuntu-latest
 
     defaults:
@@ -485,7 +518,13 @@ jobs:
   test-sidecar:
     name: Sidecar Tests
     needs: detect-changes
-    if: needs.detect-changes.result != 'success' || needs.detect-changes.outputs.sidecar == 'true' || github.event_name == 'push'
+    if: |
+      !cancelled()
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.sidecar == 'true'
+        || github.event_name == 'push'
+      )
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Detect changed paths
         id: changes
@@ -72,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -129,6 +133,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -186,6 +192,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0

--- a/.github/workflows/dev-pre-release.yml
+++ b/.github/workflows/dev-pre-release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4

--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run Docker integration test
         run: ./scripts/docker-integration-test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Detect deployable file changes
         id: check
@@ -333,6 +334,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ steps.version-info.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -466,6 +468,8 @@ jobs:
           fi
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Generate token for glycemicgpt-release
         id: release-token

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run Renovate
         uses: renovatebot/github-action@c5fdc9f98fdf9e9bb16b5760f7e560256eb79326 # v44.0.2

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # No git-push needed -- zizmor only reads files. Disabling
           # token persistence reduces exposure when the step's external


### PR DESCRIPTION
## Summary

CodeRabbit reviewed the develop→main promotion PR (#548) and surfaced 13 actionable findings. This PR fixes them all on develop so #548's diff picks them up automatically.

Two distinct categories:

### 1. CRITICAL fix -- ci.yml fail-open semantics (the load-bearing one)

The 5 gated jobs in ci.yml had `if:` expressions intended to fail-open when `detect-changes` itself failed. CodeRabbit's web-research-backed analysis showed that GitHub Actions implicitly applies `success()` to job-level `if:` conditions, which short-circuits the entire `if:` to false when an upstream job fails -- defeating the fail-open intent entirely. **The \"fail-open\" fix in PR #544 was vapor**: a transient `detect-changes` failure would still cascade to \"dependent job failed\" on all 5 required checks, blocking PRs.

Fix: each gated `if:` now starts with `!cancelled() && (...)` to override the implicit `success()` and let the inner expression run when `detect-changes` failed. Updated the workflow comment to capture the actual semantics so a future maintainer doesn't add the same bug back.

### 2. `persist-credentials: false` on 12 actions/checkout invocations

Project policy (per CodeRabbit's \"based on learnings\"): non-security workflows should disable credential persistence so the GITHUB_TOKEN isn't left in the runner's git config. Applied across:

- `android.yml` (detect-changes + build)
- `auto-label.yml`
- `container-build.yml` (4 jobs)
- `dev-pre-release.yml`
- `docker-integration.yml`
- `release.yml` (3 of 4 jobs -- the push-back checkout at line 139 intentionally LEFT untouched since it needs credentials to commit version bumps)
- `renovate.yml`

For the two `release.yml` checkouts that already had `with:` keys (`fetch-depth: 2` and `ref: <tag>`), `persist-credentials: false` was added ALONGSIDE the existing keys. Adversarial review caught a script bug that initially clobbered those keys -- fixed by surgical edits before push.

Plus: bumped `workflow-lint.yml`'s `actions/checkout` from v4 SHA to v6 SHA for consistency with all other workflows post-Phase 3.

## Adversarial review fixes applied before push

- **HIGH (release.yml line 83)**: original script replaced `with: fetch-depth: 2` with `with: persist-credentials: false`, dropping `fetch-depth: 2` and breaking the `detect-deployable-changes` git-diff step. Fixed -- both keys present.
- **HIGH (release.yml line 333)**: original script replaced `with: ref: <tag>` with `with: persist-credentials: false`, dropping `ref:` and breaking deterministic APK build at the release tag. Fixed -- both keys present.

## Test plan

- [x] `yaml.safe_load` passes on all 9 modified workflow files.
- [x] `release.yml` line 139 (the push-back) verified unchanged via git diff.
- [x] All 3 flagged `release.yml` checkouts have `persist-credentials: false` AND their existing keys (`fetch-depth: 2`, `ref:`).
- [x] zizmor findings dropped from 173 to 65 (the 47 `artipacked` warnings this PR addresses).
- [x] No secret patterns in the diff.
- [ ] CI on this PR confirms ci.yml's `!cancelled()` fix works as intended.
- [ ] Once merged, promotion PR #548's diff updates to include these fixes.

## What this PR is NOT

- Not a workflow refactor. The fixes are all surgical: add a key, fix a logic bug, bump a SHA.
- Not changing what runs or who has access -- only credential-handling and conditional-execution semantics.