### PR TITLE
fix(mobile): serialize token refresh under a single mutex (closes #520)

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -105,6 +105,15 @@ android {
             excludes += "/META-INF/versions/9/OSGI-INF/MANIFEST.MF"
         }
     }
+
+    testOptions {
+        unitTests.all {
+            // Default Android test JVM heap (512MB) is too small for our
+            // mockk-based tests; relaxed mocks of large interfaces and
+            // coroutine-aware tests accumulate enough heap pressure to OOM.
+            it.maxHeapSize = "2g"
+        }
+    }
 }
 
 ksp {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
@@ -3,6 +3,7 @@ package com.glycemicgpt.mobile.data.auth
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.remote.dto.LoginResponse
 import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
+import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -26,16 +27,20 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Manages authentication state and proactive token refresh.
+ * Manages authentication state and refresh-token rotation.
+ *
+ * Single source of truth for the refresh-token mutex: both the proactive
+ * timer and the reactive 401 interceptor route through the same lock here.
+ * Without that, the two paths could rotate the token concurrently, leaving
+ * any in-flight requests holding a now-twice-stale refresh token, which
+ * the server's replay detector then rejects (issue #520).
  *
  * Responsibilities:
  * - Exposes observable [AuthState] via [authState]
  * - Validates tokens on startup
- * - Proactively refreshes access tokens before expiry
+ * - Proactively refreshes access tokens before expiry ([performRefresh])
+ * - Refreshes on demand from the 401 interceptor ([refreshForInterceptor])
  * - Handles refresh failures gracefully (emits [AuthState.Expired])
- *
- * Thread safety: [performRefresh] is protected by a [Mutex] to prevent
- * concurrent refresh attempts (e.g., proactive timer + interceptor 401).
  */
 @Singleton
 class AuthManager @Inject constructor(
@@ -49,11 +54,33 @@ class AuthManager @Inject constructor(
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unauthenticated)
     val authState: StateFlow<AuthState> = _authState.asStateFlow()
 
+    // Volatile because refreshJob is mutated under refreshMutex by the
+    // refresh paths (scheduleProactiveRefresh) but read without the mutex
+    // by onLogout / onRefreshFailed (UI thread). Without @Volatile a stale
+    // read could miss cancelling the live job.
+    @Volatile
     private var refreshJob: Job? = null
     private val refreshMutex = Mutex()
     /** Retained scope for scheduling proactive refreshes from non-coroutine contexts. */
     @Volatile
     private var retainedScope: CoroutineScope? = null
+
+    /** Outcome of a single refresh attempt under the mutex. */
+    private sealed class RefreshOutcome {
+        /** Token was rotated. */
+        data class Success(val accessToken: String) : RefreshOutcome()
+
+        /** Server rejected the refresh token (401/403) -- session is dead. */
+        object Expired : RefreshOutcome()
+
+        /** Server returned 5xx -- session preserved for retry. */
+        object ServerError : RefreshOutcome()
+
+        /** Network IO failure -- session preserved for retry, but treated as
+         *  a fatal "no token available" outcome on the proactive path when
+         *  there is no existing access token to fall back on. */
+        object NetworkFailure : RefreshOutcome()
+    }
 
     /**
      * Validates stored tokens on startup and schedules proactive refresh.
@@ -110,71 +137,185 @@ class AuthManager @Inject constructor(
     }
 
     /**
-     * Attempts to refresh the access token using the stored refresh token.
-     * Updates [authState] based on the result.
+     * Proactive refresh entry point (called from the timer). Updates
+     * [authState] based on the outcome and reschedules the proactive timer
+     * on success.
      *
-     * Protected by [refreshMutex] to prevent concurrent refresh attempts.
-     * Runs the blocking OkHttp call on [Dispatchers.IO].
+     * Serialized with [refreshForInterceptor] via [refreshMutex] so the
+     * timer and the 401 interceptor cannot rotate the refresh token in
+     * parallel.
      */
     suspend fun performRefresh(scope: CoroutineScope) {
         refreshMutex.withLock {
-            // Re-check after acquiring the lock -- another coroutine may have refreshed already
-            val existingToken = authTokenStore.getToken()
-            if (existingToken != null && _authState.value is AuthState.Authenticated) {
+            // Fast path: another caller already produced a valid access token
+            // and the auth state agrees (Authenticated). Nothing to do.
+            //
+            // The state check is load-bearing: scheduleProactiveRefresh runs
+            // a recursive timer that re-enters performRefresh, and after a
+            // transient 502/network failure we keep state=Authenticated with
+            // an old access token. Using only `getToken() != null` here
+            // would still let those recursive ticks bypass the fast path
+            // and re-attempt the refresh forever.
+            if (authTokenStore.getToken() != null && _authState.value is AuthState.Authenticated) {
                 return
             }
 
-            val refreshToken = authTokenStore.getRefreshToken()
-            if (refreshToken == null) {
+            // Distinguish "never logged in" (no refresh token at all) from
+            // "session was rejected" (server returned 401/403). The former
+            // is Unauthenticated, the latter is Expired -- they trigger
+            // different UI flows.
+            if (authTokenStore.getRefreshToken() == null) {
                 _authState.value = AuthState.Unauthenticated
                 return
             }
 
-            if (authTokenStore.isRefreshTokenExpired()) {
-                Timber.w("Refresh token expired, cannot refresh")
-                _authState.value = AuthState.Expired()
-                return
-            }
-
-            val baseUrl = authTokenStore.getBaseUrl()
-            if (baseUrl.isNullOrBlank()) {
-                Timber.w("No base URL configured, cannot refresh")
-                _authState.value = AuthState.Expired()
-                return
-            }
-
             _authState.value = AuthState.Refreshing
-
-            try {
-                val body = RefreshTokenRequest(refreshToken = refreshToken)
-                val adapter = moshi.adapter(RefreshTokenRequest::class.java)
-                val json = adapter.toJson(body)
-
-                val request = Request.Builder()
-                    .url("http://localhost/api/auth/mobile/refresh")
-                    .post(json.toRequestBody("application/json".toMediaType()))
-                    .build()
-
-                val response = withContext(ioDispatcher) {
-                    refreshClientProvider.refreshClient.newCall(request).execute()
+            when (val outcome = refreshUnderLock()) {
+                is RefreshOutcome.Success -> {
+                    _authState.value = AuthState.Authenticated
+                    scheduleProactiveRefresh(scope)
                 }
+                is RefreshOutcome.Expired -> {
+                    authTokenStore.clearToken()
+                    onRefreshFailedLocked()
+                }
+                is RefreshOutcome.ServerError -> {
+                    // 5xx response -- preserve tokens for retry. If we have a
+                    // (possibly expired) access token we can show stale data
+                    // and schedule proactive retry. If we don't, leave state
+                    // as Refreshing so performRefreshWithRetry attempts again.
+                    val raw = authTokenStore.getRawToken()
+                    if (raw != null) {
+                        _authState.value = AuthState.Authenticated
+                        scheduleProactiveRefresh(scope)
+                    }
+                }
+                is RefreshOutcome.NetworkFailure -> {
+                    // Network IO error. Same fall-back as ServerError when we
+                    // have a stored access token. Without one we treat the
+                    // session as dead, matching prior behavior.
+                    val raw = authTokenStore.getRawToken()
+                    if (raw != null) {
+                        _authState.value = AuthState.Authenticated
+                        scheduleProactiveRefresh(scope)
+                    } else {
+                        _authState.value = AuthState.Expired()
+                    }
+                }
+            }
+        }
+    }
 
-                response.use { resp ->
-                    if (resp.isSuccessful) {
+    /**
+     * Reactive refresh entry point (called from [com.glycemicgpt.mobile.data.remote.TokenRefreshInterceptor]
+     * when a request gets a 401). Returns the access token to retry with,
+     * or null if the session is dead or the refresh failed transiently.
+     *
+     * Serialized with [performRefresh] via [refreshMutex]: any concurrent
+     * 401s queue here, the first one performs the refresh, and every other
+     * caller picks up the freshly-stored access token via the fast path.
+     * No caller ever sends a stale refresh token to the server.
+     *
+     * @param originalToken the access token from the request that got a 401
+     *   (i.e. the value of `Authorization: Bearer <originalToken>` on the
+     *   originating request, or null if no header was sent). Used to break
+     *   ties on the fast path: if the stored token is the same as the one
+     *   that just got rejected, refreshing is the only way forward (don't
+     *   loop on the rejected token).
+     */
+    suspend fun refreshForInterceptor(originalToken: String?): String? {
+        refreshMutex.withLock {
+            // Fast path: a valid access token is now stored AND it is not the
+            // same one that just got rejected. Retry with it.
+            //
+            // This is the bug fix for #520. The previous interceptor compared
+            // the original request's Authorization header with the stored
+            // token, but [AuthInterceptor] omits the header entirely when
+            // [AuthTokenStore.getToken] returns null (expired). With no
+            // header to compare, the old double-check always fell through
+            // to a fresh refresh, so every queued 401 in a burst rotated the
+            // token, replaying the previous one each time. The fix is to
+            // compare against `originalToken` (which is null when there was
+            // no header) rather than against `original.header(...)`.
+            //
+            // The "not equal to originalToken" guard prevents an infinite
+            // refresh loop when the server 401s a fresh token for a non-token
+            // reason (e.g. revoked session, IP-bound auth): we'd otherwise
+            // return the same token, retry, get another 401, return the same
+            // token again, ad infinitum.
+            authTokenStore.getToken()?.let { current ->
+                if (current != originalToken) return current
+            }
+
+            // No valid token stored, or stored token is the same one that
+            // just got rejected -- need to actually refresh.
+            return when (val outcome = refreshUnderLock()) {
+                is RefreshOutcome.Success -> {
+                    // Update state + reschedule proactive timer in-place so
+                    // we don't need a separate callback round-trip from the
+                    // interceptor.
+                    onInterceptorRefreshSuccessLocked()
+                    outcome.accessToken
+                }
+                is RefreshOutcome.Expired -> {
+                    authTokenStore.clearToken()
+                    onRefreshFailedLocked()
+                    null
+                }
+                // Transient failures (5xx, network) -- preserve session, hand
+                // the 401 back to the caller. Don't change auth state from
+                // here; the proactive timer will retry on its schedule. (The
+                // proactive performRefresh() schedules a fresh timer on
+                // transient failure, but the interceptor does not -- the
+                // interceptor is reactive, not periodic, so it has no
+                // schedule of its own to maintain.)
+                is RefreshOutcome.ServerError -> null
+                is RefreshOutcome.NetworkFailure -> null
+            }
+        }
+    }
+
+    /**
+     * Performs the actual refresh network call and persists the result.
+     * MUST be called with [refreshMutex] held.
+     */
+    private suspend fun refreshUnderLock(): RefreshOutcome {
+        val refreshToken = authTokenStore.getRefreshToken()
+            ?: return RefreshOutcome.Expired
+
+        if (authTokenStore.isRefreshTokenExpired()) {
+            Timber.w("Refresh token expired, cannot refresh")
+            return RefreshOutcome.Expired
+        }
+
+        val baseUrl = authTokenStore.getBaseUrl()
+        if (baseUrl.isNullOrBlank()) {
+            Timber.w("No base URL configured, cannot refresh")
+            return RefreshOutcome.Expired
+        }
+
+        return try {
+            val body = RefreshTokenRequest(refreshToken = refreshToken)
+            val adapter = moshi.adapter(RefreshTokenRequest::class.java)
+            val json = adapter.toJson(body)
+
+            val request = Request.Builder()
+                .url("http://localhost/api/auth/mobile/refresh")
+                .post(json.toRequestBody("application/json".toMediaType()))
+                .build()
+
+            val response = withContext(ioDispatcher) {
+                refreshClientProvider.refreshClient.newCall(request).execute()
+            }
+
+            response.use { resp ->
+                when {
+                    resp.isSuccessful -> {
                         val responseBody = resp.body?.string()
-                        if (responseBody == null) {
-                            Timber.w("Refresh response body is null")
-                            _authState.value = AuthState.Expired()
-                            return
-                        }
-
+                            ?: return@use RefreshOutcome.ServerError
                         val loginAdapter = moshi.adapter(LoginResponse::class.java)
                         val loginResponse = loginAdapter.fromJson(responseBody)
-                        if (loginResponse == null) {
-                            Timber.w("Failed to parse refresh response")
-                            _authState.value = AuthState.Expired()
-                            return
-                        }
+                            ?: return@use RefreshOutcome.ServerError
 
                         val expiresAtMs = System.currentTimeMillis() + (loginResponse.expiresIn * 1000L)
                         authTokenStore.saveCredentials(
@@ -184,43 +325,51 @@ class AuthManager @Inject constructor(
                             loginResponse.user.email,
                         )
                         authTokenStore.saveRefreshToken(loginResponse.refreshToken)
-
-                        Timber.d("Proactive token refresh succeeded")
-                        _authState.value = AuthState.Authenticated
-                        scheduleProactiveRefresh(scope)
-                    } else if (resp.code == 401 || resp.code == 403) {
+                        Timber.d("Token refreshed successfully")
+                        RefreshOutcome.Success(loginResponse.accessToken)
+                    }
+                    resp.code == 401 || resp.code == 403 -> {
                         // Definitive auth rejection -- refresh token is invalid/revoked
                         Timber.w("Token refresh rejected with HTTP ${resp.code}, clearing session")
-                        authTokenStore.clearToken()
-                        _authState.value = AuthState.Expired()
-                    } else {
-                        // Transient server error (5xx, etc.) -- preserve tokens for retry
+                        RefreshOutcome.Expired
+                    }
+                    else -> {
+                        // 5xx server error -- preserve tokens for retry
                         Timber.w("Token refresh got HTTP ${resp.code}, preserving session for retry")
-                        val currentToken = authTokenStore.getRawToken()
-                        if (currentToken != null) {
-                            // We still have a (possibly expired) access token -- mark authenticated
-                            // so the app can function, and schedule proactive retry
-                            _authState.value = AuthState.Authenticated
-                            scheduleProactiveRefresh(scope)
-                        }
-                        // If no access token, leave state as Refreshing so
-                        // performRefreshWithRetry can attempt again on startup
+                        RefreshOutcome.ServerError
                     }
                 }
-            } catch (e: CancellationException) {
-                throw e // Never swallow coroutine cancellation
-            } catch (e: Exception) {
-                Timber.w(e, "Proactive token refresh failed")
-                // Network error -- don't clear tokens, stay authenticated if we had a valid token
-                val currentToken = authTokenStore.getRawToken()
-                if (currentToken != null) {
-                    _authState.value = AuthState.Authenticated
-                    // Retry later
-                    scheduleProactiveRefresh(scope)
-                } else {
-                    _authState.value = AuthState.Expired()
-                }
             }
+        } catch (e: CancellationException) {
+            throw e // Never swallow coroutine cancellation
+        } catch (e: java.io.IOException) {
+            Timber.w(e, "Token refresh failed due to network error, preserving session")
+            RefreshOutcome.NetworkFailure
+        } catch (e: JsonDataException) {
+            Timber.w(e, "Token refresh failed: malformed response, preserving session")
+            RefreshOutcome.ServerError
+        } catch (e: Exception) {
+            Timber.w(e, "Token refresh failed unexpectedly, preserving session")
+            RefreshOutcome.NetworkFailure
+        }
+    }
+
+    /**
+     * Updates auth state and reschedules the proactive refresh timer after
+     * a successful interceptor-driven token refresh. Must be called with
+     * [refreshMutex] held.
+     */
+    private fun onInterceptorRefreshSuccessLocked() {
+        if (_authState.value is AuthState.Unauthenticated) {
+            Timber.w("Ignoring interceptor refresh success after logout")
+            return
+        }
+        _authState.value = AuthState.Authenticated
+        val scope = retainedScope
+        if (scope?.isActive == true) {
+            scheduleProactiveRefresh(scope)
+        } else {
+            Timber.w("Skipping proactive refresh scheduling: retained scope unavailable or inactive")
         }
     }
 
@@ -278,25 +427,24 @@ class AuthManager @Inject constructor(
         _authState.value = AuthState.Unauthenticated
     }
 
-    /** Called by TokenRefreshInterceptor when a refresh attempt fails. */
+    /**
+     * Called by the 401 interceptor when refresh-token preconditions fail
+     * (no token present, or token expired) -- i.e. cases the interceptor
+     * rejects without ever calling [refreshForInterceptor].
+     */
     fun onRefreshFailed() {
-        refreshJob?.cancel()
-        _authState.value = AuthState.Expired()
+        onRefreshFailedLocked()
     }
 
-    /** Called by TokenRefreshInterceptor after a successful interceptor-driven refresh. */
-    fun onInterceptorRefreshSuccess() {
-        // Guard against a late interceptor callback racing with logout
-        if (_authState.value is AuthState.Unauthenticated) {
-            Timber.w("Ignoring interceptor refresh success after logout")
-            return
-        }
-        _authState.value = AuthState.Authenticated
-        val scope = retainedScope
-        if (scope?.isActive == true) {
-            scheduleProactiveRefresh(scope)
-        } else {
-            Timber.w("Skipping proactive refresh scheduling: retained scope unavailable or inactive")
-        }
+    /**
+     * Body of [onRefreshFailed], also reused from the refresh paths inside
+     * [refreshMutex.withLock] so the Expired branches stay in sync. The
+     * underlying operations (cancel a Job, set a StateFlow value) are both
+     * thread-safe in their own right, so it is safe to call from either
+     * locked or unlocked contexts.
+     */
+    private fun onRefreshFailedLocked() {
+        refreshJob?.cancel()
+        _authState.value = AuthState.Expired()
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptor.kt
@@ -1,44 +1,46 @@
 package com.glycemicgpt.mobile.data.remote
 
 import com.glycemicgpt.mobile.data.auth.AuthManager
-import com.glycemicgpt.mobile.data.auth.RefreshClientProvider
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
-import com.glycemicgpt.mobile.data.remote.dto.LoginResponse
-import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
-import com.squareup.moshi.JsonDataException
-import com.squareup.moshi.Moshi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import timber.log.Timber
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
- * OkHttp Interceptor that transparently refreshes expired access tokens.
+ * OkHttp interceptor that transparently refreshes expired access tokens.
  *
- * When a request receives a 401 response and a refresh token is available,
- * this interceptor:
- * 1. Checks if the refresh token is still valid
- * 2. Calls the /api/auth/mobile/refresh endpoint (using a separate OkHttpClient)
- * 3. On success: saves new tokens, notifies AuthManager, and retries the original request
- * 4. On failure: clears tokens, notifies AuthManager of session expiry
+ * On a 401 response we delegate the actual refresh to
+ * [AuthManager.refreshForInterceptor], which serializes with the proactive
+ * refresh timer through a single mutex. This is the bug fix for issue #520:
+ * the previous implementation kept its own [Object] monitor that did not
+ * coordinate with the proactive timer, and used the original request's
+ * Authorization header to detect "another thread already refreshed" --
+ * which is null when the access token was already expired before the
+ * request was sent, so every queued 401 in a burst would fall through to
+ * a fresh refresh and replay the previous refresh token against the
+ * server's replay detector.
  *
- * Uses synchronized block to prevent concurrent refresh attempts.
+ * The new flow:
+ *   1. Get a 401 from a non-refresh endpoint
+ *   2. Verify a refresh token exists and is not itself expired
+ *   3. Call [AuthManager.refreshForInterceptor] (single mutex, single
+ *      source of truth for refresh state). Pass the original request's
+ *      auth token so the manager can distinguish "already refreshed"
+ *      from "this exact token was just rejected".
+ *   4. Retry the original request with the returned access token
  */
 @Singleton
 class TokenRefreshInterceptor @Inject constructor(
     private val authTokenStore: AuthTokenStore,
-    private val refreshClientProvider: RefreshClientProvider,
-    private val moshi: Moshi,
     // Use Provider to break circular dependency (AuthManager -> this -> AuthManager)
     private val authManagerProvider: Provider<AuthManager>,
 ) : Interceptor {
-
-    private val lock = Any()
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val original = chain.request()
@@ -50,106 +52,51 @@ class TokenRefreshInterceptor @Inject constructor(
         // Don't try to refresh the refresh endpoint itself
         if (original.url.encodedPath.contains("/api/auth/mobile/refresh")) return response
 
-        val refreshToken = authTokenStore.getRefreshToken() ?: return response
+        // Need a refresh token to do anything
+        if (authTokenStore.getRefreshToken() == null) return response
 
-        // Check if refresh token is expired before attempting
+        // Resolve the AuthManager once. The Hilt Provider's get() should be
+        // cheap, but we're in the request hot path so avoid repeating it.
+        val authManager = authManagerProvider.get()
+
+        // If the refresh token itself is expired, the session is dead. Clear
+        // and notify -- no point hitting the server.
         if (authTokenStore.isRefreshTokenExpired()) {
             Timber.w("Refresh token expired, cannot auto-refresh")
             authTokenStore.clearToken()
-            authManagerProvider.get().onRefreshFailed()
+            authManager.onRefreshFailed()
             return response
         }
 
-        synchronized(lock) {
-            // Double-check: another thread may have already refreshed
-            val currentToken = authTokenStore.getRawToken()
-            val originalAuth = original.header("Authorization")
-            val originalToken = originalAuth?.removePrefix("Bearer ")
-            if (currentToken != null && originalToken != null && currentToken != originalToken) {
-                // Token was already refreshed by another thread; retry with new token
-                response.close()
-                val retryRequest = original.newBuilder()
-                    .header("Authorization", "Bearer $currentToken")
-                    .build()
-                return chain.proceed(retryRequest)
+        // Capture the access token the original request actually carried so
+        // AuthManager can decide whether the refresh has already happened
+        // for us, or whether THIS exact token was just rejected.
+        val originalToken = original.header("Authorization")?.removePrefix("Bearer ")
+
+        // Delegate the refresh itself to AuthManager. Serialized via the
+        // shared mutex with proactive refreshes, and short-circuits when
+        // another caller already produced a valid access token.
+        //
+        // runBlocking is correct here: OkHttp interceptors run on the
+        // dispatcher's worker thread (not a coroutine context), and we
+        // need to return synchronously to the chain.
+        //
+        // CancellationException is translated to IOException so OkHttp
+        // callers see a recognized failure mode instead of an unchecked
+        // throwable.
+        val newAccessToken = try {
+            runBlocking {
+                authManager.refreshForInterceptor(originalToken)
             }
+        } catch (e: CancellationException) {
+            throw IOException("Token refresh cancelled", e)
+        } ?: return response
 
-            // Attempt token refresh
-            val newAccessToken = performRefresh(refreshToken)
-            if (newAccessToken != null) {
-                response.close()
-                val retryRequest = original.newBuilder()
-                    .header("Authorization", "Bearer $newAccessToken")
-                    .build()
-                return chain.proceed(retryRequest)
-            }
-        }
-
-        return response
-    }
-
-    /**
-     * Calls the refresh endpoint and saves new tokens on success.
-     * Returns the new access token, or null on failure.
-     */
-    private fun performRefresh(refreshToken: String): String? {
-        val baseUrl = authTokenStore.getBaseUrl()
-        if (baseUrl.isNullOrBlank()) {
-            Timber.w("No base URL configured, cannot refresh via interceptor")
-            authManagerProvider.get().onRefreshFailed()
-            return null
-        }
-
-        return try {
-            val body = RefreshTokenRequest(refreshToken = refreshToken)
-            val adapter = moshi.adapter(RefreshTokenRequest::class.java)
-            val json = adapter.toJson(body)
-
-            val request = Request.Builder()
-                .url("http://localhost/api/auth/mobile/refresh") // BaseUrlInterceptor rewrites this
-                .post(json.toRequestBody("application/json".toMediaType()))
-                .build()
-
-            val refreshResponse = refreshClientProvider.refreshClient.newCall(request).execute()
-
-            refreshResponse.use { resp ->
-                if (resp.isSuccessful) {
-                    val responseBody = resp.body?.string() ?: return null
-                    val loginAdapter = moshi.adapter(LoginResponse::class.java)
-                    val loginResponse = loginAdapter.fromJson(responseBody) ?: return null
-
-                    val expiresAtMs = System.currentTimeMillis() + (loginResponse.expiresIn * 1000L)
-                    authTokenStore.saveCredentials(
-                        baseUrl,
-                        loginResponse.accessToken,
-                        expiresAtMs,
-                        loginResponse.user.email,
-                    )
-                    authTokenStore.saveRefreshToken(loginResponse.refreshToken)
-
-                    Timber.d("Token refreshed successfully via interceptor")
-                    authManagerProvider.get().onInterceptorRefreshSuccess()
-                    loginResponse.accessToken
-                } else if (resp.code == 401 || resp.code == 403) {
-                    // Definitive auth rejection -- refresh token is invalid/revoked
-                    Timber.w("Token refresh rejected with HTTP ${resp.code}, clearing session")
-                    authTokenStore.clearToken()
-                    authManagerProvider.get().onRefreshFailed()
-                    null
-                } else {
-                    // Transient server error (5xx, etc.) -- preserve tokens for retry
-                    Timber.w("Token refresh got HTTP ${resp.code}, preserving session for retry")
-                    null
-                }
-            }
-        } catch (e: java.io.IOException) {
-            // Network error -- preserve tokens; connectivity will return
-            Timber.w(e, "Token refresh failed due to network error, preserving session")
-            null
-        } catch (e: JsonDataException) {
-            // Malformed refresh response -- don't crash the OkHttp chain
-            Timber.w(e, "Token refresh failed: malformed response, preserving session")
-            null
-        }
+        // Retry the original request with the fresh access token.
+        response.close()
+        val retryRequest = original.newBuilder()
+            .header("Authorization", "Bearer $newAccessToken")
+            .build()
+        return chain.proceed(retryRequest)
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
@@ -336,16 +336,200 @@ class AuthManagerTest {
         assertTrue(manager.authState.value is AuthState.Expired)
     }
 
+    // --- refreshForInterceptor (called from TokenRefreshInterceptor on 401) ---
+
     @Test
-    fun `onInterceptorRefreshSuccess sets Authenticated`() {
+    fun `refreshForInterceptor short-circuits when valid token is already stored`() = runTest {
+        // Fast path: another caller already produced a valid access token.
+        // refreshForInterceptor should return that token without hitting the
+        // network. This is the bug-fix path for issue #520 -- when multiple
+        // queued 401s arrive after an access token expired, only the first
+        // one should refresh; every subsequent caller gets the freshly-stored
+        // token here.
+        every { authTokenStore.getToken() } returns "already-fresh-token"
+        // Wire up a refresh client that throws on any call -- if the fast path
+        // works, this client is never asked to do anything.
+        every { refreshClientProvider.refreshClient } returns
+            mockClientThrowing(IllegalStateException("Network call should not happen on fast path"))
+
         val manager = createManager()
+        // originalToken=null is the load-bearing case: AuthInterceptor sends
+        // the request with no Authorization header when the access token was
+        // already expired client-side. The fast path should still trigger.
+        val result = manager.refreshForInterceptor(null)
+
+        assertEquals("already-fresh-token", result)
+    }
+
+    @Test
+    fun `refreshForInterceptor refreshes when stored token equals originalToken`() = runTest {
+        // Loop-guard: if the server 401s a fresh access token (e.g. revoked
+        // session, IP change, server bug), the stored token equals the one
+        // the request just used. Returning the stored token would loop the
+        // request forever. We must actually refresh in that case.
+        every { authTokenStore.getToken() } returns "rejected-token"
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
         every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() + 3_600_000
 
-        // Simulate a prior login so retainedScope is set
+        val body = """
+            {
+                "access_token": "post-refresh-token",
+                "refresh_token": "post-refresh-refresh",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "user": {"id": "1", "email": "user@test.com", "role": "user"}
+            }
+        """.trimIndent()
+        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(200, body))
+
+        val manager = createManager()
+        manager.onLoginSuccess(testScope)
+        // The request that got 401 carried "rejected-token" and the store
+        // still has "rejected-token" -- must refresh, not return the same
+        // rejected value.
+        val result = manager.refreshForInterceptor(originalToken = "rejected-token")
+
+        assertEquals("post-refresh-token", result)
+        verify { authTokenStore.saveCredentials(any(), "post-refresh-token", any(), any()) }
+    }
+
+    @Test
+    fun `refreshForInterceptor performs refresh when no valid token stored`() = runTest {
+        // Simulate AuthTokenStore's real behavior: getToken returns null until
+        // saveCredentials persists a value, then returns the saved value. Without
+        // this, the recursive proactive-refresh timer that fires on success would
+        // re-enter performRefresh forever (state-based fast path requires a
+        // non-null token).
+        var savedAccess: String? = null
+        every { authTokenStore.getToken() } answers { savedAccess }
+        every { authTokenStore.saveCredentials(any(), any(), any(), any()) } answers {
+            savedAccess = secondArg<String>()
+        }
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() + 3_600_000
+
+        val body = """
+            {
+                "access_token": "fresh-access",
+                "refresh_token": "fresh-refresh",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "user": {"id": "1", "email": "user@test.com", "role": "user"}
+            }
+        """.trimIndent()
+        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(200, body))
+
+        val manager = createManager()
+        manager.onLoginSuccess(testScope) // sets retainedScope so success branch can reschedule
+        val result = manager.refreshForInterceptor(null)
+
+        assertEquals("fresh-access", result)
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+        verify { authTokenStore.saveCredentials("https://test.example.com", "fresh-access", any(), "user@test.com") }
+        verify { authTokenStore.saveRefreshToken("fresh-refresh") }
+    }
+
+    @Test
+    fun `refreshForInterceptor returns null and sets Expired on 401 from server`() = runTest {
+        every { authTokenStore.getToken() } returns null
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(401))
+
+        val manager = createManager()
+        val result = manager.refreshForInterceptor(null)
+
+        assertEquals(null, result)
+        assertTrue(manager.authState.value is AuthState.Expired)
+        verify { authTokenStore.clearToken() }
+    }
+
+    @Test
+    fun `refreshForInterceptor returns null on transient server error without changing state`() = runTest {
+        // 5xx during interceptor refresh should NOT logout the user. The
+        // caller's request will see the 401 and the app keeps trying.
+        // (We avoid onLoginSuccess here because that schedules a proactive
+        // refresh that would re-enter performRefresh under the test
+        // scheduler's auto-advancing virtual time.)
+        every { authTokenStore.getToken() } returns null
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(503))
+
+        val manager = createManager()
+        val result = manager.refreshForInterceptor(null)
+
+        assertEquals(null, result)
+        // Should not be Expired
+        assertTrue(manager.authState.value !is AuthState.Expired)
+        verify(exactly = 0) { authTokenStore.clearToken() }
+    }
+
+    /**
+     * Regression for issue #520. The proactive refresh timer
+     * ([performRefresh]) and the reactive interceptor refresh
+     * ([refreshForInterceptor]) MUST share a single mutex so they cannot
+     * both rotate the refresh token. Before this fix they had independent
+     * locks and could each successfully rotate, leaving any in-flight
+     * requests carrying a now-twice-stale refresh token, which the server's
+     * replay detector then rejected.
+     *
+     * Two concurrent callers should produce exactly ONE network call.
+     */
+    @Test
+    fun `proactive and interceptor refresh share a single mutex`() = runTest {
+        // First call: getToken() returns null (must refresh).
+        // After a successful refresh, getToken() should return the new token
+        // so the second caller takes the fast path and does not hit the network.
+        var refreshed = false
+        every { authTokenStore.getToken() } answers {
+            if (refreshed) "fresh-access" else null
+        }
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() + 3_600_000
+
+        val body = """
+            {
+                "access_token": "fresh-access",
+                "refresh_token": "fresh-refresh",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "user": {"id": "1", "email": "user@test.com", "role": "user"}
+            }
+        """.trimIndent()
+
+        // Track network call count to prove the second caller skipped it.
+        var networkCallCount = 0
+        val client = mockk<OkHttpClient> {
+            every { newCall(any()) } answers {
+                mockk { every { execute() } answers {
+                    networkCallCount++
+                    // Flip `refreshed` so getToken() reports the new value the
+                    // moment any subsequent caller checks. Subsequent callers
+                    // run after this one releases the mutex (sequential
+                    // execution under UnconfinedTestDispatcher), so they hit
+                    // the fast path.
+                    refreshed = true
+                    fakeResponse(200, body)
+                } }
+            }
+        }
+        every { refreshClientProvider.refreshClient } returns client
+
+        val manager = createManager()
         manager.onLoginSuccess(testScope)
 
-        manager.onInterceptorRefreshSuccess()
+        // Run both refresh paths sequentially under the test scheduler.
+        // The mutex serializes them; the second caller hits the fast path.
+        manager.performRefresh(testScope)
+        val interceptorToken = manager.refreshForInterceptor(null)
 
-        assertEquals(AuthState.Authenticated, manager.authState.value)
+        assertEquals("fresh-access", interceptorToken)
+        // Critical assertion: only one network call happened total.
+        assertEquals("expected one /refresh call across both paths, got $networkCallCount",
+            1, networkCallCount)
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
@@ -476,7 +476,16 @@ class AuthManagerTest {
      * requests carrying a now-twice-stale refresh token, which the server's
      * replay detector then rejected.
      *
-     * Two concurrent callers should produce exactly ONE network call.
+     * What this test asserts: under [UnconfinedTestDispatcher] both paths
+     * complete with exactly ONE network call -- the second caller's
+     * fast-path correctly observes the freshly-stored token from the first
+     * caller and returns it without re-entering the refresh logic.
+     *
+     * What this test does NOT directly assert: lock contention behavior
+     * under genuine concurrent execution. The fast-path / shared-state
+     * behavior here is the load-bearing guarantee for the burst-of-401s
+     * scenario. The mutex's actual contention semantics are a property of
+     * [kotlinx.coroutines.sync.Mutex] itself.
      */
     @Test
     fun `proactive and interceptor refresh share a single mutex`() = runTest {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptorTest.kt
@@ -189,7 +189,10 @@ class TokenRefreshInterceptorTest {
         val response = interceptor.intercept(chain)
 
         assertEquals(200, response.code)
-        coVerify(exactly = 1) { authManager.refreshForInterceptor(any()) }
+        // Pin the regression: the originalToken arg MUST be null when there
+        // was no Authorization header on the request (that was the exact
+        // bug shape -- AuthInterceptor omits the header for expired tokens).
+        coVerify(exactly = 1) { authManager.refreshForInterceptor(null) }
         verify {
             chain.proceed(match { req ->
                 req.header("Authorization") == "Bearer fresh-access-token"

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptorTest.kt
@@ -1,34 +1,34 @@
 package com.glycemicgpt.mobile.data.remote
 
 import com.glycemicgpt.mobile.data.auth.AuthManager
-import com.glycemicgpt.mobile.data.auth.RefreshClientProvider
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
-import com.squareup.moshi.Moshi
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import okhttp3.Call
 import okhttp3.Interceptor
-import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.io.IOException
 import javax.inject.Provider
 
 class TokenRefreshInterceptorTest {
 
     private val authTokenStore = mockk<AuthTokenStore>(relaxed = true)
-    private val refreshClientProvider = mockk<RefreshClientProvider>(relaxed = true)
-    private val moshi = Moshi.Builder().build()
-    private val authManager = mockk<AuthManager>(relaxed = true)
+    // Relax only Unit-returning side effects so void calls like onRefreshFailed
+    // don't require explicit stubbing, but suspend functions must be stubbed
+    // explicitly. Full relaxed-mockk on AuthManager can produce expensive
+    // default-coroutine machinery in some configurations.
+    private val authManager = mockk<AuthManager>(relaxUnitFun = true)
     private val authManagerProvider = Provider { authManager }
 
     private fun createInterceptor() =
-        TokenRefreshInterceptor(authTokenStore, refreshClientProvider, moshi, authManagerProvider)
+        TokenRefreshInterceptor(authTokenStore, authManagerProvider)
 
     private fun buildResponse(code: Int, request: Request): Response =
         Response.Builder()
@@ -39,17 +39,7 @@ class TokenRefreshInterceptorTest {
             .body("".toResponseBody())
             .build()
 
-    private fun mockRefreshClient(responseCode: Int): OkHttpClient {
-        val refreshRequest = Request.Builder().url("http://localhost/api/auth/mobile/refresh").build()
-        val refreshResponse = buildResponse(responseCode, refreshRequest)
-        val call = mockk<Call> { every { execute() } returns refreshResponse }
-        return mockk { every { newCall(any()) } returns call }
-    }
-
-    private fun mockRefreshClientThrowing(exception: Exception): OkHttpClient {
-        val call = mockk<Call> { every { execute() } throws exception }
-        return mockk { every { newCall(any()) } returns call }
-    }
+    // --- pass-through cases (no refresh attempted) ---
 
     @Test
     fun `non-401 responses pass through unchanged`() {
@@ -61,7 +51,9 @@ class TokenRefreshInterceptorTest {
         }
 
         val response = interceptor.intercept(chain)
+
         assertEquals(200, response.code)
+        coVerify(exactly = 0) { authManager.refreshForInterceptor(any()) }
     }
 
     @Test
@@ -79,7 +71,9 @@ class TokenRefreshInterceptorTest {
         }
 
         val response = interceptor.intercept(chain)
+
         assertEquals(401, response.code)
+        coVerify(exactly = 0) { authManager.refreshForInterceptor(any()) }
     }
 
     @Test
@@ -96,13 +90,14 @@ class TokenRefreshInterceptorTest {
         }
 
         val response = interceptor.intercept(chain)
+
         assertEquals(401, response.code)
-        // Should NOT attempt refresh for the refresh endpoint itself
+        coVerify(exactly = 0) { authManager.refreshForInterceptor(any()) }
         verify(exactly = 0) { authTokenStore.clearToken() }
     }
 
     @Test
-    fun `401 with expired refresh token notifies AuthManager`() {
+    fun `401 with expired refresh token notifies AuthManager and clears tokens`() {
         every { authTokenStore.getRefreshToken() } returns "expired-refresh"
         every { authTokenStore.isRefreshTokenExpired() } returns true
 
@@ -117,22 +112,25 @@ class TokenRefreshInterceptorTest {
         }
 
         val response = interceptor.intercept(chain)
+
         assertEquals(401, response.code)
         verify { authTokenStore.clearToken() }
         verify { authManager.onRefreshFailed() }
+        coVerify(exactly = 0) { authManager.refreshForInterceptor(any()) }
     }
 
+    // --- delegation to AuthManager.refreshForInterceptor ---
+
     @Test
-    fun `401 retries with refreshed token when another thread already refreshed`() {
+    fun `401 retries with token returned by AuthManager`() {
         every { authTokenStore.getRefreshToken() } returns "valid-refresh"
         every { authTokenStore.isRefreshTokenExpired() } returns false
-        // Simulate another thread already refreshed
-        every { authTokenStore.getRawToken() } returns "new-token-from-other-thread"
+        coEvery { authManager.refreshForInterceptor(any()) } returns "new-access-token"
 
         val interceptor = createInterceptor()
         val request = Request.Builder()
             .url("http://localhost/api/test")
-            .header("Authorization", "Bearer old-token")
+            .header("Authorization", "Bearer expired-token")
             .build()
 
         val retryResponse = buildResponse(200, request)
@@ -142,16 +140,71 @@ class TokenRefreshInterceptorTest {
         }
 
         val response = interceptor.intercept(chain)
+
         assertEquals(200, response.code)
+        coVerify(exactly = 1) { authManager.refreshForInterceptor(any()) }
+        // Verify the retry request carried the new bearer
+        verify {
+            chain.proceed(match { req ->
+                req.header("Authorization") == "Bearer new-access-token"
+            })
+        }
+    }
+
+    /**
+     * Regression for issue #520. AuthInterceptor omits the Authorization
+     * header entirely when the access token has already expired
+     * ([AuthTokenStore.getToken] returns null for expired tokens). The 401
+     * we get back therefore has no original token to compare against. The
+     * old implementation's double-check did `currentToken != null &&
+     * originalToken != null && currentToken != originalToken` -- which is
+     * always false when originalToken is null, so every queued 401 fell
+     * through to a fresh refresh and replayed the previous refresh token.
+     *
+     * The fix routes through AuthManager.refreshForInterceptor, whose
+     * fast-path uses `getToken()` to detect a freshly-stored token without
+     * any comparison against the original request.
+     */
+    @Test
+    fun `401 with null Authorization header still retries via AuthManager`() {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        coEvery { authManager.refreshForInterceptor(any()) } returns "fresh-access-token"
+
+        val interceptor = createInterceptor()
+        // No Authorization header on the original request -- this is the
+        // exact shape the bug produced.
+        val request = Request.Builder()
+            .url("http://localhost/api/test")
+            .build()
+        assertTrue("test setup: request should have no Authorization header",
+            request.header("Authorization") == null)
+
+        val retryResponse = buildResponse(200, request)
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+            every { proceed(any()) } returnsMany listOf(buildResponse(401, request), retryResponse)
+        }
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(200, response.code)
+        coVerify(exactly = 1) { authManager.refreshForInterceptor(any()) }
+        verify {
+            chain.proceed(match { req ->
+                req.header("Authorization") == "Bearer fresh-access-token"
+            })
+        }
     }
 
     @Test
-    fun `refresh 401 clears tokens and notifies AuthManager`() {
+    fun `401 returns original response when AuthManager returns null`() {
+        // refreshForInterceptor returns null on transient failures (5xx/network)
+        // and on expired refresh tokens. Either way, we hand the 401 back to
+        // the caller and let app-level logic handle session state.
         every { authTokenStore.getRefreshToken() } returns "valid-refresh"
         every { authTokenStore.isRefreshTokenExpired() } returns false
-        every { authTokenStore.getRawToken() } returns null
-        every { authTokenStore.getBaseUrl() } returns "https://test.example.com"
-        every { refreshClientProvider.refreshClient } returns mockRefreshClient(401)
+        coEvery { authManager.refreshForInterceptor(any()) } returns null
 
         val interceptor = createInterceptor()
         val request = Request.Builder()
@@ -163,123 +216,9 @@ class TokenRefreshInterceptorTest {
             every { proceed(any()) } returns buildResponse(401, request)
         }
 
-        interceptor.intercept(chain)
-        verify { authTokenStore.clearToken() }
-        verify { authManager.onRefreshFailed() }
-    }
+        val response = interceptor.intercept(chain)
 
-    @Test
-    fun `refresh 403 clears tokens and notifies AuthManager`() {
-        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
-        every { authTokenStore.isRefreshTokenExpired() } returns false
-        every { authTokenStore.getRawToken() } returns null
-        every { authTokenStore.getBaseUrl() } returns "https://test.example.com"
-        every { refreshClientProvider.refreshClient } returns mockRefreshClient(403)
-
-        val interceptor = createInterceptor()
-        val request = Request.Builder()
-            .url("http://localhost/api/test")
-            .header("Authorization", "Bearer expired-token")
-            .build()
-        val chain = mockk<Interceptor.Chain> {
-            every { request() } returns request
-            every { proceed(any()) } returns buildResponse(401, request)
-        }
-
-        interceptor.intercept(chain)
-        verify { authTokenStore.clearToken() }
-        verify { authManager.onRefreshFailed() }
-    }
-
-    @Test
-    fun `refresh 500 preserves tokens for retry`() {
-        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
-        every { authTokenStore.isRefreshTokenExpired() } returns false
-        every { authTokenStore.getRawToken() } returns null
-        every { authTokenStore.getBaseUrl() } returns "https://test.example.com"
-        every { refreshClientProvider.refreshClient } returns mockRefreshClient(500)
-
-        val interceptor = createInterceptor()
-        val request = Request.Builder()
-            .url("http://localhost/api/test")
-            .header("Authorization", "Bearer expired-token")
-            .build()
-        val chain = mockk<Interceptor.Chain> {
-            every { request() } returns request
-            every { proceed(any()) } returns buildResponse(401, request)
-        }
-
-        interceptor.intercept(chain)
-        verify(exactly = 0) { authTokenStore.clearToken() }
-        verify(exactly = 0) { authManager.onRefreshFailed() }
-    }
-
-    @Test
-    fun `refresh 502 gateway error preserves tokens for retry`() {
-        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
-        every { authTokenStore.isRefreshTokenExpired() } returns false
-        every { authTokenStore.getRawToken() } returns null
-        every { authTokenStore.getBaseUrl() } returns "https://test.example.com"
-        every { refreshClientProvider.refreshClient } returns mockRefreshClient(502)
-
-        val interceptor = createInterceptor()
-        val request = Request.Builder()
-            .url("http://localhost/api/test")
-            .header("Authorization", "Bearer expired-token")
-            .build()
-        val chain = mockk<Interceptor.Chain> {
-            every { request() } returns request
-            every { proceed(any()) } returns buildResponse(401, request)
-        }
-
-        interceptor.intercept(chain)
-        verify(exactly = 0) { authTokenStore.clearToken() }
-        verify(exactly = 0) { authManager.onRefreshFailed() }
-    }
-
-    @Test
-    fun `refresh 503 service unavailable preserves tokens for retry`() {
-        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
-        every { authTokenStore.isRefreshTokenExpired() } returns false
-        every { authTokenStore.getRawToken() } returns null
-        every { authTokenStore.getBaseUrl() } returns "https://test.example.com"
-        every { refreshClientProvider.refreshClient } returns mockRefreshClient(503)
-
-        val interceptor = createInterceptor()
-        val request = Request.Builder()
-            .url("http://localhost/api/test")
-            .header("Authorization", "Bearer expired-token")
-            .build()
-        val chain = mockk<Interceptor.Chain> {
-            every { request() } returns request
-            every { proceed(any()) } returns buildResponse(401, request)
-        }
-
-        interceptor.intercept(chain)
-        verify(exactly = 0) { authTokenStore.clearToken() }
-        verify(exactly = 0) { authManager.onRefreshFailed() }
-    }
-
-    @Test
-    fun `refresh network error preserves tokens for retry`() {
-        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
-        every { authTokenStore.isRefreshTokenExpired() } returns false
-        every { authTokenStore.getRawToken() } returns null
-        every { authTokenStore.getBaseUrl() } returns "https://test.example.com"
-        every { refreshClientProvider.refreshClient } returns mockRefreshClientThrowing(IOException("Network unreachable"))
-
-        val interceptor = createInterceptor()
-        val request = Request.Builder()
-            .url("http://localhost/api/test")
-            .header("Authorization", "Bearer expired-token")
-            .build()
-        val chain = mockk<Interceptor.Chain> {
-            every { request() } returns request
-            every { proceed(any()) } returns buildResponse(401, request)
-        }
-
-        interceptor.intercept(chain)
-        verify(exactly = 0) { authTokenStore.clearToken() }
-        verify(exactly = 0) { authManager.onRefreshFailed() }
+        assertEquals(401, response.code)
+        coVerify(exactly = 1) { authManager.refreshForInterceptor(any()) }
     }
 }


### PR DESCRIPTION
## Summary

Closes #520.

Mobile users were getting random sign-outs while the app sat in the background. Server logs showed bursts of 4-6 `/api/auth/mobile/refresh` calls within ~1 second; the first one or two succeeded, the rest hit the replay detector and returned 401. The mobile client treats those 401s as session death and logs the user out.

## Root cause (two real bugs in the client)

1. **Two independent refresh-token locks.** `AuthManager`'s proactive timer held a Kotlin `Mutex`; `TokenRefreshInterceptor`'s 401 path held its own `Object` monitor. Neither blocked the other, so a proactive refresh and a reactive 401 refresh could each successfully rotate the refresh token in parallel.

2. **The 401 interceptor's \"already refreshed\" check was looking at the wrong thing.** It compared the original request's `Authorization` header against the stored token. But `AuthInterceptor` omits the header entirely when the access token is already expired client-side -- so the comparison trivially failed, every queued 401 in a burst fell through to a fresh refresh, and each used the refresh token captured before the lock was acquired. First one rotated; the rest replayed.

## Fix

- `TokenRefreshInterceptor` now delegates to `AuthManager.refreshForInterceptor(originalToken)`. Both refresh paths share `AuthManager.refreshMutex`. Single source of truth for refresh state.
- The double-check inside `refreshForInterceptor` uses `AuthTokenStore.getToken()` (which already returns null for expired tokens), with an `originalToken` parameter for the loop-guard case (server 401-ing a fresh token for a non-token reason -- don't return the same rejected token, refresh).
- Refresh logic extracted into a private `refreshUnderLock()` returning a `RefreshOutcome` sealed class. `ServerError` (5xx) vs `NetworkFailure` (IOException) preserved as separate outcomes so the proactive path's prior \"Expired on network error with no raw token\" semantics are unchanged.
- `onRefreshFailed` body extracted to `onRefreshFailedLocked` so the two `Expired` branches stay in sync.
- `runBlocking` in the interceptor catches `CancellationException` and translates to `IOException` so OkHttp callers don't see an unchecked throwable on cancellation.
- `@Volatile` on `refreshJob`.

## Server is unchanged

The server's replay detection (`apps/api/src/routers/auth.py:407-419`) is correct security behavior and stays as-is. The client now cooperates with it rather than fighting it.

## Tests

- `AuthManagerTest` (24 tests): added 5 new cases covering `refreshForInterceptor` across success, expired, transient, fast-path-short-circuit, the loop-guard (originalToken matches stored), and cross-path mutex serialization.
- `TokenRefreshInterceptorTest` (7 tests): rewritten to the new delegation contract, includes a regression test for \"401 with null Authorization header\" -- the exact shape of the bug.
- Test JVM heap bumped to 2g (mockk pressure under coroutine-aware test classes).

## Test plan

- [x] \`./gradlew :app:testDebugUnitTest\` passes
- [x] \`./gradlew :app:lintDebug\` passes
- [x] Adversarial review (20 findings triaged, 6 valid fixes applied)
- [x] CodeRabbit CLI review (3 findings: 1 false positive, 2 fixes applied)
- [x] Security review on staged diff (no HIGH/MEDIUM findings)
- [ ] Soak-test on prod cluster: install \`dev-latest\` APK after this lands on develop, leave running > 60 min in background, watch Loki for \`Replayed refresh token used\` warnings -- expect zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token refresh reliability with better error handling that distinguishes between expired credentials and temporary network issues.
  * Enhanced concurrent authentication operations to prevent unnecessary refresh loops.

* **Chores**
  * Increased test performance resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->