### PR TITLE
feat(api): Nightscout v1+v3 read client + SSRF guard

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -73,6 +73,9 @@ ignore = [
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 testpaths = ["tests"]
+markers = [
+    "integration: tests that hit a real external service. Skipped by default; opt in by setting the relevant *_TEST_URL env var (e.g. NIGHTSCOUT_TEST_URL).",
+]
 
 [tool.mypy]
 python_version = "3.12"

--- a/apps/api/src/services/integrations/nightscout/client.py
+++ b/apps/api/src/services/integrations/nightscout/client.py
@@ -1,0 +1,690 @@
+"""Nightscout v1 + v3 read client.
+
+The HTTP layer that the GlycemicGPT integration uses to read CGM
+entries, treatments, device status, and profile data from a user's
+Nightscout (or Nocturne) instance.
+
+Read-only by design. Story 43.3 (translator) + 43.4 (sync scheduler)
+consume this client; nothing writes back to Nightscout.
+
+Auth modes:
+
+- **v1 (`auth_type=secret`)**: send the SHA-1 hex digest of the user's
+  API_SECRET in the `api-secret` header. SHA-1 is a Nightscout
+  protocol requirement, not a security choice (server hashes its own
+  secret with SHA-1 and compares). See connection_test.py docstring
+  on `_sha1_hex` for full rationale and lint suppressions.
+- **v3 (`auth_type=token`)**: send a bearer token in the
+  `Authorization: Bearer <token>` header. The token is a Nightscout
+  v3 access token associated with a subject, not the API_SECRET. The
+  user obtains this from their Nightscout admin tools.
+- **`auth_type=auto`**: defer to the explicit api_version. If
+  api_version is also `auto`, try v1 first (universal across the
+  install base); fall back to v3 only if v1 status returns 404.
+
+Pagination:
+
+- v1 endpoints accept `count=N` (max ~50000) and `find[<field>][$gte]`
+  for time bounds. The client paginates by fetching newest-first and
+  paging by the oldest dateString seen so far.
+- v3 endpoints have a different shape (`limit`, `lastModified`). The
+  v1 path is the primary; v3 is a thin parallel for instances that
+  prefer it.
+
+Retry policy:
+
+- 429 → exponential backoff up to 3 attempts then raise NightscoutRateLimitError
+- 5xx → one retry with jitter then raise NightscoutServerError
+- 401/403 → raise NightscoutAuthError immediately (no retry)
+- 404 → raise NightscoutNotFoundError (auto-detect uses this)
+- transport errors → raise NightscoutNetworkError
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import random
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from src.models.nightscout_connection import (
+    NightscoutApiVersion,
+    NightscoutAuthType,
+)
+
+from .errors import (
+    NightscoutAuthError,
+    NightscoutNetworkError,
+    NightscoutNotFoundError,
+    NightscoutRateLimitError,
+    NightscoutServerError,
+    NightscoutValidationError,
+)
+from .ssrf import ValidatedTarget, validate_target
+
+logger = logging.getLogger(__name__)
+
+
+# Default total request timeout. Story 43.4's background sync uses
+# this; the connection-test path overrides to a tighter value for
+# fast user feedback.
+DEFAULT_TIMEOUT_SECONDS = 30.0
+CONNECT_TEST_TIMEOUT_SECONDS = 8.0
+
+# Pagination upper bound. Nightscout v1 accepts up to ~50000 but
+# pages of 5000 are a sane batch -- large enough that 7 days of
+# 5-minute CGM data (~2000 records) lands in one or two pages, small
+# enough that a single failure isn't catastrophic.
+DEFAULT_PAGE_SIZE = 5000
+
+# Retry budget for transient errors.
+MAX_RETRIES_429 = 3
+MAX_RETRIES_5XX = 1
+RETRY_BASE_DELAY_SECONDS = 1.0
+
+
+def _sha1_api_secret(secret: str) -> str:
+    """SHA-1 hex of the API_SECRET for the v1 `api-secret` header.
+
+    See connection_test.py `_sha1_hex` docstring for the protocol-
+    mandate explanation. SHA-1 here is required by Nightscout v1; we
+    are not signing or authenticating anything ourselves.
+    """
+    return hashlib.sha1(secret.encode("utf-8")).hexdigest()  # noqa: S324  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConnectionTestOutcome:
+    """Result of a connection-test attempt.
+
+    Stable shape -- the connection-test stub is a thin wrapper around
+    NightscoutClient.test_connection() and the router serializes this
+    to the wire.
+    """
+
+    ok: bool
+    server_version: str | None = None
+    api_version_detected: NightscoutApiVersion | None = None
+    auth_validated: bool = False
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class NightscoutClient:
+    """Async HTTP client for a single Nightscout instance.
+
+    One client per (user, connection) -- the URL and auth are bound
+    at construction. Use as an async context manager so the
+    underlying httpx client is closed cleanly.
+
+    **Concurrency contract**: a single client instance is intended for
+    sequential use by one coroutine at a time. The underlying
+    `httpx.AsyncClient` is reentrant for separate requests, but
+    `_effective_api_version` (set during `test_connection()` and read
+    by fetch methods) is plain mutable state with no lock. If you need
+    concurrent fetches, build separate clients. The background sync
+    scheduler (Story 43.4) follows this pattern: one client per
+    connection per sync cycle, sequential within the cycle.
+
+    Example:
+        async with NightscoutClient.create(
+            base_url="https://my-ns.example.com",
+            auth_type=NightscoutAuthType.SECRET,
+            credential="my-api-secret",
+            api_version=NightscoutApiVersion.AUTO,
+        ) as client:
+            outcome = await client.test_connection()
+            entries = await client.fetch_entries(count=500)
+    """
+
+    def __init__(
+        self,
+        target: ValidatedTarget,
+        auth_type: NightscoutAuthType,
+        credential: str,
+        api_version: NightscoutApiVersion,
+        *,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._target = target
+        self._auth_type = auth_type
+        self._credential = credential
+        self._api_version = api_version
+        self._timeout_seconds = timeout_seconds
+        # Lazily set after a successful auto-detect, or carried over
+        # from the explicit api_version. Used by the per-resource
+        # methods to pick the right endpoint shape.
+        self._effective_api_version: NightscoutApiVersion | None = (
+            api_version if api_version != NightscoutApiVersion.AUTO else None
+        )
+        self._client: httpx.AsyncClient | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    @classmethod
+    async def create(
+        cls,
+        base_url: str,
+        auth_type: NightscoutAuthType,
+        credential: str,
+        api_version: NightscoutApiVersion,
+        *,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> NightscoutClient:
+        """Validate the URL and return an opened client.
+
+        Raises NightscoutValidationError if the URL fails the SSRF
+        guard. The client must be closed via `await client.aclose()`
+        or used as an async context manager.
+        """
+        try:
+            target = await validate_target(base_url)
+        except ValueError as exc:
+            raise NightscoutValidationError(str(exc)) from exc
+        client = cls(
+            target=target,
+            auth_type=auth_type,
+            credential=credential,
+            api_version=api_version,
+            timeout_seconds=timeout_seconds,
+        )
+        client._open()
+        return client
+
+    def _open(self) -> None:
+        if self._client is not None:
+            return
+        # Granular timeouts so connect failures surface fast even
+        # when the overall budget is generous. Connect is the
+        # short-pole most often (DNS / TLS handshake / down server);
+        # read budget is what we actually want to be generous about.
+        timeout = httpx.Timeout(
+            connect=min(5.0, self._timeout_seconds),
+            read=self._timeout_seconds,
+            write=min(5.0, self._timeout_seconds),
+            pool=min(2.0, self._timeout_seconds),
+        )
+        self._client = httpx.AsyncClient(
+            base_url=self._target.base_url,
+            timeout=timeout,
+            follow_redirects=False,
+            headers={
+                "User-Agent": "GlycemicGPT/1.0 (Nightscout client)",
+                "Accept": "application/json",
+            },
+        )
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def __aenter__(self) -> NightscoutClient:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        await self.aclose()
+
+    # -- auth + headers ----------------------------------------------------
+
+    def _v1_headers(self) -> dict[str, str]:
+        # SHA-1 of the credential -- safe to send regardless of input
+        # bytes; output is always [0-9a-f]{40}.
+        return {"api-secret": _sha1_api_secret(self._credential)}
+
+    def _v3_headers(self) -> dict[str, str]:
+        # Reject control bytes in the credential before interpolating
+        # into the header. h11's LocalProtocolError quotes the entire
+        # offending header value (including the credential!) into its
+        # message, which then flows through NightscoutNetworkError ->
+        # ConnectionTestOutcome.error -> last_sync_error in the DB.
+        # Sanitize at the source.
+        if any(ord(c) < 0x20 or ord(c) == 0x7F for c in self._credential):
+            raise NightscoutValidationError(
+                "v3 token contains control characters; check for stray "
+                "newlines or whitespace from copy-paste"
+            )
+        return {"Authorization": f"Bearer {self._credential}"}
+
+    # -- low-level request with retry --------------------------------------
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        """Issue a single HTTP request with retry/backoff on 429 and 5xx."""
+        if self._client is None:
+            self._open()
+        # Plain check (not assert -- assert is stripped under -O).
+        if self._client is None:
+            raise RuntimeError("NightscoutClient was closed")
+        client = self._client
+
+        attempts_429 = 0
+        attempts_5xx = 0
+
+        while True:
+            try:
+                resp = await client.request(
+                    method,
+                    path,
+                    params=params,
+                    headers=headers,
+                    timeout=timeout,
+                )
+            except httpx.HTTPError as exc:
+                # Transport-level errors are not retried at this layer
+                # -- the scheduler retries at the connection level on
+                # the next sync interval.
+                #
+                # Defense in depth: scrub the credential out of error
+                # strings before they reach NightscoutNetworkError.
+                # h11's LocalProtocolError, in particular, includes
+                # the offending header value (which can be the bearer
+                # token) in its message. We already validate v3
+                # tokens for control bytes in `_v3_headers`, but a
+                # future header-level surface should not regress the
+                # invariant. `from None` breaks the exception chain
+                # so the original `exc.args` are not preserved on
+                # the traceback either.
+                msg = str(exc).replace(self._credential, "<redacted>")
+                raise NightscoutNetworkError(msg) from None
+
+            if resp.status_code == 429:
+                if attempts_429 >= MAX_RETRIES_429:
+                    retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+                    raise NightscoutRateLimitError(
+                        "Nightscout rate limit exceeded after retries",
+                        retry_after_seconds=retry_after,
+                    )
+                # Honor server's Retry-After when present; fall back
+                # to exponential backoff with jitter otherwise.
+                retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+                delay = retry_after if retry_after is not None else _backoff_delay(
+                    attempts_429
+                )
+                attempts_429 += 1
+                logger.info(
+                    "nightscout_429_backoff",
+                    extra={
+                        "attempt": attempts_429,
+                        "delay": delay,
+                        "request_path": path,
+                        "honored_retry_after": retry_after is not None,
+                    },
+                )
+                await asyncio.sleep(delay)
+                continue
+
+            if 500 <= resp.status_code < 600:
+                if attempts_5xx >= MAX_RETRIES_5XX:
+                    raise NightscoutServerError(
+                        f"Nightscout server returned {resp.status_code}",
+                        status_code=resp.status_code,
+                    )
+                attempts_5xx += 1
+                await asyncio.sleep(_backoff_delay(attempts_5xx))
+                continue
+
+            return resp
+
+    def _raise_for_auth_or_404(self, resp: httpx.Response, *, what: str) -> None:
+        if resp.status_code in (401, 403):
+            raise NightscoutAuthError(
+                f"Authentication rejected for {what}",
+                status_code=resp.status_code,
+            )
+        if resp.status_code == 404:
+            raise NightscoutNotFoundError(
+                f"{what} not found at this URL",
+                status_code=resp.status_code,
+            )
+
+    # -- connection test ---------------------------------------------------
+
+    async def test_connection(self) -> ConnectionTestOutcome:
+        """Probe the instance to confirm the credential is accepted.
+
+        Picks the API version per the resolution rules:
+        - explicit api_version=v1 OR (auto + auth_type=secret) → v1 only
+        - explicit api_version=v3 OR (auto + auth_type=token) → v3 only
+        - otherwise (api_version=auto, auth_type=auto): try v1, fall
+          back to v3 on 404.
+        """
+        try:
+            if self._should_use_v1_only():
+                return await self._test_v1()
+            if self._should_use_v3_only():
+                return await self._test_v3()
+
+            # Pure auto (api_version=AUTO + auth_type=AUTO). v1 first
+            # because it's universal across the install base. Fall
+            # back to v3 in two cases:
+            #   - v1 returns 404 (server doesn't speak v1 at all)
+            #   - v1 auth fails (the credential might actually be a
+            #     v3 token; the user said they didn't know which)
+            v1 = await self._test_v1()
+            if v1.ok:
+                return v1
+            v1_path_unsupported = (
+                v1.api_version_detected is None and v1.error is not None
+            )
+            v1_auth_failed = (
+                v1.api_version_detected == NightscoutApiVersion.V1
+                and v1.auth_validated is False
+            )
+            if v1_path_unsupported or v1_auth_failed:
+                v3 = await self._test_v3()
+                if v3.ok:
+                    return v3
+                # Both failed -- prefer the more informative error.
+                # If v3 reached the server (api_version_detected set)
+                # it's a better failure to report than v1's.
+                if v3.api_version_detected is not None:
+                    return v3
+            return v1
+        except NightscoutValidationError as exc:
+            return ConnectionTestOutcome(ok=False, error=str(exc))
+        except NightscoutNetworkError as exc:
+            return ConnectionTestOutcome(ok=False, error=f"network: {exc}")
+
+    def _should_use_v1_only(self) -> bool:
+        return self._api_version == NightscoutApiVersion.V1 or (
+            self._api_version == NightscoutApiVersion.AUTO
+            and self._auth_type == NightscoutAuthType.SECRET
+        )
+
+    def _should_use_v3_only(self) -> bool:
+        return self._api_version == NightscoutApiVersion.V3 or (
+            self._api_version == NightscoutApiVersion.AUTO
+            and self._auth_type == NightscoutAuthType.TOKEN
+        )
+
+    async def _test_v1(self) -> ConnectionTestOutcome:
+        try:
+            resp = await self._request(
+                "GET",
+                "/api/v1/status.json",
+                headers=self._v1_headers(),
+                timeout=CONNECT_TEST_TIMEOUT_SECONDS,
+            )
+        except NightscoutServerError as exc:
+            return ConnectionTestOutcome(
+                ok=False, error=f"Nightscout server error: {exc}"
+            )
+
+        # Status-class handling. _request() only raises on 5xx (after
+        # retries) and rate-limit-exhausted; 4xx flows through as a
+        # response.
+        if resp.status_code in (401, 403):
+            return ConnectionTestOutcome(
+                ok=False,
+                api_version_detected=NightscoutApiVersion.V1,
+                auth_validated=False,
+                error="Authentication rejected by Nightscout v1 (bad API_SECRET?)",
+            )
+        if resp.status_code == 404:
+            return ConnectionTestOutcome(
+                ok=False, error="v1 status endpoint not found at this URL"
+            )
+        if resp.status_code != 200:
+            return ConnectionTestOutcome(
+                ok=False, error=f"Unexpected status {resp.status_code}"
+            )
+        body = _parse_json_or_none(resp)
+        version = body.get("version") if isinstance(body, dict) else None
+        # Cache the detected version for subsequent calls.
+        self._effective_api_version = NightscoutApiVersion.V1
+        return ConnectionTestOutcome(
+            ok=True,
+            server_version=version,
+            api_version_detected=NightscoutApiVersion.V1,
+            auth_validated=True,
+        )
+
+    async def _test_v3(self) -> ConnectionTestOutcome:
+        # /api/v3/version is unauthenticated -- it tells us whether
+        # the server speaks v3 at all but doesn't validate the token.
+        # We follow with a /api/v3/status call (or any authenticated
+        # endpoint) to validate the token.
+        ver_resp = await self._request(
+            "GET", "/api/v3/version", timeout=CONNECT_TEST_TIMEOUT_SECONDS
+        )
+        if ver_resp.status_code == 404:
+            return ConnectionTestOutcome(
+                ok=False, error="v3 version endpoint not found at this URL"
+            )
+        if ver_resp.status_code != 200:
+            return ConnectionTestOutcome(
+                ok=False, error=f"v3 version returned status {ver_resp.status_code}"
+            )
+
+        # Now hit a token-protected endpoint to validate auth.
+        status_resp = await self._request(
+            "GET",
+            "/api/v3/status",
+            headers=self._v3_headers(),
+            timeout=CONNECT_TEST_TIMEOUT_SECONDS,
+        )
+        if status_resp.status_code in (401, 403):
+            return ConnectionTestOutcome(
+                ok=False,
+                api_version_detected=NightscoutApiVersion.V3,
+                auth_validated=False,
+                error="Authentication rejected by Nightscout v3 (bad token?)",
+            )
+        if status_resp.status_code == 404:
+            return ConnectionTestOutcome(ok=False, error="v3 status endpoint not found")
+
+        # Real Nightscout v3 returns
+        # {"status": 200, "version": "15.0.8", "apiVersion": "3.0.5", ...}
+        # -- there is no `result` envelope. (Verified against
+        # cgm-remote-monitor 15.0.8 running locally during development.)
+        body = _parse_json_or_none(ver_resp)
+        version = body.get("version") if isinstance(body, dict) else None
+        self._effective_api_version = NightscoutApiVersion.V3
+        return ConnectionTestOutcome(
+            ok=True,
+            server_version=version,
+            api_version_detected=NightscoutApiVersion.V3,
+            auth_validated=True,
+        )
+
+    # -- data fetches (v1 paths; v3 wrappers can come later) ---------------
+
+    def _require_v1_for_fetch(self, what: str) -> None:
+        """Guard for fetch methods.
+
+        v3 data fetches (with their different pagination + endpoint
+        shape) are out of scope for this PR. Story 43.4's background
+        sync drives the v1 path; if/when the project sees a v3-only
+        Nightscout user, add v3 endpoints here in a follow-up.
+
+        Failing loudly with NotImplementedError is preferable to
+        silently sending v1 paths with a v3 token (the previous
+        behavior of this code).
+        """
+        if self._effective_api_version == NightscoutApiVersion.V3 or (
+            self._api_version == NightscoutApiVersion.V3
+        ):
+            raise NotImplementedError(
+                f"v3 {what} fetches are not yet implemented. Use api_version=v1 "
+                "or wait for v3 fetch support to land."
+            )
+
+    async def fetch_entries(
+        self,
+        *,
+        since: datetime | None = None,
+        count: int = DEFAULT_PAGE_SIZE,
+    ) -> list[dict[str, Any]]:
+        """Fetch CGM entries newest-first.
+
+        Args:
+            since: only return entries with dateString >= this UTC
+                timestamp. **Must be timezone-aware** (raises ValueError
+                on naive datetimes -- silently treating naive as UTC
+                corrupted wall-clock data on dev machines outside UTC).
+                None = no lower bound (subject to Nightscout's
+                own retention).
+            count: page size. Server caps at ~50000 silently.
+        """
+        self._require_v1_for_fetch("entries")
+        return await self._fetch_v1_collection(
+            "/api/v1/entries.json",
+            since=since,
+            since_field="dateString",
+            count=count,
+        )
+
+    async def fetch_treatments(
+        self,
+        *,
+        since: datetime | None = None,
+        count: int = DEFAULT_PAGE_SIZE,
+    ) -> list[dict[str, Any]]:
+        self._require_v1_for_fetch("treatments")
+        return await self._fetch_v1_collection(
+            "/api/v1/treatments.json",
+            since=since,
+            since_field="created_at",
+            count=count,
+        )
+
+    async def fetch_devicestatus(
+        self,
+        *,
+        since: datetime | None = None,
+        count: int = DEFAULT_PAGE_SIZE,
+    ) -> list[dict[str, Any]]:
+        self._require_v1_for_fetch("devicestatus")
+        return await self._fetch_v1_collection(
+            "/api/v1/devicestatus.json",
+            since=since,
+            since_field="created_at",
+            count=count,
+        )
+
+    async def fetch_profile(self) -> list[dict[str, Any]]:
+        """Profile data is not paginated; returns the full profile list.
+
+        Most Nightscout instances have one or two profiles total
+        (Default + maybe a sleep / exercise variant). The profile
+        endpoint returns everything; no since-filter is meaningful.
+        """
+        self._require_v1_for_fetch("profile")
+        resp = await self._request(
+            "GET", "/api/v1/profile.json", headers=self._v1_headers()
+        )
+        self._raise_for_auth_or_404(resp, what="profile")
+        if resp.status_code != 200:
+            raise NightscoutServerError(
+                f"profile returned status {resp.status_code}",
+                status_code=resp.status_code,
+            )
+        body = _parse_json_or_none(resp)
+        return body if isinstance(body, list) else []
+
+    async def _fetch_v1_collection(
+        self,
+        path: str,
+        *,
+        since: datetime | None,
+        since_field: str,
+        count: int,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"count": count}
+        if since is not None:
+            # Reject naive datetimes loudly. The previous behavior
+            # ("treat as UTC") silently corrupted wall-clock data
+            # when callers ran outside UTC.
+            if since.tzinfo is None:
+                raise ValueError(
+                    "since must be a timezone-aware datetime "
+                    "(use datetime.now(UTC) or attach tzinfo explicitly)"
+                )
+            since_utc = since.astimezone(UTC)
+            params[f"find[{since_field}][$gte]"] = since_utc.isoformat().replace(
+                "+00:00", "Z"
+            )
+        resp = await self._request(
+            "GET", path, params=params, headers=self._v1_headers()
+        )
+        self._raise_for_auth_or_404(resp, what=path)
+        if resp.status_code != 200:
+            raise NightscoutServerError(
+                f"{path} returned status {resp.status_code}",
+                status_code=resp.status_code,
+            )
+        body = _parse_json_or_none(resp)
+        return body if isinstance(body, list) else []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_PARSE_FAILED = object()  # sentinel distinct from None / [] / {}
+
+
+def _parse_json_or_none(resp: httpx.Response) -> Any:
+    """Parse a response as JSON; return None on empty body, sentinel on
+    malformed.
+
+    Distinguishing empty-body (status 204 / valid empty) from malformed
+    JSON matters for diagnostics: callers want to know "server has no
+    records" vs "server returned garbage." For now we keep the contract
+    simple (return None for both, callers downcast to []), but the
+    sentinel is plumbed for future expansion.
+    """
+    if not resp.content:
+        return None
+    try:
+        return resp.json()
+    except (ValueError, TypeError):
+        # Don't log resp.text -- a malformed body could contain user
+        # PII (glucose values, free-text "Notes" treatments, etc.)
+        # that we don't want shipped to log aggregators. Status code
+        # + length is enough to triage.
+        logger.warning(
+            "nightscout_response_parse_failed",
+            extra={
+                "status": resp.status_code,
+                "content_length": len(resp.content),
+            },
+        )
+        return _PARSE_FAILED
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Exponential backoff with full jitter."""
+    return RETRY_BASE_DELAY_SECONDS * (2**attempt) * (0.5 + random.random() / 2)
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    if not value:
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None

--- a/apps/api/src/services/integrations/nightscout/client.py
+++ b/apps/api/src/services/integrations/nightscout/client.py
@@ -24,12 +24,16 @@ Auth modes:
 
 Pagination:
 
-- v1 endpoints accept `count=N` (max ~50000) and `find[<field>][$gte]`
-  for time bounds. The client paginates by fetching newest-first and
-  paging by the oldest dateString seen so far.
-- v3 endpoints have a different shape (`limit`, `lastModified`). The
-  v1 path is the primary; v3 is a thin parallel for instances that
-  prefer it.
+- The fetch methods issue a **single request** with `count=N` and an
+  optional `find[<field>][$gte]` lower bound. They do NOT loop. Story
+  43.4's background sync calls them on a fixed cadence, so multi-page
+  pagination is unnecessary as long as `count` exceeds one cycle's
+  worth of records (5000 covers a week of 5-min CGM, far more than
+  any sane sync interval). If a future caller needs to drain a large
+  backlog in one go, layer a paging loop on top.
+- v3 endpoints have a different shape (`limit`, `lastModified`) and
+  are not implemented for fetches in this client; `_require_v1_for_fetch`
+  raises `NotImplementedError` for v3 callers.
 
 Retry policy:
 
@@ -86,6 +90,12 @@ DEFAULT_PAGE_SIZE = 5000
 MAX_RETRIES_429 = 3
 MAX_RETRIES_5XX = 1
 RETRY_BASE_DELAY_SECONDS = 1.0
+# Server-supplied Retry-After is bounded by the user's URL (any
+# Nightscout instance, including misconfigured or hostile ones), so
+# clamp before sleeping. A pathological `Retry-After: 86400` from a
+# misbehaving proxy would otherwise pin the connection-test endpoint
+# or a sync worker for hours.
+RETRY_AFTER_CAP_SECONDS = 30.0
 
 
 def _sha1_api_secret(secret: str) -> str:
@@ -310,18 +320,20 @@ class NightscoutClient:
                 raise NightscoutNetworkError(msg) from None
 
             if resp.status_code == 429:
+                retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
                 if attempts_429 >= MAX_RETRIES_429:
-                    retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
                     raise NightscoutRateLimitError(
                         "Nightscout rate limit exceeded after retries",
                         retry_after_seconds=retry_after,
                     )
-                # Honor server's Retry-After when present; fall back
-                # to exponential backoff with jitter otherwise.
-                retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
-                delay = retry_after if retry_after is not None else _backoff_delay(
-                    attempts_429
-                )
+                # Honor server's Retry-After when present, but clamp
+                # to a sane ceiling so a hostile/misconfigured server
+                # can't pin us for hours. Fall back to exponential
+                # backoff with jitter otherwise.
+                if retry_after is not None:
+                    delay = min(retry_after, RETRY_AFTER_CAP_SECONDS)
+                else:
+                    delay = _backoff_delay(attempts_429)
                 attempts_429 += 1
                 logger.info(
                     "nightscout_429_backoff",
@@ -406,6 +418,13 @@ class NightscoutClient:
             return ConnectionTestOutcome(ok=False, error=str(exc))
         except NightscoutNetworkError as exc:
             return ConnectionTestOutcome(ok=False, error=f"network: {exc}")
+        except NightscoutRateLimitError as exc:
+            # _test_v3 doesn't catch rate-limit-exhaustion locally
+            # (only _test_v1 does, for its server-error path); cover
+            # it here so test_connection() always returns an outcome.
+            return ConnectionTestOutcome(ok=False, error=f"rate limited: {exc}")
+        except NightscoutServerError as exc:
+            return ConnectionTestOutcome(ok=False, error=f"server error: {exc}")
 
     def _should_use_v1_only(self) -> bool:
         return self._api_version == NightscoutApiVersion.V1 or (
@@ -523,9 +542,10 @@ class NightscoutClient:
         silently sending v1 paths with a v3 token (the previous
         behavior of this code).
         """
-        if self._effective_api_version == NightscoutApiVersion.V3 or (
-            self._api_version == NightscoutApiVersion.V3
-        ):
+        # `_effective_api_version` is seeded from `_api_version`
+        # whenever the latter isn't AUTO, so checking the effective
+        # value alone covers both explicit-v3 and auto-resolved-to-v3.
+        if self._effective_api_version == NightscoutApiVersion.V3:
             raise NotImplementedError(
                 f"v3 {what} fetches are not yet implemented. Use api_version=v1 "
                 "or wait for v3 fetch support to land."
@@ -682,9 +702,18 @@ def _backoff_delay(attempt: int) -> float:
 
 
 def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a Retry-After header as seconds.
+
+    Returns None for missing, malformed, or negative values. The HTTP
+    spec also allows an HTTP-date form, which we don't support; servers
+    in the wild use the integer-seconds form.
+    """
     if not value:
         return None
     try:
-        return float(value)
+        parsed = float(value)
     except (ValueError, TypeError):
         return None
+    if parsed < 0:
+        return None
+    return parsed

--- a/apps/api/src/services/integrations/nightscout/connection_test.py
+++ b/apps/api/src/services/integrations/nightscout/connection_test.py
@@ -1,367 +1,35 @@
-"""Story 43.1: minimal connection-test stub for Nightscout.
+"""Connection-test entry point used by the router.
 
-This is a deliberate stub. It exists so the POST /api/integrations/nightscout
-endpoint can return a real success/failure result before the full HTTP
-client (Story 43.2) lands. Once 43.2 ships, that module replaces this
-file -- the public function signature `test_connection()` stays stable
-so the router doesn't change.
+Thin wrapper around `NightscoutClient.test_connection()`. The router's
+`POST /api/integrations/nightscout` endpoint calls `test_connection()`
+from this module; keeping this module's public surface stable means
+the router doesn't change when the underlying client evolves.
 
-Security posture for the Story 43.1 stub:
+Public API:
+- `test_connection(base_url, auth_type, credential, api_version)` →
+  `ConnectionTestOutcome`
+- `ConnectionTestOutcome` (re-exported from client)
 
-- DNS is resolved once via asyncio's resolver with a timeout; the
-  resolved IPs are validated against metadata blocks AND
-  private/loopback ranges (the latter only when
-  `settings.allow_private_ai_urls` is true).
-- Metadata blocks are enforced regardless of homelab mode -- IMDS,
-  Google metadata, Azure metadata, Alibaba, Oracle, DigitalOcean.
-- The HTTP request connects via the original hostname (httpx's
-  default), so TLS SNI is correct for cert-based vhosts. This leaves
-  a narrow DNS-rebinding window between pre-flight validation and
-  connect; see `_client_for_target` for the trade-off rationale.
-  Story 43.2 ships transport-level pinning + SNI override that
-  closes this gap.
-- `follow_redirects=False` so the HTTP layer can't redirect us off
-  the validated host.
-
-What this stub explicitly does NOT do (Story 43.2 owns these):
-
-- Pagination
-- Retry/backoff on transient failures
-- Streaming response handling
-- Rate-limit-aware backoff
-- Auto-detection-with-detection-cache
+The validation/probe logic lives in
+`src.services.integrations.nightscout.client`. SSRF guards live in
+`.ssrf`. Typed errors in `.errors`.
 """
 
-import asyncio
-import contextlib
-import hashlib
-import ipaddress
-import logging
-import socket
-from dataclasses import dataclass
-from urllib.parse import urlparse
+from __future__ import annotations
 
-import httpx
-
-from src.config import settings
 from src.models.nightscout_connection import (
     NightscoutApiVersion,
     NightscoutAuthType,
 )
 
-logger = logging.getLogger(__name__)
-
-
-# Tight overall timeout for connection-tests so the user gets fast
-# feedback. Story 43.4's background sync uses a longer timeout.
-CONNECTION_TEST_TIMEOUT_SECONDS = 8.0
-DNS_TIMEOUT_SECONDS = 3.0
-
-
-# Metadata blocks across the major cloud providers. Always enforced,
-# regardless of `allow_private_ai_urls`. Includes both IPv4 and the
-# IPv6 link-local range used for IMDS.
-_METADATA_NETS_V4 = (
-    ipaddress.IPv4Network("169.254.169.254/32"),  # AWS / Azure / GCP / DO
-    ipaddress.IPv4Network("100.100.100.200/32"),  # Alibaba
-    ipaddress.IPv4Network("192.0.0.192/32"),  # Oracle Cloud
+from .client import (
+    CONNECT_TEST_TIMEOUT_SECONDS,
+    ConnectionTestOutcome,
+    NightscoutClient,
 )
-_METADATA_NETS_V6 = (
-    # AWS uses fd00:ec2::254 for IPv6 IMDS
-    ipaddress.IPv6Network("fd00:ec2::254/128"),
-)
+from .errors import NightscoutValidationError
 
-
-@dataclass
-class ConnectionTestOutcome:
-    """Result of attempting to talk to a Nightscout instance."""
-
-    ok: bool
-    server_version: str | None = None
-    api_version_detected: NightscoutApiVersion | None = None
-    auth_validated: bool = False
-    error: str | None = None
-
-
-def _ip_is_metadata(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    """True if the address is a known cloud-metadata endpoint."""
-    if isinstance(addr, ipaddress.IPv4Address):
-        return any(addr in net for net in _METADATA_NETS_V4)
-    # IPv6: also check for IPv4-mapped IPv6 forms of the IPv4 metadata IPs.
-    if addr.ipv4_mapped is not None:
-        return any(addr.ipv4_mapped in net for net in _METADATA_NETS_V4)
-    return any(addr in net for net in _METADATA_NETS_V6)
-
-
-def _ip_is_disallowed_private(
-    addr: ipaddress.IPv4Address | ipaddress.IPv6Address,
-) -> bool:
-    """True if the address is private/loopback/link-local/etc and
-    `allow_private_ai_urls` is false (i.e. cloud-deployment mode)."""
-    if settings.allow_private_ai_urls:
-        # Homelab mode: allow private IPs (still blocks metadata via
-        # the dedicated check above).
-        return False
-    return (
-        addr.is_private
-        or addr.is_loopback
-        or addr.is_link_local
-        or addr.is_multicast
-        or addr.is_reserved
-        or addr.is_unspecified
-    )
-
-
-async def _resolve_host(
-    hostname: str,
-) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
-    """Resolve a hostname to its IP addresses with a hard timeout.
-
-    Uses the running event loop's `getaddrinfo` so the call is
-    non-blocking. Wrapped in `wait_for` so a hung resolver can't park
-    a worker indefinitely.
-    """
-    loop = asyncio.get_running_loop()
-    try:
-        addrs = await asyncio.wait_for(
-            loop.getaddrinfo(hostname, None, type=socket.SOCK_STREAM),
-            timeout=DNS_TIMEOUT_SECONDS,
-        )
-    except TimeoutError as exc:
-        raise ValueError(f"DNS resolution timed out for {hostname}") from exc
-    except socket.gaierror as exc:
-        raise ValueError(f"Could not resolve host: {hostname}") from exc
-
-    out: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
-    for entry in addrs:
-        sockaddr = entry[4]
-        try:
-            out.append(ipaddress.ip_address(sockaddr[0]))
-        except ValueError:
-            continue
-    if not out:
-        raise ValueError(f"No usable IP addresses for {hostname}")
-    return out
-
-
-@dataclass(frozen=True)
-class _ValidatedTarget:
-    """A successfully validated Nightscout target.
-
-    The HTTP client connects to `ip` directly and sets the `Host`
-    header to `host_header`, eliminating DNS rebinding between
-    validation and request.
-    """
-
-    scheme: str
-    host_header: str  # original host[:port] for SNI/Host header
-    ip: ipaddress.IPv4Address | ipaddress.IPv6Address
-    port: int
-    path_prefix: str  # e.g. "" or "/nightscout"
-
-
-async def _validate_nightscout_url(url: str) -> _ValidatedTarget:
-    """SSRF guard for user-supplied Nightscout URLs.
-
-    Resolves the host once (with a timeout), validates every resolved
-    address against metadata + (homelab-aware) private-ip blocks, and
-    returns a validated target the HTTP layer can pin to without
-    re-resolving.
-
-    Always rejects:
-    - Non-http(s) schemes
-    - URLs with query strings or fragments (defense against parser
-      tricks like `https://valid.com/?@evil.com`)
-    - Resolved addresses that hit a known cloud metadata endpoint
-    - Resolved addresses that are private/loopback when
-      `allow_private_ai_urls=false`
-    """
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError("base_url must use http:// or https://")
-
-    if parsed.query or parsed.fragment:
-        raise ValueError("base_url must not contain query strings or fragments")
-
-    hostname = parsed.hostname
-    if not hostname:
-        raise ValueError("Invalid URL: missing host")
-
-    addrs = await _resolve_host(hostname)
-
-    chosen: ipaddress.IPv4Address | ipaddress.IPv6Address | None = None
-    for addr in addrs:
-        if _ip_is_metadata(addr):
-            raise ValueError(
-                "URL resolves to a cloud metadata endpoint; refusing to connect"
-            )
-        if _ip_is_disallowed_private(addr):
-            raise ValueError(
-                "URL resolves to a private/loopback/reserved IP. Set "
-                "ALLOW_PRIVATE_AI_URLS=true if this is a homelab deployment."
-            )
-        # Prefer the first address that survived validation.
-        if chosen is None:
-            chosen = addr
-
-    if chosen is None:
-        raise ValueError(f"No usable address for {hostname}")
-
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    host_header = f"{hostname}:{parsed.port}" if parsed.port is not None else hostname
-
-    return _ValidatedTarget(
-        scheme=parsed.scheme,
-        host_header=host_header,
-        ip=chosen,
-        port=port,
-        path_prefix=parsed.path.rstrip("/"),
-    )
-
-
-def _sha1_hex(s: str) -> str:
-    """SHA-1 of the API_SECRET for the Nightscout v1 `api-secret` header.
-
-    SHA-1 here is a PROTOCOL REQUIREMENT, not a cryptographic-strength
-    choice. Nightscout v1 servers compare the SHA-1 hex digest of their
-    configured API_SECRET against the value in this header; sending
-    SHA-256 (or any other digest) is rejected as an invalid credential.
-    See: https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/server/auth.js
-    Static-analysis suppressions:
-    - `noqa: S324` -- bandit "use of insecure hash" (Python lint)
-    - `nosemgrep` -- Semgrep insecure-hash-algorithm-sha1 rule
-    Both are false positives for this protocol-compatibility usage; we
-    are not signing or authenticating anything ourselves.
-    """
-    return hashlib.sha1(s.encode("utf-8")).hexdigest()  # noqa: S324  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
-
-
-@contextlib.asynccontextmanager
-async def _client_for_target(target: _ValidatedTarget):
-    """An httpx client targeted at the validated hostname.
-
-    Trade-off (intentional for the Story 43.1 stub):
-
-    - We connect via the hostname (httpx's default), so TLS SNI is set
-      correctly. This matters because the most common Nightscout
-      deployment is NS behind a reverse proxy with cert-based virtual
-      hosting -- connecting to the IP literal gives the wrong SNI and
-      breaks HTTPS for those users.
-    - The cost is a narrow DNS-rebinding window between
-      `_validate_nightscout_url` and the actual connect: a malicious
-      resolver could return a public IP for the validation and a
-      private/metadata IP for the request.
-    - The metadata block above always rejects when validation sees a
-      metadata IP, but a rebinding attack that returns a *different*
-      private IP at request time is not caught here.
-
-    Story 43.2 ships the full client with transport-level pinning +
-    SNI override (e.g. custom `httpx.AsyncHTTPTransport` with the
-    resolver constrained to the validated IP). Until then, the SSRF
-    surface for this stub is "user has access to a malicious resolver
-    AND can swap to a private IP after validation." The
-    high-impact metadata-exfiltration case is closed by the IP-block
-    defense above.
-    """
-    base = f"{target.scheme}://{target.host_header}{target.path_prefix}"
-
-    async with httpx.AsyncClient(
-        timeout=CONNECTION_TEST_TIMEOUT_SECONDS,
-        follow_redirects=False,
-        headers={
-            "User-Agent": "GlycemicGPT/1.0 (Nightscout connection test)",
-        },
-        base_url=base,
-    ) as client:
-        yield client
-
-
-async def _try_v1(client: httpx.AsyncClient, secret: str) -> ConnectionTestOutcome:
-    """v1 auth: api-secret header carrying SHA-1 hex of API_SECRET."""
-    try:
-        resp = await client.get(
-            "/api/v1/status.json", headers={"api-secret": _sha1_hex(secret)}
-        )
-    except httpx.HTTPError as exc:
-        return ConnectionTestOutcome(ok=False, error=f"network: {exc}")
-
-    if resp.status_code in (401, 403):
-        return ConnectionTestOutcome(
-            ok=False,
-            api_version_detected=NightscoutApiVersion.V1,
-            auth_validated=False,
-            error="Authentication rejected by Nightscout v1 (bad API_SECRET?)",
-        )
-    if resp.status_code == 404:
-        return ConnectionTestOutcome(
-            ok=False,
-            error="v1 status endpoint not found at this URL",
-        )
-    if resp.status_code >= 500:
-        return ConnectionTestOutcome(
-            ok=False,
-            error=f"Nightscout server returned {resp.status_code}",
-        )
-    if resp.status_code != 200:
-        return ConnectionTestOutcome(
-            ok=False, error=f"Unexpected status {resp.status_code}"
-        )
-
-    try:
-        body = resp.json()
-    except ValueError:
-        return ConnectionTestOutcome(ok=False, error="v1 status returned non-JSON")
-
-    server_version = body.get("version") if isinstance(body, dict) else None
-    return ConnectionTestOutcome(
-        ok=True,
-        server_version=server_version,
-        api_version_detected=NightscoutApiVersion.V1,
-        auth_validated=True,
-    )
-
-
-async def _try_v3(client: httpx.AsyncClient, token: str) -> ConnectionTestOutcome:
-    """v3 auth: Bearer token in Authorization header."""
-    try:
-        resp = await client.get(
-            "/api/v3/version", headers={"Authorization": f"Bearer {token}"}
-        )
-    except httpx.HTTPError as exc:
-        return ConnectionTestOutcome(ok=False, error=f"network: {exc}")
-
-    if resp.status_code in (401, 403):
-        return ConnectionTestOutcome(
-            ok=False,
-            api_version_detected=NightscoutApiVersion.V3,
-            auth_validated=False,
-            error="Authentication rejected by Nightscout v3 (bad token?)",
-        )
-    if resp.status_code == 404:
-        return ConnectionTestOutcome(
-            ok=False, error="v3 version endpoint not found at this URL"
-        )
-    if resp.status_code >= 500:
-        return ConnectionTestOutcome(
-            ok=False, error=f"Nightscout server returned {resp.status_code}"
-        )
-    if resp.status_code != 200:
-        return ConnectionTestOutcome(
-            ok=False, error=f"Unexpected status {resp.status_code}"
-        )
-
-    try:
-        body = resp.json()
-    except ValueError:
-        return ConnectionTestOutcome(ok=False, error="v3 version returned non-JSON")
-
-    server_version = body.get("version") if isinstance(body, dict) else None
-    return ConnectionTestOutcome(
-        ok=True,
-        server_version=server_version,
-        api_version_detected=NightscoutApiVersion.V3,
-        auth_validated=True,
-    )
+__all__ = ["ConnectionTestOutcome", "test_connection"]
 
 
 async def test_connection(
@@ -370,46 +38,38 @@ async def test_connection(
     credential: str,
     api_version: NightscoutApiVersion,
 ) -> ConnectionTestOutcome:
-    """Probe a Nightscout instance to validate it accepts our credential.
+    """Probe a Nightscout instance to validate it accepts the credential.
 
-    Args:
-        base_url: Nightscout root URL (no trailing slash).
-        auth_type: secret | token | auto.
-        credential: API_SECRET (v1) or bearer token (v3).
-        api_version: v1 | v3 | auto.
-
-    Returns:
-        ConnectionTestOutcome describing success or the failure reason.
+    Returns a structured outcome describing success or the failure
+    reason. **Never raises** -- the router relies on this contract to
+    serialize the outcome to the wire and persist it to
+    `last_sync_error`. Validation errors from `NightscoutClient.create`
+    and any unexpected exceptions are flattened into
+    `ConnectionTestOutcome(ok=False, error=...)`.
     """
     try:
-        target = await _validate_nightscout_url(base_url)
-    except ValueError as exc:
+        client = await NightscoutClient.create(
+            base_url=base_url,
+            auth_type=auth_type,
+            credential=credential,
+            api_version=api_version,
+            timeout_seconds=CONNECT_TEST_TIMEOUT_SECONDS,
+        )
+    except NightscoutValidationError as exc:
         return ConnectionTestOutcome(ok=False, error=str(exc))
+    except Exception as exc:  # noqa: BLE001
+        # Defense in depth: any unexpected exception during create()
+        # (DNS surprises, httpx-side bugs, etc.) is flattened into the
+        # outcome rather than propagated to the router. The router has
+        # no story for handling exceptions here -- it expects an
+        # outcome it can persist.
+        return ConnectionTestOutcome(ok=False, error=f"unexpected error: {exc}")
 
-    async with _client_for_target(target) as client:
-        # Strategy:
-        # - explicit v1 with secret auth -> _try_v1
-        # - explicit v3 with token auth -> _try_v3
-        # - auto: try v1 first (more widely deployed), fall back to v3
-        if api_version == NightscoutApiVersion.V1 or (
-            api_version == NightscoutApiVersion.AUTO
-            and auth_type == NightscoutAuthType.SECRET
-        ):
-            return await _try_v1(client, credential)
-
-        if api_version == NightscoutApiVersion.V3 or (
-            api_version == NightscoutApiVersion.AUTO
-            and auth_type == NightscoutAuthType.TOKEN
-        ):
-            return await _try_v3(client, credential)
-
-        # Pure-auto with auto auth_type: try v1 first, fall back to v3.
-        v1 = await _try_v1(client, credential)
-        if v1.ok:
-            return v1
-        # If v1 was a 404, the instance might be v3-only.
-        if v1.error and "not found" in v1.error.lower():
-            v3 = await _try_v3(client, credential)
-            if v3.ok:
-                return v3
-        return v1
+    try:
+        async with client:
+            return await client.test_connection()
+    except Exception as exc:  # noqa: BLE001
+        # `client.test_connection()` already catches its expected
+        # error classes and returns an outcome. This handler exists
+        # for the same defense-in-depth reason as above.
+        return ConnectionTestOutcome(ok=False, error=f"unexpected error: {exc}")

--- a/apps/api/src/services/integrations/nightscout/errors.py
+++ b/apps/api/src/services/integrations/nightscout/errors.py
@@ -1,0 +1,67 @@
+"""Typed exceptions for the Nightscout client.
+
+Callers can switch on these to drive UI status (auth_failed → re-auth
+prompt; rate_limited → backoff; etc.) without parsing string messages.
+"""
+
+from __future__ import annotations
+
+
+class NightscoutError(Exception):
+    """Base class for all Nightscout client errors."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class NightscoutValidationError(NightscoutError):
+    """Pre-flight validation failed (bad URL, SSRF guard rejected, etc.).
+
+    Maps to last_sync_status='error' in the connection model. Does not
+    indicate a server-side problem -- the request never went out.
+    """
+
+
+class NightscoutAuthError(NightscoutError):
+    """Server rejected the credential (401 or 403).
+
+    Maps to last_sync_status='auth_failed'. Do not retry; surface a
+    re-authenticate prompt to the user.
+    """
+
+
+class NightscoutNotFoundError(NightscoutError):
+    """The endpoint or resource was not found (404).
+
+    For auto-detect: a v1 endpoint 404 is the signal to fall back to
+    v3 (or vice versa). For data fetches: indicates the user's NS
+    instance does not expose the requested resource type.
+    """
+
+
+class NightscoutRateLimitError(NightscoutError):
+    """Server signalled rate limiting (429).
+
+    Caller (or background sync scheduler) should back off. The client
+    handles short-term backoff itself; this error is raised when the
+    backoff budget is exhausted.
+    """
+
+    def __init__(
+        self, message: str, *, retry_after_seconds: float | None = None
+    ) -> None:
+        super().__init__(message, status_code=429)
+        self.retry_after_seconds = retry_after_seconds
+
+
+class NightscoutServerError(NightscoutError):
+    """Server returned a 5xx after our retry budget was used."""
+
+
+class NightscoutNetworkError(NightscoutError):
+    """Transport-level failure (DNS, TCP, TLS, timeout). No status code.
+
+    The remote may or may not be reachable; user-facing surface is
+    "could not reach <host>." Caller can decide whether to retry.
+    """

--- a/apps/api/src/services/integrations/nightscout/ssrf.py
+++ b/apps/api/src/services/integrations/nightscout/ssrf.py
@@ -102,7 +102,12 @@ async def resolve_host(
         # `TimeoutError` since Python 3.11; the project requires 3.11+
         # so catching the builtin covers both.
         raise ValueError(f"DNS resolution timed out for {hostname}") from exc
-    except socket.gaierror as exc:
+    except OSError as exc:
+        # `getaddrinfo` documents `gaierror` (a subclass of OSError),
+        # but the underlying syscall can also surface plain OSError
+        # (e.g., "Network is unreachable" / EAI_SYSTEM). Catch the
+        # base class so any resolution failure maps cleanly to
+        # ValueError -- the contract callers rely on.
         raise ValueError(f"Could not resolve host: {hostname}") from exc
 
     out: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []

--- a/apps/api/src/services/integrations/nightscout/ssrf.py
+++ b/apps/api/src/services/integrations/nightscout/ssrf.py
@@ -1,0 +1,190 @@
+"""SSRF guard for Nightscout client.
+
+Pre-flight URL/IP validation. Cloud-metadata endpoints are blocked
+unconditionally; private and loopback IPs are blocked only when
+`settings.allow_private_ai_urls` is false (cloud-deployment mode --
+the homelab default permits private targets so users can connect to
+self-hosted Nightscout instances on their LAN).
+
+What this module does NOT do (intentionally):
+
+- Transport-level IP pinning. The httpx client connects via hostname
+  and re-resolves at connect time. There is a narrow DNS-rebinding
+  window between this pre-flight validation and the actual TCP
+  connect. A determined attacker controlling a malicious DNS server
+  (and able to convince a user to type that hostname as their
+  Nightscout base URL) could swap the resolved IP between validation
+  and connect.
+
+  Why we accept this for the v1 client:
+  1. The threat requires the user to (a) type a hostname controlled
+     by an attacker as their Nightscout URL and (b) the attacker's
+     DNS server to be timed precisely.
+  2. The metadata IP block above always fires when validation sees a
+     metadata IP -- so the high-impact metadata-exfiltration case is
+     closed even if rebinding occurs.
+  3. Implementing transport-level pinning requires subclassing
+     httpcore internals (httpx's transport doesn't expose the
+     resolver). That code is substantial, version-coupled, and
+     unjustified for the threat reduction it offers in our deployment
+     model (homelab-first).
+  4. HTTPS deployments are protected by TLS cert verification: a
+     rebinding to a different IP would not have the expected
+     certificate.
+
+  If a future deployment scenario warrants closing this window
+  (e.g., multi-tenant SaaS where users connect to arbitrary
+  Nightscout URLs), add a custom httpcore transport then.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from src.config import settings
+
+DNS_TIMEOUT_SECONDS = 3.0
+
+
+# Cloud metadata blocks -- always enforced regardless of homelab flag.
+_METADATA_NETS_V4 = (
+    ipaddress.IPv4Network("169.254.169.254/32"),  # AWS / Azure / GCP / DO
+    ipaddress.IPv4Network("100.100.100.200/32"),  # Alibaba
+    ipaddress.IPv4Network("192.0.0.192/32"),  # Oracle Cloud
+)
+_METADATA_NETS_V6 = (
+    ipaddress.IPv6Network("fd00:ec2::254/128"),  # AWS IPv6 IMDS
+)
+
+
+def ip_is_metadata(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """True if the address is a known cloud-metadata endpoint."""
+    if isinstance(addr, ipaddress.IPv4Address):
+        return any(addr in net for net in _METADATA_NETS_V4)
+    # IPv6: also check IPv4-mapped forms of the IPv4 metadata IPs.
+    if addr.ipv4_mapped is not None:
+        return any(addr.ipv4_mapped in net for net in _METADATA_NETS_V4)
+    return any(addr in net for net in _METADATA_NETS_V6)
+
+
+def ip_is_disallowed_private(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    """True if the address is private/loopback and homelab mode is OFF."""
+    if settings.allow_private_ai_urls:
+        return False
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_reserved
+        or addr.is_unspecified
+    )
+
+
+async def resolve_host(
+    hostname: str,
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Resolve a hostname with a hard DNS timeout. Non-blocking."""
+    loop = asyncio.get_running_loop()
+    try:
+        addrs = await asyncio.wait_for(
+            loop.getaddrinfo(hostname, None, type=socket.SOCK_STREAM),
+            timeout=DNS_TIMEOUT_SECONDS,
+        )
+    except TimeoutError as exc:
+        # `asyncio.TimeoutError` is an alias for the builtin
+        # `TimeoutError` since Python 3.11; the project requires 3.11+
+        # so catching the builtin covers both.
+        raise ValueError(f"DNS resolution timed out for {hostname}") from exc
+    except socket.gaierror as exc:
+        raise ValueError(f"Could not resolve host: {hostname}") from exc
+
+    out: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for entry in addrs:
+        sockaddr = entry[4]
+        try:
+            out.append(ipaddress.ip_address(sockaddr[0]))
+        except ValueError:
+            continue
+    if not out:
+        raise ValueError(f"No usable IP addresses for {hostname}")
+    return out
+
+
+@dataclass(frozen=True)
+class ValidatedTarget:
+    """A successfully validated Nightscout target."""
+
+    scheme: str
+    hostname: str
+    host_header: str  # host[:port] for the Host header
+    port: int
+    path_prefix: str  # e.g. "" or "/nightscout" (no trailing slash)
+    base_url: str  # scheme://host_header + path_prefix
+
+    @property
+    def is_https(self) -> bool:
+        return self.scheme == "https"
+
+
+async def validate_target(url: str) -> ValidatedTarget:
+    """Pre-flight URL parse + DNS resolution + IP-block check.
+
+    Raises:
+        ValueError: if any check fails. The caller should map this to
+            a user-facing connection-error message.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("URL must use http:// or https://")
+    if parsed.query or parsed.fragment:
+        raise ValueError("URL must not contain query strings or fragments")
+    if parsed.username or parsed.password:
+        raise ValueError("URL must not contain embedded user:password credentials")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("Invalid URL: missing host")
+
+    addrs = await resolve_host(hostname)
+    for addr in addrs:
+        if ip_is_metadata(addr):
+            raise ValueError(
+                "URL resolves to a cloud metadata endpoint; refusing to connect"
+            )
+        if ip_is_disallowed_private(addr):
+            raise ValueError(
+                "URL resolves to a private/loopback/reserved IP. Set "
+                "ALLOW_PRIVATE_AI_URLS=true if this is a homelab deployment."
+            )
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    # Only include the port in the Host header when it's NOT the
+    # scheme-default. Many reverse proxies (nginx, Caddy, Traefik)
+    # match vhosts against `Host: example.com` and refuse
+    # `Host: example.com:443`, breaking the connection.
+    is_default_port = (parsed.scheme == "https" and parsed.port == 443) or (
+        parsed.scheme == "http" and parsed.port == 80
+    )
+    host_header = (
+        f"{hostname}:{parsed.port}"
+        if (parsed.port is not None and not is_default_port)
+        else hostname
+    )
+    path_prefix = parsed.path.rstrip("/")
+    base_url = f"{parsed.scheme}://{host_header}{path_prefix}"
+
+    return ValidatedTarget(
+        scheme=parsed.scheme,
+        hostname=hostname,
+        host_header=host_header,
+        port=port,
+        path_prefix=path_prefix,
+        base_url=base_url,
+    )

--- a/apps/api/tests/test_nightscout_client.py
+++ b/apps/api/tests/test_nightscout_client.py
@@ -30,7 +30,9 @@ from src.models.nightscout_connection import (
 )
 from src.services.integrations.nightscout.client import (
     DEFAULT_PAGE_SIZE,
+    MAX_RETRIES_5XX,
     MAX_RETRIES_429,
+    RETRY_AFTER_CAP_SECONDS,
     NightscoutClient,
     _backoff_delay,
     _parse_retry_after,
@@ -304,9 +306,11 @@ class TestRetryPolicy:
         assert exc_info.value.retry_after_seconds == 30.0
 
     @pytest.mark.asyncio
-    async def test_500_retries_once_then_raises(self):
+    async def test_500_retries_then_raises(self):
         c = _make_client()
-        responses = [_resp(500), _resp(500)]
+        # Size from MAX_RETRIES_5XX so the test stays in lockstep with
+        # the constant if it's ever bumped.
+        responses = [_resp(500)] * (MAX_RETRIES_5XX + 1)
         with (
             patch.object(c._client, "request", new=AsyncMock(side_effect=responses)),
             patch(
@@ -320,7 +324,9 @@ class TestRetryPolicy:
     @pytest.mark.asyncio
     async def test_500_then_200_succeeds_on_retry(self):
         c = _make_client()
-        responses = [_resp(503), _resp(200, [{"sgv": 100}])]
+        # MAX_RETRIES_5XX failures followed by a success should be
+        # within budget regardless of how the constant is tuned.
+        responses = [_resp(503)] * MAX_RETRIES_5XX + [_resp(200, [{"sgv": 100}])]
         with (
             patch.object(c._client, "request", new=AsyncMock(side_effect=responses)),
             patch(
@@ -330,6 +336,28 @@ class TestRetryPolicy:
         ):
             result = await c.fetch_entries()
         assert result == [{"sgv": 100}]
+
+    @pytest.mark.asyncio
+    async def test_429_retry_after_clamped_to_cap(self):
+        """Pathological Retry-After should not pin us for hours."""
+        c = _make_client()
+        responses = [
+            _resp(429, headers={"Retry-After": "86400"}),
+            _resp(200, []),
+        ]
+        sleep_mock = AsyncMock()
+        with (
+            patch.object(c._client, "request", new=AsyncMock(side_effect=responses)),
+            patch(
+                "src.services.integrations.nightscout.client.asyncio.sleep",
+                new=sleep_mock,
+            ),
+        ):
+            result = await c.fetch_entries()
+        assert result == []
+        # First (and only) sleep should be the clamped cap, not 86400.
+        sleep_mock.assert_awaited_once()
+        assert sleep_mock.await_args.args[0] == RETRY_AFTER_CAP_SECONDS
 
 
 # ---------------------------------------------------------------------------
@@ -561,6 +589,46 @@ class TestConnectionTest:
         assert outcome.ok is False
         assert "network" in (outcome.error or "").lower()
 
+    @pytest.mark.asyncio
+    async def test_v3_server_error_returns_failure_outcome(self):
+        """5xx burst on /api/v3/version (after retry exhaustion)
+        must surface as an outcome, not propagate as an exception.
+        `_test_v3` doesn't catch it locally -- the outer handler in
+        `test_connection` is what saves us."""
+        c = _make_client(
+            auth_type=NightscoutAuthType.TOKEN, api_version=NightscoutApiVersion.V3
+        )
+        responses = [_resp(500)] * (MAX_RETRIES_5XX + 1)
+        with (
+            patch.object(c._client, "request", new=AsyncMock(side_effect=responses)),
+            patch(
+                "src.services.integrations.nightscout.client.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            outcome = await c.test_connection()
+        assert outcome.ok is False
+        assert "server error" in (outcome.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_v3_rate_limit_returns_failure_outcome(self):
+        """429 storm on v3 probes (after retry exhaustion) must surface
+        as an outcome, not propagate as an exception."""
+        c = _make_client(
+            auth_type=NightscoutAuthType.TOKEN, api_version=NightscoutApiVersion.V3
+        )
+        responses = [_resp(429, headers={"Retry-After": "1"})] * (MAX_RETRIES_429 + 1)
+        with (
+            patch.object(c._client, "request", new=AsyncMock(side_effect=responses)),
+            patch(
+                "src.services.integrations.nightscout.client.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            outcome = await c.test_connection()
+        assert outcome.ok is False
+        assert "rate limited" in (outcome.error or "").lower()
+
 
 # ---------------------------------------------------------------------------
 # Helper functions
@@ -579,9 +647,15 @@ class TestHelpers:
 
     def test_parse_retry_after_seconds(self):
         assert _parse_retry_after("30") == 30.0
+        assert _parse_retry_after("0") == 0.0
         assert _parse_retry_after("") is None
         assert _parse_retry_after(None) is None
         assert _parse_retry_after("not-a-number") is None
+
+    def test_parse_retry_after_rejects_negatives(self):
+        """Negative values are nonsensical; treat as missing."""
+        assert _parse_retry_after("-1") is None
+        assert _parse_retry_after("-30.5") is None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_nightscout_client.py
+++ b/apps/api/tests/test_nightscout_client.py
@@ -1,0 +1,720 @@
+"""Unit + integration tests for NightscoutClient.
+
+Two layers:
+
+1. **Unit tests** (the bulk) -- mock `validate_target` so DNS isn't
+   touched, then mock `httpx.AsyncClient.request` so HTTP isn't
+   touched either. Covers auth headers, pagination params, retry
+   policy, error mapping, auto-detect, and cleanup.
+
+2. **Integration tests** (`@pytest.mark.integration`) -- hit the
+   local test Nightscout via `NIGHTSCOUT_TEST_URL` env var. Skipped
+   if the env var isn't set, so CI doesn't depend on a real instance.
+   These tests run against the seeded `~/dev-test/nightscout/` stack
+   when developing locally.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from src.models.nightscout_connection import (
+    NightscoutApiVersion,
+    NightscoutAuthType,
+)
+from src.services.integrations.nightscout.client import (
+    DEFAULT_PAGE_SIZE,
+    MAX_RETRIES_429,
+    NightscoutClient,
+    _backoff_delay,
+    _parse_retry_after,
+    _sha1_api_secret,
+)
+from src.services.integrations.nightscout.errors import (
+    NightscoutAuthError,
+    NightscoutNetworkError,
+    NightscoutNotFoundError,
+    NightscoutRateLimitError,
+    NightscoutServerError,
+    NightscoutValidationError,
+)
+from src.services.integrations.nightscout.ssrf import ValidatedTarget
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_target(
+    *, scheme: str = "https", hostname: str = "ns.example.com", port: int | None = None
+) -> ValidatedTarget:
+    p = port or (443 if scheme == "https" else 80)
+    host_header = f"{hostname}:{port}" if port else hostname
+    return ValidatedTarget(
+        scheme=scheme,
+        hostname=hostname,
+        host_header=host_header,
+        port=p,
+        path_prefix="",
+        base_url=f"{scheme}://{host_header}",
+    )
+
+
+def _make_client(
+    *,
+    auth_type: NightscoutAuthType = NightscoutAuthType.SECRET,
+    api_version: NightscoutApiVersion = NightscoutApiVersion.V1,
+    credential: str = "test-secret-12chars-long",
+    target: ValidatedTarget | None = None,
+) -> NightscoutClient:
+    """Build a client without going through `create()` (which does DNS)."""
+    c = NightscoutClient(
+        target=target or _fake_target(),
+        auth_type=auth_type,
+        credential=credential,
+        api_version=api_version,
+    )
+    c._open()  # noqa: SLF001  -- exercising lifecycle from tests
+    return c
+
+
+def _resp(
+    status: int, body: object = None, headers: dict | None = None
+) -> httpx.Response:
+    """Build a synthetic httpx Response."""
+    if body is None:
+        content = b""
+    elif isinstance(body, bytes):
+        content = body
+    else:
+        import json
+
+        content = json.dumps(body).encode("utf-8")
+    return httpx.Response(
+        status_code=status,
+        content=content,
+        headers=headers or {"content-type": "application/json"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAuthHeaders:
+    def test_v1_headers_use_sha1_of_credential(self):
+        c = _make_client(auth_type=NightscoutAuthType.SECRET, credential="my-secret")
+        headers = c._v1_headers()
+        # Compare against an independently-computed SHA-1 to verify it's
+        # really the right hash (and the suppressed lint isn't masking
+        # an algorithm mistake).
+        expected = hashlib.sha1(b"my-secret").hexdigest()  # noqa: S324  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+        assert headers == {"api-secret": expected}
+
+    def test_v3_headers_use_bearer_token(self):
+        c = _make_client(auth_type=NightscoutAuthType.TOKEN, credential="abc.def.ghi")
+        assert c._v3_headers() == {"Authorization": "Bearer abc.def.ghi"}
+
+    def test_sha1_helper_matches_nightscout_protocol(self):
+        # The Nightscout test instance uses this exact secret. The
+        # SHA-1 below was independently verified against the running
+        # instance during development.
+        secret = "glycemicgpt-test-secret-min12chars"
+        expected = hashlib.sha1(secret.encode()).hexdigest()  # noqa: S324  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+        assert _sha1_api_secret(secret) == expected
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_create_validates_url_and_returns_open_client(self):
+        with patch(
+            "src.services.integrations.nightscout.client.validate_target",
+            new=AsyncMock(return_value=_fake_target()),
+        ):
+            c = await NightscoutClient.create(
+                base_url="https://ns.example.com",
+                auth_type=NightscoutAuthType.SECRET,
+                credential="x",
+                api_version=NightscoutApiVersion.V1,
+            )
+        assert c._client is not None
+        await c.aclose()
+        assert c._client is None
+
+    @pytest.mark.asyncio
+    async def test_create_raises_validation_error_on_bad_url(self):
+        with (
+            patch(
+                "src.services.integrations.nightscout.client.validate_target",
+                new=AsyncMock(side_effect=ValueError("bad")),
+            ),
+            pytest.raises(NightscoutValidationError),
+        ):
+            await NightscoutClient.create(
+                base_url="bad",
+                auth_type=NightscoutAuthType.SECRET,
+                credential="x",
+                api_version=NightscoutApiVersion.V1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager_closes_underlying_client(self):
+        with patch(
+            "src.services.integrations.nightscout.client.validate_target",
+            new=AsyncMock(return_value=_fake_target()),
+        ):
+            async with await NightscoutClient.create(
+                base_url="https://ns.example.com",
+                auth_type=NightscoutAuthType.SECRET,
+                credential="x",
+                api_version=NightscoutApiVersion.V1,
+            ) as c:
+                assert c._client is not None
+            assert c._client is None
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @pytest.mark.asyncio
+    async def test_401_raises_auth_error(self):
+        c = _make_client()
+        with (
+            patch.object(c._client, "request", new=AsyncMock(return_value=_resp(401))),
+            pytest.raises(NightscoutAuthError),
+        ):
+            await c.fetch_entries()
+
+    @pytest.mark.asyncio
+    async def test_403_raises_auth_error(self):
+        c = _make_client()
+        with (
+            patch.object(c._client, "request", new=AsyncMock(return_value=_resp(403))),
+            pytest.raises(NightscoutAuthError),
+        ):
+            await c.fetch_entries()
+
+    @pytest.mark.asyncio
+    async def test_404_raises_not_found_error(self):
+        c = _make_client()
+        with (
+            patch.object(c._client, "request", new=AsyncMock(return_value=_resp(404))),
+            pytest.raises(NightscoutNotFoundError),
+        ):
+            await c.fetch_entries()
+
+    @pytest.mark.asyncio
+    async def test_transport_error_raises_network_error(self):
+        c = _make_client()
+        with (
+            patch.object(
+                c._client,
+                "request",
+                new=AsyncMock(side_effect=httpx.ConnectError("conn refused")),
+            ),
+            pytest.raises(NightscoutNetworkError),
+        ):
+            await c.fetch_entries()
+
+    @pytest.mark.asyncio
+    async def test_credential_scrubbed_from_network_error_message(self):
+        """Defense-in-depth: if h11/httpx leaks the credential into an
+        exception message (LocalProtocolError quotes the offending
+        header value), NightscoutNetworkError must not propagate the
+        raw value -- it gets persisted to last_sync_error and shown
+        to caregivers / written to logs."""
+        secret = "super-secret-bearer-token-9zk"
+        c = _make_client(
+            auth_type=NightscoutAuthType.TOKEN,
+            api_version=NightscoutApiVersion.V3,
+            credential=secret,
+        )
+        err = httpx.RemoteProtocolError(
+            f"Illegal header value b'Bearer {secret}\\r\\n'"
+        )
+        with (
+            patch.object(c._client, "request", new=AsyncMock(side_effect=err)),
+            pytest.raises(NightscoutNetworkError) as exc_info,
+        ):
+            await c._request("GET", "/api/v3/version")
+        assert secret not in str(exc_info.value)
+        assert "<redacted>" in str(exc_info.value)
+
+    def test_v3_headers_reject_control_chars_in_credential(self):
+        """Pre-flight rejection of credentials with embedded CRLF/etc.
+        Catches the common copy-paste-with-stray-newline case before
+        the credential ever reaches the wire."""
+        c = _make_client(
+            auth_type=NightscoutAuthType.TOKEN,
+            credential="bearer-token-with-newline\r\nInjected: header",
+        )
+        with pytest.raises(NightscoutValidationError, match="control"):
+            c._v3_headers()
+
+
+# ---------------------------------------------------------------------------
+# Retry / backoff
+# ---------------------------------------------------------------------------
+
+
+class TestRetryPolicy:
+    @pytest.mark.asyncio
+    async def test_429_retries_then_succeeds(self):
+        c = _make_client()
+        responses = [_resp(429), _resp(429), _resp(200, [])]
+        with (
+            patch.object(c._client, "request", new=AsyncMock(side_effect=responses)),
+            patch(
+                "src.services.integrations.nightscout.client.asyncio.sleep",
+                new=AsyncMock(),  # don't actually sleep in tests
+            ),
+        ):
+            result = await c.fetch_entries()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_429_exhausts_budget_raises_rate_limit_error(self):
+        c = _make_client()
+        # MAX_RETRIES_429 + 1 = 4 attempts before giving up.
+        responses = [_resp(429, headers={"Retry-After": "30"})] * (MAX_RETRIES_429 + 1)
+        with (
+            patch.object(c._client, "request", new=AsyncMock(side_effect=responses)),
+            patch(
+                "src.services.integrations.nightscout.client.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+            pytest.raises(NightscoutRateLimitError) as exc_info,
+        ):
+            await c.fetch_entries()
+        assert exc_info.value.retry_after_seconds == 30.0
+
+    @pytest.mark.asyncio
+    async def test_500_retries_once_then_raises(self):
+        c = _make_client()
+        responses = [_resp(500), _resp(500)]
+        with (
+            patch.object(c._client, "request", new=AsyncMock(side_effect=responses)),
+            patch(
+                "src.services.integrations.nightscout.client.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+            pytest.raises(NightscoutServerError),
+        ):
+            await c.fetch_entries()
+
+    @pytest.mark.asyncio
+    async def test_500_then_200_succeeds_on_retry(self):
+        c = _make_client()
+        responses = [_resp(503), _resp(200, [{"sgv": 100}])]
+        with (
+            patch.object(c._client, "request", new=AsyncMock(side_effect=responses)),
+            patch(
+                "src.services.integrations.nightscout.client.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            result = await c.fetch_entries()
+        assert result == [{"sgv": 100}]
+
+
+# ---------------------------------------------------------------------------
+# Pagination params
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEntries:
+    @pytest.mark.asyncio
+    async def test_fetch_entries_default_params(self):
+        c = _make_client()
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_entries()
+        call = mock_request.call_args
+        assert call.args[0] == "GET"
+        assert call.args[1] == "/api/v1/entries.json"
+        assert call.kwargs["params"] == {"count": DEFAULT_PAGE_SIZE}
+
+    @pytest.mark.asyncio
+    async def test_fetch_entries_with_since_and_count(self):
+        c = _make_client()
+        since = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_entries(since=since, count=100)
+        params = mock_request.call_args.kwargs["params"]
+        assert params["count"] == 100
+        assert params["find[dateString][$gte]"] == "2026-05-01T12:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_fetch_treatments_uses_created_at_field(self):
+        c = _make_client()
+        since = datetime(2026, 5, 1, tzinfo=UTC)
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_treatments(since=since, count=200)
+        params = mock_request.call_args.kwargs["params"]
+        assert params["find[created_at][$gte]"] == "2026-05-01T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_fetch_devicestatus_uses_created_at_field(self):
+        c = _make_client()
+        since = datetime(2026, 5, 1, tzinfo=UTC)
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_devicestatus(since=since)
+        params = mock_request.call_args.kwargs["params"]
+        assert "find[created_at][$gte]" in params
+
+    @pytest.mark.asyncio
+    async def test_fetch_entries_naive_datetime_raises_value_error(self):
+        """Naive datetimes are rejected. The previous "treat as UTC"
+        behavior silently corrupted wall-clock data when callers ran
+        outside UTC. Force the caller to be explicit."""
+        c = _make_client()
+        naive = datetime(2026, 5, 1, 12, 0, 0)  # no tzinfo
+        with (
+            patch.object(
+                c._client, "request", new=AsyncMock(return_value=_resp(200, []))
+            ),
+            pytest.raises(ValueError, match="timezone-aware"),
+        ):
+            await c.fetch_entries(since=naive)
+
+
+# ---------------------------------------------------------------------------
+# fetch_profile
+# ---------------------------------------------------------------------------
+
+
+class TestFetchProfile:
+    @pytest.mark.asyncio
+    async def test_fetch_profile_returns_list(self):
+        c = _make_client()
+        with patch.object(
+            c._client,
+            "request",
+            new=AsyncMock(return_value=_resp(200, [{"defaultProfile": "Default"}])),
+        ):
+            profiles = await c.fetch_profile()
+        assert profiles == [{"defaultProfile": "Default"}]
+
+    @pytest.mark.asyncio
+    async def test_fetch_profile_handles_non_list_body(self):
+        c = _make_client()
+        with patch.object(
+            c._client,
+            "request",
+            new=AsyncMock(return_value=_resp(200, {"unexpected": True})),
+        ):
+            profiles = await c.fetch_profile()
+        # Defensive: shouldn't crash on unexpected shapes.
+        assert profiles == []
+
+
+# ---------------------------------------------------------------------------
+# test_connection / auto-detect
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionTest:
+    @pytest.mark.asyncio
+    async def test_v1_only_path_used_for_explicit_v1(self):
+        c = _make_client(api_version=NightscoutApiVersion.V1)
+        mock_request = AsyncMock(return_value=_resp(200, {"version": "15.0.8"}))
+        with patch.object(c._client, "request", new=mock_request):
+            outcome = await c.test_connection()
+        assert outcome.ok is True
+        assert outcome.api_version_detected == NightscoutApiVersion.V1
+        assert outcome.server_version == "15.0.8"
+        assert mock_request.call_count == 1
+        assert mock_request.call_args.args[1] == "/api/v1/status.json"
+
+    @pytest.mark.asyncio
+    async def test_v3_only_path_used_for_explicit_v3(self):
+        c = _make_client(
+            auth_type=NightscoutAuthType.TOKEN, api_version=NightscoutApiVersion.V3
+        )
+        # Real Nightscout v3 /api/v3/version response shape (verified
+        # against cgm-remote-monitor 15.0.8) -- no `result` envelope.
+        responses = [
+            _resp(
+                200,
+                {"status": 200, "version": "15.0.8", "apiVersion": "3.0.5"},
+            ),  # /api/v3/version
+            _resp(200, {}),  # /api/v3/status with auth
+        ]
+        with patch.object(c._client, "request", new=AsyncMock(side_effect=responses)):
+            outcome = await c.test_connection()
+        assert outcome.ok is True
+        assert outcome.api_version_detected == NightscoutApiVersion.V3
+        assert outcome.server_version == "15.0.8"
+
+    @pytest.mark.asyncio
+    async def test_auto_with_secret_uses_v1_only(self):
+        c = _make_client(
+            auth_type=NightscoutAuthType.SECRET, api_version=NightscoutApiVersion.AUTO
+        )
+        mock_request = AsyncMock(return_value=_resp(200, {"version": "15.0.8"}))
+        with patch.object(c._client, "request", new=mock_request):
+            outcome = await c.test_connection()
+        assert outcome.api_version_detected == NightscoutApiVersion.V1
+        # Only one call (no v3 fallback attempted).
+        assert mock_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_auto_with_token_uses_v3_only(self):
+        c = _make_client(
+            auth_type=NightscoutAuthType.TOKEN, api_version=NightscoutApiVersion.AUTO
+        )
+        responses = [
+            _resp(200, {"status": 200, "version": "15.0.8", "apiVersion": "3.0.5"}),
+            _resp(200, {}),
+        ]
+        with patch.object(c._client, "request", new=AsyncMock(side_effect=responses)):
+            outcome = await c.test_connection()
+        assert outcome.api_version_detected == NightscoutApiVersion.V3
+
+    @pytest.mark.asyncio
+    async def test_pure_auto_falls_back_to_v3_on_v1_404(self):
+        """auto/auto -- v1 status 404, v3 path succeeds."""
+        c = _make_client(
+            auth_type=NightscoutAuthType.AUTO, api_version=NightscoutApiVersion.AUTO
+        )
+        responses = [
+            _resp(404),  # /api/v1/status.json -- server doesn't speak v1
+            _resp(200, {"status": 200, "version": "15.0.8", "apiVersion": "3.0.5"}),
+            _resp(200, {}),  # /v3/status with auth
+        ]
+        with patch.object(c._client, "request", new=AsyncMock(side_effect=responses)):
+            outcome = await c.test_connection()
+        assert outcome.ok is True
+        assert outcome.api_version_detected == NightscoutApiVersion.V3
+
+    @pytest.mark.asyncio
+    async def test_pure_auto_falls_back_to_v3_on_v1_auth_failure(self):
+        """auto/auto: if v1 401s, the credential might actually be a
+        v3 token (the user said they didn't know which type it was).
+        Fall back and try v3."""
+        c = _make_client(
+            auth_type=NightscoutAuthType.AUTO,
+            api_version=NightscoutApiVersion.AUTO,
+            credential="v3-bearer-token-not-a-secret",
+        )
+        responses = [
+            _resp(401),  # v1 rejected
+            _resp(200, {"status": 200, "version": "15.0.8", "apiVersion": "3.0.5"}),
+            _resp(200, {}),  # v3 status accepts the token
+        ]
+        with patch.object(c._client, "request", new=AsyncMock(side_effect=responses)):
+            outcome = await c.test_connection()
+        assert outcome.ok is True
+        assert outcome.api_version_detected == NightscoutApiVersion.V3
+
+    @pytest.mark.asyncio
+    async def test_explicit_secret_does_not_fall_back_on_v1_auth_failure(self):
+        """If user explicitly said `auth_type=secret`, a 401 is a real
+        auth failure -- don't second-guess by trying v3."""
+        c = _make_client(
+            auth_type=NightscoutAuthType.SECRET, api_version=NightscoutApiVersion.AUTO
+        )
+        mock_request = AsyncMock(return_value=_resp(401))
+        with patch.object(c._client, "request", new=mock_request):
+            outcome = await c.test_connection()
+        assert outcome.ok is False
+        assert outcome.auth_validated is False
+        assert mock_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_v1_auth_failure_returns_failure_outcome_not_exception(self):
+        c = _make_client(api_version=NightscoutApiVersion.V1)
+        with patch.object(c._client, "request", new=AsyncMock(return_value=_resp(401))):
+            outcome = await c.test_connection()
+        assert outcome.ok is False
+        assert outcome.auth_validated is False
+        assert outcome.api_version_detected == NightscoutApiVersion.V1
+        assert "Authentication rejected" in (outcome.error or "")
+
+    @pytest.mark.asyncio
+    async def test_network_error_during_test_returns_failure_outcome(self):
+        c = _make_client(api_version=NightscoutApiVersion.V1)
+        with patch.object(
+            c._client,
+            "request",
+            new=AsyncMock(side_effect=httpx.ConnectError("conn refused")),
+        ):
+            outcome = await c.test_connection()
+        assert outcome.ok is False
+        assert "network" in (outcome.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_backoff_delay_grows_with_attempts(self):
+        d0 = _backoff_delay(0)
+        d2 = _backoff_delay(2)
+        # With jitter we can't assert exact values, but the upper
+        # bounds are clearly increasing.
+        assert d0 <= 2.0
+        assert d2 <= 8.0
+        assert d2 > d0  # almost always true with jitter; if flaky, drop
+
+    def test_parse_retry_after_seconds(self):
+        assert _parse_retry_after("30") == 30.0
+        assert _parse_retry_after("") is None
+        assert _parse_retry_after(None) is None
+        assert _parse_retry_after("not-a-number") is None
+
+
+# ---------------------------------------------------------------------------
+# v3 fetch guard
+# ---------------------------------------------------------------------------
+
+
+class TestV3FetchGuard:
+    """v3 data fetches aren't implemented yet -- raise loudly rather
+    than silently sending v1 paths with a Bearer token."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_entries_with_v3_raises(self):
+        c = _make_client(
+            api_version=NightscoutApiVersion.V3, auth_type=NightscoutAuthType.TOKEN
+        )
+        with pytest.raises(NotImplementedError, match="v3"):
+            await c.fetch_entries()
+
+    @pytest.mark.asyncio
+    async def test_fetch_treatments_with_v3_raises(self):
+        c = _make_client(
+            api_version=NightscoutApiVersion.V3, auth_type=NightscoutAuthType.TOKEN
+        )
+        with pytest.raises(NotImplementedError):
+            await c.fetch_treatments()
+
+    @pytest.mark.asyncio
+    async def test_fetch_devicestatus_with_v3_raises(self):
+        c = _make_client(
+            api_version=NightscoutApiVersion.V3, auth_type=NightscoutAuthType.TOKEN
+        )
+        with pytest.raises(NotImplementedError):
+            await c.fetch_devicestatus()
+
+    @pytest.mark.asyncio
+    async def test_fetch_profile_with_v3_raises(self):
+        c = _make_client(
+            api_version=NightscoutApiVersion.V3, auth_type=NightscoutAuthType.TOKEN
+        )
+        with pytest.raises(NotImplementedError):
+            await c.fetch_profile()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (live local Nightscout)
+# ---------------------------------------------------------------------------
+#
+# Run by pointing NIGHTSCOUT_TEST_URL at a running instance, e.g.:
+#
+#   NIGHTSCOUT_TEST_URL=http://127.0.0.1:1337 \
+#   NIGHTSCOUT_TEST_SECRET=glycemicgpt-test-secret-min12chars \
+#   uv run pytest tests/test_nightscout_client.py -m integration
+#
+# Skipped automatically when the env vars aren't set.
+
+_NS_URL = os.environ.get("NIGHTSCOUT_TEST_URL")
+_NS_SECRET = os.environ.get(
+    "NIGHTSCOUT_TEST_SECRET", "glycemicgpt-test-secret-min12chars"
+)
+_skip_no_live = pytest.mark.skipif(
+    not _NS_URL,
+    reason="set NIGHTSCOUT_TEST_URL to run integration tests against a real instance",
+)
+
+
+@_skip_no_live
+@pytest.mark.integration
+class TestLiveIntegration:
+    @pytest.mark.asyncio
+    async def test_v1_test_connection_against_live(self):
+        async with await NightscoutClient.create(
+            base_url=_NS_URL,
+            auth_type=NightscoutAuthType.SECRET,
+            credential=_NS_SECRET,
+            api_version=NightscoutApiVersion.V1,
+        ) as c:
+            outcome = await c.test_connection()
+        assert outcome.ok is True
+        assert outcome.api_version_detected == NightscoutApiVersion.V1
+        assert outcome.server_version  # any non-empty version string
+
+    @pytest.mark.asyncio
+    async def test_v1_fetch_entries_returns_recent_data(self):
+        async with await NightscoutClient.create(
+            base_url=_NS_URL,
+            auth_type=NightscoutAuthType.SECRET,
+            credential=_NS_SECRET,
+            api_version=NightscoutApiVersion.V1,
+        ) as c:
+            entries = await c.fetch_entries(count=10)
+        # The seed script populates ~2000 entries; expect at least some
+        # if the seeder ran. If the instance is empty this returns [].
+        assert isinstance(entries, list)
+        if entries:
+            first = entries[0]
+            assert "sgv" in first or "type" in first
+
+    @pytest.mark.asyncio
+    async def test_v1_fetch_entries_with_since_filter(self):
+        async with await NightscoutClient.create(
+            base_url=_NS_URL,
+            auth_type=NightscoutAuthType.SECRET,
+            credential=_NS_SECRET,
+            api_version=NightscoutApiVersion.V1,
+        ) as c:
+            since = datetime.now(UTC) - timedelta(days=1)
+            entries = await c.fetch_entries(since=since, count=500)
+        assert isinstance(entries, list)
+        # If we have entries, they should all be newer than `since`.
+        for e in entries:
+            ds = e.get("dateString") or e.get("date")
+            assert ds is not None
+
+    @pytest.mark.asyncio
+    async def test_v1_auth_rejected_with_wrong_secret(self):
+        async with await NightscoutClient.create(
+            base_url=_NS_URL,
+            auth_type=NightscoutAuthType.SECRET,
+            credential="wrong-secret-min12chars-but-bad",
+            api_version=NightscoutApiVersion.V1,
+        ) as c:
+            outcome = await c.test_connection()
+        assert outcome.ok is False
+        assert outcome.auth_validated is False
+
+    @pytest.mark.asyncio
+    async def test_v1_fetch_profile(self):
+        async with await NightscoutClient.create(
+            base_url=_NS_URL,
+            auth_type=NightscoutAuthType.SECRET,
+            credential=_NS_SECRET,
+            api_version=NightscoutApiVersion.V1,
+        ) as c:
+            profiles = await c.fetch_profile()
+        assert isinstance(profiles, list)

--- a/apps/api/tests/test_nightscout_connection.py
+++ b/apps/api/tests/test_nightscout_connection.py
@@ -867,13 +867,14 @@ class TestSsrfGuard:
         """A hostname that resolves to AWS IMDS must be rejected even
         if the hostname itself is a regular FQDN."""
         from src.services.integrations.nightscout import connection_test as ct
+        from src.services.integrations.nightscout import ssrf as ct_ssrf
 
         async def fake_resolve(_hostname):
             import ipaddress as ip
 
             return [ip.ip_address("169.254.169.254")]
 
-        with patch.object(ct, "_resolve_host", new=fake_resolve):
+        with patch.object(ct_ssrf, "resolve_host", new=fake_resolve):
             outcome = await ct.test_connection(
                 "https://attacker.example.com",
                 ct.NightscoutAuthType.SECRET,
@@ -886,13 +887,14 @@ class TestSsrfGuard:
     @pytest.mark.asyncio
     async def test_rejects_alibaba_metadata(self):
         from src.services.integrations.nightscout import connection_test as ct
+        from src.services.integrations.nightscout import ssrf as ct_ssrf
 
         async def fake_resolve(_hostname):
             import ipaddress as ip
 
             return [ip.ip_address("100.100.100.200")]
 
-        with patch.object(ct, "_resolve_host", new=fake_resolve):
+        with patch.object(ct_ssrf, "resolve_host", new=fake_resolve):
             outcome = await ct.test_connection(
                 "https://attacker.example.com",
                 ct.NightscoutAuthType.SECRET,
@@ -905,13 +907,14 @@ class TestSsrfGuard:
     @pytest.mark.asyncio
     async def test_rejects_oracle_metadata(self):
         from src.services.integrations.nightscout import connection_test as ct
+        from src.services.integrations.nightscout import ssrf as ct_ssrf
 
         async def fake_resolve(_hostname):
             import ipaddress as ip
 
             return [ip.ip_address("192.0.0.192")]
 
-        with patch.object(ct, "_resolve_host", new=fake_resolve):
+        with patch.object(ct_ssrf, "resolve_host", new=fake_resolve):
             outcome = await ct.test_connection(
                 "https://attacker.example.com",
                 ct.NightscoutAuthType.SECRET,
@@ -926,13 +929,14 @@ class TestSsrfGuard:
         """169.254.169.254 expressed as ::ffff:169.254.169.254 must
         also be blocked."""
         from src.services.integrations.nightscout import connection_test as ct
+        from src.services.integrations.nightscout import ssrf as ct_ssrf
 
         async def fake_resolve(_hostname):
             import ipaddress as ip
 
             return [ip.ip_address("::ffff:169.254.169.254")]
 
-        with patch.object(ct, "_resolve_host", new=fake_resolve):
+        with patch.object(ct_ssrf, "resolve_host", new=fake_resolve):
             outcome = await ct.test_connection(
                 "https://attacker.example.com",
                 ct.NightscoutAuthType.SECRET,
@@ -945,13 +949,14 @@ class TestSsrfGuard:
     @pytest.mark.asyncio
     async def test_rejects_aws_ipv6_imds(self):
         from src.services.integrations.nightscout import connection_test as ct
+        from src.services.integrations.nightscout import ssrf as ct_ssrf
 
         async def fake_resolve(_hostname):
             import ipaddress as ip
 
             return [ip.ip_address("fd00:ec2::254")]
 
-        with patch.object(ct, "_resolve_host", new=fake_resolve):
+        with patch.object(ct_ssrf, "resolve_host", new=fake_resolve):
             outcome = await ct.test_connection(
                 "https://attacker.example.com",
                 ct.NightscoutAuthType.SECRET,
@@ -964,6 +969,7 @@ class TestSsrfGuard:
     @pytest.mark.asyncio
     async def test_rejects_private_ip_when_homelab_disabled(self):
         from src.services.integrations.nightscout import connection_test as ct
+        from src.services.integrations.nightscout import ssrf as ct_ssrf
 
         async def fake_resolve(_hostname):
             import ipaddress as ip
@@ -971,8 +977,8 @@ class TestSsrfGuard:
             return [ip.ip_address("10.0.0.5")]
 
         with (
-            patch.object(ct, "_resolve_host", new=fake_resolve),
-            patch.object(ct.settings, "allow_private_ai_urls", False),
+            patch.object(ct_ssrf, "resolve_host", new=fake_resolve),
+            patch.object(ct_ssrf.settings, "allow_private_ai_urls", False),
         ):
             outcome = await ct.test_connection(
                 "https://internal.example.com",
@@ -986,11 +992,12 @@ class TestSsrfGuard:
     @pytest.mark.asyncio
     async def test_dns_resolution_failure_yields_clean_error(self):
         from src.services.integrations.nightscout import connection_test as ct
+        from src.services.integrations.nightscout import ssrf as ct_ssrf
 
         async def fake_resolve(_hostname):
             raise ValueError("Could not resolve host: nonexistent.example.invalid")
 
-        with patch.object(ct, "_resolve_host", new=fake_resolve):
+        with patch.object(ct_ssrf, "resolve_host", new=fake_resolve):
             outcome = await ct.test_connection(
                 "https://nonexistent.example.invalid",
                 ct.NightscoutAuthType.SECRET,

--- a/apps/api/tests/test_nightscout_ssrf.py
+++ b/apps/api/tests/test_nightscout_ssrf.py
@@ -1,0 +1,155 @@
+"""Direct tests for the SSRF guard module.
+
+Most of the SSRF behavior is also exercised end-to-end via
+test_nightscout_connection.py's TestSsrfGuard class. This file
+focuses on the pure-helper cases (URL parsing, host_header
+construction) that don't need DNS mocks.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from unittest.mock import patch
+
+import pytest
+
+from src.services.integrations.nightscout import ssrf
+
+
+@pytest.mark.asyncio
+async def test_validate_target_strips_default_https_port():
+    """https://example.com:443/ should produce host_header='example.com'
+    (no :443) so reverse-proxied vhosts match correctly."""
+    with patch.object(
+        ssrf,
+        "resolve_host",
+        return_value=[ipaddress.IPv4Address("8.8.8.8")],
+    ):
+        target = await ssrf.validate_target("https://example.com:443/")
+    assert target.host_header == "example.com"
+    assert target.base_url == "https://example.com"
+
+
+@pytest.mark.asyncio
+async def test_validate_target_strips_default_http_port():
+    with patch.object(
+        ssrf,
+        "resolve_host",
+        return_value=[ipaddress.IPv4Address("8.8.8.8")],
+    ):
+        target = await ssrf.validate_target("http://example.com:80/")
+    assert target.host_header == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_validate_target_keeps_nondefault_port():
+    """A non-default port (e.g. 1337) should be preserved in the
+    Host header so requests reach the right virtual host."""
+    with patch.object(
+        ssrf,
+        "resolve_host",
+        return_value=[ipaddress.IPv4Address("8.8.8.8")],
+    ):
+        target = await ssrf.validate_target("http://example.com:1337/")
+    assert target.host_header == "example.com:1337"
+    assert target.port == 1337
+
+
+@pytest.mark.asyncio
+async def test_validate_target_preserves_path_prefix():
+    """Some Nightscout deployments live at a sub-path
+    (e.g. /nightscout). The validator must keep that intact."""
+    with patch.object(
+        ssrf,
+        "resolve_host",
+        return_value=[ipaddress.IPv4Address("8.8.8.8")],
+    ):
+        target = await ssrf.validate_target("https://example.com/nightscout")
+    assert target.path_prefix == "/nightscout"
+    assert target.base_url == "https://example.com/nightscout"
+
+
+@pytest.mark.asyncio
+async def test_validate_target_strips_trailing_slash():
+    with patch.object(
+        ssrf,
+        "resolve_host",
+        return_value=[ipaddress.IPv4Address("8.8.8.8")],
+    ):
+        target = await ssrf.validate_target("https://example.com/path/")
+    assert target.path_prefix == "/path"
+
+
+@pytest.mark.asyncio
+async def test_validate_target_rejects_query_string():
+    with pytest.raises(ValueError, match="query"):
+        await ssrf.validate_target("https://example.com/?foo=bar")
+
+
+@pytest.mark.asyncio
+async def test_validate_target_rejects_fragment():
+    with pytest.raises(ValueError, match="fragment"):
+        await ssrf.validate_target("https://example.com/#hash")
+
+
+@pytest.mark.asyncio
+async def test_validate_target_rejects_embedded_creds():
+    with pytest.raises(ValueError, match="user:password"):
+        await ssrf.validate_target("https://user:pass@example.com")
+
+
+@pytest.mark.asyncio
+async def test_validate_target_rejects_non_http_scheme():
+    with pytest.raises(ValueError, match="http"):
+        await ssrf.validate_target("ftp://example.com")
+
+
+@pytest.mark.asyncio
+async def test_validate_target_rejects_missing_host():
+    with pytest.raises(ValueError, match="host"):
+        await ssrf.validate_target("https:///path")
+
+
+def test_ip_is_metadata_aws_imds_v4():
+    assert ssrf.ip_is_metadata(ipaddress.IPv4Address("169.254.169.254")) is True
+
+
+def test_ip_is_metadata_alibaba():
+    assert ssrf.ip_is_metadata(ipaddress.IPv4Address("100.100.100.200")) is True
+
+
+def test_ip_is_metadata_oracle():
+    assert ssrf.ip_is_metadata(ipaddress.IPv4Address("192.0.0.192")) is True
+
+
+def test_ip_is_metadata_aws_ipv6():
+    assert ssrf.ip_is_metadata(ipaddress.IPv6Address("fd00:ec2::254")) is True
+
+
+def test_ip_is_metadata_ipv4_mapped_ipv6():
+    """169.254.169.254 expressed as ::ffff:169.254.169.254 is still
+    a metadata IP."""
+    assert ssrf.ip_is_metadata(ipaddress.IPv6Address("::ffff:169.254.169.254")) is True
+
+
+def test_ip_is_metadata_normal_ip():
+    assert ssrf.ip_is_metadata(ipaddress.IPv4Address("8.8.8.8")) is False
+    assert ssrf.ip_is_metadata(ipaddress.IPv6Address("2001:db8::1")) is False
+
+
+def test_ip_is_disallowed_private_homelab_off():
+    """When `allow_private_ai_urls=false`, private IPs are rejected."""
+    with patch.object(ssrf.settings, "allow_private_ai_urls", False):
+        assert ssrf.ip_is_disallowed_private(ipaddress.IPv4Address("10.0.0.1")) is True
+        assert ssrf.ip_is_disallowed_private(ipaddress.IPv4Address("127.0.0.1")) is True
+        assert ssrf.ip_is_disallowed_private(ipaddress.IPv4Address("8.8.8.8")) is False
+
+
+def test_ip_is_disallowed_private_homelab_on():
+    """When `allow_private_ai_urls=true`, private IPs are permitted
+    (homelab default). Metadata IPs are still blocked separately."""
+    with patch.object(ssrf.settings, "allow_private_ai_urls", True):
+        assert ssrf.ip_is_disallowed_private(ipaddress.IPv4Address("10.0.0.1")) is False
+        assert (
+            ssrf.ip_is_disallowed_private(ipaddress.IPv4Address("127.0.0.1")) is False
+        )

--- a/apps/api/tests/test_nightscout_ssrf.py
+++ b/apps/api/tests/test_nightscout_ssrf.py
@@ -69,6 +69,29 @@ async def test_validate_target_preserves_path_prefix():
     assert target.base_url == "https://example.com/nightscout"
 
 
+def test_httpx_preserves_subpath_with_leading_slash_request_path():
+    """Lock in the httpx behavior the client relies on: when the
+    base_url has a sub-path (e.g. `/nightscout`) and requests are made
+    with a leading-slash path (e.g. `/api/v1/entries.json`), the
+    resulting wire URL must be `https://host/nightscout/api/...`,
+    NOT `https://host/api/...` (which would drop the prefix and
+    break sub-path Nightscout deployments).
+
+    Older httpx versions stripped the prefix in this case; current
+    versions merge correctly. This regression test guards against a
+    future bump that re-introduces the bug.
+    """
+    import httpx
+
+    client = httpx.AsyncClient(base_url="https://example.com/nightscout")
+    try:
+        req = client.build_request("GET", "/api/v1/entries.json")
+        assert str(req.url) == "https://example.com/nightscout/api/v1/entries.json"
+    finally:
+        # build_request doesn't open connections, but be tidy.
+        pass
+
+
 @pytest.mark.asyncio
 async def test_validate_target_strips_trailing_slash():
     with patch.object(


### PR DESCRIPTION
## Summary

Builds on PR #568 (Nightscout connection model + endpoints, already on develop). Replaces the connection-test stub with a real HTTP client that the background sync (next PR) will drive. Read-only by design — nothing writes back to Nightscout.

## What ships

**`NightscoutClient`** in `apps/api/src/services/integrations/nightscout/client.py`:

- `fetch_entries(since, count)` — CGM glucose readings
- `fetch_treatments(since, count)` — bolus / carbs / temp basal / etc.
- `fetch_devicestatus(since, count)` — pump / uploader status (Loop, OpenAPS, AAPS, xDrip+)
- `fetch_profile()` — target / carb-ratio / ISF / basal schedules
- `test_connection()` — probe + auth-validate; never raises (returns structured `ConnectionTestOutcome`)

**Auth modes:**

- **v1** (`auth_type=secret`): SHA-1 hex of API_SECRET in `api-secret` header. Nightscout protocol requirement (server hashes its own secret with SHA-1 and compares); not a security choice. Documented and lint-suppressed at the source.
- **v3** (`auth_type=token`): Bearer token in `Authorization` header. Token is provisioned via Nightscout admin tools; separate from the API_SECRET.
- **`auto`**: defers to the explicit `api_version`. If that's also `auto`: tries v1 first (universal across the install base since 2014; v3 is post-2021 and not always present), falls back to v3 on **404** (server doesn't speak v1) or **401** (the credential might be a v3 token the user said they didn't know the type of).

**SSRF guard** in `apps/api/src/services/integrations/nightscout/ssrf.py`:

- DNS resolved once via async resolver with a 3s timeout
- Cloud metadata IPs always blocked (AWS / Azure / GCP / DO + IPv6, Alibaba, Oracle, IPv4-mapped-IPv6 forms)
- Private/loopback blocked when `allow_private_ai_urls=false`; permitted in homelab default
- URL parser rejects query strings, fragments, embedded `user:password@host`, non-http(s) schemes
- Default ports stripped from Host header (`Host: example.com` not `Host: example.com:443`) so reverse-proxied vhosts match
- Residual DNS rebinding window between pre-flight and connect is documented and accepted; the metadata IP block closes the high-impact case, HTTPS cert verification covers the rest

**Retry policy** in `_request`:

- 429 → exp backoff up to 3 attempts; **honors `Retry-After` header** when present
- 5xx → one retry with jitter then surface
- 401/403 → `NightscoutAuthError` immediately, no retry
- 404 → `NightscoutNotFoundError`; auto-detect uses this for v3 fallback
- Transport errors → `NightscoutNetworkError` with the credential scrubbed from the message (defense in depth — h11's `LocalProtocolError` quotes header values which would otherwise leak a v3 token)

**Refactored:** `connection_test.py` is now a 60-line shim over the new client. Public function signature unchanged so the router didn't need to change.

## Adversarial review (5 HIGH + 7 MEDIUM, all fixed)

- Pure-auto + token credential now correctly falls back to v3 on v1 401 (was silently failing forever)
- v3 fetch methods raise `NotImplementedError` loudly rather than silently sending v1 paths with a Bearer token
- Bare `assert` replaced with explicit None check (was stripped under `python -O`)
- Honors server `Retry-After` instead of always using exp backoff
- v3 version response parser fixed to match the real Nightscout shape (no `result` envelope — original test fixtures fabricated one)
- Host header strips default ports (443/https, 80/http) for reverse-proxy compatibility
- Naive datetime in `since` raises `ValueError` instead of silently treating as UTC
- Granular `httpx.Timeout` (connect/read/write/pool) instead of one total timeout
- Single-coroutine concurrency contract documented on the class

## Security review (1 MEDIUM, fixed)

- Credential could leak into `last_sync_error` via `h11.LocalProtocolError` if the v3 token contained CRLF (e.g., copy-paste with stray newline). Fixed two ways: control-byte rejection in `_v3_headers()` rejects bad credentials before the wire, and `_request()`'s `httpx.HTTPError` handler scrubs the credential from the error message before raising.

## CodeRabbit CLI (3 findings, all fixed)

- `connection_test.test_connection` was claimed to "never raise" but only caught `NightscoutValidationError`. Added defense-in-depth `except Exception` so unexpected errors are flattened into the outcome.
- `ssrf.resolve_host` `except TimeoutError` covers Python 3.11+ (where `asyncio.TimeoutError` aliases the builtin); comment updated.
- Parse-failure log no longer includes `resp.text[:200]` (could contain user PII); replaced with `content_length`.

## Local test setup

A throwaway Nightscout 15.0.8 + MongoDB stack lives at `~/dev-test/nightscout/` on the dev VM (intentionally outside the repo). Used for the live integration tests. Not part of this PR; not committed anywhere.

## Test plan

- [x] **85 unit tests** (`test_nightscout_client.py`, `test_nightscout_ssrf.py`, updated `test_nightscout_connection.py`)
- [x] **5 live integration tests** against the local Nightscout 15.0.8 with seeded synthetic data, gated behind `NIGHTSCOUT_TEST_URL` env var (skipped in CI)
- [x] **Full `:api` test suite passes:** 1603 passed, 6 skipped, 0 failed (920s)
- [x] `ruff check` + `ruff format` clean
- [x] No mention of Stories/Epics in PR title/body/commit per project convention


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nightscout integration with connection testing and automatic API version detection
  * Implemented secure client with built-in retry logic, rate-limit handling, and credential management
  * Added URL validation and SSRF protection for external connections

* **Tests**
  * Added comprehensive unit and integration test suites for Nightscout functionality and security validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->