### PR TITLE
fix(ci): switch container cleanup to tag-aware action (re #550)

### DIFF
--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -31,22 +31,25 @@ permissions:
 
 jobs:
   cleanup:
-    name: Cleanup ${{ matrix.package }}
+    name: Cleanup container packages
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - glycemicgpt-api
-          - glycemicgpt-web
-          - glycemicgpt-sidecar
+    # Belt-and-suspenders against accidental concurrent runs (e.g. a manual
+    # workflow_dispatch firing while the weekly schedule is mid-run). The
+    # upstream action is not designed for concurrent execution.
+    concurrency:
+      group: container-cleanup
+      cancel-in-progress: false
     steps:
-      - name: Cleanup ${{ matrix.package }}
+      - name: Cleanup container packages
+        # Action supports a comma-separated package list (v1.0.12+) and
+        # processes them sequentially in a single run, which is the upstream
+        # author's recommended pattern. A matrix here would parallelize
+        # cleanup jobs and is explicitly discouraged.
         uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ github.repository_owner }}
-          package: ${{ matrix.package }}
+          packages: glycemicgpt-api,glycemicgpt-web,glycemicgpt-sidecar
           # Preserve every tag we publish. Wildcard syntax is built-in.
           # Patterns covered:
           #   latest                  - rolling pointer to most recent stable release

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -1,55 +1,75 @@
 name: Cleanup Container Images
 
+# Removes stale untagged manifests from GHCR while preserving every tagged
+# release artifact (latest, dev, sha-<short>, semver tags).
+#
+# WHY NOT actions/delete-package-versions:
+# That action's `ignore-versions` regex is matched against the package
+# version's NAME field, which for container packages on GHCR is the SHA256
+# manifest digest -- not the tag. So a regex like `latest|0\.5\.0` never
+# matches anything (digests are sha256:... strings) and tagged versions get
+# culled by the date-based `min-versions-to-keep` cutoff. This was the
+# root cause of issue #550 ("no latest tag").
+#
+# dataaxiom/ghcr-cleanup-action operates on tags via wildcard/regex and
+# is multi-platform-aware (it reads manifest lists and preserves all
+# referenced platform sub-manifests automatically), so we can safely
+# delete untagged orphans without breaking arm64/amd64 fan-out.
+
 on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (log what would be deleted, change nothing)'
+        type: boolean
+        default: true
 
 permissions:
   packages: write
 
 jobs:
-  cleanup-api:
-    name: Cleanup API Images
+  cleanup:
+    name: Cleanup ${{ matrix.package }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - glycemicgpt-api
+          - glycemicgpt-web
+          - glycemicgpt-sidecar
     steps:
-      - name: Delete old API image versions
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
+      - name: Cleanup ${{ matrix.package }}
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          package-name: glycemicgpt-api
-          package-type: container
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: false
-          ignore-versions: '^(latest|dev|sha-.*|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
-
-  cleanup-web:
-    name: Cleanup Web Images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete old Web image versions
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
-        with:
-          package-name: glycemicgpt-web
-          package-type: container
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: false
-          ignore-versions: '^(latest|dev|sha-.*|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
-
-  cleanup-sidecar:
-    name: Cleanup Sidecar Images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete old Sidecar image versions
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
-        with:
-          package-name: glycemicgpt-sidecar
-          package-type: container
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: false
-          ignore-versions: '^(latest|dev|sha-.*|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'
-
-  # NOTE: Do NOT add a "cleanup untagged versions" job here.
-  # Multi-platform images (linux/amd64 + linux/arm64) store platform-specific
-  # manifests as UNTAGGED sub-versions in GHCR. Deleting these breaks all
-  # tagged images because the manifest list points to deleted content.
-  # The tagged cleanup above (min-versions-to-keep: 10) is sufficient.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: ${{ github.repository_owner }}
+          package: ${{ matrix.package }}
+          # Preserve every tag we publish. Wildcard syntax is built-in.
+          # Patterns covered:
+          #   latest                  - rolling pointer to most recent stable release
+          #   dev                     - rolling pointer to latest develop build
+          #   sha-*                   - per-commit immutable tags
+          #   <major>.<minor>.<patch> - stable semver release tags (e.g. 0.5.0)
+          #   <major>.<minor>         - minor-line floating tags (e.g. 0.5)
+          exclude-tags: latest,dev,sha-*,*.*.*,*.*
+          # Of versions matching the above patterns, keep all (no upper bound).
+          # GHCR storage is free for public repos so we don't trade safety for space.
+          # Untagged sub-manifests of those tagged versions are kept automatically
+          # via the action's manifest-list awareness.
+          keep-n-tagged: 100
+          # Cap orphaned untagged manifests (build attestations etc. that no
+          # tagged version references) to a reasonable history.
+          keep-n-untagged: 20
+          # Only touch images older than 14 days so an in-flight build/release
+          # is never disturbed.
+          older-than: 14 days
+          # Validate every multi-architecture manifest after cleanup -- fails
+          # the run if any tagged image is missing a referenced platform layer.
+          validate: true
+          # workflow_dispatch defaults to dry_run=true so first manual run is
+          # observation only; scheduled runs have no input so dry_run resolves
+          # to false and the action actually deletes.
+          dry-run: ${{ github.event.inputs.dry_run || 'false' }}


### PR DESCRIPTION
## Summary

Replaces the broken `actions/delete-package-versions`-based cleanup with `dataaxiom/ghcr-cleanup-action`, which filters by actual tag names instead of by GHCR's internal version-name field (SHA digest). The previous setup could not preserve specific tags by intent — it preserved them only when their manifests happened to be in the most recent N by date, and any release older than the last few develop builds got culled.

## Root cause analysis (re: #550)

Investigation of issue #550:

1. v0.5.0 release on 2026-04-30 successfully pushed `0.5.0`, `0.5`, `latest`, `sha-7402486` (verified in build logs)
2. Weekly cleanup ran 2026-05-03 with `actions/delete-package-versions` and `ignore-versions: '^(latest|dev|sha-.*|\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+)$'`
3. That regex was matched against `version.name` — for GHCR container packages, that's the SHA256 manifest digest (`sha256:...`), not the tag
4. Regex never matched anything; only `min-versions-to-keep: 10` was effectively in force
5. The v0.5.0 manifest was older than several recent develop builds, so it fell off the keep list — taking `latest`, `0.5.0`, and `0.5` tags with it

I traced this in [`actions/delete-package-versions/src/delete.ts`](https://github.com/actions/delete-package-versions/blob/main/src/delete.ts) and confirmed via direct GHCR API inspection of our package versions.

## What changed

| | Before | After |
|---|---|---|
| Action | `actions/delete-package-versions` | `dataaxiom/ghcr-cleanup-action` |
| Filtering | Regex on digest (broken) | Wildcard on actual tag names |
| Multi-arch awareness | Manual ("don't delete untagged" comment) | Built-in (reads manifest lists) |
| Validation | None | Post-cleanup multi-arch verification |
| Dry-run | None | Default for manual invocations |
| Time window | Unbounded | `older-than: 14 days` |

## What this PR does NOT do

It does **not** republish the missing `:latest` tag on the current registry. After this PR merges, `:latest` will reappear on the next:

- Stable release (release-please publishes a tag → `container-build.yml` fires)
- Manual `workflow_dispatch` on `container-build.yml` against main

Either is fine — recommend a manual dispatch right after this merges so users can `docker pull ghcr.io/glycemicgpt/glycemicgpt-api:latest` immediately.

## Authentication note

I explored using the `glycemicgpt-ci` GitHub App for branding consistency. **GitHub Apps cannot manage GHCR packages** — the Packages API rejects app installation tokens (well-documented platform limitation, ref [community discussion #26920](https://github.com/orgs/community/discussions/26920)). Workflow keeps `secrets.GITHUB_TOKEN` (same as `container-build.yml`), which means audit logs show `github-actions[bot]` for both build and cleanup — at least consistent.

## Test plan

- [ ] CI passes
- [ ] Manually dispatch the cleanup workflow with `dry_run: true` (default) and confirm log output reports zero unexpected deletions on `glycemicgpt-api`, `-web`, `-sidecar`
- [ ] After verified safe, run `workflow_dispatch` with `dry_run: false` to actually clean any untagged orphans
- [ ] After cleanup is verified correct, manually dispatch `container-build.yml` against main to republish `:latest` for v0.5.0
- [ ] Verify `docker pull ghcr.io/glycemicgpt/glycemicgpt-api:latest` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Optimized the container cleanup workflow with enhanced configuration options
* Added a dry-run parameter to safely test cleanup operations before execution
* Improved cleanup logic with more granular control over package retention

<!-- end of auto-generated comment: release notes by coderabbit.ai -->