### PR TITLE
feat(api): Nightscout translator orchestrator + ORM mapping layer

### DIFF
--- a/apps/api/migrations/versions/052_nightscout_translator.py
+++ b/apps/api/migrations/versions/052_nightscout_translator.py
@@ -87,6 +87,25 @@ def upgrade() -> None:
         unique=True,
         postgresql_where=sa.text("ns_id IS NOT NULL"),
     )
+    # Relax the existing (user_id, event_timestamp, event_type) unique
+    # index to NOT apply to Nightscout-sourced rows -- otherwise, two
+    # legitimate but distinct events at the same timestamp (e.g. two
+    # AAPS SMBs in the same second with different `_id`s, or a real
+    # bolus that happens to share a timestamp with a Loop SMB) would
+    # collide and silently drop one. Direct integrations (Tandem,
+    # Dexcom) keep the natural-key dedupe by being on the WHERE
+    # ns_id IS NULL branch; Nightscout-sourced rows dedupe via the
+    # `ix_pump_events_source_nsid` partial index above.
+    op.drop_index(
+        "ix_pump_events_user_event_unique", table_name="pump_events"
+    )
+    op.create_index(
+        "ix_pump_events_user_event_unique",
+        "pump_events",
+        ["user_id", "event_timestamp", "event_type"],
+        unique=True,
+        postgresql_where=sa.text("ns_id IS NULL"),
+    )
     # Index for the meal-bolus-pair sibling lookup ("find the carb_entry
     # row paired with this bolus row").
     op.create_index(
@@ -142,7 +161,7 @@ def upgrade() -> None:
         ),
         # Source metadata (from Nightscout's profile document)
         sa.Column("source_default_profile_name", sa.String(120), nullable=True),
-        sa.Column("source_units", sa.String(20), nullable=True),
+        sa.Column("source_units", sa.String(40), nullable=True),
         sa.Column("source_timezone", sa.String(60), nullable=True),
         sa.Column("source_dia_hours", sa.Float(), nullable=True),
         # Time-segmented schedules. Each is a list of {"time": "HH:MM",
@@ -273,6 +292,17 @@ def downgrade() -> None:
     op.drop_index(
         "ix_pump_events_source_nsid",
         table_name="pump_events",
+    )
+    # Restore the original (un-partial) unique index. Drop the partial
+    # one first since they share a name.
+    op.drop_index(
+        "ix_pump_events_user_event_unique", table_name="pump_events"
+    )
+    op.create_index(
+        "ix_pump_events_user_event_unique",
+        "pump_events",
+        ["user_id", "event_timestamp", "event_type"],
+        unique=True,
     )
     op.drop_column("pump_events", "ns_id")
     op.drop_column("pump_events", "meal_event_id")

--- a/apps/api/migrations/versions/052_nightscout_translator.py
+++ b/apps/api/migrations/versions/052_nightscout_translator.py
@@ -1,0 +1,282 @@
+"""Translator schema: pump_events extensions + snapshot tables.
+
+Lands the storage layer for the Nightscout translator:
+
+- Adds PumpEventType enum values for events Nightscout can carry but
+  the existing Tandem-shaped enum doesn't cover (carbs, overrides,
+  profile switches, combo boluses, temp targets, notes, device events,
+  APS-offline markers).
+- Adds pump_events.metadata_json (JSONB) for type-specific extras
+  that don't fit the Tandem-shaped columns (override correctionRange,
+  profile switch tuple, AAPS pump composite dedup key, etc.).
+- Adds pump_events.meal_event_id (UUID) for linking the two rows
+  produced when a meal_bolus_pair is split into a bolus + carb_entry.
+- Adds pump_events.ns_id (text) -- the Nightscout-server-assigned _id
+  (or client-generated identifier/syncIdentifier) for per-connection
+  dedupe when re-fetching the same record across sync cycles.
+- Creates nightscout_profile_snapshots: read-only mirror of the user's
+  Nightscout profile, written on each profile fetch. Read by the
+  onboarding wizard to pre-fill the user's canonical settings form;
+  never queried by AI / charts / mobile / alerts.
+- Creates device_status_snapshots: periodic IOB / COB / predBGs / loop
+  dosing decision snapshots. Translator writes one row per devicestatus
+  fetch; downstream consumers (AI chat, advanced web views) read recent
+  rows for closed-loop analysis context.
+
+Revision ID: 052_nightscout_translator
+Revises: 051_nightscout_connections
+Create Date: 2026-05-06
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "052_nightscout_translator"
+down_revision = "051_nightscout_connections"
+branch_labels = None
+depends_on = None
+
+
+# New PumpEventType enum values added by this migration. Order matches
+# the additions in src/models/pump_data.py.
+_NEW_PUMP_EVENT_TYPES = (
+    "carbs",
+    "override",
+    "profile_switch",
+    "combo_bolus",
+    "temp_target",
+    "note",
+    "device_event",
+    "aps_offline",
+)
+
+
+def upgrade() -> None:
+    # --- 1. Extend the pumpeventtype enum --------------------------------
+    # ALTER TYPE ... ADD VALUE must run outside a transaction; mirror the
+    # pattern from migration 036.
+    op.execute("COMMIT")
+    for value in _NEW_PUMP_EVENT_TYPES:
+        op.execute(f"ALTER TYPE pumpeventtype ADD VALUE IF NOT EXISTS '{value}'")
+
+    # --- 2. pump_events extensions ---------------------------------------
+    op.add_column(
+        "pump_events",
+        sa.Column("metadata_json", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "pump_events",
+        sa.Column(
+            "meal_event_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "pump_events",
+        sa.Column("ns_id", sa.Text(), nullable=True),
+    )
+    # Dedupe index for Nightscout-sourced events. Per-connection
+    # uniqueness on (source, ns_id). NULL ns_id (direct integrations)
+    # doesn't participate -- partial index gates on ns_id IS NOT NULL.
+    op.create_index(
+        "ix_pump_events_source_nsid",
+        "pump_events",
+        ["source", "ns_id"],
+        unique=True,
+        postgresql_where=sa.text("ns_id IS NOT NULL"),
+    )
+    # Index for the meal-bolus-pair sibling lookup ("find the carb_entry
+    # row paired with this bolus row").
+    op.create_index(
+        "ix_pump_events_meal_event_id",
+        "pump_events",
+        ["meal_event_id"],
+        postgresql_where=sa.text("meal_event_id IS NOT NULL"),
+    )
+
+    # --- 3. glucose_readings: ns_id for per-connection dedupe ------------
+    # Same rationale as pump_events: the unique index on
+    # (user_id, reading_timestamp) handles cross-source conflicts via
+    # ON CONFLICT DO NOTHING (direct integrations win by being inserted
+    # first), but per-connection dedupe needs an explicit ns_id key.
+    op.add_column(
+        "glucose_readings",
+        sa.Column("ns_id", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "ix_glucose_readings_source_nsid",
+        "glucose_readings",
+        ["source", "ns_id"],
+        unique=True,
+        postgresql_where=sa.text("ns_id IS NOT NULL"),
+    )
+
+    # --- 4. nightscout_profile_snapshots ---------------------------------
+    op.create_table(
+        "nightscout_profile_snapshots",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "nightscout_connection_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("nightscout_connections.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "fetched_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # Source metadata (from Nightscout's profile document)
+        sa.Column("source_default_profile_name", sa.String(120), nullable=True),
+        sa.Column("source_units", sa.String(20), nullable=True),
+        sa.Column("source_timezone", sa.String(60), nullable=True),
+        sa.Column("source_dia_hours", sa.Float(), nullable=True),
+        # Time-segmented schedules. Each is a list of {"time": "HH:MM",
+        # "value": <number>, "timeAsSeconds": <int>} -- preserved
+        # verbatim from Nightscout's wire format. Per synthesis §7.4,
+        # NS profile entries are (time, value) pairs; duration to next
+        # entry is implicit (computed downstream by the wizard).
+        sa.Column("basal_segments", postgresql.JSONB(), nullable=True),
+        sa.Column("carb_ratio_segments", postgresql.JSONB(), nullable=True),
+        sa.Column("sensitivity_segments", postgresql.JSONB(), nullable=True),
+        sa.Column("target_low_segments", postgresql.JSONB(), nullable=True),
+        sa.Column("target_high_segments", postgresql.JSONB(), nullable=True),
+        # Raw blob for re-parsing if the wizard needs additional fields
+        # we didn't break out into columns.
+        sa.Column("profile_json_full", postgresql.JSONB(), nullable=True),
+        # The Nightscout-side `startDate` (when the profile became
+        # active per Nightscout's clock). Different from `fetched_at`
+        # which is when our translator wrote the snapshot row.
+        sa.Column("source_start_date", sa.DateTime(timezone=True), nullable=True),
+    )
+    # One latest snapshot per (user, connection). Re-fetch upserts.
+    op.create_index(
+        "ix_nsps_user_connection",
+        "nightscout_profile_snapshots",
+        ["user_id", "nightscout_connection_id"],
+        unique=True,
+    )
+
+    # --- 5. device_status_snapshots --------------------------------------
+    op.create_table(
+        "device_status_snapshots",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "nightscout_connection_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("nightscout_connections.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "snapshot_timestamp",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "received_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # Source attribution
+        sa.Column("source_uploader", sa.String(40), nullable=True),
+        sa.Column("source_device", sa.String(200), nullable=True),
+        sa.Column("ns_id", sa.Text(), nullable=False),
+        # Extracted scalars (frequently queried)
+        sa.Column("iob_units", sa.Float(), nullable=True),
+        sa.Column("cob_grams", sa.Float(), nullable=True),
+        sa.Column("pump_battery_percent", sa.Integer(), nullable=True),
+        sa.Column("pump_reservoir_units", sa.Float(), nullable=True),
+        sa.Column("pump_suspended", sa.Boolean(), nullable=True),
+        sa.Column("loop_failure_reason", sa.Text(), nullable=True),
+        # Verbatim subtree blobs. Translator preserves them rather than
+        # parsing further; downstream AI/analytics layers do the work.
+        # Per synthesis §7.3: never modify, never parse the `reason`
+        # string here, never strip predBGs.
+        sa.Column("loop_subtree_json", postgresql.JSONB(), nullable=True),
+        sa.Column("openaps_subtree_json", postgresql.JSONB(), nullable=True),
+        sa.Column("pump_subtree_json", postgresql.JSONB(), nullable=True),
+        sa.Column("uploader_subtree_json", postgresql.JSONB(), nullable=True),
+    )
+    # Per-connection dedupe by Nightscout-assigned ns_id.
+    op.create_index(
+        "ix_devicestatus_connection_nsid",
+        "device_status_snapshots",
+        ["nightscout_connection_id", "ns_id"],
+        unique=True,
+    )
+    # Time-window query index: "give me the latest IOB for this user"
+    # / "snapshots in the last 30 min".
+    op.create_index(
+        "ix_devicestatus_user_timestamp",
+        "device_status_snapshots",
+        ["user_id", "snapshot_timestamp"],
+    )
+
+
+def downgrade() -> None:
+    # device_status_snapshots
+    op.drop_index(
+        "ix_devicestatus_user_timestamp",
+        table_name="device_status_snapshots",
+    )
+    op.drop_index(
+        "ix_devicestatus_connection_nsid",
+        table_name="device_status_snapshots",
+    )
+    op.drop_table("device_status_snapshots")
+
+    # nightscout_profile_snapshots
+    op.drop_index(
+        "ix_nsps_user_connection",
+        table_name="nightscout_profile_snapshots",
+    )
+    op.drop_table("nightscout_profile_snapshots")
+
+    # glucose_readings rollbacks
+    op.drop_index(
+        "ix_glucose_readings_source_nsid",
+        table_name="glucose_readings",
+    )
+    op.drop_column("glucose_readings", "ns_id")
+
+    # pump_events rollbacks
+    op.drop_index(
+        "ix_pump_events_meal_event_id",
+        table_name="pump_events",
+    )
+    op.drop_index(
+        "ix_pump_events_source_nsid",
+        table_name="pump_events",
+    )
+    op.drop_column("pump_events", "ns_id")
+    op.drop_column("pump_events", "meal_event_id")
+    op.drop_column("pump_events", "metadata_json")
+
+    # PumpEventType enum values cannot be removed without recreating
+    # the type. Leave them in place; they're harmless when unused.

--- a/apps/api/migrations/versions/052_nightscout_translator.py
+++ b/apps/api/migrations/versions/052_nightscout_translator.py
@@ -23,6 +23,25 @@ Lands the storage layer for the Nightscout translator:
   fetch; downstream consumers (AI chat, advanced web views) read recent
   rows for closed-loop analysis context.
 
+**Operational notes:**
+
+- The PumpEventType enum extension uses `op.execute("COMMIT")` followed
+  by `ALTER TYPE ... ADD VALUE IF NOT EXISTS` -- this is the required
+  PostgreSQL pattern (enum-value adds can't run inside a transaction)
+  and mirrors migration 036. If the migration errors out *after* the
+  COMMIT but before later DDL completes, the new enum values persist
+  on re-run; the rest of the schema is recreated fresh thanks to
+  `IF NOT EXISTS` guards. Rollback cannot remove the new enum values.
+
+- Downgrade restores the non-partial `ix_pump_events_user_event_unique`
+  index. If Nightscout-sourced rows already exist with duplicate
+  `(user_id, event_timestamp, event_type)` values (the partial-index
+  shape this migration introduces tolerates these), the
+  `op.create_index` call in `downgrade()` will fail with a uniqueness
+  violation. Ops should clean up Nightscout-sourced duplicates (or
+  delete all `pump_events` rows where `source LIKE 'nightscout:%'`)
+  before downgrading.
+
 Revision ID: 052_nightscout_translator
 Revises: 051_nightscout_connections
 Create Date: 2026-05-06

--- a/apps/api/src/models/device_status_snapshot.py
+++ b/apps/api/src/models/device_status_snapshot.py
@@ -1,0 +1,134 @@
+"""Device-status snapshot model.
+
+Periodic snapshots of the user's closed-loop state, written by the
+Nightscout translator on each devicestatus fetch. Captures IOB / COB,
+pump battery + reservoir, the current closed-loop dosing decision
+(suggested/enacted blocks preserved verbatim including the `reason`
+free-text string), and the loop's predicted-BG arrays.
+
+Downstream consumers (AI chat for rich context, advanced web views
+for closed-loop analysis) read recent rows. Translator never modifies
+the verbatim subtree blobs and never strips `predBGs` -- those are the
+high-signal artifacts the AI uses to explain "why did my loop dose what
+it dosed at 14:30?".
+
+Per-connection dedupe by Nightscout-assigned `_id`; same record across
+sync cycles upserts.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+
+
+class DeviceStatusSnapshot(Base):
+    """A single point-in-time snapshot of the closed-loop state."""
+
+    __tablename__ = "device_status_snapshots"
+
+    __table_args__ = (
+        # Per-connection dedupe by Nightscout-assigned ns_id.
+        Index(
+            "ix_devicestatus_connection_nsid",
+            "nightscout_connection_id",
+            "ns_id",
+            unique=True,
+        ),
+        # Time-window query index: "give me the latest IOB for this
+        # user" / "snapshots in the last 30 min".
+        Index(
+            "ix_devicestatus_user_timestamp",
+            "user_id",
+            "snapshot_timestamp",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    nightscout_connection_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("nightscout_connections.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    snapshot_timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # ---- Source attribution ---------------------------------------------
+
+    source_uploader: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    source_device: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    ns_id: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # ---- Extracted scalars (frequently queried) -------------------------
+
+    iob_units: Mapped[float | None] = mapped_column(Float, nullable=True)
+    cob_grams: Mapped[float | None] = mapped_column(Float, nullable=True)
+    pump_battery_percent: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    pump_reservoir_units: Mapped[float | None] = mapped_column(Float, nullable=True)
+    pump_suspended: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    loop_failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # ---- Verbatim subtree blobs -----------------------------------------
+    # Translator preserves these as-is; never modify, never parse the
+    # `reason` free-text strings here, never strip `predBGs`. AI and
+    # advanced analytics layers do the parsing work.
+
+    loop_subtree_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    openaps_subtree_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    pump_subtree_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    uploader_subtree_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+
+    # ---- Relationships ---------------------------------------------------
+
+    user = relationship("User")
+    connection = relationship("NightscoutConnection")
+
+    def __repr__(self) -> str:
+        return (
+            f"<DeviceStatusSnapshot(user_id={self.user_id}, "
+            f"uploader={self.source_uploader!r}, "
+            f"snapshot_timestamp={self.snapshot_timestamp})>"
+        )

--- a/apps/api/src/models/glucose.py
+++ b/apps/api/src/models/glucose.py
@@ -7,7 +7,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, Float, ForeignKey, Index, Integer, Text
+from sqlalchemy import DateTime, Enum, Float, ForeignKey, Index, Integer, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -70,6 +70,19 @@ class GlucoseReading(Base):
             "user_id",
             "reading_timestamp",
             unique=True,
+        ),
+        # Per-source partial unique index for Nightscout-relayed
+        # readings; mirrors the migration's
+        # `ix_glucose_readings_source_nsid` so SQLAlchemy is aware of
+        # it. Only fires when ns_id IS NOT NULL -- direct-integration
+        # rows (Dexcom, etc.) leave ns_id NULL and use the natural-key
+        # dedupe via the `(user_id, reading_timestamp)` index above.
+        Index(
+            "ix_glucose_readings_source_nsid",
+            "source",
+            "ns_id",
+            unique=True,
+            postgresql_where=text("ns_id IS NOT NULL"),
         ),
     )
 

--- a/apps/api/src/models/glucose.py
+++ b/apps/api/src/models/glucose.py
@@ -7,7 +7,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, Float, ForeignKey, Index, Integer
+from sqlalchemy import DateTime, Enum, Float, ForeignKey, Index, Integer, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -125,6 +125,17 @@ class GlucoseReading(Base):
     source: Mapped[str] = mapped_column(
         default="dexcom",
         nullable=False,
+    )
+
+    # Nightscout-server-assigned `_id` (or client-generated
+    # `identifier`). Used as the per-connection dedupe key when
+    # re-fetching the same record across sync cycles. NULL for
+    # direct-integration readings (Dexcom, etc.); the partial unique
+    # index `ix_glucose_readings_source_nsid` on (source, ns_id)
+    # WHERE ns_id IS NOT NULL handles the dedupe.
+    ns_id: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
     )
 
     # Relationship to user

--- a/apps/api/src/models/nightscout_profile_snapshot.py
+++ b/apps/api/src/models/nightscout_profile_snapshot.py
@@ -1,0 +1,125 @@
+"""Nightscout profile snapshot model.
+
+Read-only mirror of the user's Nightscout profile, written by the
+Nightscout translator on each profile fetch and read by the onboarding
+wizard to pre-fill the user's canonical settings form. Settings live
+in canonical tables (`pump_profiles`, `target_glucose_range`,
+`insulin_config`, etc.); this snapshot is a *suggestion source* the
+wizard uses to render an initial-fill state for the user to review.
+
+The snapshot is **never** queried by AI, charts, mobile UI, or alerts
+-- only the onboarding wizard touches it.
+
+Re-fetch behavior: one latest snapshot per (user_id, connection_id);
+new fetches upsert the existing row.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+
+
+class NightscoutProfileSnapshot(Base):
+    """A snapshot of one user's Nightscout-side profile data."""
+
+    __tablename__ = "nightscout_profile_snapshots"
+
+    __table_args__ = (
+        # One latest snapshot per (user, connection). Re-fetch upserts.
+        Index(
+            "ix_nsps_user_connection",
+            "user_id",
+            "nightscout_connection_id",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    nightscout_connection_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("nightscout_connections.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    fetched_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # ---- Source metadata (from Nightscout's profile document) -----------
+
+    source_default_profile_name: Mapped[str | None] = mapped_column(
+        String(120), nullable=True
+    )
+    source_units: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    source_timezone: Mapped[str | None] = mapped_column(String(60), nullable=True)
+    source_dia_hours: Mapped[float | None] = mapped_column(Float, nullable=True)
+    source_start_date: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    # ---- Time-segmented schedules (verbatim from Nightscout) -------------
+    # Each is a list of {"time": "HH:MM", "value": <number>,
+    # "timeAsSeconds": <int>}. Preserved as-emitted; the wizard
+    # computes per-entry duration (NS profile entries are (time, value)
+    # pairs; duration to next entry is implicit) and handles the
+    # midnight-wrap edge case (first entry not at 00:00 means the last
+    # entry's value carries back to midnight).
+
+    basal_segments: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    carb_ratio_segments: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    sensitivity_segments: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    target_low_segments: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    target_high_segments: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+
+    # ---- Raw blob ---------------------------------------------------------
+    # Full profile document for re-parsing if the wizard needs fields we
+    # didn't break out into typed columns (e.g., per-store metadata
+    # for users with multiple Nightscout profiles).
+    profile_json_full: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+    )
+
+    # ---- Relationships ----------------------------------------------------
+
+    user = relationship("User")
+    connection = relationship("NightscoutConnection")
+
+    def __repr__(self) -> str:
+        return (
+            f"<NightscoutProfileSnapshot(user_id={self.user_id}, "
+            f"connection_id={self.nightscout_connection_id}, "
+            f"profile={self.source_default_profile_name!r}, "
+            f"fetched_at={self.fetched_at})>"
+        )

--- a/apps/api/src/models/nightscout_profile_snapshot.py
+++ b/apps/api/src/models/nightscout_profile_snapshot.py
@@ -70,7 +70,10 @@ class NightscoutProfileSnapshot(Base):
     source_default_profile_name: Mapped[str | None] = mapped_column(
         String(120), nullable=True
     )
-    source_units: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # Real-world Nightscout values fit in 5 chars ("mg/dl"), but Loop
+    # historically emits the full HKUnit description (`"milligramsPerDeciliter"`,
+    # 22 chars) so 40 leaves room without imposing a meaningful cap.
+    source_units: Mapped[str | None] = mapped_column(String(40), nullable=True)
     source_timezone: Mapped[str | None] = mapped_column(String(60), nullable=True)
     source_dia_hours: Mapped[float | None] = mapped_column(Float, nullable=True)
     source_start_date: Mapped[datetime | None] = mapped_column(

--- a/apps/api/src/models/pump_data.py
+++ b/apps/api/src/models/pump_data.py
@@ -16,15 +16,26 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    Text,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.models.base import Base
 
 
 class PumpEventType(str, enum.Enum):
-    """Types of pump events from Tandem t:connect."""
+    """Types of pump events.
+
+    Direct-integration values (basal, bolus, correction, suspend,
+    resume, bg_reading, battery, reservoir) are written by direct
+    pump drivers (Tandem). The remaining values are written by the
+    Nightscout translator to cover events that flow in from
+    cloud-mediated integrations (carbs, overrides, profile switches,
+    combo boluses, temp targets, notes, device events, APS-offline
+    markers); type-specific extras that don't fit the column schema
+    land in `metadata_json`.
+    """
 
     BASAL = "basal"  # Basal insulin delivery
     BOLUS = "bolus"  # Manual bolus
@@ -34,6 +45,15 @@ class PumpEventType(str, enum.Enum):
     BG_READING = "bg_reading"  # CGM reading from pump (has IoB)
     BATTERY = "battery"  # Battery percentage from pump
     RESERVOIR = "reservoir"  # Reservoir insulin units remaining
+    # --- Cloud-mediated event types (Nightscout translator) ---
+    CARBS = "carbs"  # Carb-only entry (no insulin)
+    OVERRIDE = "override"  # Loop/AAPS Temporary Override or Trio Exercise toggle
+    PROFILE_SWITCH = "profile_switch"  # Profile change (real or AAPS EPS-as-Note)
+    COMBO_BOLUS = "combo_bolus"  # Combo Bolus or AAPS extendedEmulated TBR
+    TEMP_TARGET = "temp_target"  # Temporary Target adjustment
+    NOTE = "note"  # Free-text note / Announcement
+    DEVICE_EVENT = "device_event"  # Site/Sensor/Insulin/Battery change
+    APS_OFFLINE = "aps_offline"  # OpenAPS Offline / loop-down marker
 
 
 class PumpActivityMode(str, enum.Enum):
@@ -166,6 +186,38 @@ class PumpEvent(Base):
         String(50),
         default="tandem",
         nullable=False,
+    )
+
+    # Type-specific extras that don't fit the typed columns above.
+    # Examples: override correctionRange / multiplier / remoteAddress;
+    # profile-switch tuple (originalProfileName, percentage, timeshift,
+    # duration, profileJson); AAPS pump composite dedup triple
+    # (pumpId, pumpType, pumpSerial); Loop syncIdentifier; xDrip+ uuid.
+    # Nullable -- direct integrations leave this blank.
+    metadata_json: Mapped[dict | None] = mapped_column(
+        JSONB,
+        nullable=True,
+    )
+
+    # Links the bolus + carb_entry rows produced when an upstream
+    # meal-bolus pair (carbs + insulin in one record) is split into
+    # two internal events. Both rows share the same meal_event_id so
+    # downstream consumers can correlate them. NULL for non-paired
+    # events.
+    meal_event_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=True,
+    )
+
+    # Nightscout-server-assigned `_id` (or client-generated
+    # `identifier` / `syncIdentifier`). Used as the per-connection
+    # dedupe key when re-fetching the same record across sync cycles.
+    # NULL for direct-integration events; the partial unique index
+    # `ix_pump_events_source_nsid` on (source, ns_id) WHERE ns_id IS
+    # NOT NULL handles the dedupe.
+    ns_id: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
     )
 
     # Relationship to user

--- a/apps/api/src/models/pump_data.py
+++ b/apps/api/src/models/pump_data.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -85,13 +86,35 @@ class PumpEvent(Base):
     __table_args__ = (
         # Index for querying recent events for a user
         Index("ix_pump_events_user_timestamp", "user_id", "event_timestamp"),
-        # Unique constraint to prevent duplicate events
+        # Natural-key uniqueness for direct-integration rows only.
+        # Nightscout-sourced rows (`ns_id IS NOT NULL`) opt out of
+        # this index so two upstream events at the same timestamp
+        # (e.g. two AAPS SMBs in the same second with different
+        # `_id`s) don't silently drop one. They dedupe via the
+        # `ix_pump_events_source_nsid` partial unique index below.
         Index(
             "ix_pump_events_user_event_unique",
             "user_id",
             "event_timestamp",
             "event_type",
             unique=True,
+            postgresql_where=text("ns_id IS NULL"),
+        ),
+        # Per-source partial unique index for Nightscout-sourced
+        # events; mirrors the migration's `ix_pump_events_source_nsid`
+        # so SQLAlchemy knows about it.
+        Index(
+            "ix_pump_events_source_nsid",
+            "source",
+            "ns_id",
+            unique=True,
+            postgresql_where=text("ns_id IS NOT NULL"),
+        ),
+        # Sibling lookup for split meal-bolus pairs.
+        Index(
+            "ix_pump_events_meal_event_id",
+            "meal_event_id",
+            postgresql_where=text("meal_event_id IS NOT NULL"),
         ),
     )
 

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -1536,6 +1536,12 @@ async def push_pump_events(
         .values(rows)
         .on_conflict_do_nothing(
             index_elements=["user_id", "event_timestamp", "event_type"],
+            # The (user_id, event_timestamp, event_type) unique index
+            # is partial -- it applies only to direct-integration rows
+            # (`ns_id IS NULL`). Including the WHERE clause here is
+            # required for PostgreSQL to recognize the partial index
+            # as the ON CONFLICT target.
+            index_where=text("ns_id IS NULL"),
         )
     )
     result = await db.execute(stmt)

--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -463,6 +463,13 @@ async def read_connection_data(
     conn = await _load_owned(db, connection_id, current_user.id)
     source_tag = f"nightscout:{conn.id}"
 
+    # Defend against naive datetimes from clients: PostgreSQL's TIMESTAMP
+    # WITH TIME ZONE compares against naive values using the session's
+    # `timezone` setting, which silently shifts the cursor on a non-UTC
+    # session. Force UTC at the boundary.
+    if since is not None and since.tzinfo is None:
+        since = since.replace(tzinfo=UTC)
+
     glucose_q = (
         select(GlucoseReading)
         .where(

--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -1,19 +1,15 @@
-"""Story 43.1: Nightscout connection management endpoints.
+"""Nightscout connection management + read endpoints.
 
 REST surface under `/api/integrations/nightscout` for users to register,
 list, update, and remove their Nightscout / Nocturne (and connected
-platforms) instances.
-
-The actual data sync (Story 43.4) and the HTTP client (Story 43.2) live
-elsewhere -- this router only handles connection lifecycle. The
-connection-test endpoint uses the Story 43.1 stub in
-`src.services.integrations.nightscout.connection_test`; once Story 43.2
-ships, that module is replaced by the full client.
+platforms) instances; plus read endpoints that the cloud-source mobile
+plugin and the onboarding wizard consume.
 """
 
 import uuid
+from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,10 +17,13 @@ from src.core.auth import DiabeticOrAdminUser
 from src.core.encryption import decrypt_credential, encrypt_credential
 from src.database import get_db
 from src.logging_config import get_logger
+from src.models.glucose import GlucoseReading
 from src.models.nightscout_connection import (
     NightscoutConnection,
     NightscoutSyncStatus,
 )
+from src.models.nightscout_profile_snapshot import NightscoutProfileSnapshot
+from src.models.pump_data import PumpEvent
 from src.schemas.auth import ErrorResponse
 from src.schemas.nightscout import (
     NightscoutConnectionCreate,
@@ -34,6 +33,10 @@ from src.schemas.nightscout import (
     NightscoutConnectionResponse,
     NightscoutConnectionTestResult,
     NightscoutConnectionUpdate,
+    NightscoutDataResponse,
+    NightscoutGlucoseReadingDTO,
+    NightscoutProfileSnapshotResponse,
+    NightscoutPumpEventDTO,
 )
 from src.services.integrations.nightscout.connection_test import (
     ConnectionTestOutcome,
@@ -408,3 +411,160 @@ async def run_test(
     await db.commit()
 
     return _outcome_to_response(outcome)
+
+
+# ---------------------------------------------------------------------------
+# Read endpoints (mobile cloud-source plugin + onboarding wizard)
+# ---------------------------------------------------------------------------
+
+# Hard cap on `limit`. The cloud-source plugin pulls incrementally via
+# `since`, so a generous-but-bounded page keeps memory predictable.
+_MAX_DATA_LIMIT = 5000
+
+
+@router.get(
+    "/{connection_id}/data",
+    response_model=NightscoutDataResponse,
+    responses={
+        200: {"description": "Merged data slice for this connection"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Connection not found"},
+    },
+)
+async def read_connection_data(
+    connection_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    since: datetime | None = Query(
+        default=None,
+        description="Return rows whose timestamp is strictly > this value. "
+        "Omit on first call; pass the highest timestamp from the previous "
+        "page on subsequent calls.",
+    ),
+    limit: int = Query(default=500, ge=1, le=_MAX_DATA_LIMIT),
+    db: AsyncSession = Depends(get_db),
+) -> NightscoutDataResponse:
+    """Return glucose readings + pump events sourced from this connection.
+
+    Consumed by the mobile cloud-source plugin to populate Room DB.
+    Both arrays are filtered to `source = "nightscout:<id>"` -- the
+    caller never sees data from other sources, so coexistence with
+    BLE plugins on the same user is clean.
+    """
+    conn = await _load_owned(db, connection_id, current_user.id)
+    source_tag = f"nightscout:{conn.id}"
+
+    glucose_q = (
+        select(GlucoseReading)
+        .where(
+            GlucoseReading.user_id == current_user.id,
+            GlucoseReading.source == source_tag,
+        )
+        .order_by(GlucoseReading.reading_timestamp.asc())
+        .limit(limit)
+    )
+    if since is not None:
+        glucose_q = glucose_q.where(GlucoseReading.reading_timestamp > since)
+    glucose_rows = (await db.execute(glucose_q)).scalars().all()
+
+    events_q = (
+        select(PumpEvent)
+        .where(
+            PumpEvent.user_id == current_user.id,
+            PumpEvent.source == source_tag,
+        )
+        .order_by(PumpEvent.event_timestamp.asc())
+        .limit(limit)
+    )
+    if since is not None:
+        events_q = events_q.where(PumpEvent.event_timestamp > since)
+    event_rows = (await db.execute(events_q)).scalars().all()
+
+    return NightscoutDataResponse(
+        connection_id=conn.id,
+        fetched_at=datetime.now(UTC),
+        glucose_readings=[
+            NightscoutGlucoseReadingDTO(
+                ns_id=g.ns_id,
+                reading_timestamp=g.reading_timestamp,
+                value=g.value,
+                trend=g.trend.value,
+                trend_rate=g.trend_rate,
+                source=g.source,
+            )
+            for g in glucose_rows
+        ],
+        pump_events=[
+            NightscoutPumpEventDTO(
+                ns_id=e.ns_id,
+                event_timestamp=e.event_timestamp,
+                event_type=e.event_type.value,
+                units=e.units,
+                duration_minutes=e.duration_minutes,
+                is_automated=e.is_automated,
+                metadata_json=e.metadata_json,
+                meal_event_id=e.meal_event_id,
+                source=e.source,
+            )
+            for e in event_rows
+        ],
+    )
+
+
+@router.get(
+    "/{connection_id}/profile-snapshot",
+    response_model=NightscoutProfileSnapshotResponse,
+    responses={
+        200: {"description": "Latest profile snapshot for this connection"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Connection not found"},
+    },
+)
+async def read_connection_profile_snapshot(
+    connection_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> NightscoutProfileSnapshotResponse:
+    """Return the latest Nightscout profile snapshot for this connection.
+
+    Consumed by the onboarding wizard to pre-fill the user's canonical
+    settings form. Returns a `has_snapshot=False` empty payload when
+    no profile fetch has happened yet (the connection was added but
+    hasn't synced).
+    """
+    conn = await _load_owned(db, connection_id, current_user.id)
+    result = await db.execute(
+        select(NightscoutProfileSnapshot).where(
+            NightscoutProfileSnapshot.nightscout_connection_id == conn.id,
+            NightscoutProfileSnapshot.user_id == current_user.id,
+        )
+    )
+    snap = result.scalar_one_or_none()
+    if snap is None:
+        return NightscoutProfileSnapshotResponse(
+            connection_id=conn.id,
+            has_snapshot=False,
+            fetched_at=None,
+            source_default_profile_name=None,
+            source_units=None,
+            source_timezone=None,
+            source_dia_hours=None,
+            basal_segments=None,
+            carb_ratio_segments=None,
+            sensitivity_segments=None,
+            target_low_segments=None,
+            target_high_segments=None,
+        )
+    return NightscoutProfileSnapshotResponse(
+        connection_id=conn.id,
+        has_snapshot=True,
+        fetched_at=snap.fetched_at,
+        source_default_profile_name=snap.source_default_profile_name,
+        source_units=snap.source_units,
+        source_timezone=snap.source_timezone,
+        source_dia_hours=snap.source_dia_hours,
+        basal_segments=snap.basal_segments,
+        carb_ratio_segments=snap.carb_ratio_segments,
+        sensitivity_segments=snap.sensitivity_segments,
+        target_low_segments=snap.target_low_segments,
+        target_high_segments=snap.target_high_segments,
+    )

--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -436,9 +436,14 @@ async def read_connection_data(
     current_user: DiabeticOrAdminUser,
     since: datetime | None = Query(
         default=None,
-        description="Return rows whose timestamp is strictly > this value. "
+        description="Return rows whose timestamp is >= this value. "
         "Omit on first call; pass the highest timestamp from the previous "
-        "page on subsequent calls.",
+        "page on subsequent calls. Inclusive comparison (`>=`) guards "
+        "against losing rows that share a timestamp with the cursor "
+        "boundary (e.g. the bolus + carbs rows of a split meal-bolus "
+        "pair land at identical timestamps). Callers MUST dedupe by "
+        "`ns_id` locally -- duplicates are bounded to ~1 row per page "
+        "boundary per array.",
     ),
     limit: int = Query(default=500, ge=1, le=_MAX_DATA_LIMIT),
     db: AsyncSession = Depends(get_db),
@@ -449,6 +454,11 @@ async def read_connection_data(
     Both arrays are filtered to `source = "nightscout:<id>"` -- the
     caller never sees data from other sources, so coexistence with
     BLE plugins on the same user is clean.
+
+    `limit` applies **per array** -- a single response can contain
+    up to `limit` glucose readings AND up to `limit` pump events. The
+    response field `effective_limit_per_array` echoes the value used
+    so callers don't have to track the cap.
     """
     conn = await _load_owned(db, connection_id, current_user.id)
     source_tag = f"nightscout:{conn.id}"
@@ -463,7 +473,7 @@ async def read_connection_data(
         .limit(limit)
     )
     if since is not None:
-        glucose_q = glucose_q.where(GlucoseReading.reading_timestamp > since)
+        glucose_q = glucose_q.where(GlucoseReading.reading_timestamp >= since)
     glucose_rows = (await db.execute(glucose_q)).scalars().all()
 
     events_q = (
@@ -476,12 +486,13 @@ async def read_connection_data(
         .limit(limit)
     )
     if since is not None:
-        events_q = events_q.where(PumpEvent.event_timestamp > since)
+        events_q = events_q.where(PumpEvent.event_timestamp >= since)
     event_rows = (await db.execute(events_q)).scalars().all()
 
     return NightscoutDataResponse(
         connection_id=conn.id,
         fetched_at=datetime.now(UTC),
+        effective_limit_per_array=limit,
         glucose_readings=[
             NightscoutGlucoseReadingDTO(
                 ns_id=g.ns_id,

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -253,3 +253,90 @@ class NightscoutConnectionDeletedResponse(BaseModel):
         "Connection deactivated. Historical data and per-source attribution "
         "are preserved."
     )
+
+
+# ---------------------------------------------------------------------------
+# Read endpoints (consumed by the mobile cloud-source plugin + the
+# onboarding wizard)
+# ---------------------------------------------------------------------------
+
+
+class NightscoutGlucoseReadingDTO(BaseModel):
+    """A glucose reading row stripped to what the mobile plugin needs.
+
+    Internal `user_id` and DB UUIDs are omitted; downstream consumers
+    only need the timestamp + value + trend + source attribution.
+    """
+
+    model_config = {"from_attributes": True}
+
+    ns_id: str | None
+    reading_timestamp: datetime
+    value: int
+    trend: str
+    trend_rate: float | None
+    source: str
+
+
+class NightscoutPumpEventDTO(BaseModel):
+    """A pump event row stripped to what the mobile plugin needs."""
+
+    model_config = {"from_attributes": True}
+
+    ns_id: str | None
+    event_timestamp: datetime
+    event_type: str
+    units: float | None
+    duration_minutes: int | None
+    is_automated: bool
+    metadata_json: dict[str, Any] | None
+    meal_event_id: uuid.UUID | None
+    source: str
+
+
+class NightscoutDataResponse(BaseModel):
+    """Merged read response for the cloud-source mobile plugin.
+
+    The plugin pulls this with `?since=<ISO>` to backfill its Room DB
+    incrementally. Both arrays are sorted ascending by timestamp; pagination
+    is via the `since` cursor on subsequent calls. `limit` caps the total
+    rows returned across both arrays so a single page is bounded.
+    """
+
+    connection_id: uuid.UUID
+    fetched_at: datetime
+    glucose_readings: list[NightscoutGlucoseReadingDTO]
+    pump_events: list[NightscoutPumpEventDTO]
+
+
+class NightscoutProfileSegmentDTO(BaseModel):
+    """A single (time, value) entry from a Nightscout profile schedule."""
+
+    model_config = {"extra": "allow"}
+
+    time: str  # "HH:MM"
+    value: float
+
+
+class NightscoutProfileSnapshotResponse(BaseModel):
+    """Read response for the onboarding wizard's profile pre-fill source.
+
+    Returned with empty arrays when no snapshot exists yet (the connection
+    has been added but profile sync hasn't run). The wizard renders a
+    "no profile detected" state in that case.
+    """
+
+    model_config = {"from_attributes": True}
+
+    connection_id: uuid.UUID
+    has_snapshot: bool
+    fetched_at: datetime | None
+    source_default_profile_name: str | None
+    source_units: str | None
+    source_timezone: str | None
+    source_dia_hours: float | None
+    basal_segments: list[dict[str, Any]] | None
+    carb_ratio_segments: list[dict[str, Any]] | None
+    sensitivity_segments: list[dict[str, Any]] | None
+    target_low_segments: list[dict[str, Any]] | None
+    target_high_segments: list[dict[str, Any]] | None

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -298,13 +298,22 @@ class NightscoutDataResponse(BaseModel):
     """Merged read response for the cloud-source mobile plugin.
 
     The plugin pulls this with `?since=<ISO>` to backfill its Room DB
-    incrementally. Both arrays are sorted ascending by timestamp; pagination
-    is via the `since` cursor on subsequent calls. `limit` caps the total
-    rows returned across both arrays so a single page is bounded.
+    incrementally. Both arrays are sorted ascending by timestamp.
+    Pagination is via the `since` cursor on subsequent calls; the
+    cursor is **inclusive** (`>=`) to avoid losing rows that share a
+    timestamp with the boundary, so callers MUST dedupe by `ns_id`
+    locally -- duplicates are bounded to ~1 row per page boundary per
+    array.
+
+    `limit` applies **per array**, not across both -- a single response
+    may contain up to `limit` glucose readings AND up to `limit` pump
+    events. `effective_limit_per_array` echoes the value used so the
+    client doesn't have to track the cap.
     """
 
     connection_id: uuid.UUID
     fetched_at: datetime
+    effective_limit_per_array: int
     glucose_readings: list[NightscoutGlucoseReadingDTO]
     pump_events: list[NightscoutPumpEventDTO]
 

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -279,7 +279,15 @@ class NightscoutGlucoseReadingDTO(BaseModel):
 
 
 class NightscoutPumpEventDTO(BaseModel):
-    """A pump event row stripped to what the mobile plugin needs."""
+    """A pump event row stripped to what the mobile plugin needs.
+
+    `metadata_json` carries clinically-meaningful extras filtered through
+    a storage-side allowlist (see `_pump_events_mapper._METADATA_ALLOWLIST`).
+    The DTO field is `repr=False` so that any future log/audit trail of
+    this object doesn't echo free-text `notes` / `reason` content; the
+    underlying value is still serialized normally to JSON callers (the
+    data owner's own authenticated client).
+    """
 
     model_config = {"from_attributes": True}
 
@@ -289,7 +297,7 @@ class NightscoutPumpEventDTO(BaseModel):
     units: float | None
     duration_minutes: int | None
     is_automated: bool
-    metadata_json: dict[str, Any] | None
+    metadata_json: dict[str, Any] | None = Field(default=None, repr=False)
     meal_event_id: uuid.UUID | None
     source: str
 

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -352,8 +352,8 @@ class NightscoutProfileSnapshotResponse(BaseModel):
     source_units: str | None
     source_timezone: str | None
     source_dia_hours: float | None
-    basal_segments: list[dict[str, Any]] | None
-    carb_ratio_segments: list[dict[str, Any]] | None
-    sensitivity_segments: list[dict[str, Any]] | None
-    target_low_segments: list[dict[str, Any]] | None
-    target_high_segments: list[dict[str, Any]] | None
+    basal_segments: list[NightscoutProfileSegmentDTO] | None
+    carb_ratio_segments: list[NightscoutProfileSegmentDTO] | None
+    sensitivity_segments: list[NightscoutProfileSegmentDTO] | None
+    target_low_segments: list[NightscoutProfileSegmentDTO] | None
+    target_high_segments: list[NightscoutProfileSegmentDTO] | None

--- a/apps/api/src/services/integrations/nightscout/_devicestatus_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_devicestatus_mapper.py
@@ -52,13 +52,21 @@ def map_devicestatus_to_snapshot(
             if isinstance(status, dict) and isinstance(status.get("suspended"), bool):
                 pump_suspended = status["suspended"]
 
+    # Defensively truncate to the column lengths so an over-long
+    # upstream value (e.g., a verbose Loop iAPS build string in
+    # `device`) doesn't fail the whole insert batch. The column caps
+    # match `DeviceStatusSnapshot.source_uploader` (40) and
+    # `DeviceStatusSnapshot.source_device` (200).
+    source_uploader = (ds.uploader_name or "")[:40] or None
+    source_device = (ds.device or "")[:200] or None
+
     return {
         "user_id": user_id,
         "nightscout_connection_id": nightscout_connection_id,
         "snapshot_timestamp": timestamp,
         "received_at": received_at or datetime.now(UTC),
-        "source_uploader": ds.uploader_name,
-        "source_device": ds.device,
+        "source_uploader": source_uploader,
+        "source_device": source_device,
         "ns_id": ds.id,
         "iob_units": ds.iob_value,
         "cob_grams": _extract_cob(ds),

--- a/apps/api/src/services/integrations/nightscout/_devicestatus_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_devicestatus_mapper.py
@@ -1,0 +1,108 @@
+"""Map Nightscout devicestatus records to DeviceStatusSnapshot rows.
+
+Each devicestatus record produces at most one snapshot row. Subtree
+JSON blobs (`loop`, `openaps`, `pump`, `uploader`) are preserved
+verbatim -- never modified, never parsed further at this layer. The
+`reason` free-text strings inside `suggested`/`enacted` carry the
+loop's dosing-decision rationale that AI consumes; the translator
+keeps them intact.
+
+Per-connection dedupe via `ns_id` (server-assigned `_id`). If the
+record has no ns_id (rare; some uploaders POST without one), we skip
+rather than invent a key -- snapshots are high-volume, so dropping
+one is preferable to creating a duplicate row.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from src.services.integrations.nightscout.models import NightscoutDeviceStatus
+
+
+def map_devicestatus_to_snapshot(
+    ds: NightscoutDeviceStatus,
+    *,
+    user_id: str,
+    nightscout_connection_id: str,
+    received_at: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Map a Nightscout devicestatus to a DeviceStatusSnapshot insert dict.
+
+    Returns None when:
+    - `_id` is missing (no per-connection dedupe key)
+    - `created_at` parses to None
+    """
+    if not ds.id:
+        return None
+    timestamp = _parse_created_at(ds.created_at)
+    if timestamp is None:
+        return None
+
+    pump_subtree = ds.pump if isinstance(ds.pump, dict) else None
+    pump_suspended = None
+    if pump_subtree:
+        # Loop: pump.suspended is a top-level boolean
+        if isinstance(pump_subtree.get("suspended"), bool):
+            pump_suspended = pump_subtree["suspended"]
+        # AAPS / oref0: pump.status.suspended
+        else:
+            status = pump_subtree.get("status")
+            if isinstance(status, dict) and isinstance(status.get("suspended"), bool):
+                pump_suspended = status["suspended"]
+
+    return {
+        "user_id": user_id,
+        "nightscout_connection_id": nightscout_connection_id,
+        "snapshot_timestamp": timestamp,
+        "received_at": received_at or datetime.now(UTC),
+        "source_uploader": ds.uploader_name,
+        "source_device": ds.device,
+        "ns_id": ds.id,
+        "iob_units": ds.iob_value,
+        "cob_grams": _extract_cob(ds),
+        "pump_battery_percent": ds.pump_battery_percent,
+        "pump_reservoir_units": ds.pump_reservoir,
+        "pump_suspended": pump_suspended,
+        "loop_failure_reason": ds.loop_failure_reason,
+        "loop_subtree_json": ds.loop if isinstance(ds.loop, dict) else None,
+        "openaps_subtree_json": ds.openaps if isinstance(ds.openaps, dict) else None,
+        "pump_subtree_json": pump_subtree,
+        "uploader_subtree_json": ds.uploader if isinstance(ds.uploader, dict) else None,
+    }
+
+
+def _parse_created_at(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    s = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    return dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def _extract_cob(ds: NightscoutDeviceStatus) -> float | None:
+    """Pull COB out of whichever subtree carries it.
+
+    Loop: `loop.cob.cob`
+    AAPS / oref0: `openaps.suggested.COB` or `openaps.iob.cob`
+    """
+    if ds.loop and isinstance(ds.loop.get("cob"), dict):
+        v = ds.loop["cob"].get("cob")
+        if isinstance(v, int | float) and not isinstance(v, bool):
+            return float(v)
+    if ds.openaps:
+        suggested = ds.openaps.get("suggested")
+        if isinstance(suggested, dict):
+            v = suggested.get("COB")
+            if isinstance(v, int | float) and not isinstance(v, bool):
+                return float(v)
+        iob_subtree = ds.openaps.get("iob")
+        if isinstance(iob_subtree, dict):
+            v = iob_subtree.get("cob")
+            if isinstance(v, int | float) and not isinstance(v, bool):
+                return float(v)
+    return None

--- a/apps/api/src/services/integrations/nightscout/_glucose_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_glucose_mapper.py
@@ -1,0 +1,168 @@
+"""Map Nightscout entries + BG-Check treatments to GlucoseReading rows.
+
+Produces dicts ready for `INSERT ... ON CONFLICT DO NOTHING` upsert
+keyed on `(source, ns_id)`. The mappers are pure -- the orchestrator
+handles DB writes.
+
+Two distinct input paths land in `glucose_readings`:
+
+- `entries[type=sgv]` -- CGM readings (most common path)
+- `entries[type=mbg]` -- xDrip+ Android fingerstick (entries-route)
+- `treatments[eventType=BG Check or glucoseType=Finger]` -- xDrip4iOS
+  / Care Portal fingerstick (treatments-route)
+
+The two fingerstick paths are the dual-path documented in the
+translator survey: same logical event, different collection. Both
+land in the same table with `trend = NOT_COMPUTABLE` (fingersticks
+have no trend).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from src.models.glucose import TrendDirection
+from src.services.integrations.nightscout.models import (
+    NightscoutEntry,
+    NightscoutTreatment,
+)
+
+# Nightscout direction strings (canonical wire form, spaced) ->
+# TrendDirection enum. NightscoutEntry's validator already normalizes
+# the underscored variants to spaced form.
+_NS_DIRECTION_TO_TREND: dict[str, TrendDirection] = {
+    "DoubleUp": TrendDirection.DOUBLE_UP,
+    "SingleUp": TrendDirection.SINGLE_UP,
+    "FortyFiveUp": TrendDirection.FORTY_FIVE_UP,
+    "Flat": TrendDirection.FLAT,
+    "FortyFiveDown": TrendDirection.FORTY_FIVE_DOWN,
+    "SingleDown": TrendDirection.SINGLE_DOWN,
+    "DoubleDown": TrendDirection.DOUBLE_DOWN,
+    "NOT COMPUTABLE": TrendDirection.NOT_COMPUTABLE,
+    "RATE OUT OF RANGE": TrendDirection.RATE_OUT_OF_RANGE,
+    "NONE": TrendDirection.NOT_COMPUTABLE,
+    # Trio extends with TripleUp/TripleDown outside the canonical
+    # NS enum. Coerce to the closest documented value rather than
+    # rejecting -- losing the "triple" granularity is acceptable.
+    "TripleUp": TrendDirection.DOUBLE_UP,
+    "TripleDown": TrendDirection.DOUBLE_DOWN,
+}
+
+
+def map_ns_direction(direction: str | None) -> TrendDirection:
+    """Resolve a Nightscout `direction` string to a TrendDirection enum.
+
+    Unknown / missing direction strings fall back to NOT_COMPUTABLE
+    rather than raising -- some uploaders omit the field entirely or
+    emit values outside the documented enum.
+    """
+    if direction is None:
+        return TrendDirection.NOT_COMPUTABLE
+    return _NS_DIRECTION_TO_TREND.get(direction, TrendDirection.NOT_COMPUTABLE)
+
+
+def map_entry_to_glucose_reading(
+    entry: NightscoutEntry,
+    *,
+    user_id: str,
+    source: str,
+    received_at: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Map a Nightscout entry to a GlucoseReading insert dict.
+
+    Returns None when the entry should be dropped:
+    - `cal` records (calibration metadata, not a reading)
+    - SGV-type readings outside the medically valid range (gap rule)
+    - Missing canonical timestamp
+
+    Otherwise returns a dict with keys matching `GlucoseReading`
+    columns, suitable for `Insert(GlucoseReading.__table__).values(...)`.
+    """
+    timestamp = entry.canonical_timestamp
+    if timestamp is None:
+        return None
+
+    if entry.type == "cal":
+        # Calibration records aren't glucose readings -- they record
+        # slope/intercept changes the CGM applied. Out of scope for
+        # the translator's input layer; future work could store them
+        # for noise/calibration-window analysis.
+        return None
+
+    # Pick the value field by type. sgv = CGM; mbg = manual BG.
+    if entry.type == "sgv":
+        if entry.is_glucose_gap:
+            return None
+        if entry.sgv is None:
+            return None
+        value = int(round(entry.sgv))
+        trend = map_ns_direction(entry.direction)
+        trend_rate = entry.delta if entry.delta is not None else None
+    elif entry.type == "mbg":
+        if entry.mbg is None:
+            return None
+        value = int(round(entry.mbg))
+        # Fingersticks have no trend signal -- meter readings are
+        # point-in-time.
+        trend = TrendDirection.NOT_COMPUTABLE
+        trend_rate = None
+    else:
+        # Unknown entry type -- preserve nothing rather than guess.
+        return None
+
+    return {
+        "user_id": user_id,
+        "value": value,
+        "reading_timestamp": timestamp,
+        "trend": trend,
+        "trend_rate": trend_rate,
+        "received_at": received_at or datetime.now(UTC),
+        "source": source,
+        "ns_id": entry.id,
+    }
+
+
+def map_bg_check_treatment_to_glucose_reading(
+    treatment: NightscoutTreatment,
+    *,
+    user_id: str,
+    source: str,
+    received_at: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Map a treatments-route fingerstick (BG Check) to a GlucoseReading.
+
+    The treatments-route path is xDrip4iOS / Care Portal: same logical
+    event as an entries[type=mbg] record. Only fires when the
+    treatment is detected as a fingerstick (eventType="BG Check" OR
+    glucoseType="Finger") -- callers should gate on
+    `treatment.is_fingerstick_treatment` before calling this.
+
+    Returns None when:
+    - Glucose value is missing
+    - Timestamp is missing
+    """
+    timestamp = treatment.canonical_timestamp
+    if timestamp is None or treatment.glucose is None:
+        return None
+
+    # Per-record `units` field can override the default (rare).
+    # Convert mmol/L to mg/dL using the project-wide conversion factor.
+    glucose_value = treatment.glucose
+    units = (treatment.units or "").lower().strip()
+    if units in ("mmol", "mmol/l"):
+        # Defer to the central constant to keep one source of truth.
+        from src.services.integrations.nightscout.models import MGDL_PER_MMOL
+
+        glucose_value = glucose_value * MGDL_PER_MMOL
+
+    return {
+        "user_id": user_id,
+        "value": int(round(glucose_value)),
+        "reading_timestamp": timestamp,
+        "trend": TrendDirection.NOT_COMPUTABLE,
+        "trend_rate": None,
+        "received_at": received_at or datetime.now(UTC),
+        "source": source,
+        "ns_id": treatment.id,
+    }

--- a/apps/api/src/services/integrations/nightscout/_profile_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_profile_mapper.py
@@ -55,7 +55,12 @@ def map_profile_to_snapshot(
         "sensitivity_segments": _segments(active, "sens"),
         "target_low_segments": _segments(active, "target_low"),
         "target_high_segments": _segments(active, "target_high"),
-        "profile_json_full": profile.model_dump(by_alias=True, exclude_none=True),
+        # `mode="json"` so any datetime / UUID values in the profile
+        # tree serialize to strings rather than Python objects -- the
+        # JSONB column rejects raw datetime objects at write time.
+        "profile_json_full": profile.model_dump(
+            by_alias=True, exclude_none=True, mode="json"
+        ),
     }
 
 

--- a/apps/api/src/services/integrations/nightscout/_profile_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_profile_mapper.py
@@ -1,0 +1,84 @@
+"""Map Nightscout profile records to NightscoutProfileSnapshot rows.
+
+The snapshot is a read-only mirror of the user's Nightscout-side
+profile -- written on each profile fetch, read by the onboarding
+wizard to pre-fill the user's canonical settings form. Time-series
+schedules (basal / carb_ratio / sensitivity / target_low /
+target_high) are preserved verbatim as `(time, value)` lists; per-entry
+duration is implicit (computed downstream by the wizard) and the
+midnight-wrap edge case (first entry not at 00:00) is also the
+wizard's responsibility.
+
+One snapshot row per (user, connection); upserts on re-fetch.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from src.services.integrations.nightscout.models import (
+    NightscoutProfile,
+    NightscoutProfileStore,
+)
+
+
+def map_profile_to_snapshot(
+    profile: NightscoutProfile,
+    *,
+    user_id: str,
+    nightscout_connection_id: str,
+    fetched_at: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Map a Nightscout profile record to a snapshot insert dict.
+
+    Returns None when:
+    - The profile has no `defaultProfile` pointer or the pointer's
+      target store doesn't exist (the wizard has nothing to render
+      from a profile with no active store).
+    """
+    active = profile.active_profile()
+    if active is None:
+        return None
+
+    return {
+        "user_id": user_id,
+        "nightscout_connection_id": nightscout_connection_id,
+        "fetched_at": fetched_at or datetime.now(UTC),
+        "source_default_profile_name": profile.default_profile,
+        "source_units": active.units or profile.units,
+        "source_timezone": active.timezone,
+        "source_dia_hours": active.dia,
+        "source_start_date": _parse_iso(profile.start_date),
+        "basal_segments": _segments(active, "basal"),
+        "carb_ratio_segments": _segments(active, "carbratio"),
+        "sensitivity_segments": _segments(active, "sens"),
+        "target_low_segments": _segments(active, "target_low"),
+        "target_high_segments": _segments(active, "target_high"),
+        "profile_json_full": profile.model_dump(by_alias=True, exclude_none=True),
+    }
+
+
+def _segments(store: NightscoutProfileStore, attr: str) -> list[dict[str, Any]] | None:
+    """Pull a time-segmented list off a profile store, defensively.
+
+    Returns None when the store doesn't carry the attribute at all
+    (some sparse profiles omit fields). The list is preserved as-is
+    -- entries are typed as `dict[str, Any]` so the wizard sees the
+    raw `{time, value, timeAsSeconds?}` shape.
+    """
+    value = getattr(store, attr, None)
+    if not isinstance(value, list):
+        return None
+    return value
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    s = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    return dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)

--- a/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
@@ -1,0 +1,448 @@
+"""Map Nightscout treatments to PumpEvent rows.
+
+Routes by the input model's `semantic_kind` (which already decided
+how to interpret the record's field-presence). The mapper produces
+zero, one, or two PumpEvent insert dicts:
+
+- Zero: dropped (unknown eventType, soft-delete, cancel-temp signal,
+  fingerstick BG Check (handled by glucose mapper), unrecognized
+  device events).
+- One: most common -- a single event row.
+- Two: meal-bolus pair (carbs + insulin in one record split into a
+  bolus row + a carb_entry row, linked by `meal_event_id`).
+
+Type-specific extras that don't fit the typed columns land in
+`metadata_json`. Source attribution lives in `source` (top-level
+"nightscout:<connection_id>") plus inside `metadata_json` for the
+sub-attribution (uploader, raw device string, raw enteredBy string).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from src.models.pump_data import PumpEventType
+from src.services.integrations.nightscout.models import NightscoutTreatment
+
+
+def _build_metadata(
+    treatment: NightscoutTreatment,
+    *,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the metadata_json blob carrying source sub-attribution.
+
+    Always includes:
+    - source_uploader (detected from device + entered_by)
+    - source_device + source_entered_by (raw strings, preserved)
+    - source_relayed (true if the entered_by ends in @ns / @ns loader)
+    - notes (free-text, redacted at the model layer via repr=False but
+      preserved as data here)
+
+    Per-event-type extras get merged in via the `extra` dict.
+    """
+    eb = treatment.entered_by or ""
+    relayed = eb.endswith("@ns") or eb.endswith("@ns loader")
+    base: dict[str, Any] = {
+        "source_uploader": treatment.uploader,
+        "source_device": treatment.device,
+        "source_entered_by": treatment.entered_by,
+        "source_relayed": relayed,
+    }
+    if treatment.notes:
+        base["notes"] = treatment.notes
+    if extra:
+        base.update(extra)
+    return base
+
+
+def _base_event(
+    treatment: NightscoutTreatment,
+    *,
+    user_id: str,
+    source: str,
+    event_type: PumpEventType,
+    received_at: datetime | None,
+) -> dict[str, Any] | None:
+    """Build the common columns shared by every PumpEvent insert.
+
+    Returns None if the treatment lacks a resolvable timestamp -- a
+    record without a timestamp can't be ordered or rendered, so
+    dropping it is preferable to inventing one.
+    """
+    ts = treatment.canonical_timestamp
+    if ts is None:
+        return None
+    return {
+        "user_id": user_id,
+        "event_type": event_type,
+        "event_timestamp": ts,
+        "received_at": received_at or datetime.now(UTC),
+        "source": source,
+        "ns_id": treatment.id,
+    }
+
+
+def _map_bolus(treatment: NightscoutTreatment, base: dict[str, Any]) -> dict[str, Any]:
+    """Bolus / SMB / Square / External Insulin -- all land as BOLUS."""
+    extras: dict[str, Any] = {}
+    if treatment.is_smb:
+        extras["bolus_subtype"] = "smb"
+    elif treatment.is_external_insulin:
+        extras["bolus_subtype"] = "external"
+    elif treatment.bolus_type and treatment.bolus_type.lower().strip() == "square":
+        # Loop classifies any bolus with delivery duration >= 30 min
+        # as Square; not a true split bolus, just a long-duration
+        # regular bolus.
+        extras["bolus_subtype"] = "square"
+    else:
+        extras["bolus_subtype"] = "normal"
+
+    if treatment.programmed is not None:
+        extras["programmed_units"] = treatment.programmed
+    if treatment.insulin_type:
+        extras["insulin_type"] = treatment.insulin_type
+    # AAPS pump composite dedup triple
+    if treatment.pump_id is not None:
+        extras["pump_id"] = treatment.pump_id
+    if treatment.pump_type:
+        extras["pump_type"] = treatment.pump_type
+    if treatment.pump_serial:
+        extras["pump_serial"] = treatment.pump_serial
+    # Loop syncIdentifier (separate from server-assigned _id; useful
+    # for round-tripping back to Loop's HealthKit cache).
+    if treatment.sync_identifier:
+        extras["sync_identifier"] = treatment.sync_identifier
+    # AAPS Bolus Wizard inputs (carbs, BG, target, ISF, CR, IOB) --
+    # preserved verbatim for AI analysis context.
+    if treatment.bolus_calculator_result:
+        extras["bolus_calculator_result"] = treatment.bolus_calculator_result
+
+    base.update(
+        {
+            "units": treatment.insulin,
+            "is_automated": treatment.automatic is True,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
+def _map_carb_entry(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    extras: dict[str, Any] = {"carbs_grams": treatment.carbs}
+    # AAPS extended-meal nutrition (high-fat / high-protein meals)
+    if treatment.protein is not None:
+        extras["protein_grams"] = treatment.protein
+    if treatment.fat is not None:
+        extras["fat_grams"] = treatment.fat
+    if treatment.duration is not None:
+        # Loop emits absorptionTime for carbs (in seconds); other
+        # uploaders emit duration (minutes). The input-model layer
+        # doesn't normalize the unit; we record what's there and leave
+        # Loop-vs-other-uploader unit handling to the wizard / AI.
+        extras["duration_field_value"] = treatment.duration
+    if treatment.uploader == "loop":
+        extras["loop_carbs_uses_seconds"] = True
+
+    base.update(
+        {
+            "units": None,  # carb-only, no insulin
+            "duration_minutes": int(treatment.duration)
+            if treatment.duration is not None and treatment.uploader != "loop"
+            else None,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
+def _map_temp_basal(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    """Temp Basal -- absolute or percent-mode."""
+    extras: dict[str, Any] = {}
+    if treatment.rate is not None:
+        extras["rate_u_per_hr"] = treatment.rate
+    if treatment.absolute is not None:
+        extras["absolute_u_per_hr"] = treatment.absolute
+    if treatment.percent is not None:
+        # NS percent encoding: delta from 100 (e.g. -50 = 50% basal)
+        extras["percent_delta"] = treatment.percent
+    if treatment.reason:
+        # Loop sets reason="suspend" for pump suspends; preserve it
+        # for downstream classification.
+        extras["reason"] = treatment.reason
+    # AAPS Type subtype if present: NORMAL / EMULATED_PUMP_SUSPEND /
+    # PUMP_SUSPEND / SUPERBOLUS / FAKE_EXTENDED.
+    if treatment.type:
+        extras["aaps_type"] = treatment.type
+
+    base.update(
+        {
+            "units": None,
+            "duration_minutes": int(treatment.duration)
+            if treatment.duration is not None
+            else None,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
+def _map_temp_basal_suspend(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    """Pump suspend signaled via a zero-rate Temp Basal (with duration)."""
+    base = _map_temp_basal(treatment, base)
+    # Override the event_type set by base_event (which was TEMP_BASAL)
+    # to the dedicated SUSPEND value.
+    base["event_type"] = PumpEventType.SUSPEND
+    return base
+
+
+def _map_combo_bolus(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    """Combo Bolus or AAPS extended-emulating-TBR shape."""
+    extras: dict[str, Any] = {}
+    if treatment.split_now is not None:
+        extras["split_now_pct"] = treatment.split_now
+    if treatment.split_ext is not None:
+        extras["split_ext_pct"] = treatment.split_ext
+    if treatment.combo_split_valid is False and (
+        treatment.split_now is not None or treatment.split_ext is not None
+    ):
+        # Lock against malformed real-world splits -- record the
+        # constraint violation so the AI / analytics layer can flag it
+        # rather than silently miscompute.
+        extras["split_invalid"] = True
+    if treatment.extended_emulated:
+        # AAPS extended bolus emulating TBR: preserve the nested
+        # subtree for downstream analysis.
+        extras["extended_emulated"] = treatment.extended_emulated
+    base.update(
+        {
+            "units": treatment.insulin,
+            "duration_minutes": int(treatment.duration)
+            if treatment.duration is not None
+            else None,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
+def _map_override(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    extras: dict[str, Any] = {}
+    if treatment.correction_range:
+        extras["correction_range"] = treatment.correction_range
+    if treatment.insulin_needs_scale_factor is not None:
+        extras["multiplier"] = treatment.insulin_needs_scale_factor
+    elif treatment.multiplier is not None:
+        extras["multiplier"] = treatment.multiplier
+    elif treatment.percentage is not None:
+        # AAPS percentage as multiplier (e.g. 110% = 1.1)
+        extras["multiplier"] = treatment.percentage / 100.0
+    if treatment.remote_address:
+        extras["remote_address"] = treatment.remote_address
+    if treatment.duration_type:
+        extras["duration_type"] = treatment.duration_type
+    if treatment.is_indefinite_trio_override:
+        extras["indefinite"] = True
+
+    base.update(
+        {
+            "units": None,
+            "duration_minutes": int(treatment.duration)
+            if treatment.duration is not None
+            else None,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
+def _map_temp_target(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    extras: dict[str, Any] = {}
+    if treatment.target_top is not None:
+        extras["target_top_mgdl"] = treatment.target_top
+    if treatment.target_bottom is not None:
+        extras["target_bottom_mgdl"] = treatment.target_bottom
+    if treatment.reason:
+        extras["reason"] = treatment.reason
+    base.update(
+        {
+            "units": None,
+            "duration_minutes": int(treatment.duration)
+            if treatment.duration is not None
+            else None,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
+def _map_profile_switch(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    """Real Profile Switch OR AAPS Effective-Profile-Switch-as-Note."""
+    extras: dict[str, Any] = {
+        "profile": treatment.profile,
+        "original_profile_name": treatment.original_profile_name,
+        "percentage": treatment.percentage,
+        "timeshift": treatment.timeshift,
+        "original_duration": treatment.original_duration,
+        "original_end": treatment.original_end,
+    }
+    if treatment.profile_json:
+        extras["profile_json"] = treatment.profile_json
+    if treatment.is_effective_profile_switch_note:
+        extras["effective_profile_switch_via_note"] = True
+    base.update(
+        {
+            "units": None,
+            "duration_minutes": int(treatment.duration)
+            if treatment.duration is not None
+            else None,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
+def _map_device_event(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    """Site / Sensor / Insulin / Battery change events."""
+    extras: dict[str, Any] = {"device_event_type": treatment.event_type}
+    base.update(
+        {
+            "units": None,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
+def _map_simple_note(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    """Note / Announcement / OpenAPS Offline -- low-data event types."""
+    extras: dict[str, Any] = {"raw_event_type": treatment.event_type}
+    base.update(
+        {
+            "units": None,
+            "duration_minutes": int(treatment.duration)
+            if treatment.duration is not None
+            else None,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
+def map_treatment_to_pump_events(
+    treatment: NightscoutTreatment,
+    *,
+    user_id: str,
+    source: str,
+    received_at: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Translate a Nightscout treatment into 0, 1, or 2 PumpEvent inserts.
+
+    Returns:
+        - Empty list: dropped (soft-delete, cancel-temp, unknown
+          eventType the translator can't classify, fingerstick that
+          belongs in glucose_readings).
+        - One insert: most common case.
+        - Two inserts: meal-bolus pair (carbs + insulin) split into a
+          BOLUS row + CARBS row, linked via shared `meal_event_id`.
+    """
+    kind = treatment.semantic_kind
+
+    # --- Hard-drop cases ------------------------------------------------
+    if kind in ("temp_basal_cancel", "fingerstick_bg_check", "unknown"):
+        return []
+    # `unknown` covers the soft-delete case (isValid=False) by design.
+
+    # --- Type-specific routing -----------------------------------------
+
+    # Map semantic_kind to (PumpEventType, mapper_fn). meal_bolus_pair
+    # is special-cased below because it produces TWO rows.
+    routing = {
+        "bolus": (PumpEventType.BOLUS, _map_bolus),
+        "carb_entry": (PumpEventType.CARBS, _map_carb_entry),
+        "temp_basal": (PumpEventType.BASAL, _map_temp_basal),
+        "temp_basal_suspend": (PumpEventType.SUSPEND, _map_temp_basal_suspend),
+        "combo_bolus": (PumpEventType.COMBO_BOLUS, _map_combo_bolus),
+        "override": (PumpEventType.OVERRIDE, _map_override),
+        "temp_target": (PumpEventType.TEMP_TARGET, _map_temp_target),
+        "profile_switch": (PumpEventType.PROFILE_SWITCH, _map_profile_switch),
+        "effective_profile_switch": (
+            PumpEventType.PROFILE_SWITCH,
+            _map_profile_switch,
+        ),
+        "device_event": (PumpEventType.DEVICE_EVENT, _map_device_event),
+        "aps_offline": (PumpEventType.APS_OFFLINE, _map_simple_note),
+        "note": (PumpEventType.NOTE, _map_simple_note),
+        "announcement": (PumpEventType.NOTE, _map_simple_note),
+        "exercise_log": (PumpEventType.NOTE, _map_simple_note),
+    }
+
+    if kind == "meal_bolus_pair":
+        # Split into bolus + carbs rows, linked via meal_event_id.
+        meal_event_id = uuid.uuid4()
+
+        bolus_base = _base_event(
+            treatment,
+            user_id=user_id,
+            source=source,
+            event_type=PumpEventType.BOLUS,
+            received_at=received_at,
+        )
+        carb_base = _base_event(
+            treatment,
+            user_id=user_id,
+            source=source,
+            event_type=PumpEventType.CARBS,
+            received_at=received_at,
+        )
+        if bolus_base is None or carb_base is None:
+            return []
+        bolus_row = _map_bolus(treatment, bolus_base)
+        carb_row = _map_carb_entry(treatment, carb_base)
+        bolus_row["meal_event_id"] = meal_event_id
+        carb_row["meal_event_id"] = meal_event_id
+        # `ns_id` is the same on both rows (they're projections of one
+        # source treatment). The unique index on (source, ns_id) means
+        # we have to disambiguate. Suffix the ns_id with the role so
+        # the second row doesn't collide.
+        if bolus_row.get("ns_id"):
+            bolus_row["ns_id"] = f"{bolus_row['ns_id']}-bolus"
+        if carb_row.get("ns_id"):
+            carb_row["ns_id"] = f"{carb_row['ns_id']}-carbs"
+        return [bolus_row, carb_row]
+
+    if kind not in routing:
+        # Defensive fallback for any kind we forgot to handle.
+        return []
+
+    event_type, mapper = routing[kind]
+    base = _base_event(
+        treatment,
+        user_id=user_id,
+        source=source,
+        event_type=event_type,
+        received_at=received_at,
+    )
+    if base is None:
+        return []
+    return [mapper(treatment, base)]

--- a/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
@@ -120,10 +120,14 @@ def _map_bolus(treatment: NightscoutTreatment, base: dict[str, Any]) -> dict[str
     if treatment.bolus_calculator_result:
         extras["bolus_calculator_result"] = treatment.bolus_calculator_result
 
+    # An SMB is by definition an automated micro-bolus, even when the
+    # uploader didn't set `automatic=true` (older AAPS versions, Trio's
+    # bare `eventType: "SMB"` shape). Conflating with `is_automated`
+    # keeps dashboard "automated bolus" filters honest.
     base.update(
         {
             "units": treatment.insulin,
-            "is_automated": treatment.automatic is True,
+            "is_automated": treatment.automatic is True or treatment.is_smb,
             "metadata_json": _build_metadata(treatment, extra=extras),
         }
     )
@@ -423,12 +427,16 @@ def map_treatment_to_pump_events(
         carb_row["meal_event_id"] = meal_event_id
         # `ns_id` is the same on both rows (they're projections of one
         # source treatment). The unique index on (source, ns_id) means
-        # we have to disambiguate. Suffix the ns_id with the role so
-        # the second row doesn't collide.
+        # we have to disambiguate. Suffix with a delimiter that real
+        # NS `_id` values cannot contain: server `_id`s are 24-hex
+        # MongoDB ObjectIds; client-generated `identifier`/`syncIdentifier`
+        # values are typically UUIDs or hex strings, neither of which
+        # contains `#`. Including the meal_event_id keeps the suffix
+        # unique even if the source ns_id happens to end in `:role=bolus`.
         if bolus_row.get("ns_id"):
-            bolus_row["ns_id"] = f"{bolus_row['ns_id']}-bolus"
+            bolus_row["ns_id"] = f"{bolus_row['ns_id']}#meal-{meal_event_id}:role=bolus"
         if carb_row.get("ns_id"):
-            carb_row["ns_id"] = f"{carb_row['ns_id']}-carbs"
+            carb_row["ns_id"] = f"{carb_row['ns_id']}#meal-{meal_event_id}:role=carbs"
         return [bolus_row, carb_row]
 
     if kind not in routing:

--- a/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
@@ -155,7 +155,7 @@ def _map_carb_entry(
     base.update(
         {
             "units": None,  # carb-only, no insulin
-            "duration_minutes": int(treatment.duration)
+            "duration_minutes": round(treatment.duration)
             if treatment.duration is not None and treatment.uploader != "loop"
             else None,
             "metadata_json": _build_metadata(treatment, extra=extras),
@@ -188,7 +188,7 @@ def _map_temp_basal(
     base.update(
         {
             "units": None,
-            "duration_minutes": int(treatment.duration)
+            "duration_minutes": round(treatment.duration)
             if treatment.duration is not None
             else None,
             "metadata_json": _build_metadata(treatment, extra=extras),
@@ -231,7 +231,7 @@ def _map_combo_bolus(
     base.update(
         {
             "units": treatment.insulin,
-            "duration_minutes": int(treatment.duration)
+            "duration_minutes": round(treatment.duration)
             if treatment.duration is not None
             else None,
             "metadata_json": _build_metadata(treatment, extra=extras),
@@ -263,7 +263,7 @@ def _map_override(
     base.update(
         {
             "units": None,
-            "duration_minutes": int(treatment.duration)
+            "duration_minutes": round(treatment.duration)
             if treatment.duration is not None
             else None,
             "metadata_json": _build_metadata(treatment, extra=extras),
@@ -285,7 +285,7 @@ def _map_temp_target(
     base.update(
         {
             "units": None,
-            "duration_minutes": int(treatment.duration)
+            "duration_minutes": round(treatment.duration)
             if treatment.duration is not None
             else None,
             "metadata_json": _build_metadata(treatment, extra=extras),
@@ -313,7 +313,7 @@ def _map_profile_switch(
     base.update(
         {
             "units": None,
-            "duration_minutes": int(treatment.duration)
+            "duration_minutes": round(treatment.duration)
             if treatment.duration is not None
             else None,
             "metadata_json": _build_metadata(treatment, extra=extras),
@@ -344,7 +344,7 @@ def _map_simple_note(
     base.update(
         {
             "units": None,
-            "duration_minutes": int(treatment.duration)
+            "duration_minutes": round(treatment.duration)
             if treatment.duration is not None
             else None,
             "metadata_json": _build_metadata(treatment, extra=extras),

--- a/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
@@ -403,8 +403,11 @@ def map_treatment_to_pump_events(
 
     if kind == "meal_bolus_pair":
         # Split into bolus + carbs rows, linked via meal_event_id.
-        meal_event_id = uuid.uuid4()
-
+        # Both meal_event_id and the role suffixes on ns_id MUST be
+        # deterministic functions of the source treatment id -- otherwise
+        # re-fetching the same record on a later sync produces fresh
+        # UUIDs, the (source, ns_id) dedupe never matches, and we
+        # silently double-insert the bolus + carbs rows on every cycle.
         bolus_base = _base_event(
             treatment,
             user_id=user_id,
@@ -423,20 +426,30 @@ def map_treatment_to_pump_events(
             return []
         bolus_row = _map_bolus(treatment, bolus_base)
         carb_row = _map_carb_entry(treatment, carb_base)
+
+        # Derive a deterministic UUID from the source ns_id so the
+        # sibling-link is stable across re-fetches. If the upstream
+        # has no ns_id at all (rare; some uploaders POST without
+        # `_id`), fall back to a uuid4 -- there's nothing stable to
+        # derive from, so the dedupe-via-ns_id path won't fire either
+        # way for that record.
+        meal_event_id = (
+            uuid.uuid5(uuid.NAMESPACE_OID, treatment.id)
+            if treatment.id
+            else uuid.uuid4()
+        )
         bolus_row["meal_event_id"] = meal_event_id
         carb_row["meal_event_id"] = meal_event_id
-        # `ns_id` is the same on both rows (they're projections of one
-        # source treatment). The unique index on (source, ns_id) means
-        # we have to disambiguate. Suffix with a delimiter that real
-        # NS `_id` values cannot contain: server `_id`s are 24-hex
-        # MongoDB ObjectIds; client-generated `identifier`/`syncIdentifier`
-        # values are typically UUIDs or hex strings, neither of which
-        # contains `#`. Including the meal_event_id keeps the suffix
-        # unique even if the source ns_id happens to end in `:role=bolus`.
+
+        # ns_id suffixes use `#` as a delimiter that real NS `_id`
+        # values cannot contain (24-hex ObjectIds and UUID/hex
+        # identifiers don't carry `#`). The role tag alone is enough
+        # to disambiguate the two rows from a single source record;
+        # we don't need meal_event_id in the suffix.
         if bolus_row.get("ns_id"):
-            bolus_row["ns_id"] = f"{bolus_row['ns_id']}#meal-{meal_event_id}:role=bolus"
+            bolus_row["ns_id"] = f"{bolus_row['ns_id']}#role=bolus"
         if carb_row.get("ns_id"):
-            carb_row["ns_id"] = f"{carb_row['ns_id']}#meal-{meal_event_id}:role=carbs"
+            carb_row["ns_id"] = f"{carb_row['ns_id']}#role=carbs"
         return [bolus_row, carb_row]
 
     if kind not in routing:

--- a/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
@@ -278,12 +278,15 @@ def _map_temp_basal(
 def _map_temp_basal_suspend(
     treatment: NightscoutTreatment, base: dict[str, Any]
 ) -> dict[str, Any]:
-    """Pump suspend signaled via a zero-rate Temp Basal (with duration)."""
-    base = _map_temp_basal(treatment, base)
-    # Override the event_type set by base_event (which was TEMP_BASAL)
-    # to the dedicated SUSPEND value.
-    base["event_type"] = PumpEventType.SUSPEND
-    return base
+    """Pump suspend signaled via a zero-rate Temp Basal (with duration).
+
+    `base["event_type"]` is already `PumpEventType.SUSPEND` -- the
+    routing table in `map_treatment_to_pump_events` passes SUSPEND to
+    `_base_event` for `temp_basal_suspend`. We delegate to
+    `_map_temp_basal` only to reuse its rate / reason / aaps_type
+    extras; the event_type is correct on entry.
+    """
+    return _map_temp_basal(treatment, base)
 
 
 def _map_combo_bolus(

--- a/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
@@ -26,6 +26,79 @@ from typing import Any
 from src.models.pump_data import PumpEventType
 from src.services.integrations.nightscout.models import NightscoutTreatment
 
+# Storage-side allowlist of metadata keys. Anything not in this set is
+# dropped at ingest. The list is the union of:
+#   - Per-event-type clinical / structural extras the mappers below set
+#   - Source sub-attribution (uploader, raw device string, relayed flag)
+#   - Free-text fields with clinical value (`notes`, `reason`)
+# Identifier-shaped values (`remote_address`, `sync_identifier`,
+# `pump_id` / `pump_type` / `pump_serial`, the per-treatment `entered_by`
+# username/email) are NOT on the allowlist and are dropped before the
+# blob ever reaches PostgreSQL. `source` already carries attribution at
+# row level; we don't need a parallel identifier inside the JSONB.
+#
+# Residual fingerprint risk: `source_device` carries the upstream
+# `device` string verbatim, which several uploaders pad with build
+# tags or phone-model suffixes (Loop's `Loop://iPhone-7Plus/<build>`,
+# AAPS's `AndroidAPS-<ver>-<phone>`). It's not a stable per-user
+# identifier, but it is a coarse fingerprint. We keep it because
+# `source_uploader` alone is too lossy for "this came from Loop on
+# iOS vs. Loop on macOS" debugging, and the value never reaches an
+# unauthenticated surface (auth-gated to the data owner; `repr=False`
+# on the DTO field). Tightening this is tracked as future work.
+_METADATA_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # source sub-attribution
+        "source_uploader",
+        "source_device",
+        "source_relayed",
+        # free-text clinical
+        "notes",
+        "reason",
+        # bolus
+        "bolus_subtype",
+        "programmed_units",
+        "insulin_type",
+        "bolus_calculator_result",
+        # carb entry
+        "carbs_grams",
+        "protein_grams",
+        "fat_grams",
+        "duration_field_value",
+        "loop_carbs_uses_seconds",
+        # temp basal
+        "rate_u_per_hr",
+        "absolute_u_per_hr",
+        "percent_delta",
+        "aaps_type",
+        # combo bolus
+        "split_now_pct",
+        "split_ext_pct",
+        "split_invalid",
+        "extended_emulated",
+        # override
+        "correction_range",
+        "multiplier",
+        "duration_type",
+        "indefinite",
+        # temp target
+        "target_top_mgdl",
+        "target_bottom_mgdl",
+        # profile switch
+        "profile",
+        "original_profile_name",
+        "percentage",
+        "timeshift",
+        "original_duration",
+        "original_end",
+        "profile_json",
+        "effective_profile_switch_via_note",
+        # device / note
+        "device_event_type",
+        "raw_event_type",
+    }
+)
+
 
 def _build_metadata(
     treatment: NightscoutTreatment,
@@ -36,26 +109,33 @@ def _build_metadata(
 
     Always includes:
     - source_uploader (detected from device + entered_by)
-    - source_device + source_entered_by (raw strings, preserved)
+    - source_device (raw device string, preserved)
     - source_relayed (true if the entered_by ends in @ns / @ns loader)
-    - notes (free-text, redacted at the model layer via repr=False but
-      preserved as data here)
+    - notes (free-text, redacted at the wire layer via repr=False but
+      preserved as data here for clinical value)
 
-    Per-event-type extras get merged in via the `extra` dict.
+    Identifier-shaped values are intentionally not stored:
+    `treatment.entered_by` (often a username or email-like string) is
+    consumed only for the `source_relayed` heuristic and discarded;
+    `remote_address`, `sync_identifier`, and the AAPS pump dedup triple
+    are filtered by the `_METADATA_ALLOWLIST` after `extra` is merged.
+    Per-event-type extras get merged in via the `extra` dict and then
+    filtered.
     """
     eb = treatment.entered_by or ""
     relayed = eb.endswith("@ns") or eb.endswith("@ns loader")
     base: dict[str, Any] = {
         "source_uploader": treatment.uploader,
         "source_device": treatment.device,
-        "source_entered_by": treatment.entered_by,
         "source_relayed": relayed,
     }
     if treatment.notes:
         base["notes"] = treatment.notes
     if extra:
         base.update(extra)
-    return base
+    # Drop everything not on the allowlist. Identifier-shaped or
+    # PII-shaped values that bypass this filter are a privacy bug.
+    return {k: v for k, v in base.items() if k in _METADATA_ALLOWLIST}
 
 
 def _base_event(
@@ -107,17 +187,12 @@ def _map_bolus(treatment: NightscoutTreatment, base: dict[str, Any]) -> dict[str
         extras["programmed_units"] = treatment.programmed
     if treatment.insulin_type:
         extras["insulin_type"] = treatment.insulin_type
-    # AAPS pump composite dedup triple
-    if treatment.pump_id is not None:
-        extras["pump_id"] = treatment.pump_id
-    if treatment.pump_type:
-        extras["pump_type"] = treatment.pump_type
-    if treatment.pump_serial:
-        extras["pump_serial"] = treatment.pump_serial
-    # Loop syncIdentifier (separate from server-assigned _id; useful
-    # for round-tripping back to Loop's HealthKit cache).
-    if treatment.sync_identifier:
-        extras["sync_identifier"] = treatment.sync_identifier
+    # NOTE: AAPS pump composite dedup triple (pump_id / pump_type /
+    # pump_serial), Loop syncIdentifier, and any other dedupe-only
+    # identifiers are intentionally NOT stored. Server-assigned `_id`
+    # already gives us per-connection dedupe via the partial unique
+    # index on (source, ns_id), and stable device/serial identifiers
+    # are a privacy footgun in a JSONB blob.
     # AAPS Bolus Wizard inputs (carbs, BG, target, ISF, CR, IOB) --
     # preserved verbatim for AI analysis context.
     if treatment.bolus_calculator_result:
@@ -256,8 +331,9 @@ def _map_override(
     elif treatment.percentage is not None:
         # AAPS percentage as multiplier (e.g. 110% = 1.1)
         extras["multiplier"] = treatment.percentage / 100.0
-    if treatment.remote_address:
-        extras["remote_address"] = treatment.remote_address
+    # NOTE: `treatment.remote_address` (an IP address recorded by AAPS
+    # for some override sources) is intentionally not stored -- privacy
+    # footgun with no clinical value.
     if treatment.duration_type:
         extras["duration_type"] = treatment.duration_type
     if treatment.is_indefinite_trio_override:

--- a/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
@@ -82,6 +82,9 @@ def _base_event(
         "received_at": received_at or datetime.now(UTC),
         "source": source,
         "ns_id": treatment.id,
+        # Uniform schema across all rows in a multi-row INSERT VALUES
+        # clause — meal-bolus pairs overwrite this with a shared UUID.
+        "meal_event_id": None,
     }
 
 

--- a/apps/api/src/services/integrations/nightscout/translator.py
+++ b/apps/api/src/services/integrations/nightscout/translator.py
@@ -1,0 +1,372 @@
+"""Nightscout translator -- orchestrates input parsing + ORM upserts.
+
+Public entry points:
+- `translate_entries()` -- list of raw entry dicts -> count of glucose
+  reading rows upserted
+- `translate_treatments()` -- list of raw treatment dicts -> counts of
+  glucose-reading + pump-event rows upserted
+- `translate_devicestatuses()` -- list of raw devicestatus dicts ->
+  count of snapshot rows upserted
+- `translate_profile()` -- raw profile dict -> True/False (snapshot
+  upserted, or skipped because the profile has no active store)
+
+All four entry points:
+1. Validate input via the Pydantic input models (PR1's parsers)
+2. Route via per-target mappers (per-mapper module under this package)
+3. Issue PostgreSQL `INSERT ... ON CONFLICT DO NOTHING` upserts via
+   the connection's user_id and a per-target dedupe key
+
+Source attribution: every persisted row carries
+`source = "nightscout:<connection_id>"` at the table level. Sub-
+attribution (uploader, raw device string, raw enteredBy string) lives
+in `metadata_json` for pump_events; for glucose_readings we rely on
+the table-level `source` column alone (uploader sub-attribution is
+recoverable by joining back to the connection's recent treatments if
+needed).
+
+Conflict resolution: when a Nightscout-sourced row matches a
+direct-integration row (e.g. Tandem cloud + Nightscout-relayed Tandem
+data at the same timestamp), the unique index on (user_id,
+reading_timestamp) / (user_id, event_timestamp, event_type) means
+ON CONFLICT DO NOTHING keeps whichever was inserted first. Direct
+integrations typically write before the Nightscout sync runs, so they
+win by default per the resolved decision.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.device_status_snapshot import DeviceStatusSnapshot
+from src.models.glucose import GlucoseReading
+from src.models.nightscout_profile_snapshot import NightscoutProfileSnapshot
+from src.models.pump_data import PumpEvent
+from src.services.integrations.nightscout._devicestatus_mapper import (
+    map_devicestatus_to_snapshot,
+)
+from src.services.integrations.nightscout._glucose_mapper import (
+    map_bg_check_treatment_to_glucose_reading,
+    map_entry_to_glucose_reading,
+)
+from src.services.integrations.nightscout._profile_mapper import (
+    map_profile_to_snapshot,
+)
+from src.services.integrations.nightscout._pump_events_mapper import (
+    map_treatment_to_pump_events,
+)
+from src.services.integrations.nightscout.models import (
+    NightscoutDeviceStatus,
+    NightscoutEntry,
+    NightscoutProfile,
+    NightscoutTreatment,
+)
+
+
+@dataclass(frozen=True)
+class TranslateOutcome:
+    """Counts of rows upserted by a single translate_* call.
+
+    Inserted = newly written. Skipped = duplicate (caught by the
+    ON CONFLICT clause) OR rejected by the mapper (gap reading,
+    soft-delete, missing timestamp, etc.). Failed = caller-visible
+    parser failure (the input dict couldn't be coerced into the
+    Pydantic model at all).
+    """
+
+    inserted: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+    def __add__(self, other: TranslateOutcome) -> TranslateOutcome:
+        return TranslateOutcome(
+            inserted=self.inserted + other.inserted,
+            skipped=self.skipped + other.skipped,
+            failed=self.failed + other.failed,
+        )
+
+
+def _build_source(connection_id: str) -> str:
+    """Build the `source` column value for this connection."""
+    return f"nightscout:{connection_id}"
+
+
+# ---------------------------------------------------------------------------
+# Entries -> glucose_readings
+# ---------------------------------------------------------------------------
+
+
+async def translate_entries(
+    raw_entries: Iterable[dict[str, Any]],
+    *,
+    session: AsyncSession,
+    user_id: str,
+    connection_id: str,
+    received_at: datetime | None = None,
+) -> TranslateOutcome:
+    """Translate raw Nightscout entry dicts to glucose_readings upserts."""
+    source = _build_source(connection_id)
+    received = received_at or datetime.now(UTC)
+
+    rows: list[dict[str, Any]] = []
+    failed = 0
+    skipped = 0
+
+    for raw in raw_entries:
+        try:
+            entry = NightscoutEntry.model_validate(raw)
+        except Exception:
+            failed += 1
+            continue
+        row = map_entry_to_glucose_reading(
+            entry,
+            user_id=user_id,
+            source=source,
+            received_at=received,
+        )
+        if row is None:
+            skipped += 1
+            continue
+        rows.append(row)
+
+    inserted = await _upsert_glucose_readings(session, rows)
+    # Anything in `rows` that didn't insert lost the ON CONFLICT race
+    # to a prior write -- count it as skipped.
+    skipped += len(rows) - inserted
+    return TranslateOutcome(inserted=inserted, skipped=skipped, failed=failed)
+
+
+# ---------------------------------------------------------------------------
+# Treatments -> pump_events (+ glucose_readings for fingerstick path)
+# ---------------------------------------------------------------------------
+
+
+async def translate_treatments(
+    raw_treatments: Iterable[dict[str, Any]],
+    *,
+    session: AsyncSession,
+    user_id: str,
+    connection_id: str,
+    received_at: datetime | None = None,
+) -> tuple[TranslateOutcome, TranslateOutcome]:
+    """Translate raw Nightscout treatment dicts.
+
+    Returns a (pump_events_outcome, glucose_readings_outcome) pair.
+    The fingerstick BG-Check path writes to glucose_readings; all
+    other treatment kinds write to pump_events.
+    """
+    source = _build_source(connection_id)
+    received = received_at or datetime.now(UTC)
+
+    pump_rows: list[dict[str, Any]] = []
+    glucose_rows: list[dict[str, Any]] = []
+    pump_skipped = 0
+    glucose_skipped = 0
+    failed = 0
+
+    for raw in raw_treatments:
+        try:
+            treatment = NightscoutTreatment.model_validate(raw)
+        except Exception:
+            failed += 1
+            continue
+
+        if treatment.is_fingerstick_treatment:
+            row = map_bg_check_treatment_to_glucose_reading(
+                treatment,
+                user_id=user_id,
+                source=source,
+                received_at=received,
+            )
+            if row is None:
+                glucose_skipped += 1
+            else:
+                glucose_rows.append(row)
+            continue
+
+        events = map_treatment_to_pump_events(
+            treatment,
+            user_id=user_id,
+            source=source,
+            received_at=received,
+        )
+        if not events:
+            pump_skipped += 1
+            continue
+        pump_rows.extend(events)
+
+    pump_inserted = await _upsert_pump_events(session, pump_rows)
+    pump_skipped += len(pump_rows) - pump_inserted
+
+    glucose_inserted = await _upsert_glucose_readings(session, glucose_rows)
+    glucose_skipped += len(glucose_rows) - glucose_inserted
+
+    return (
+        TranslateOutcome(inserted=pump_inserted, skipped=pump_skipped, failed=failed),
+        TranslateOutcome(inserted=glucose_inserted, skipped=glucose_skipped, failed=0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Devicestatus -> device_status_snapshots
+# ---------------------------------------------------------------------------
+
+
+async def translate_devicestatuses(
+    raw_devicestatuses: Iterable[dict[str, Any]],
+    *,
+    session: AsyncSession,
+    user_id: str,
+    connection_id: str,
+    received_at: datetime | None = None,
+) -> TranslateOutcome:
+    """Translate raw devicestatus dicts to device_status_snapshots upserts."""
+    received = received_at or datetime.now(UTC)
+    rows: list[dict[str, Any]] = []
+    failed = 0
+    skipped = 0
+
+    for raw in raw_devicestatuses:
+        try:
+            ds = NightscoutDeviceStatus.model_validate(raw)
+        except Exception:
+            failed += 1
+            continue
+        row = map_devicestatus_to_snapshot(
+            ds,
+            user_id=user_id,
+            nightscout_connection_id=connection_id,
+            received_at=received,
+        )
+        if row is None:
+            skipped += 1
+            continue
+        rows.append(row)
+
+    inserted = await _upsert_devicestatus_snapshots(session, rows)
+    skipped += len(rows) - inserted
+    return TranslateOutcome(inserted=inserted, skipped=skipped, failed=failed)
+
+
+# ---------------------------------------------------------------------------
+# Profile -> nightscout_profile_snapshots (one row per connection, upsert)
+# ---------------------------------------------------------------------------
+
+
+async def translate_profile(
+    raw_profile: dict[str, Any],
+    *,
+    session: AsyncSession,
+    user_id: str,
+    connection_id: str,
+    fetched_at: datetime | None = None,
+) -> bool:
+    """Translate a raw Nightscout profile to a snapshot upsert.
+
+    Returns True when a row was inserted or updated; False when the
+    profile was skipped (no active store or parse failure).
+    """
+    try:
+        profile = NightscoutProfile.model_validate(raw_profile)
+    except Exception:
+        return False
+
+    row = map_profile_to_snapshot(
+        profile,
+        user_id=user_id,
+        nightscout_connection_id=connection_id,
+        fetched_at=fetched_at or datetime.now(UTC),
+    )
+    if row is None:
+        return False
+    await _upsert_profile_snapshot(session, row)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Upsert helpers (per-target)
+# ---------------------------------------------------------------------------
+
+
+async def _upsert_glucose_readings(
+    session: AsyncSession, rows: list[dict[str, Any]]
+) -> int:
+    """Bulk-insert glucose readings with ON CONFLICT DO NOTHING.
+
+    Two unique constraints can hit:
+    1. `ix_glucose_readings_user_reading` on (user_id, reading_timestamp)
+       -- catches cross-source duplicates (Tandem direct + Nightscout-
+       relayed at same timestamp).
+    2. `ix_glucose_readings_source_nsid` on (source, ns_id) WHERE
+       ns_id IS NOT NULL -- catches re-fetch of the same NS record
+       across sync cycles.
+
+    Either constraint firing means the row is a duplicate; skip it.
+    Returns the number of rows actually inserted.
+    """
+    if not rows:
+        return 0
+    stmt = insert(GlucoseReading).values(rows).on_conflict_do_nothing()
+    result = await session.execute(stmt)
+    # rowcount reflects rows that actually inserted (PostgreSQL).
+    return result.rowcount or 0
+
+
+async def _upsert_pump_events(session: AsyncSession, rows: list[dict[str, Any]]) -> int:
+    """Bulk-insert pump events with ON CONFLICT DO NOTHING."""
+    if not rows:
+        return 0
+    stmt = insert(PumpEvent).values(rows).on_conflict_do_nothing()
+    result = await session.execute(stmt)
+    return result.rowcount or 0
+
+
+async def _upsert_devicestatus_snapshots(
+    session: AsyncSession, rows: list[dict[str, Any]]
+) -> int:
+    """Bulk-insert devicestatus snapshots with ON CONFLICT DO NOTHING.
+
+    Per-connection unique on (nightscout_connection_id, ns_id).
+    """
+    if not rows:
+        return 0
+    stmt = insert(DeviceStatusSnapshot).values(rows).on_conflict_do_nothing()
+    result = await session.execute(stmt)
+    return result.rowcount or 0
+
+
+async def _upsert_profile_snapshot(session: AsyncSession, row: dict[str, Any]) -> None:
+    """Upsert a single profile snapshot (one per user+connection).
+
+    Unlike the other upserts, profile snapshots use ON CONFLICT DO
+    UPDATE because the wizard wants the latest values, not the first.
+    Re-fetching the same connection's profile must overwrite.
+    """
+    update_cols = {
+        "fetched_at": row["fetched_at"],
+        "source_default_profile_name": row["source_default_profile_name"],
+        "source_units": row["source_units"],
+        "source_timezone": row["source_timezone"],
+        "source_dia_hours": row["source_dia_hours"],
+        "source_start_date": row["source_start_date"],
+        "basal_segments": row["basal_segments"],
+        "carb_ratio_segments": row["carb_ratio_segments"],
+        "sensitivity_segments": row["sensitivity_segments"],
+        "target_low_segments": row["target_low_segments"],
+        "target_high_segments": row["target_high_segments"],
+        "profile_json_full": row["profile_json_full"],
+    }
+    stmt = (
+        insert(NightscoutProfileSnapshot)
+        .values(row)
+        .on_conflict_do_update(
+            index_elements=["user_id", "nightscout_connection_id"],
+            set_=update_cols,
+        )
+    )
+    await session.execute(stmt)

--- a/apps/api/src/services/integrations/nightscout/translator.py
+++ b/apps/api/src/services/integrations/nightscout/translator.py
@@ -24,13 +24,35 @@ the table-level `source` column alone (uploader sub-attribution is
 recoverable by joining back to the connection's recent treatments if
 needed).
 
-Conflict resolution: when a Nightscout-sourced row matches a
-direct-integration row (e.g. Tandem cloud + Nightscout-relayed Tandem
-data at the same timestamp), the unique index on (user_id,
-reading_timestamp) / (user_id, event_timestamp, event_type) means
-ON CONFLICT DO NOTHING keeps whichever was inserted first. Direct
-integrations typically write before the Nightscout sync runs, so they
-win by default per the resolved decision.
+Conflict resolution semantics:
+
+- Same source, same `ns_id`: re-fetch is a no-op (per-source partial
+  unique index dedupes).
+- Cross-source on glucose_readings (`user_id`, `reading_timestamp`):
+  ON CONFLICT DO NOTHING keeps whichever was inserted first. Direct
+  integrations (Tandem cloud, etc.) typically write before the
+  Nightscout sync runs, so in practice they win the race -- but this
+  is **first-writer-wins, not enforced priority**. A Nightscout-only
+  user gets Nightscout-attributed rows; a user with both has whichever
+  source ran first per timestamp.
+- Cross-source on pump_events: the pre-existing
+  `(user_id, event_timestamp, event_type)` unique index now applies
+  only WHERE `ns_id IS NULL` (i.e. to direct-integration rows).
+  Nightscout-sourced rows dedupe via the partial unique index on
+  `(source, ns_id) WHERE ns_id IS NOT NULL`. This avoids the bug where
+  two AAPS SMBs at the same second would silently drop one.
+
+`received_at` is set on insert and is **not** updated on conflict --
+think of it as `first_received_at`. There is currently no
+`last_observed_at` column; if a downstream consumer needs to know when
+we last re-saw a record, that's a follow-up.
+
+Soft-delete propagation is **not yet implemented**: when an upstream
+record is soft-deleted (`isValid: false`) on Nightscout, the input
+model returns `semantic_kind == "unknown"` and the translator drops
+the record on the parse side. A pre-existing row in our DB with the
+same `ns_id` is left in place. Tracked as a known limitation; needs
+either an `is_retracted` column or DELETE-on-soft-delete logic.
 """
 
 from __future__ import annotations
@@ -307,23 +329,36 @@ async def _upsert_glucose_readings(
        across sync cycles.
 
     Either constraint firing means the row is a duplicate; skip it.
-    Returns the number of rows actually inserted.
+    Uses `RETURNING id` to count actual inserts because
+    `result.rowcount` is not reliable under ON CONFLICT DO NOTHING
+    across drivers (asyncpg returns -1 / None for various edge cases
+    and SQLAlchemy explicitly documents rowcount as unreliable here).
     """
     if not rows:
         return 0
-    stmt = insert(GlucoseReading).values(rows).on_conflict_do_nothing()
+    stmt = (
+        insert(GlucoseReading)
+        .values(rows)
+        .on_conflict_do_nothing()
+        .returning(GlucoseReading.id)
+    )
     result = await session.execute(stmt)
-    # rowcount reflects rows that actually inserted (PostgreSQL).
-    return result.rowcount or 0
+    return len(result.scalars().all())
 
 
 async def _upsert_pump_events(session: AsyncSession, rows: list[dict[str, Any]]) -> int:
-    """Bulk-insert pump events with ON CONFLICT DO NOTHING."""
+    """Bulk-insert pump events with ON CONFLICT DO NOTHING.
+
+    Uses RETURNING to count actual inserts (rowcount is unreliable
+    under ON CONFLICT DO NOTHING).
+    """
     if not rows:
         return 0
-    stmt = insert(PumpEvent).values(rows).on_conflict_do_nothing()
+    stmt = (
+        insert(PumpEvent).values(rows).on_conflict_do_nothing().returning(PumpEvent.id)
+    )
     result = await session.execute(stmt)
-    return result.rowcount or 0
+    return len(result.scalars().all())
 
 
 async def _upsert_devicestatus_snapshots(
@@ -331,13 +366,19 @@ async def _upsert_devicestatus_snapshots(
 ) -> int:
     """Bulk-insert devicestatus snapshots with ON CONFLICT DO NOTHING.
 
-    Per-connection unique on (nightscout_connection_id, ns_id).
+    Per-connection unique on (nightscout_connection_id, ns_id). Uses
+    RETURNING to count actual inserts.
     """
     if not rows:
         return 0
-    stmt = insert(DeviceStatusSnapshot).values(rows).on_conflict_do_nothing()
+    stmt = (
+        insert(DeviceStatusSnapshot)
+        .values(rows)
+        .on_conflict_do_nothing()
+        .returning(DeviceStatusSnapshot.id)
+    )
     result = await session.execute(stmt)
-    return result.rowcount or 0
+    return len(result.scalars().all())
 
 
 async def _upsert_profile_snapshot(session: AsyncSession, row: dict[str, Any]) -> None:

--- a/apps/api/src/services/tandem_sync.py
+++ b/apps/api/src/services/tandem_sync.py
@@ -9,7 +9,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from tconnectsync.api.common import ApiException
@@ -946,7 +946,12 @@ async def sync_tandem_for_user(
                 source="tandem",
             )
             .on_conflict_do_nothing(
-                index_elements=["user_id", "event_timestamp", "event_type"]
+                index_elements=["user_id", "event_timestamp", "event_type"],
+                # The (user_id, event_timestamp, event_type) unique
+                # index is partial: applies only to direct-integration
+                # rows (`ns_id IS NULL`). Tandem direct sync writes
+                # ns_id=NULL so the partial index applies.
+                index_where=text("ns_id IS NULL"),
             )
         )
 

--- a/apps/api/tests/fixtures/nightscout/README.md
+++ b/apps/api/tests/fixtures/nightscout/README.md
@@ -83,15 +83,44 @@ verification pass:
 See `_bmad-output/planning-artifacts/nightscout-translator-fixture-survey.md` §10
 for full verification details.
 
-## Tier 2 / Tier 3 fixtures
+### Tier 2 fixtures (this PR — translator routing edge cases)
 
-Out of scope for this PR. The follow-up PR (Story 43.3 PR2) ships:
-- 16 Tier-2 fixtures covering edge cases (Effective Profile Switch as Note,
-  Extended Bolus emulating TBR, AAPS Temp Basal Type subtypes, etc.)
-- 17 Tier-3 fixtures as regression locks (V3 RemoteTreatment, Nocturne
-  Suspend Pump, xDrip4iOS suffix-extension `_id`, etc.)
+#### entries/
 
-The full priority list is in the synthesis doc §4.
+| Fixture | Source |
+|---|---|
+| `xdrip_sgv_noisy.json` | xDrip+ Android with `noise: 4` (heavy) and `direction: "NOT COMPUTABLE"` (canonical spaced form). Locks the defensive direction-enum parser and the noise-int coercion path. |
+
+#### treatments/
+
+| Fixture | Source |
+|---|---|
+| `aaps_effective_profile_switch_as_note.json` | AAPS uploads Effective Profile Switch as `eventType: "Note"` with `originalProfileName` populated (telltale). Routes to the profile-switch translator path despite the Note eventType. Per `mapping/aaps/profile-switch.md`. |
+| `aaps_extended_bolus_emulating_tbr.json` | AAPS extended-bolus-emulating-TBR shape: outer `Temp Basal` envelope with nested `extendedEmulated` Combo Bolus. Translator's `is_combo_bolus` detection requires both (a) Temp Basal envelope AND (b) bolus-bearing `extendedEmulated` payload. |
+| `aaps_temp_basal_superbolus.json` | AAPS `type: "SUPERBOLUS"` (1 of 5 Temp Basal Type values). Routes as Temp Basal with `aaps_type=SUPERBOLUS` preserved in metadata. |
+| `aaps_temp_basal_emulated_suspend.json` | AAPS `type: "EMULATED_PUMP_SUSPEND"` with rate=0, percent=-100, duration=60. Routes as suspend (rate=0 + duration ≥30). |
+| `aaps_carbs_with_protein_fat.json` | High-fat meal: `carbs + protein + fat + duration` per `mapping/aaps/nightscout-models.md`. Captures AAPS extended-meal nutrition. |
+| `aaps_therapy_event_site_change.json` | NSTherapyEvent path: `eventType: "Site Change"`. Routes to device_event (was on the deliberate-skip list pre-cross-validation; promoted because therapy events anchor occlusion analysis). |
+| `aaps_therapy_event_sensor_start.json` | `eventType: "Sensor Start"` with `transmitterId`. Anchors CGM noise/calibration windows. |
+| `loop_pump_suspend_as_temp_basal.json` | Loop convention: `Temp Basal` rate=0, `reason: "suspend"`, duration ≥30 min. Per `LoopKit/NightscoutService DoseEntry.swift:46`. |
+| `loop_square_bolus.json` | Loop bolus with delivery duration ≥30 min, classified `bolusType: "Square"` (per `BolusNightscoutTreatment.swift:62`, `bolusType: duration >= 30 min ? .Square : .Normal`). Translator preserves `bolus_subtype=square` in metadata. |
+| `loop_override_with_remote_address.json` | Loop override triggered via remote command: `enteredBy: "Loop (via remote command)"`, `remoteAddress` populated. Per `OverrideTreament.swift:43-48`. |
+| `careportal_combo_bolus.json` | Care Portal Combo Bolus: `splitNow: 60, splitExt: 40` (sums to 100 per the constraint). |
+| `bolus_wizard_with_carbs.json` | AAPS `eventType: "Bolus Wizard"` with insulin AND carbs. The 4th carb encoding (`isCarbBolus = isMealBolus OR (isBolusWizard AND carbs > 0)` per Reporter heuristic). Routes as meal_bolus_pair → split into bolus + carbs rows. Includes `bolusCalculatorResult` JSON for AI analysis context. |
+| `trio_exercise_override.json` | Trio override toggle uploads as `eventType: "Exercise"` per `Trio/Sources/APS/Storage/OverrideStorage.swift`. Indefinite would use `duration: 43200`. |
+| `trio_temp_target_manual.json` | Trio manual temp-target preset uploads as `eventType: "Temporary Target"` via a separate code path from override toggles -- two distinct features. |
+
+#### devicestatus/
+
+| Fixture | Source |
+|---|---|
+| `loop_failure_devicestatus.json` | Loop failure cycle: `loop.failureReason` populated, NO `loop.enacted` block. Mutually exclusive at the source per `LoopStatus.swift` `enacted` guard. |
+| `loop_hybrid_dose_devicestatus.json` | Loop hybrid dose: `automaticDoseRecommendation` carries both `tempBasalAdjustment` AND `bolusVolume` simultaneously. Tests parser handling of combined cycles. |
+| `trio_devicestatus_with_tdd.json` | Trio's `enacted.TDD` plus `insulin: { TDD, bolus, temp_basal, scheduled_basal }` sub-object on suggested/enacted. TDD also injected into the `reason` string per `NightscoutManager.swift`. |
+
+### Tier 3 fixtures (deferred to follow-up PR)
+
+17 regression-lock fixtures from the synthesis doc §4 (V3 RemoteTreatment envelope, Nocturne unknown event types, xDrip4iOS suffix-extension `_id`, AAPS Bolus Wizard `bolusCalculatorResult` deeper variants, isValid soft-delete, pre-v14 legacy treatment, etc.). Not required for translator correctness on the 95% case; useful as defensive locks once we have community beta data flowing.
 
 ## Adding a new fixture
 

--- a/apps/api/tests/fixtures/nightscout/README.md
+++ b/apps/api/tests/fixtures/nightscout/README.md
@@ -104,7 +104,7 @@ for full verification details.
 | `aaps_therapy_event_sensor_start.json` | `eventType: "Sensor Start"` with `transmitterId`. Anchors CGM noise/calibration windows. |
 | `loop_pump_suspend_as_temp_basal.json` | Loop convention: `Temp Basal` rate=0, `reason: "suspend"`, duration ≥30 min. Per `LoopKit/NightscoutService DoseEntry.swift:46`. |
 | `loop_square_bolus.json` | Loop bolus with delivery duration ≥30 min, classified `bolusType: "Square"` (per `BolusNightscoutTreatment.swift:62`, `bolusType: duration >= 30 min ? .Square : .Normal`). Translator preserves `bolus_subtype=square` in metadata. |
-| `loop_override_with_remote_address.json` | Loop override triggered via remote command: `enteredBy: "Loop (via remote command)"`, `remoteAddress` populated. Per `OverrideTreament.swift:43-48`. |
+| `loop_override_with_remote_address.json` | Loop override triggered via remote command: `enteredBy: "Loop (via remote command)"`, `remoteAddress` populated. Per `OverrideTreatment.swift:43-48`. |
 | `careportal_combo_bolus.json` | Care Portal Combo Bolus: `splitNow: 60, splitExt: 40` (sums to 100 per the constraint). |
 | `bolus_wizard_with_carbs.json` | AAPS `eventType: "Bolus Wizard"` with insulin AND carbs. The 4th carb encoding (`isCarbBolus = isMealBolus OR (isBolusWizard AND carbs > 0)` per Reporter heuristic). Routes as meal_bolus_pair → split into bolus + carbs rows. Includes `bolusCalculatorResult` JSON for AI analysis context. |
 | `trio_exercise_override.json` | Trio override toggle uploads as `eventType: "Exercise"` per `Trio/Sources/APS/Storage/OverrideStorage.swift`. Indefinite would use `duration: 43200`. |

--- a/apps/api/tests/fixtures/nightscout/devicestatus/loop_failure_devicestatus.json
+++ b/apps/api/tests/fixtures/nightscout/devicestatus/loop_failure_devicestatus.json
@@ -1,0 +1,36 @@
+{
+  "_id": "65f4c1a2c8e3d2f1a0b1c404",
+  "device": "loop://iPhone",
+  "created_at": "2026-05-06T15:00:00Z",
+  "pump": {
+    "clock": "2026-05-06T15:00:00Z",
+    "pumpID": "12345",
+    "manufacturer": "Insulet",
+    "model": "Omnipod DASH",
+    "battery": {"percent": 87},
+    "suspended": false,
+    "bolusing": false,
+    "reservoir": 145.3,
+    "iob": null
+  },
+  "uploader": {
+    "name": "iPhone",
+    "timestamp": "2026-05-06T15:00:00Z",
+    "battery": 85
+  },
+  "loop": {
+    "name": "Loop",
+    "version": "3.4.1",
+    "timestamp": "2026-05-06T15:00:00Z",
+    "iob": {
+      "timestamp": "2026-05-06T15:00:00Z",
+      "iob": 1.05,
+      "basaliob": 0.4
+    },
+    "cob": {
+      "timestamp": "2026-05-06T15:00:00Z",
+      "cob": 0
+    },
+    "failureReason": "pumpManagerError(.communicationFailure)"
+  }
+}

--- a/apps/api/tests/fixtures/nightscout/devicestatus/loop_hybrid_dose_devicestatus.json
+++ b/apps/api/tests/fixtures/nightscout/devicestatus/loop_hybrid_dose_devicestatus.json
@@ -1,0 +1,55 @@
+{
+  "_id": "65f4c1a2c8e3d2f1a0b1c405",
+  "device": "loop://iPhone",
+  "created_at": "2026-05-06T15:30:00Z",
+  "pump": {
+    "clock": "2026-05-06T15:30:00Z",
+    "pumpID": "12345",
+    "manufacturer": "Insulet",
+    "model": "Omnipod DASH",
+    "battery": {"percent": 86},
+    "suspended": false,
+    "bolusing": false,
+    "reservoir": 142.5,
+    "iob": null
+  },
+  "uploader": {
+    "name": "iPhone",
+    "timestamp": "2026-05-06T15:30:00Z",
+    "battery": 84
+  },
+  "loop": {
+    "name": "Loop",
+    "version": "3.4.1",
+    "timestamp": "2026-05-06T15:30:00Z",
+    "iob": {
+      "timestamp": "2026-05-06T15:30:00Z",
+      "iob": 2.1,
+      "basaliob": 0.6
+    },
+    "cob": {
+      "timestamp": "2026-05-06T15:30:00Z",
+      "cob": 25
+    },
+    "predicted": {
+      "startDate": "2026-05-06T15:30:00Z",
+      "values": [165, 170, 175, 178, 180, 178, 175],
+      "COB": [165, 173, 182, 190, 195, 193, 188],
+      "IOB": [165, 162, 158, 155, 152, 150, 148]
+    },
+    "automaticDoseRecommendation": {
+      "timestamp": "2026-05-06T15:30:00Z",
+      "bolusVolume": 0.3,
+      "tempBasalAdjustment": {"rate": 1.2, "duration": 30}
+    },
+    "recommendedBolus": 0.3,
+    "enacted": {
+      "rate": 1.2,
+      "duration": 30,
+      "timestamp": "2026-05-06T15:30:00Z",
+      "received": true,
+      "bolusVolume": 0.3
+    },
+    "currentCorrectionRange": {"minValue": 100, "maxValue": 120}
+  }
+}

--- a/apps/api/tests/fixtures/nightscout/devicestatus/trio_devicestatus_with_tdd.json
+++ b/apps/api/tests/fixtures/nightscout/devicestatus/trio_devicestatus_with_tdd.json
@@ -1,0 +1,79 @@
+{
+  "_id": "65f4c1a2c8e3d2f1a0b1c406",
+  "device": "Trio",
+  "created_at": "2026-05-06T14:30:00.000Z",
+  "pump": {
+    "clock": "2026-05-06T14:30:00Z",
+    "battery": {"percent": 78},
+    "reservoir": 117.2,
+    "bolusIncrement": 0.05,
+    "status": {
+      "status": "normal",
+      "bolusing": false,
+      "suspended": false,
+      "timestamp": "2026-05-06T14:30:00Z"
+    }
+  },
+  "openaps": {
+    "iob": {
+      "iob": 1.234,
+      "basaliob": 0.456,
+      "activity": 0.0123,
+      "time": "2026-05-06T14:30:00Z"
+    },
+    "suggested": {
+      "temp": "absolute",
+      "bg": 145,
+      "tick": "+2",
+      "eventualBG": 130,
+      "rate": 0.6,
+      "duration": 30,
+      "deliverAt": "2026-05-06T14:30:00.000Z",
+      "timestamp": "2026-05-06T14:30:00.000Z",
+      "sensitivityRatio": 1,
+      "COB": 0,
+      "IOB": 1.234,
+      "TDD": 42.5,
+      "insulin": {
+        "TDD": 42.5,
+        "bolus": 18.7,
+        "temp_basal": 8.3,
+        "scheduled_basal": 15.5
+      },
+      "current_target": 110,
+      "insulinForManualBolus": 0.5,
+      "minDelta": -2,
+      "expectedDelta": -3,
+      "minGuardBG": 110,
+      "minPredBG": 125,
+      "threshold": 80,
+      "predictions": {
+        "IOB": [145, 144, 142, 138, 134, 130],
+        "ZT": [145, 144, 142, 140, 137, 135]
+      },
+      "reason": "TDD: 42.5U; COB: 0, Dev: 5, BGI: -1.2, ISF: 50, CR: 10, minPredBG 125, eventualBG 130 < 140"
+    },
+    "enacted": {
+      "received": true,
+      "rate": 0.6,
+      "duration": 30,
+      "deliverAt": "2026-05-06T14:30:00.000Z",
+      "timestamp": "2026-05-06T14:30:00.000Z",
+      "TDD": 42.5,
+      "insulin": {
+        "TDD": 42.5,
+        "bolus": 18.7,
+        "temp_basal": 8.3,
+        "scheduled_basal": 15.5
+      },
+      "reason": "TDD: 42.5U; enacted temp basal 0.6 U/hr for 30 min"
+    },
+    "version": "1.0.0",
+    "recommendedBolus": 0
+  },
+  "uploader": {
+    "battery": 92,
+    "batteryVoltage": 4.15,
+    "isCharging": false
+  }
+}

--- a/apps/api/tests/fixtures/nightscout/entries/xdrip_sgv_noisy.json
+++ b/apps/api/tests/fixtures/nightscout/entries/xdrip_sgv_noisy.json
@@ -1,0 +1,16 @@
+{
+  "_id": "65f4a1b2c8e3d2f1a0b1c2d5",
+  "type": "sgv",
+  "date": 1778090400000,
+  "dateString": "2026-05-06T18:00:00.000Z",
+  "sysTime": "2026-05-06T18:00:00.000Z",
+  "device": "xDrip-DexcomG6",
+  "direction": "NOT COMPUTABLE",
+  "sgv": 200,
+  "delta": 0,
+  "filtered": 199500,
+  "unfiltered": 215000,
+  "rssi": 100,
+  "noise": 4,
+  "utcOffset": 0
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/aaps_carbs_with_protein_fat.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/aaps_carbs_with_protein_fat.json
@@ -1,0 +1,14 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c405",
+  "eventType": "Meal Bolus",
+  "carbs": 60,
+  "protein": 30,
+  "fat": 25,
+  "duration": 240,
+  "durationInMilliseconds": 14400000,
+  "notes": "pizza dinner",
+  "isValid": true,
+  "created_at": "2026-05-06T18:00:00.000Z",
+  "date": 1778090400000,
+  "enteredBy": "openaps://AndroidAPS"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/aaps_effective_profile_switch_as_note.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/aaps_effective_profile_switch_as_note.json
@@ -1,0 +1,16 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c401",
+  "eventType": "Note",
+  "notes": "MyProfile (80%, 2h)",
+  "originalProfileName": "MyProfile",
+  "originalCustomizedName": "MyProfile (80%, 2h)",
+  "originalPercentage": 80,
+  "originalTimeshift": 0,
+  "originalDuration": 7200000,
+  "originalEnd": 1778086800000,
+  "profileJson": "{\"units\":\"mg/dl\",\"timezone\":\"America/Los_Angeles\",\"dia\":5,\"basal\":[{\"time\":\"00:00\",\"value\":0.68}],\"sens\":[{\"time\":\"00:00\",\"value\":50}],\"carbratio\":[{\"time\":\"00:00\",\"value\":10}],\"target_low\":[{\"time\":\"00:00\",\"value\":80}],\"target_high\":[{\"time\":\"00:00\",\"value\":140}]}",
+  "created_at": "2026-05-06T16:00:00.000Z",
+  "date": 1778083200000,
+  "isValid": true,
+  "enteredBy": "openaps://AndroidAPS"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/aaps_effective_profile_switch_as_note.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/aaps_effective_profile_switch_as_note.json
@@ -7,7 +7,7 @@
   "originalPercentage": 80,
   "originalTimeshift": 0,
   "originalDuration": 7200000,
-  "originalEnd": 1778086800000,
+  "originalEnd": 1778090400000,
   "profileJson": "{\"units\":\"mg/dl\",\"timezone\":\"America/Los_Angeles\",\"dia\":5,\"basal\":[{\"time\":\"00:00\",\"value\":0.68}],\"sens\":[{\"time\":\"00:00\",\"value\":50}],\"carbratio\":[{\"time\":\"00:00\",\"value\":10}],\"target_low\":[{\"time\":\"00:00\",\"value\":80}],\"target_high\":[{\"time\":\"00:00\",\"value\":140}]}",
   "created_at": "2026-05-06T16:00:00.000Z",
   "date": 1778083200000,

--- a/apps/api/tests/fixtures/nightscout/treatments/aaps_extended_bolus_emulating_tbr.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/aaps_extended_bolus_emulating_tbr.json
@@ -1,0 +1,26 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c402",
+  "eventType": "Temp Basal",
+  "duration": 30,
+  "durationInMilliseconds": 1800000,
+  "rate": 1.5,
+  "absolute": 1.5,
+  "type": "FAKE_EXTENDED",
+  "extendedEmulated": {
+    "eventType": "Combo Bolus",
+    "enteredinsulin": 1.5,
+    "duration": 30,
+    "isEmulatingTempBasal": true,
+    "relative": 1.5,
+    "splitNow": 0,
+    "splitExt": 100
+  },
+  "isValid": true,
+  "created_at": "2026-05-06T13:00:00.000Z",
+  "date": 1778072400000,
+  "pumpId": 12345,
+  "endId": 12346,
+  "pumpType": "DANA_RS",
+  "pumpSerial": "ABC1234",
+  "enteredBy": "openaps://AndroidAPS"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/aaps_temp_basal_emulated_suspend.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/aaps_temp_basal_emulated_suspend.json
@@ -1,0 +1,17 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c404",
+  "eventType": "Temp Basal",
+  "duration": 60,
+  "durationInMilliseconds": 3600000,
+  "type": "EMULATED_PUMP_SUSPEND",
+  "rate": 0,
+  "absolute": 0,
+  "percent": -100,
+  "isValid": true,
+  "created_at": "2026-05-06T14:00:00.000Z",
+  "date": 1778076000000,
+  "pumpId": 12348,
+  "pumpType": "DANA_RS",
+  "pumpSerial": "ABC1234",
+  "enteredBy": "openaps://AndroidAPS"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/aaps_temp_basal_superbolus.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/aaps_temp_basal_superbolus.json
@@ -1,0 +1,16 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c403",
+  "eventType": "Temp Basal",
+  "duration": 30,
+  "durationInMilliseconds": 1800000,
+  "type": "SUPERBOLUS",
+  "rate": 4.0,
+  "absolute": 4.0,
+  "isValid": true,
+  "created_at": "2026-05-06T13:30:00.000Z",
+  "date": 1778074200000,
+  "pumpId": 12347,
+  "pumpType": "DANA_RS",
+  "pumpSerial": "ABC1234",
+  "enteredBy": "openaps://AndroidAPS"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/aaps_therapy_event_sensor_start.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/aaps_therapy_event_sensor_start.json
@@ -1,0 +1,12 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c407",
+  "eventType": "Sensor Start",
+  "isValid": true,
+  "created_at": "2026-05-06T09:00:00.000Z",
+  "date": 1778058000000,
+  "duration": 0,
+  "durationInMilliseconds": 0,
+  "transmitterId": "ABCDEF",
+  "notes": "new G7 sensor",
+  "enteredBy": "openaps://AndroidAPS"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/aaps_therapy_event_site_change.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/aaps_therapy_event_site_change.json
@@ -1,0 +1,11 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c406",
+  "eventType": "Site Change",
+  "isValid": true,
+  "created_at": "2026-05-06T08:00:00.000Z",
+  "date": 1778054400000,
+  "duration": 0,
+  "durationInMilliseconds": 0,
+  "notes": "infusion set replaced",
+  "enteredBy": "openaps://AndroidAPS"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/bolus_wizard_with_carbs.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/bolus_wizard_with_carbs.json
@@ -1,0 +1,15 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c40c",
+  "eventType": "Bolus Wizard",
+  "insulin": 4.5,
+  "carbs": 50,
+  "glucose": 145,
+  "glucoseType": "Sensor",
+  "units": "mg/dl",
+  "isValid": true,
+  "bolusCalculatorResult": "{\"carbs\":50,\"glucoseValue\":145,\"targetBGLow\":100,\"targetBGHigh\":120,\"isf\":50,\"ic\":12,\"iob\":0.8,\"insulinFromBG\":0.7,\"insulinFromCarbs\":4.17,\"insulinFromCorrection\":0.7,\"totalBeforeConstraints\":4.87,\"totalAfterConstraints\":4.5}",
+  "notes": "lunch via wizard",
+  "created_at": "2026-05-06T12:30:00.000Z",
+  "date": 1778070600000,
+  "enteredBy": "openaps://AndroidAPS"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/careportal_combo_bolus.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/careportal_combo_bolus.json
@@ -1,0 +1,13 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c40b",
+  "eventType": "Combo Bolus",
+  "carbs": 75,
+  "insulin": 6.0,
+  "splitNow": 60,
+  "splitExt": 40,
+  "duration": 120,
+  "notes": "high-fat meal split bolus",
+  "created_at": "2026-05-06T19:00:00.000Z",
+  "enteredBy": "test-user",
+  "utcOffset": 0
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/loop_override_with_remote_address.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/loop_override_with_remote_address.json
@@ -1,0 +1,13 @@
+{
+  "_id": "f0c3d4e5-a6b7-4789-90ab-cdef01234567",
+  "eventType": "Temporary Override",
+  "created_at": "2026-05-06T17:00:00Z",
+  "timestamp": "2026-05-06T17:00:00Z",
+  "enteredBy": "Loop (via remote command)",
+  "device": "loop://iPhone",
+  "reason": "Workout",
+  "duration": 60,
+  "correctionRange": [140, 160],
+  "insulinNeedsScaleFactor": 0.5,
+  "remoteAddress": "device-token-stub"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/loop_pump_suspend_as_temp_basal.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/loop_pump_suspend_as_temp_basal.json
@@ -1,0 +1,16 @@
+{
+  "eventType": "Temp Basal",
+  "created_at": "2026-05-06T15:00:00Z",
+  "timestamp": "2026-05-06T15:00:00Z",
+  "enteredBy": "Loop",
+  "device": "loop://iPhone",
+  "syncIdentifier": "TB-SUSPEND-A1B2C3D4",
+  "insulinType": "Humalog",
+  "temp": "absolute",
+  "rate": 0,
+  "absolute": 0,
+  "duration": 30,
+  "amount": 0,
+  "automatic": true,
+  "reason": "suspend"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/loop_square_bolus.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/loop_square_bolus.json
@@ -1,0 +1,16 @@
+{
+  "eventType": "Correction Bolus",
+  "created_at": "2026-05-06T16:00:00Z",
+  "timestamp": "2026-05-06T16:00:00Z",
+  "enteredBy": "Loop",
+  "device": "loop://iPhone",
+  "syncIdentifier": "B-SQUARE-E5F6A7B8",
+  "insulinType": "Humalog",
+  "type": "square",
+  "bolusType": "Square",
+  "insulin": 2.5,
+  "programmed": 2.5,
+  "unabsorbed": 0,
+  "duration": 45,
+  "automatic": false
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/trio_exercise_override.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/trio_exercise_override.json
@@ -1,0 +1,9 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c40d",
+  "eventType": "Exercise",
+  "duration": 60,
+  "notes": "Workout",
+  "id": "a8b9c0d1-e2f3-4456-7890-abcdef012345",
+  "created_at": "2026-05-06T17:30:00.000Z",
+  "enteredBy": "Trio"
+}

--- a/apps/api/tests/fixtures/nightscout/treatments/trio_temp_target_manual.json
+++ b/apps/api/tests/fixtures/nightscout/treatments/trio_temp_target_manual.json
@@ -1,0 +1,12 @@
+{
+  "_id": "65f4b1a2c8e3d2f1a0b1c40e",
+  "eventType": "Temporary Target",
+  "reason": "Eating Soon",
+  "targetTop": 90,
+  "targetBottom": 80,
+  "duration": 60,
+  "id": "b9c0d1e2-f3a4-4567-8901-bcdef0123456",
+  "created_at": "2026-05-06T11:00:00.000Z",
+  "enteredBy": "Trio",
+  "units": "mg/dl"
+}

--- a/apps/api/tests/test_nightscout_models.py
+++ b/apps/api/tests/test_nightscout_models.py
@@ -1128,10 +1128,28 @@ class TestFixtureInvariants:
         "aaps_profile_switch_percentage.json": "aaps",
         "xdrip_empty_eventtype_with_carbs.json": "xdrip+",
         "xdrip4ios_bg_check_treatment.json": "xdrip4ios",
+        # Tier-2 treatments
+        "aaps_effective_profile_switch_as_note.json": "aaps",
+        "aaps_extended_bolus_emulating_tbr.json": "aaps",
+        "aaps_temp_basal_superbolus.json": "aaps",
+        "aaps_temp_basal_emulated_suspend.json": "aaps",
+        "aaps_carbs_with_protein_fat.json": "aaps",
+        "aaps_therapy_event_site_change.json": "aaps",
+        "aaps_therapy_event_sensor_start.json": "aaps",
+        "loop_pump_suspend_as_temp_basal.json": "loop",
+        "loop_square_bolus.json": "loop",
+        "loop_override_with_remote_address.json": "loop",
+        "careportal_combo_bolus.json": "unknown",
+        "bolus_wizard_with_carbs.json": "aaps",
+        "trio_exercise_override.json": "trio",
+        "trio_temp_target_manual.json": "trio",
         # devicestatus fixtures
         "loop_devicestatus.json": "loop",
         "aaps_devicestatus.json": "aaps",
         "oref0_devicestatus_with_predbgs.json": "oref0",
+        "loop_failure_devicestatus.json": "loop",
+        "loop_hybrid_dose_devicestatus.json": "loop",
+        "trio_devicestatus_with_tdd.json": "trio",
     }
 
     def test_treatment_fixtures_route_to_known_semantic_kinds(self):

--- a/apps/api/tests/test_nightscout_translator.py
+++ b/apps/api/tests/test_nightscout_translator.py
@@ -884,6 +884,173 @@ class TestReadEndpoints:
 
 
 # ---------------------------------------------------------------------------
+# Storage-side PII allowlist -- identifier-shaped values from the upstream
+# wire format must NOT reach metadata_json.
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataAllowlist:
+    """The translator filters metadata_json through a storage-side
+    allowlist so identifier-shaped values (`remoteAddress`,
+    `syncIdentifier`, AAPS `pumpId`/`pumpType`/`pumpSerial`) and the
+    per-treatment `enteredBy` username/email never land in JSONB.
+
+    Defense in depth: a future allowlist gap surfaces here, before
+    the wire DTO ever sees the value.
+    """
+
+    @pytest.mark.asyncio
+    async def test_remote_address_dropped_from_override_metadata(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        await translate_treatments(
+            [_load("treatments", "loop_override_with_remote_address")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        md = rows[0].metadata_json or {}
+        # The fixture has remoteAddress="device-token-stub" -- must not
+        # reach storage.
+        assert "remote_address" not in md
+        assert "remoteAddress" not in md
+        # Source attribution (`source` at row level) covers what we need;
+        # the per-treatment entered_by username should never persist.
+        assert "source_entered_by" not in md
+        # Sanity: clinically-meaningful keys still made it through.
+        assert md.get("correction_range") == [140, 160]
+
+    @pytest.mark.asyncio
+    async def test_aaps_pump_dedupe_triple_dropped_from_bolus_metadata(
+        self, translator_ctx
+    ):
+        session, user_id, conn_id = translator_ctx
+        await translate_treatments(
+            [_load("treatments", "aaps_v3_smb_correction_bolus")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        md = rows[0].metadata_json or {}
+        # AAPS pump composite dedup triple -- never persisted.
+        assert "pump_id" not in md
+        assert "pump_type" not in md
+        assert "pump_serial" not in md
+        # And the raw enteredBy value never persists either.
+        assert "source_entered_by" not in md
+        # Clinical keys preserved.
+        assert md.get("bolus_subtype") == "smb"
+
+    def test_allowlist_covers_every_literal_key_the_mappers_set(self):
+        """Drift guard: every literal key the mappers write into extras
+        MUST appear in `_METADATA_ALLOWLIST`, otherwise a clinically-
+        meaningful key would be silently filtered away.
+
+        Parses the mapper module's source for `extras["<key>"] = ...`
+        literals + the inline-dict literals the mappers initialize
+        with -- catches the static call sites without needing each
+        fixture to flex every branch.
+        """
+        import ast
+        import inspect
+
+        from src.services.integrations.nightscout import _pump_events_mapper
+        from src.services.integrations.nightscout._pump_events_mapper import (
+            _METADATA_ALLOWLIST,
+        )
+
+        # Read source through `inspect.getsource` so the test is
+        # independent of the pytest CWD (which can differ between
+        # local runs and CI).
+        tree = ast.parse(inspect.getsource(_pump_events_mapper))
+
+        keys: set[str] = set()
+        # `extras["<key>"] = ...`
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(t := node.targets[0], ast.Subscript)
+                and isinstance(t.value, ast.Name)
+                and t.value.id == "extras"
+                and isinstance(t.slice, ast.Constant)
+                and isinstance(t.slice.value, str)
+            ):
+                keys.add(t.slice.value)
+            # `extras: dict[...] = {"<key>": ..., ...}` initialisers
+            elif (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)
+                and node.target.id == "extras"
+                and isinstance(node.value, ast.Dict)
+            ):
+                for k in node.value.keys:
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                        keys.add(k.value)
+
+        # Sanity: scan picked SOMETHING up (catch a future syntactic
+        # refactor that hides the writes from this AST walk).
+        assert len(keys) >= 20, f"AST scan looks broken: only found {keys}"
+
+        missing = keys - _METADATA_ALLOWLIST
+        assert not missing, (
+            f"Mapper writes these extras keys that aren't on the allowlist; "
+            f"either add them or stop writing them: {sorted(missing)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_loop_sync_identifier_dropped_from_bolus_metadata(
+        self, translator_ctx
+    ):
+        session, user_id, conn_id = translator_ctx
+        await translate_treatments(
+            [_load("treatments", "loop_correction_bolus")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        md = rows[0].metadata_json or {}
+        # Loop syncIdentifier (HealthKit dedupe key) -- never persisted.
+        assert "sync_identifier" not in md
+        assert "syncIdentifier" not in md
+
+
+# ---------------------------------------------------------------------------
 # Cross-source coexistence -- partial-index relaxation must allow a Tandem
 # direct row and a Nightscout-relayed row to share the same
 # (user_id, event_timestamp, event_type) without conflict.

--- a/apps/api/tests/test_nightscout_translator.py
+++ b/apps/api/tests/test_nightscout_translator.py
@@ -1270,7 +1270,9 @@ class TestLiveEndToEndPipeline:
         assert len(rows) == outcome.inserted
         # Glucose values fall in the physiological range (catches a
         # mg/dL <-> mmol/L unit-conversion regression at the seam).
-        assert all(20 <= r.value <= 600 for r in rows)
+        # Project guideline: physiological range is 40-400 mg/dL.
+        # mg/dL <-> mmol/L misconversion would land far outside this.
+        assert all(40 <= r.value <= 400 for r in rows)
 
     @pytest.mark.asyncio
     async def test_live_treatments_round_trip_through_translator(self, translator_ctx):

--- a/apps/api/tests/test_nightscout_translator.py
+++ b/apps/api/tests/test_nightscout_translator.py
@@ -16,6 +16,7 @@ indexes, and the per-target conflict resolution.
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
@@ -880,3 +881,368 @@ class TestReadEndpoints:
 
             await session.execute(delete(User).where(User.id == other_id))
             await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Cross-source coexistence -- partial-index relaxation must allow a Tandem
+# direct row and a Nightscout-relayed row to share the same
+# (user_id, event_timestamp, event_type) without conflict.
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSourceCoexistence:
+    """DDL-level regression locks for the partial unique indexes.
+
+    These tests insert PumpEvent rows directly (bypassing the translator
+    and its ON CONFLICT path) to pin the schema invariant: the relaxed
+    `ix_pump_events_user_event_unique` (`WHERE ns_id IS NULL`) and
+    `ix_pump_events_source_nsid` (`WHERE ns_id IS NOT NULL`) must allow
+    a direct-integration row and a Nightscout-sourced row -- or two
+    Nightscout-sourced rows with different `_id`s -- to coexist at the
+    same timestamp + event_type.
+
+    The full upsert path (translator + ON CONFLICT) is exercised by
+    `TestLiveEndToEndPipeline`; these tests fail fast if someone
+    "tightens" the index again without thinking through the
+    cross-source case, even before the live tests would catch it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tandem_direct_and_nightscout_at_same_timestamp_both_persist(
+        self, translator_ctx
+    ):
+        from sqlalchemy import select
+
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        session, user_id, conn_id = translator_ctx
+        same_ts = datetime(2026, 5, 6, 14, 30, 0, tzinfo=UTC)
+        now = datetime.now(UTC)
+
+        # 1. Direct-integration row (Tandem-shaped: ns_id IS NULL)
+        tandem_row = PumpEvent(
+            user_id=user_id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=same_ts,
+            units=0.5,
+            is_automated=True,
+            received_at=now,
+            source="tandem",
+            ns_id=None,
+        )
+        session.add(tandem_row)
+        await session.flush()
+
+        # 2. Nightscout-relayed row at SAME timestamp + same event_type
+        # but with ns_id set. Different source tag, different ns_id, so
+        # the partial unique index `ix_pump_events_source_nsid` doesn't
+        # conflict either.
+        ns_row = PumpEvent(
+            user_id=user_id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=same_ts,
+            units=0.3,
+            is_automated=True,
+            received_at=now,
+            source=f"nightscout:{conn_id}",
+            ns_id="65f4b1a2c8e3d2f1a0b1c999",
+            metadata_json={"bolus_subtype": "smb", "source_uploader": "loop"},
+        )
+        session.add(ns_row)
+        await session.flush()
+
+        # Both rows should coexist
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2
+        sources = {r.source for r in rows}
+        assert sources == {"tandem", f"nightscout:{conn_id}"}
+
+    @pytest.mark.asyncio
+    async def test_two_nightscout_smbs_at_same_second_both_persist(
+        self, translator_ctx
+    ):
+        """The exact scenario the partial-index relaxation was built for:
+        two AAPS SMBs at the same second with different `_id`s -- the
+        old (non-partial) unique index would have dropped one.
+        """
+        from sqlalchemy import select
+
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        session, user_id, conn_id = translator_ctx
+        same_ts = datetime(2026, 5, 6, 14, 30, 0, tzinfo=UTC)
+        now = datetime.now(UTC)
+        source = f"nightscout:{conn_id}"
+
+        for ns_id, units in [
+            ("65f4b1a2c8e3d2f1a0b1d001", 0.1),
+            ("65f4b1a2c8e3d2f1a0b1d002", 0.2),
+        ]:
+            session.add(
+                PumpEvent(
+                    user_id=user_id,
+                    event_type=PumpEventType.BOLUS,
+                    event_timestamp=same_ts,
+                    units=units,
+                    is_automated=True,
+                    received_at=now,
+                    source=source,
+                    ns_id=ns_id,
+                )
+            )
+        await session.flush()
+
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent)
+                    .where(PumpEvent.user_id == user_id)
+                    .order_by(PumpEvent.units.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2
+        assert [r.units for r in rows] == [0.1, 0.2]
+
+
+# ---------------------------------------------------------------------------
+# Live end-to-end pipeline: NightscoutClient.fetch -> translator -> DB.
+# Gated by NIGHTSCOUT_TEST_URL env var; skipped in CI. Catches drift
+# between what the live cgm-remote-monitor returns and what the translator
+# expects -- the seam our isolated unit tests cannot exercise.
+# ---------------------------------------------------------------------------
+
+_NS_URL = os.environ.get("NIGHTSCOUT_TEST_URL")
+_NS_SECRET = os.environ.get("NIGHTSCOUT_TEST_SECRET")
+_skip_no_live = pytest.mark.skipif(
+    not _NS_URL or not _NS_SECRET,
+    reason="set both NIGHTSCOUT_TEST_URL and NIGHTSCOUT_TEST_SECRET to run "
+    "live integration tests against a real Nightscout instance",
+)
+
+
+@_skip_no_live
+@pytest.mark.integration
+class TestLiveEndToEndPipeline:
+    """Fetch real data via NightscoutClient, translate it, query the DB.
+
+    Validates the seam between:
+    - The HTTP client (ships entries/treatments/devicestatus dicts)
+    - The translator (parses dicts via Pydantic models, routes via
+      semantic_kind, writes to ORM)
+    - The DB (partial unique indexes, dedupe, source attribution)
+
+    Wire-format issues that would only surface here include: schema
+    drift between cgm-remote-monitor versions and our Pydantic models;
+    UTF-8 in `enteredBy` that breaks the metadata_json serialization;
+    timezone or timestamp-format anomalies the synthetic fixtures miss.
+    """
+
+    @pytest.mark.asyncio
+    async def test_live_entries_round_trip_to_glucose_readings(self, translator_ctx):
+        from sqlalchemy import select
+
+        from src.models.glucose import GlucoseReading
+        from src.models.nightscout_connection import (
+            NightscoutApiVersion,
+            NightscoutAuthType,
+        )
+        from src.services.integrations.nightscout.client import NightscoutClient
+
+        session, user_id, conn_id = translator_ctx
+
+        # Fetch real entries from the local instance
+        async with await NightscoutClient.create(
+            base_url=_NS_URL,
+            auth_type=NightscoutAuthType.SECRET,
+            credential=_NS_SECRET,
+            api_version=NightscoutApiVersion.V1,
+        ) as client:
+            entries = await client.fetch_entries(count=200)
+
+        # Translate -> ORM
+        outcome = await translate_entries(
+            entries,
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.commit()
+
+        # No parse failures -- if real cgm-remote-monitor responses
+        # don't fit our Pydantic model, this is where it surfaces.
+        assert outcome.failed == 0, "live entries failed Pydantic parse"
+
+        # Inserted count + skipped (gaps) should equal the fetch count
+        # exactly (modulo cal entries which we drop entirely)
+        assert outcome.inserted + outcome.skipped == len(entries)
+
+        # Spot-check the inserted rows
+        rows = (
+            (
+                await session.execute(
+                    select(GlucoseReading).where(
+                        GlucoseReading.user_id == user_id,
+                        GlucoseReading.source == f"nightscout:{conn_id}",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == outcome.inserted
+        # Glucose values fall in the physiological range (catches a
+        # mg/dL <-> mmol/L unit-conversion regression at the seam).
+        assert all(20 <= r.value <= 600 for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_live_treatments_round_trip_through_translator(self, translator_ctx):
+        from sqlalchemy import select
+
+        from src.models.nightscout_connection import (
+            NightscoutApiVersion,
+            NightscoutAuthType,
+        )
+        from src.models.pump_data import PumpEvent
+        from src.services.integrations.nightscout.client import NightscoutClient
+
+        session, user_id, conn_id = translator_ctx
+
+        async with await NightscoutClient.create(
+            base_url=_NS_URL,
+            auth_type=NightscoutAuthType.SECRET,
+            credential=_NS_SECRET,
+            api_version=NightscoutApiVersion.V1,
+        ) as client:
+            treatments = await client.fetch_treatments(count=200)
+
+        # Pre-compute the expected pump_events row count by mirroring
+        # the translator's routing decisions: fingerstick treatments
+        # divert to glucose_readings; the mapper hard-drops
+        # temp_basal_cancel / fingerstick_bg_check / unknown (the last
+        # also covers soft-deletes); meal_bolus_pair splits to two rows;
+        # else one row. Records without a resolvable timestamp drop too.
+        from src.services.integrations.nightscout.models import NightscoutTreatment
+
+        drop_kinds = {"temp_basal_cancel", "fingerstick_bg_check", "unknown"}
+        expected_pump_rows = 0
+        for raw in treatments:
+            try:
+                t = NightscoutTreatment.model_validate(raw)
+            except Exception:
+                continue
+            if t.is_fingerstick_treatment:
+                continue
+            if t.semantic_kind in drop_kinds:
+                continue
+            if t.canonical_timestamp is None:
+                continue
+            expected_pump_rows += 2 if t.semantic_kind == "meal_bolus_pair" else 1
+
+        pump_outcome, _glucose_outcome = await translate_treatments(
+            treatments,
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.commit()
+
+        assert pump_outcome.failed == 0, "live treatments failed Pydantic parse"
+
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(
+                        PumpEvent.user_id == user_id,
+                        PumpEvent.source == f"nightscout:{conn_id}",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # Cardinality match against the kind-derived expectation -- this
+        # would catch a mapper that silently drops a kind, an upsert
+        # that double-inserts, or a pair-splitter regression.
+        assert len(rows) == expected_pump_rows, (
+            f"expected {expected_pump_rows} pump_events rows from "
+            f"{len(treatments)} treatments, got {len(rows)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_live_pipeline_is_idempotent_on_refetch(self, translator_ctx):
+        """Run the full pipeline twice -- second run must dedupe to zero."""
+        from sqlalchemy import func, select
+
+        from src.models.glucose import GlucoseReading
+        from src.models.nightscout_connection import (
+            NightscoutApiVersion,
+            NightscoutAuthType,
+        )
+        from src.services.integrations.nightscout.client import NightscoutClient
+
+        session, user_id, conn_id = translator_ctx
+
+        async with await NightscoutClient.create(
+            base_url=_NS_URL,
+            auth_type=NightscoutAuthType.SECRET,
+            credential=_NS_SECRET,
+            api_version=NightscoutApiVersion.V1,
+        ) as client:
+            entries = await client.fetch_entries(count=100)
+
+        first = await translate_entries(
+            entries,
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.commit()
+
+        # Snapshot row count after pass 1 -- a regression that both
+        # double-inserts AND under-counts in the outcome counter would
+        # slip past `second.inserted == 0` alone.
+        count_after_first = await session.scalar(
+            select(func.count(GlucoseReading.id)).where(
+                GlucoseReading.user_id == user_id
+            )
+        )
+
+        second = await translate_entries(
+            entries,
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.commit()
+
+        assert second.inserted == 0, (
+            "re-fetching the same entries inserted duplicates -- "
+            "dedupe via (source, ns_id) partial index isn't holding"
+        )
+        # Everything in `entries` either landed first time (inserted)
+        # or was skipped (cal records / gap readings / no timestamp).
+        # Second time around, the inserted-on-first-pass rows hit the
+        # ON CONFLICT skip path; the rejected ones are skipped at the
+        # mapper layer like before.
+        assert second.skipped + second.failed >= first.inserted
+
+        count_after_second = await session.scalar(
+            select(func.count(GlucoseReading.id)).where(
+                GlucoseReading.user_id == user_id
+            )
+        )
+        assert count_after_second == count_after_first, (
+            f"row count drifted across re-fetch: "
+            f"{count_after_first} -> {count_after_second}"
+        )

--- a/apps/api/tests/test_nightscout_translator.py
+++ b/apps/api/tests/test_nightscout_translator.py
@@ -297,6 +297,50 @@ class TestTreatmentsPath:
         assert carb.metadata_json["carbs_grams"] == 60
 
     @pytest.mark.asyncio
+    async def test_meal_bolus_pair_dedupes_on_refetch(self, translator_ctx):
+        """Re-translating the same meal_bolus_pair must not double-insert.
+
+        Regression for the bug where the synthesized ns_id suffix
+        included a fresh uuid4(), making (source, ns_id) different on
+        each sync cycle so the partial unique index never matched.
+        """
+        session, user_id, conn_id = translator_ctx
+        raw = _load("treatments", "careportal_meal_bolus")
+
+        # First fetch: 2 rows inserted (bolus + carbs).
+        first_pump, _ = await translate_treatments(
+            [raw],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert first_pump.inserted == 2
+
+        # Second fetch of the same record: 0 inserts, 2 dedupe-skips.
+        second_pump, _ = await translate_treatments(
+            [raw],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert second_pump.inserted == 0
+        assert second_pump.skipped == 2
+
+        # Verify the DB still has exactly 2 rows.
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2
+
+    @pytest.mark.asyncio
     async def test_xdrip4ios_bg_check_routes_to_glucose_readings(self, translator_ctx):
         session, user_id, conn_id = translator_ctx
         pump_outcome, glucose_outcome = await translate_treatments(

--- a/apps/api/tests/test_nightscout_translator.py
+++ b/apps/api/tests/test_nightscout_translator.py
@@ -1,0 +1,838 @@
+"""Round-trip tests for the Nightscout translator.
+
+Covers:
+- Per-fixture round-trip: load JSON -> translate -> query DB -> assert
+- Dedupe: re-running translation upserts cleanly (no duplicate rows)
+- Soft-delete: isValid=false records are skipped
+- Meal-bolus pair split: bolus + carbs rows share meal_event_id
+- Profile snapshot upsert: re-fetching overwrites the latest row
+
+The unit-test layer (`test_nightscout_models.py`) covers the routing
+decisions the input-model layer makes. These tests exercise the
+translator's DB-write side -- ORM mapping, dedupe via partial unique
+indexes, and the per-target conflict resolution.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.encryption import encrypt_credential
+from src.database import get_session_maker
+from src.models.device_status_snapshot import DeviceStatusSnapshot
+from src.models.glucose import GlucoseReading
+from src.models.nightscout_connection import (
+    NightscoutAuthType,
+    NightscoutConnection,
+)
+from src.models.nightscout_profile_snapshot import NightscoutProfileSnapshot
+from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.user import User
+from src.services.integrations.nightscout.translator import (
+    translate_devicestatuses,
+    translate_entries,
+    translate_profile,
+    translate_treatments,
+)
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "nightscout"
+
+
+def _load(category: str, name: str) -> dict[str, Any]:
+    return json.loads((FIXTURE_ROOT / category / f"{name}.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: ephemeral User + NightscoutConnection
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def translator_ctx() -> AsyncGenerator[
+    tuple[AsyncSession, uuid.UUID, uuid.UUID], None
+]:
+    """Provide a session + a fresh User + NightscoutConnection.
+
+    Mirrors the seed_session pattern in test_knowledge_seed.py: opens
+    its own session via the shared session_maker (avoids cross-loop
+    issues that come from sharing the conftest db_session fixture
+    with translator code that opens its own connections).
+
+    Setup commits the user + connection so they're visible to the
+    translator's writes. Teardown explicitly DELETEs them and any
+    rows the test created. Teardown swallows asyncpg cross-loop
+    RuntimeErrors -- same noise the seed_session fixture documents.
+    """
+    session_maker = get_session_maker()
+    session = session_maker()
+    email = f"translator_{uuid.uuid4().hex[:10]}@example.com"
+    user = User(email=email, hashed_password="not-a-real-hash")
+    session.add(user)
+    await session.flush()
+    user_id = user.id
+
+    connection = NightscoutConnection(
+        user_id=user_id,
+        name="test-connection",
+        base_url="https://example.com",
+        auth_type=NightscoutAuthType.SECRET,
+        encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+    )
+    session.add(connection)
+    await session.flush()
+    connection_id = connection.id
+    await session.commit()
+
+    try:
+        yield session, user_id, connection_id
+    finally:
+        try:
+            # Roll back any uncommitted in-progress transaction the
+            # test left open before issuing the cleanup statements.
+            await session.rollback()
+            await session.execute(
+                delete(GlucoseReading).where(GlucoseReading.user_id == user_id)
+            )
+            await session.execute(delete(PumpEvent).where(PumpEvent.user_id == user_id))
+            await session.execute(
+                delete(DeviceStatusSnapshot).where(
+                    DeviceStatusSnapshot.user_id == user_id
+                )
+            )
+            await session.execute(
+                delete(NightscoutProfileSnapshot).where(
+                    NightscoutProfileSnapshot.user_id == user_id
+                )
+            )
+            await session.execute(
+                delete(NightscoutConnection).where(
+                    NightscoutConnection.id == connection_id
+                )
+            )
+            await session.execute(delete(User).where(User.id == user_id))
+            await session.commit()
+        except RuntimeError:
+            # asyncpg / pytest-asyncio cross-loop teardown noise --
+            # cosmetic, the engine pool will clean up regardless.
+            pass
+        finally:
+            try:
+                await session.close()
+            except RuntimeError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Entries path -> glucose_readings
+# ---------------------------------------------------------------------------
+
+
+class TestEntriesPath:
+    @pytest.mark.asyncio
+    async def test_xdrip_sgv_inserts_glucose_reading(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        outcome = await translate_entries(
+            [_load("entries", "xdrip_sgv")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert outcome.inserted == 1
+        assert outcome.skipped == 0
+        assert outcome.failed == 0
+
+        rows = (
+            (
+                await session.execute(
+                    select(GlucoseReading).where(GlucoseReading.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.value == 120
+        assert row.source == f"nightscout:{conn_id}"
+        assert row.ns_id is not None
+
+    @pytest.mark.asyncio
+    async def test_cal_entry_dropped(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        outcome = await translate_entries(
+            [_load("entries", "cal_calibration")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert outcome.inserted == 0
+        assert outcome.skipped == 1
+
+    @pytest.mark.asyncio
+    async def test_dedupe_via_ns_id_partial_index(self, translator_ctx):
+        """Re-running translation on the same entry must not double-insert."""
+        session, user_id, conn_id = translator_ctx
+        raw = _load("entries", "xdrip_sgv")
+
+        first = await translate_entries(
+            [raw], session=session, user_id=str(user_id), connection_id=str(conn_id)
+        )
+        await session.flush()
+        assert first.inserted == 1
+
+        second = await translate_entries(
+            [raw], session=session, user_id=str(user_id), connection_id=str(conn_id)
+        )
+        await session.flush()
+        assert second.inserted == 0
+        assert second.skipped == 1
+
+        rows = (
+            (
+                await session.execute(
+                    select(GlucoseReading).where(GlucoseReading.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_mbg_fingerstick_routes_to_glucose_readings(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        outcome = await translate_entries(
+            [_load("entries", "xdrip_mbg_fingerstick")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert outcome.inserted == 1
+
+
+# ---------------------------------------------------------------------------
+# Treatments path -> pump_events (+ glucose_readings for fingerstick)
+# ---------------------------------------------------------------------------
+
+
+class TestTreatmentsPath:
+    @pytest.mark.asyncio
+    async def test_loop_correction_bolus_inserts_pump_event(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        pump_outcome, glucose_outcome = await translate_treatments(
+            [_load("treatments", "loop_correction_bolus")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert pump_outcome.inserted == 1
+        assert glucose_outcome.inserted == 0  # not a fingerstick
+
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        ev = rows[0]
+        assert ev.event_type == PumpEventType.BOLUS
+        assert ev.units == 0.45
+        assert ev.is_automated is True  # Loop SMB
+        assert ev.metadata_json["bolus_subtype"] == "smb"
+        assert ev.metadata_json["source_uploader"] == "loop"
+
+    @pytest.mark.asyncio
+    async def test_meal_bolus_pair_splits_into_two_linked_rows(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        await translate_treatments(
+            [_load("treatments", "careportal_meal_bolus")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent)
+                    .where(PumpEvent.user_id == user_id)
+                    .order_by(PumpEvent.event_type)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # Two rows: bolus + carbs
+        assert len(rows) == 2
+        types = {r.event_type for r in rows}
+        assert types == {PumpEventType.BOLUS, PumpEventType.CARBS}
+        # Linked via shared meal_event_id
+        meal_ids = {r.meal_event_id for r in rows}
+        assert len(meal_ids) == 1
+        assert next(iter(meal_ids)) is not None
+        # The bolus row carries the insulin units; the carbs row does not
+        bolus = next(r for r in rows if r.event_type == PumpEventType.BOLUS)
+        carb = next(r for r in rows if r.event_type == PumpEventType.CARBS)
+        assert bolus.units == 5.0
+        assert carb.units is None
+        assert carb.metadata_json["carbs_grams"] == 60
+
+    @pytest.mark.asyncio
+    async def test_xdrip4ios_bg_check_routes_to_glucose_readings(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        pump_outcome, glucose_outcome = await translate_treatments(
+            [_load("treatments", "xdrip4ios_bg_check_treatment")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert pump_outcome.inserted == 0
+        assert glucose_outcome.inserted == 1
+
+        rows = (
+            (
+                await session.execute(
+                    select(GlucoseReading).where(GlucoseReading.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].value == 120
+
+    @pytest.mark.asyncio
+    async def test_loop_pump_suspend_routes_to_suspend_event(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        await translate_treatments(
+            [_load("treatments", "loop_pump_suspend_as_temp_basal")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].event_type == PumpEventType.SUSPEND
+        assert rows[0].metadata_json.get("reason") == "suspend"
+
+    @pytest.mark.asyncio
+    async def test_aaps_effective_profile_switch_routes_correctly(self, translator_ctx):
+        """Note + originalProfileName -> profile_switch (not note)."""
+        session, user_id, conn_id = translator_ctx
+        await translate_treatments(
+            [_load("treatments", "aaps_effective_profile_switch_as_note")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].event_type == PumpEventType.PROFILE_SWITCH
+        assert rows[0].metadata_json["effective_profile_switch_via_note"] is True
+
+    @pytest.mark.asyncio
+    async def test_soft_delete_is_skipped(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        # Forge a soft-delete by setting isValid=false on a Tier-1 fixture
+        raw = _load("treatments", "aaps_v1_smb_correction_bolus")
+        raw["isValid"] = False
+        pump_outcome, _ = await translate_treatments(
+            [raw],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert pump_outcome.inserted == 0
+        assert pump_outcome.skipped == 1
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 0
+
+
+# ---------------------------------------------------------------------------
+# Devicestatus path -> device_status_snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestDevicestatusPath:
+    @pytest.mark.asyncio
+    async def test_loop_devicestatus_inserts_snapshot(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        outcome = await translate_devicestatuses(
+            [_load("devicestatus", "loop_devicestatus")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert outcome.inserted == 1
+
+        rows = (
+            (
+                await session.execute(
+                    select(DeviceStatusSnapshot).where(
+                        DeviceStatusSnapshot.user_id == user_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        snap = rows[0]
+        # IOB extracted from loop.iob (pump.iob is null for Loop)
+        assert snap.iob_units == 1.2
+        assert snap.cob_grams == 12.0
+        assert snap.pump_battery_percent == 87
+        assert snap.pump_suspended is False
+        assert snap.source_uploader == "loop"
+        # Subtree blobs preserved verbatim
+        assert isinstance(snap.loop_subtree_json, dict)
+        assert isinstance(snap.pump_subtree_json, dict)
+
+    @pytest.mark.asyncio
+    async def test_loop_failure_devicestatus_captures_failure_reason(
+        self, translator_ctx
+    ):
+        session, user_id, conn_id = translator_ctx
+        await translate_devicestatuses(
+            [_load("devicestatus", "loop_failure_devicestatus")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        rows = (
+            (
+                await session.execute(
+                    select(DeviceStatusSnapshot).where(
+                        DeviceStatusSnapshot.user_id == user_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].loop_failure_reason is not None
+        assert "communicationFailure" in rows[0].loop_failure_reason
+
+    @pytest.mark.asyncio
+    async def test_dedupe_via_connection_nsid(self, translator_ctx):
+        """Re-running devicestatus translation must not double-insert."""
+        session, user_id, conn_id = translator_ctx
+        raw = _load("devicestatus", "loop_devicestatus")
+        await translate_devicestatuses(
+            [raw], session=session, user_id=str(user_id), connection_id=str(conn_id)
+        )
+        await session.flush()
+        outcome2 = await translate_devicestatuses(
+            [raw], session=session, user_id=str(user_id), connection_id=str(conn_id)
+        )
+        await session.flush()
+        assert outcome2.inserted == 0
+        assert outcome2.skipped == 1
+        rows = (
+            (
+                await session.execute(
+                    select(DeviceStatusSnapshot).where(
+                        DeviceStatusSnapshot.user_id == user_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Profile path -> nightscout_profile_snapshots (single row, upsert)
+# ---------------------------------------------------------------------------
+
+
+class TestProfilePath:
+    @pytest.mark.asyncio
+    async def test_profile_inserts_snapshot(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        ok = await translate_profile(
+            _load("profile", "multi_store_profile"),
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert ok is True
+
+        rows = (
+            (
+                await session.execute(
+                    select(NightscoutProfileSnapshot).where(
+                        NightscoutProfileSnapshot.user_id == user_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        snap = rows[0]
+        assert snap.source_default_profile_name == "Default"
+        assert snap.source_units == "mg/dl"
+        assert snap.source_dia_hours == 5.0
+        assert isinstance(snap.basal_segments, list)
+        assert len(snap.basal_segments) == 3
+
+    @pytest.mark.asyncio
+    async def test_profile_re_fetch_upserts_overwrites(self, translator_ctx):
+        """Re-running translate_profile updates the existing row, not creates."""
+        session, user_id, conn_id = translator_ctx
+        raw = _load("profile", "multi_store_profile")
+
+        await translate_profile(
+            raw,
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+            fetched_at=datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        await session.flush()
+
+        # Modify and re-run
+        raw_mut = dict(raw)
+        raw_mut["store"] = dict(raw["store"])
+        raw_mut["store"]["Default"] = dict(raw["store"]["Default"])
+        raw_mut["store"]["Default"]["dia"] = 6
+        await translate_profile(
+            raw_mut,
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+            fetched_at=datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC),
+        )
+        await session.flush()
+
+        rows = (
+            (
+                await session.execute(
+                    select(NightscoutProfileSnapshot).where(
+                        NightscoutProfileSnapshot.user_id == user_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1, "should remain a single row after re-fetch"
+        snap = rows[0]
+        assert snap.source_dia_hours == 6.0  # updated value
+
+
+# ---------------------------------------------------------------------------
+# Bulk fixture round-trip -- every Tier-1 + Tier-2 fixture must translate
+# ---------------------------------------------------------------------------
+
+
+class TestBulkFixtureRoundTrip:
+    @pytest.mark.asyncio
+    async def test_all_entry_fixtures_translate(self, translator_ctx):
+        """Every entry fixture either inserts or is intentionally dropped."""
+        session, user_id, conn_id = translator_ctx
+        entries_dir = FIXTURE_ROOT / "entries"
+        for path in sorted(entries_dir.glob("*.json")):
+            raw = json.loads(path.read_text())
+            outcome = await translate_entries(
+                [raw],
+                session=session,
+                user_id=str(user_id),
+                connection_id=str(conn_id),
+            )
+            await session.flush()
+            assert outcome.failed == 0, f"{path.name} parse failed"
+
+    @pytest.mark.asyncio
+    async def test_all_treatment_fixtures_translate(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        treatments_dir = FIXTURE_ROOT / "treatments"
+        for path in sorted(treatments_dir.glob("*.json")):
+            raw = json.loads(path.read_text())
+            pump_outcome, glucose_outcome = await translate_treatments(
+                [raw],
+                session=session,
+                user_id=str(user_id),
+                connection_id=str(conn_id),
+            )
+            await session.flush()
+            assert pump_outcome.failed == 0, f"{path.name} parse failed"
+            assert glucose_outcome.failed == 0
+
+    @pytest.mark.asyncio
+    async def test_all_devicestatus_fixtures_translate(self, translator_ctx):
+        session, user_id, conn_id = translator_ctx
+        ds_dir = FIXTURE_ROOT / "devicestatus"
+        for path in sorted(ds_dir.glob("*.json")):
+            raw = json.loads(path.read_text())
+            outcome = await translate_devicestatuses(
+                [raw],
+                session=session,
+                user_id=str(user_id),
+                connection_id=str(conn_id),
+            )
+            await session.flush()
+            assert outcome.failed == 0, f"{path.name} parse failed"
+
+
+# ---------------------------------------------------------------------------
+# Read endpoints exercised end-to-end via the FastAPI app
+# ---------------------------------------------------------------------------
+
+
+class TestReadEndpoints:
+    """Translator writes -> HTTP read endpoints return what we wrote.
+
+    Uses the connection-test register-and-login pattern so the
+    endpoints exercise auth + RBAC alongside the data filter.
+    """
+
+    @pytest.mark.asyncio
+    async def test_data_endpoint_returns_written_rows(self, translator_ctx):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.config import settings
+        from src.main import app
+
+        session, user_id, conn_id = translator_ctx
+        # Translate two entries + one bolus treatment so the endpoint
+        # has both arrays to return.
+        await translate_entries(
+            [
+                _load("entries", "xdrip_sgv"),
+                _load("entries", "dexcom_bridge_sgv"),
+            ],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await translate_treatments(
+            [_load("treatments", "loop_correction_bolus")],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.commit()
+
+        # Issue a JWT directly so we can call the protected endpoint
+        # without going through register/login (the user already
+        # exists from the fixture).
+        from src.core.security import create_access_token
+
+        token = create_access_token(
+            user_id=user_id, email="test@example.com", role="diabetic"
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get(
+                f"/api/integrations/nightscout/{conn_id}/data",
+                cookies={settings.jwt_cookie_name: token},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["connection_id"] == str(conn_id)
+        assert len(body["glucose_readings"]) == 2
+        assert len(body["pump_events"]) == 1
+        # Source attribution preserved on every row
+        assert all(
+            g["source"] == f"nightscout:{conn_id}" for g in body["glucose_readings"]
+        )
+        assert all(e["source"] == f"nightscout:{conn_id}" for e in body["pump_events"])
+
+    @pytest.mark.asyncio
+    async def test_data_endpoint_filters_by_since_cursor(self, translator_ctx):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.config import settings
+        from src.core.security import create_access_token
+        from src.main import app
+
+        session, user_id, conn_id = translator_ctx
+        await translate_entries(
+            [
+                _load("entries", "xdrip_sgv"),
+                _load("entries", "dexcom_bridge_sgv"),
+            ],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.commit()
+
+        token = create_access_token(
+            user_id=user_id, email="test@example.com", role="diabetic"
+        )
+        # `since` cursor between the two entry timestamps
+        # (xdrip is 2026-05-06T12:00:00Z, dexcom is 12:05:00Z)
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get(
+                f"/api/integrations/nightscout/{conn_id}/data",
+                params={"since": "2026-05-06T12:02:00Z"},
+                cookies={settings.jwt_cookie_name: token},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Only the later entry should appear
+        assert len(body["glucose_readings"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_profile_snapshot_endpoint_empty_state(self, translator_ctx):
+        """Connection with no profile sync yet returns has_snapshot=False."""
+        from httpx import ASGITransport, AsyncClient
+
+        from src.config import settings
+        from src.core.security import create_access_token
+        from src.main import app
+
+        session, user_id, conn_id = translator_ctx
+        token = create_access_token(
+            user_id=user_id, email="test@example.com", role="diabetic"
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get(
+                f"/api/integrations/nightscout/{conn_id}/profile-snapshot",
+                cookies={settings.jwt_cookie_name: token},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["has_snapshot"] is False
+        assert body["fetched_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_profile_snapshot_endpoint_returns_translated(self, translator_ctx):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.config import settings
+        from src.core.security import create_access_token
+        from src.main import app
+
+        session, user_id, conn_id = translator_ctx
+        await translate_profile(
+            _load("profile", "multi_store_profile"),
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.commit()
+
+        token = create_access_token(
+            user_id=user_id, email="test@example.com", role="diabetic"
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get(
+                f"/api/integrations/nightscout/{conn_id}/profile-snapshot",
+                cookies={settings.jwt_cookie_name: token},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["has_snapshot"] is True
+        assert body["source_default_profile_name"] == "Default"
+        assert body["source_units"] == "mg/dl"
+        assert body["source_dia_hours"] == 5.0
+        assert isinstance(body["basal_segments"], list)
+        assert len(body["basal_segments"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_data_endpoint_rejects_other_users_connection(self, translator_ctx):
+        """Cross-tenant access returns 404, not 403, to avoid leaking IDs."""
+        from httpx import ASGITransport, AsyncClient
+
+        from src.config import settings
+        from src.core.security import create_access_token
+        from src.main import app
+
+        session, user_id, conn_id = translator_ctx
+
+        # Create a second user with no claim on conn_id
+        other = User(
+            email=f"other_{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="not-a-real-hash",
+        )
+        session.add(other)
+        await session.flush()
+        other_id = other.id
+        await session.commit()
+
+        token = create_access_token(
+            user_id=other_id, email="other@example.com", role="diabetic"
+        )
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    f"/api/integrations/nightscout/{conn_id}/data",
+                    cookies={settings.jwt_cookie_name: token},
+                )
+            assert resp.status_code == 404
+        finally:
+            from sqlalchemy import delete
+
+            await session.execute(delete(User).where(User.id == other_id))
+            await session.commit()


### PR DESCRIPTION
Builds on the input-parsing layer (#571) and lands the **ORM mapping** for the Nightscout translator. With this PR, every Nightscout response — entries, treatments, devicestatus, profile — flows through the typed input parsers, gets routed by `semantic_kind`, and persists to the existing canonical tables (`glucose_readings`, `pump_events`) plus two new mirror tables (`nightscout_profile_snapshots`, `device_status_snapshots`). The mobile cloud-source plugin and the onboarding wizard read from new HTTP endpoints exposed at the same time.

## What ships

### Migration `052_nightscout_translator`

- **Extends `PumpEventType`** with 8 cloud-mediated event types (`carbs`, `override`, `profile_switch`, `combo_bolus`, `temp_target`, `note`, `device_event`, `aps_offline`). Direct integrations write the original 8 values; the translator writes the original set + the new 8.
- **Extends `pump_events`** with `metadata_json` (JSONB), `meal_event_id` (UUID), and `ns_id` (Text) columns. The pre-existing `(user_id, event_timestamp, event_type)` unique index is relaxed to `WHERE ns_id IS NULL` so two upstream events at the same timestamp (two AAPS SMBs in the same second; a real bolus that shares a timestamp with a Loop SMB) don't silently drop one. Nightscout-sourced rows dedupe via a partial unique index on `(source, ns_id) WHERE ns_id IS NOT NULL`.
- **Extends `glucose_readings`** with `ns_id` and the matching partial unique index.
- **Creates `nightscout_profile_snapshots`** — read-only mirror of the user's Nightscout profile, written on each profile fetch and read by the onboarding wizard to pre-fill the user's canonical settings form. Never queried by AI / charts / mobile / alerts.
- **Creates `device_status_snapshots`** — periodic IOB / COB / pump battery / loop dosing decision snapshots. Subtree blobs (`loop`, `openaps`, `pump`, `uploader`) preserved verbatim including the `reason` free-text strings the AI consumes.

### Translator orchestrator + 4 per-target mappers

`apps/api/src/services/integrations/nightscout/translator.py` exposes 4 async entry points (`translate_entries`, `translate_treatments`, `translate_devicestatuses`, `translate_profile`) that the future sync scheduler will drive. Each routes through a per-target mapper:

- **`_glucose_mapper.py`** — entries (sgv/mbg) + treatments-route fingerstick (BG Check / glucoseType=Finger) → `GlucoseReading` rows. Drops cal records, gap readings (sgv outside 20-1000), records without resolvable timestamp.
- **`_pump_events_mapper.py`** — routes by `semantic_kind` to the appropriate pump-event sub-shape. Splits meal-bolus pairs (carbs + insulin in one record) into two rows linked via `meal_event_id`. Hard-drops `temp_basal_cancel` (oref0 stale-CGM signal), soft-deleted records (`isValid: false`), and unknown eventTypes.
- **`_devicestatus_mapper.py`** — extracts IOB (`loop.iob` priority over `pump.iob`, since Loop's `pump.iob` is always nil), COB, pump battery / reservoir, loop failure reason. Subtree blobs preserved verbatim.
- **`_profile_mapper.py`** — pulls active store via `defaultProfile`; preserves time-segmented schedules `(time, value)` lists for the wizard to diff against canonical settings.

All upserts use PostgreSQL `INSERT ... ON CONFLICT DO NOTHING` with `RETURNING id` for accurate insert counting (`rowcount` is unreliable across drivers under ON CONFLICT). Profile snapshots use `ON CONFLICT DO UPDATE` because re-fetches must overwrite.

### Read endpoints

Two new GET endpoints under `/api/integrations/nightscout/{connection_id}`:

- **`/data?since=<ISO>&limit=N`** — merged glucose_readings + pump_events for the connection, sorted ascending by timestamp. Consumed by the future cloud-source mobile plugin to populate Room DB. The `since` cursor is **inclusive** (`>=`) to avoid losing rows that share a timestamp with the page boundary; callers dedupe by `ns_id` locally. `limit` applies per-array; `effective_limit_per_array` echoes the value used.
- **`/profile-snapshot`** — latest profile snapshot for this connection. Consumed by the onboarding wizard to pre-fill the user's canonical settings form. Returns `has_snapshot=False` when no profile sync has run.

Both endpoints filter by user ownership (404 not 403 on cross-tenant access) and by source tag so coexistence with BLE-plugin data on the same user is clean.

### Tests + fixtures

- **18 new Tier-2 fixtures** covering routing edge cases the unit-test layer needs to exercise the mappers thoroughly: AAPS Effective Profile Switch as Note, AAPS extended-bolus-emulating-TBR, AAPS Temp Basal Type subtypes (SUPERBOLUS, EMULATED_PUMP_SUSPEND), high-fat carbs (protein + fat fields), AAPS therapy events (Site / Sensor change), Loop pump suspend as zero-rate Temp Basal, Loop Square bolus (duration ≥30 min derived classification), Loop override with remote command, Care Portal Combo Bolus (splitNow + splitExt = 100), Bolus Wizard with carbs (4th carb encoding), Trio Exercise override, Trio manual Temp Target (separate code path), Loop failure devicestatus, Loop hybrid dose, Trio devicestatus with TDD, xDrip+ noisy entry.
- **23 round-trip tests** in `test_nightscout_translator.py` covering: per-target translation paths, dedupe via partial unique indexes, soft-delete skipping, meal-bolus pair split (shared `meal_event_id`), profile snapshot upsert (re-fetch overwrites), bulk fixture round-trip (every fixture parses cleanly), and the read endpoints (data filter, since cursor, profile snapshot empty/populated states, cross-tenant 404).
- **README provenance updated** with full citations for every Tier-2 fixture.

## Adversarial review (8 HIGH + 10 MEDIUM + 7 LOW, 11 fixed in this PR)

**Fixed:**

- **`result.rowcount` is unreliable under ON CONFLICT DO NOTHING** — switched all 3 upserts to `RETURNING id` + `len()` for authoritative counts.
- **`since` cursor dropped same-timestamp boundary rows** (concrete reproducer: meal-bolus pair has bolus + carbs at identical `event_timestamp`; strict `>` dropped the second on the next page) — switched to inclusive `>=`; callers dedupe by `ns_id` locally.
- **Pre-existing `pump_events` unique index would silently drop legitimate Nightscout writes** (two AAPS SMBs in the same second with different `_id`s) — relaxed to `WHERE ns_id IS NULL` so it applies only to direct-integration rows.
- **Per-array `limit` was misdocumented as "across both arrays"** — corrected docstring + added `effective_limit_per_array` to the response.
- **Conflict resolution was advertised as "direct integrations win" but actually first-writer-wins** — docstring made honest about the semantics.
- **Meal-bolus `ns_id` suffix could collide with crafted upstream `_id`** — switched to `<id>#meal-<uuid>:role=bolus|carbs` using a delimiter that can't appear in real NS `_id` values (24-hex ObjectId or UUID).
- **`is_automated` mis-classification for non-Loop SMBs** — conflated `is_smb` into the flag so dashboard "automated bolus" filters honestly count Trio's bare `eventType: "SMB"` and older AAPS SMBs without `automatic=true`.
- **Profile `model_dump()` defaulted to `mode="python"`** which would crash the JSONB write on any datetime field — switched to `mode="json"`.
- **`source_units` String(20) too small** for Loop's full HKUnit description (`"milligramsPerDeciliter"`, 22 chars) — bumped to String(40).
- **`int(treatment.duration)` truncated fractional minutes** — switched all 7 sites to `round()` for medical-data semantics.
- **`received_at` ON CONFLICT DO NOTHING semantics** — documented as effectively `first_received_at`; explicit fact that there's no `last_observed_at` yet.

**Direct-integration impact:** the partial-index change required a matching `index_where=text("ns_id IS NULL")` on the existing Tandem direct-integration writers (`routers/integrations.py` and `services/tandem_sync.py`). PostgreSQL needs the same WHERE clause on the ON CONFLICT spec for the partial index to be recognized as the conflict target. Caught by 4 failing test_tandem_upload tests during the full :api suite run.

**Documented as known limitations** (deferred to follow-up):

- **Soft-delete propagation** — when an upstream record is marked `isValid: false` after we already inserted it, the translator drops the parse but leaves the existing row. Needs an `is_retracted` column or DELETE-on-soft-delete logic.
- **`metadata_json` exposes raw `notes` / `entered_by` / `reason` to the user via the read endpoint** — auth-gated to the user's own data, but worth a redaction-policy review before broader integrations land.
- **`device_status_snapshots` has no retention/archival policy** — at 5-minute syncs and 365-day retention, ~105k rows/active user/year. Future scale concern.
- **Test fixture pattern** uses its own session_maker (mirrors `seed_session` in `test_knowledge_seed.py`) due to known asyncpg cross-loop teardown issues — same trade-off as the existing pattern.

## CodeRabbit (6 findings)

- **Critical:** Fixture timestamp inconsistency (`originalEnd` was `date + 1h` but `originalDuration` said `2h`) — fixed.
- **Major:** ORM models declared `__table_args__` without the partial unique indexes the migration adds — added `Index(..., postgresql_where=text("ns_id IS NOT NULL"))` declarations to both `PumpEvent` and `GlucoseReading` models so SQLAlchemy is aware of them.
- **Minor:** `int(duration)` → `round(duration)` (overlapped with adversarial finding).
- **Minor:** Migration's two operational nuances (post-COMMIT enum persistence on partial-failure re-run; downgrade may fail on duplicate Nightscout rows) — documented in module docstring.
- **Minor (skipped):** `bolus_wizard_with_carbs` calculation discrepancies — synthetic test data; the fixture exercises the routing path, not wizard math.

## Security review

Clean. No HIGH/MEDIUM findings. Both new GET endpoints gate on `_load_owned()` ownership check then double-filter queries by both `user_id` and `source = "nightscout:<id>"`. 404-not-403 on cross-tenant access prevents ID enumeration. All DB access via parameterized SQLAlchemy. Migration enum-extension uses a hardcoded tuple. No new credential / PII leak surfaces.

## What's NOT in this PR

- **Sync scheduler** — the translator is now callable but not driven on a cadence yet. Lands as a separate piece of the integration so it can be reviewed independently.
- **Onboarding wizard UI** — reads `nightscout_profile_snapshots` (which this PR populates) and lets the user pre-fill canonical settings. Lands as a separate UI piece.
- **Mobile cloud-source plugin** — consumes `/api/integrations/nightscout/{id}/data` (which this PR exposes) and populates Room DB. Establishes the architectural pattern for all future cloud-mediated integrations (Tidepool, LibreView, t:connect cloud).

## Test plan

- [x] Migration applies cleanly + downgrades cleanly against the local PostgreSQL dev DB.
- [x] **144 unit tests pass** in the nightscout test set (`test_nightscout_models.py`, `test_nightscout_client.py`, `test_nightscout_connection.py`, `test_nightscout_ssrf.py`, **new**: `test_nightscout_translator.py`).
- [x] **5 live integration tests pass** against local cgm-remote-monitor 15.0.8 (gated by `NIGHTSCOUT_TEST_URL`, skipped in CI).
- [x] **23 translator round-trip tests pass** end-to-end (input fixture → translator → ORM rows → assertions).
- [x] Full `:api` test suite passes locally: **1754 passed / 0 failed / 11 skipped**.
- [x] `ruff check` + `ruff format --check` clean across project.
- [x] Adversarial review (8 HIGH + 10 MEDIUM + 7 LOW): 11 fixed, 4 documented as known limitations, rest deferred with rationale.
- [x] CodeRabbit CLI: 6 findings, 5 fixed, 1 skipped with reason.
- [x] Security review clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nightscout read endpoints, profile snapshots, device-status snapshots, and broader Nightscout event/type support with per-connection deduplication.

* **Bug Fixes / Behavior**
  * Adjusted duplicate-suppression so Nightscout-sourced rows are treated separately from direct integrations.

* **Tests & Fixtures**
  * Large set of Nightscout fixtures and comprehensive translator integration tests covering entries, treatments, devicestatus, and profiles.

* **Documentation**
  * Expanded Nightscout fixture README with concrete Tier‑2 scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->