### PR TITLE
feat: Nightscout connection management UI + manual sync trigger

### DIFF
--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -6,6 +6,7 @@ platforms) instances; plus read endpoints that the cloud-source mobile
 plugin and the onboarding wizard consume.
 """
 
+import asyncio
 import uuid
 from datetime import UTC, datetime
 
@@ -35,12 +36,16 @@ from src.schemas.nightscout import (
     NightscoutConnectionUpdate,
     NightscoutDataResponse,
     NightscoutGlucoseReadingDTO,
+    NightscoutManualSyncResponse,
     NightscoutProfileSnapshotResponse,
     NightscoutPumpEventDTO,
 )
 from src.services.integrations.nightscout.connection_test import (
     ConnectionTestOutcome,
     test_connection,
+)
+from src.services.integrations.nightscout.sync import (
+    sync_nightscout_for_connection,
 )
 
 logger = get_logger(__name__)
@@ -50,6 +55,11 @@ router = APIRouter(
     tags=["integrations", "nightscout"],
 )
 
+# Manual sync wraps a synchronous translator round-trip; bound the
+# worker so a slow / unresponsive user-controlled NS URL can't pin a
+# request thread for the full upstream client timeout (often 30s+).
+_SYNC_TIMEOUT_SECONDS = 20.0
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -57,19 +67,27 @@ router = APIRouter(
 
 
 async def _load_owned(
-    db: AsyncSession, connection_id: uuid.UUID, user_id: uuid.UUID
+    db: AsyncSession,
+    connection_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    require_active: bool = False,
 ) -> NightscoutConnection:
     """Fetch a connection ensuring it belongs to the requesting user.
 
     Returns 404 (not 403) on cross-tenant access so we don't leak the
-    existence of other users' connection IDs.
+    existence of other users' connection IDs. Same 404 when
+    `require_active=True` and the row was soft-deleted (`is_active=False`)
+    -- that path is gated for endpoints that perform side effects
+    (sync, test) so a deleted-but-known-id can't be reanimated.
     """
-    result = await db.execute(
-        select(NightscoutConnection).where(
-            NightscoutConnection.id == connection_id,
-            NightscoutConnection.user_id == user_id,
-        )
-    )
+    where = [
+        NightscoutConnection.id == connection_id,
+        NightscoutConnection.user_id == user_id,
+    ]
+    if require_active:
+        where.append(NightscoutConnection.is_active.is_(True))
+    result = await db.execute(select(NightscoutConnection).where(*where))
     conn = result.scalar_one_or_none()
     if conn is None:
         raise HTTPException(
@@ -398,7 +416,9 @@ async def run_test(
     Updates `last_sync_status` to reflect the outcome so the dashboard
     UI shows current health without waiting for the scheduled sync.
     """
-    conn = await _load_owned(db, connection_id, current_user.id)
+    # Soft-deleted connections must not be reanimated via test/sync; we
+    # 404 them here even though the row is still in the DB.
+    conn = await _load_owned(db, connection_id, current_user.id, require_active=True)
     outcome = await test_connection(
         base_url=conn.base_url,
         auth_type=conn.auth_type,
@@ -411,6 +431,72 @@ async def run_test(
     await db.commit()
 
     return _outcome_to_response(outcome)
+
+
+@router.post(
+    "/{connection_id}/sync",
+    response_model=NightscoutManualSyncResponse,
+    responses={
+        200: {"description": "Sync executed (check `status` for outcome)"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Connection not found"},
+    },
+)
+async def run_sync(
+    connection_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> NightscoutManualSyncResponse:
+    """Manually trigger a sync for one connection (Story 43.4 AC10).
+
+    Synchronous from the user's POV: the request blocks until the
+    fetch + translate completes (subject to `_SYNC_TIMEOUT_SECONDS`).
+    Updates `last_synced_at` (only on full success) and
+    `last_sync_status` regardless. Same code path the background
+    scheduler uses, so the manual button validates the scheduler's
+    behavior.
+
+    Soft-deleted connections are 404'd here so a stale connection ID
+    can't be used to reanimate sync activity for a deactivated
+    instance.
+    """
+    conn = await _load_owned(db, connection_id, current_user.id, require_active=True)
+    try:
+        result = await asyncio.wait_for(
+            sync_nightscout_for_connection(db, conn),
+            timeout=_SYNC_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        # Caller-controlled URL: bound the worker. Surface as NETWORK
+        # status (matches what we'd record for a hung-socket case) and
+        # write back to the connection so the UI badge updates.
+        # Roll back first: the cancelled sync may have flushed partial
+        # rows; we don't want to commit those alongside the status
+        # update. The translator's ON CONFLICT DO NOTHING means the
+        # next successful sync will re-write what we drop here.
+        await db.rollback()
+        conn.last_sync_status = NightscoutSyncStatus.NETWORK
+        conn.last_sync_error = f"Sync exceeded {_SYNC_TIMEOUT_SECONDS}s timeout"
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=conn.last_sync_error,
+        ) from None
+    return NightscoutManualSyncResponse(
+        connection_id=conn.id,
+        status=result.status,
+        entries_inserted=result.entries_inserted,
+        entries_skipped=result.entries_skipped,
+        entries_failed=result.entries_failed,
+        treatments_inserted_pump=result.treatments_inserted_pump,
+        treatments_inserted_glucose=result.treatments_inserted_glucose,
+        treatments_failed=result.treatments_failed,
+        devicestatuses_inserted=result.devicestatuses_inserted,
+        devicestatuses_failed=result.devicestatuses_failed,
+        profile_synced=result.profile_synced,
+        duration_ms=result.duration_ms,
+        error=result.error,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -255,6 +255,32 @@ class NightscoutConnectionDeletedResponse(BaseModel):
     )
 
 
+class NightscoutManualSyncResponse(BaseModel):
+    """Response shape for POST /api/integrations/nightscout/{id}/sync.
+
+    Story 43.4 AC10 -- the user-triggered "sync now" path. The
+    background scheduler returns the same shape internally; only this
+    endpoint exposes it to clients.
+    """
+
+    connection_id: uuid.UUID
+    status: NightscoutSyncStatus
+    entries_inserted: int
+    entries_skipped: int
+    entries_failed: int
+    treatments_inserted_pump: int
+    treatments_inserted_glucose: int
+    treatments_failed: int
+    devicestatuses_inserted: int
+    devicestatuses_failed: int
+    profile_synced: bool
+    duration_ms: int
+    error: str | None = Field(
+        default=None,
+        description="Human-readable failure reason when status != ok",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Read endpoints (consumed by the mobile cloud-source plugin + the
 # onboarding wizard)

--- a/apps/api/src/services/integrations/nightscout/sync.py
+++ b/apps/api/src/services/integrations/nightscout/sync.py
@@ -1,0 +1,324 @@
+"""Per-connection Nightscout sync.
+
+Drives the four translator entry points against a single
+`NightscoutConnection`. Used by:
+
+- The manual `POST /api/integrations/nightscout/{id}/sync` endpoint
+  (Story 43.4 AC10) so a user can pull "now" from the UI.
+- The Story 43.4 background scheduler (`run_nightscout_sync_all_users`)
+  which calls this once per due connection on each tick.
+
+`since` semantics:
+- First sync (no `last_synced_at`): default backfill window from
+  `initial_sync_window_days` (0 = unbounded for entries/treatments;
+  always capped at 30 days for devicestatus to bound blast radius).
+- Subsequent syncs: `last_synced_at` (timezone-aware UTC).
+
+`last_synced_at` advancement: only on full success (all four
+translate calls returned without raising). On any partial failure the
+status / error are recorded but the cursor stays put so the next run
+re-fetches the same window. Documented + tested in `test_sync.py`.
+
+Exception mapping:
+- NightscoutAuthError              -> AUTH_FAILED
+- NightscoutRateLimitError         -> RATE_LIMITED
+- NightscoutNetworkError           -> NETWORK
+- NightscoutValidationError / etc. -> ERROR
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.encryption import decrypt_credential
+from src.logging_config import get_logger
+from src.models.nightscout_connection import (
+    NightscoutConnection,
+    NightscoutSyncStatus,
+)
+from src.services.integrations.nightscout.client import NightscoutClient
+from src.services.integrations.nightscout.errors import (
+    NightscoutAuthError,
+    NightscoutError,
+    NightscoutNetworkError,
+    NightscoutRateLimitError,
+)
+from src.services.integrations.nightscout.translator import (
+    TranslateOutcome,
+    translate_devicestatuses,
+    translate_entries,
+    translate_profile,
+    translate_treatments,
+)
+
+logger = get_logger(__name__)
+
+# Cap the devicestatus initial backfill regardless of
+# `initial_sync_window_days` — high-volume tables on busy uploaders
+# can have tens of thousands of rows per day.
+_DEVICESTATUS_INITIAL_CAP_DAYS = 30
+
+# Per-connection in-flight guard. Two concurrent sync calls for the
+# same connection (manual button + scheduler tick, or two browser tabs)
+# would both fetch the same window upstream, double the API calls, and
+# race on cursor writes. Translators are dedupe-safe via the partial
+# unique indexes, but the wasted I/O and last_sync_error flapping is
+# real. The lock is process-local (one API replica) and held only for
+# the duration of one sync; cross-replica concurrency is bounded by
+# the scheduler tick spacing in Story 43.4.
+#
+# Entries are evicted opportunistically when the lock is released and
+# no one else is waiting on it (see `_release_lock`), so the dict size
+# tracks "currently-syncing connections" rather than "every connection
+# ever seen by this worker."
+_in_flight_locks: dict[uuid.UUID, asyncio.Lock] = {}
+
+
+def _lock_for(connection_id: uuid.UUID) -> asyncio.Lock:
+    lock = _in_flight_locks.get(connection_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _in_flight_locks[connection_id] = lock
+    return lock
+
+
+def _release_lock(connection_id: uuid.UUID, lock: asyncio.Lock) -> None:
+    """Drop the lock entry if no one else is contending for it.
+
+    Called after we exit the `async with` block. `lock.locked()` is
+    False at this point (we just released). If `_waiters` is empty,
+    no other task is queued for it and we can let the entry go.
+    A subsequent call to `_lock_for` will lazily re-create one.
+    """
+    waiters = getattr(lock, "_waiters", None)
+    if not waiters:
+        _in_flight_locks.pop(connection_id, None)
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """Outcome of a single connection sync."""
+
+    connection_id: str
+    status: NightscoutSyncStatus
+    entries_inserted: int
+    entries_skipped: int
+    entries_failed: int
+    treatments_inserted_pump: int
+    treatments_inserted_glucose: int
+    treatments_failed: int
+    devicestatuses_inserted: int
+    devicestatuses_failed: int
+    profile_synced: bool
+    duration_ms: int
+    error: str | None
+
+
+def _resolve_since(
+    last_synced_at: datetime | None,
+    initial_sync_window_days: int,
+    now: datetime,
+    *,
+    cap_days: int | None = None,
+) -> datetime | None:
+    """Pick the `since` cursor for one fetch call.
+
+    - If we have a `last_synced_at`, use it as the lower bound.
+    - Otherwise, this is the first sync; fall back to
+      `now - initial_sync_window_days` (0 means "unbounded").
+    - `cap_days`: if the chosen window is older than this many days,
+      clamp to it. Used for devicestatus to bound blast radius.
+    """
+    if last_synced_at is not None:
+        return last_synced_at
+    if initial_sync_window_days <= 0 and cap_days is None:
+        return None
+    days = initial_sync_window_days if initial_sync_window_days > 0 else cap_days
+    if cap_days is not None and (days is None or days > cap_days):
+        days = cap_days
+    if days is None:
+        return None
+    return now - timedelta(days=days)
+
+
+def _classify_exception(exc: BaseException) -> NightscoutSyncStatus:
+    if isinstance(exc, NightscoutAuthError):
+        return NightscoutSyncStatus.AUTH_FAILED
+    if isinstance(exc, NightscoutRateLimitError):
+        return NightscoutSyncStatus.RATE_LIMITED
+    if isinstance(exc, NightscoutNetworkError):
+        return NightscoutSyncStatus.NETWORK
+    return NightscoutSyncStatus.ERROR
+
+
+async def sync_nightscout_for_connection(
+    session: AsyncSession,
+    conn: NightscoutConnection,
+) -> SyncResult:
+    """Pull-and-translate one connection's data into the canonical tables.
+
+    **Session ownership**: this function takes exclusive ownership of
+    the passed session for its lifetime and commits before returning.
+    Callers must NOT have other pending writes staged on the same
+    session; the manual-sync endpoint hands in a request-scoped
+    session that's only used here, and the Story 43.4 scheduler
+    opens a fresh per-connection session for the same reason.
+
+    **Exception handling**: NightscoutError is classified into a
+    NightscoutSyncStatus and surfaced via the result + connection row.
+    `asyncio.CancelledError` / `SystemExit` / `KeyboardInterrupt`
+    propagate so the runtime can shut down or cancel cleanly. Any
+    other exception is logged with traceback and recorded as ERROR
+    -- this swallow is intentional so the scheduler's per-row
+    isolation holds and one buggy connection doesn't kill the tick.
+
+    **Concurrency**: a per-connection asyncio lock prevents two
+    concurrent sync calls (e.g. manual button + scheduler tick) from
+    racing on the cursor and doubling upstream API load. Within one
+    process; cross-replica concurrency is bounded by scheduler tick
+    spacing in Story 43.4.
+    """
+    lock = _lock_for(conn.id)
+    async with lock:
+        try:
+            return await _do_sync(session, conn)
+        finally:
+            _release_lock(conn.id, lock)
+
+
+async def _do_sync(session: AsyncSession, conn: NightscoutConnection) -> SyncResult:
+    started = time.monotonic()
+    now = datetime.now(UTC)
+    user_id_str = str(conn.user_id)
+    connection_id_str = str(conn.id)
+    last_synced = conn.last_synced_at
+    window_days = conn.initial_sync_window_days
+
+    entries_outcome = TranslateOutcome()
+    pump_outcome = TranslateOutcome()
+    glucose_from_treatments_outcome = TranslateOutcome()
+    devicestatus_outcome = TranslateOutcome()
+    profile_synced = False
+    error_msg: str | None = None
+    status = NightscoutSyncStatus.OK
+
+    try:
+        async with await NightscoutClient.create(
+            base_url=conn.base_url,
+            auth_type=conn.auth_type,
+            credential=decrypt_credential(conn.encrypted_credential),
+            api_version=conn.api_version,
+        ) as client:
+            entries = await client.fetch_entries(
+                since=_resolve_since(last_synced, window_days, now)
+            )
+            treatments = await client.fetch_treatments(
+                since=_resolve_since(last_synced, window_days, now)
+            )
+            devicestatuses = await client.fetch_devicestatus(
+                since=_resolve_since(
+                    last_synced,
+                    window_days,
+                    now,
+                    cap_days=_DEVICESTATUS_INITIAL_CAP_DAYS,
+                )
+            )
+            profiles = await client.fetch_profile()
+
+        entries_outcome = await translate_entries(
+            entries,
+            session=session,
+            user_id=user_id_str,
+            connection_id=connection_id_str,
+        )
+        pump_outcome, glucose_from_treatments_outcome = await translate_treatments(
+            treatments,
+            session=session,
+            user_id=user_id_str,
+            connection_id=connection_id_str,
+        )
+        devicestatus_outcome = await translate_devicestatuses(
+            devicestatuses,
+            session=session,
+            user_id=user_id_str,
+            connection_id=connection_id_str,
+        )
+        if profiles:
+            await translate_profile(
+                profiles[0],
+                session=session,
+                user_id=user_id_str,
+                connection_id=connection_id_str,
+            )
+            profile_synced = True
+
+    except NightscoutError as exc:
+        status = _classify_exception(exc)
+        error_msg = str(exc)
+        logger.warning(
+            "nightscout_sync_failed",
+            connection_id=connection_id_str,
+            user_id=user_id_str,
+            status=status.value,
+            error=error_msg,
+        )
+    except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
+        # Cooperative shutdown / cancellation must propagate so the
+        # runtime can drain cleanly. We do NOT update the connection
+        # row in this case -- the next sync will re-evaluate.
+        raise
+    except Exception as exc:  # noqa: BLE001 - surfaced via SyncResult
+        status = NightscoutSyncStatus.ERROR
+        error_msg = str(exc)
+        logger.exception(
+            "nightscout_sync_unexpected_error",
+            connection_id=connection_id_str,
+            user_id=user_id_str,
+        )
+
+    # Persist status + (only on success) advance the cursor.
+    conn.last_sync_status = status
+    conn.last_sync_error = error_msg
+    if status == NightscoutSyncStatus.OK:
+        conn.last_synced_at = now
+    await session.commit()
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    logger.info(
+        "nightscout_sync_completed",
+        connection_id=connection_id_str,
+        user_id=user_id_str,
+        status=status.value,
+        entries_inserted=entries_outcome.inserted,
+        entries_skipped=entries_outcome.skipped,
+        treatments_inserted=pump_outcome.inserted
+        + glucose_from_treatments_outcome.inserted,
+        devicestatuses_inserted=devicestatus_outcome.inserted,
+        profile_synced=profile_synced,
+        duration_ms=duration_ms,
+    )
+
+    return SyncResult(
+        connection_id=connection_id_str,
+        status=status,
+        entries_inserted=entries_outcome.inserted,
+        entries_skipped=entries_outcome.skipped,
+        entries_failed=entries_outcome.failed,
+        treatments_inserted_pump=pump_outcome.inserted,
+        treatments_inserted_glucose=glucose_from_treatments_outcome.inserted,
+        # `translate_treatments` returns two outcomes (pump rows + glucose
+        # rows for fingerstick treatments). Sum both failure counts so a
+        # parser failure on a fingerstick treatment isn't silently dropped.
+        treatments_failed=pump_outcome.failed + glucose_from_treatments_outcome.failed,
+        devicestatuses_inserted=devicestatus_outcome.inserted,
+        devicestatuses_failed=devicestatus_outcome.failed,
+        profile_synced=profile_synced,
+        duration_ms=duration_ms,
+        error=error_msg,
+    )

--- a/apps/api/tests/test_nightscout_sync.py
+++ b/apps/api/tests/test_nightscout_sync.py
@@ -1,0 +1,284 @@
+"""Tests for the per-connection Nightscout sync service.
+
+Mocks the NightscoutClient at the class level so we exercise the real
+translator + DB write paths but don't depend on a running Nightscout
+instance. Live end-to-end coverage lives in `test_nightscout_translator.py`
+gated by the NIGHTSCOUT_TEST_URL / NIGHTSCOUT_TEST_SECRET env vars.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.encryption import encrypt_credential
+from src.database import get_session_maker
+from src.models.glucose import GlucoseReading
+from src.models.nightscout_connection import (
+    NightscoutAuthType,
+    NightscoutConnection,
+    NightscoutSyncStatus,
+)
+from src.models.user import User
+from src.services.integrations.nightscout.errors import (
+    NightscoutAuthError,
+    NightscoutNetworkError,
+    NightscoutRateLimitError,
+)
+from src.services.integrations.nightscout.sync import (
+    _resolve_since,
+    sync_nightscout_for_connection,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def sync_ctx() -> AsyncGenerator[tuple[AsyncSession, NightscoutConnection], None]:
+    """Provide a session + a fresh user + connection.
+
+    Mirrors the pattern in test_nightscout_translator.py -- own
+    session_maker so cross-loop teardown doesn't crash.
+    """
+    session_maker = get_session_maker()
+    session = session_maker()
+    email = f"sync_{uuid.uuid4().hex[:10]}@example.com"
+    user = User(email=email, hashed_password="not-a-real-hash")
+    session.add(user)
+    await session.flush()
+    user_id = user.id
+
+    conn = NightscoutConnection(
+        user_id=user_id,
+        name="test-sync",
+        base_url="https://example.com",
+        auth_type=NightscoutAuthType.SECRET,
+        encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+        initial_sync_window_days=7,
+    )
+    session.add(conn)
+    await session.flush()
+    await session.commit()
+
+    try:
+        yield session, conn
+    finally:
+        try:
+            await session.rollback()
+            await session.execute(
+                delete(GlucoseReading).where(GlucoseReading.user_id == user_id)
+            )
+            await session.execute(
+                delete(NightscoutConnection).where(
+                    NightscoutConnection.user_id == user_id
+                )
+            )
+            await session.execute(delete(User).where(User.id == user_id))
+            await session.commit()
+        except RuntimeError:
+            pass
+        finally:
+            try:
+                await session.close()
+            except RuntimeError:
+                pass
+
+
+def _mk_client_mock(
+    *,
+    entries: list[dict] | None = None,
+    treatments: list[dict] | None = None,
+    devicestatus: list[dict] | None = None,
+    profile: list[dict] | None = None,
+    fetch_exception: Exception | None = None,
+) -> MagicMock:
+    """Build a mock standing in for an opened `NightscoutClient`.
+
+    Exposes the four `fetch_*` coroutines plus `__aenter__`/`__aexit__`
+    so the `async with await NightscoutClient.create(...)` in sync.py
+    works against the mock.
+    """
+    client_instance = AsyncMock()
+    if fetch_exception is not None:
+        client_instance.fetch_entries = AsyncMock(side_effect=fetch_exception)
+        client_instance.fetch_treatments = AsyncMock(side_effect=fetch_exception)
+        client_instance.fetch_devicestatus = AsyncMock(side_effect=fetch_exception)
+        client_instance.fetch_profile = AsyncMock(side_effect=fetch_exception)
+    else:
+        client_instance.fetch_entries = AsyncMock(return_value=entries or [])
+        client_instance.fetch_treatments = AsyncMock(return_value=treatments or [])
+        client_instance.fetch_devicestatus = AsyncMock(return_value=devicestatus or [])
+        client_instance.fetch_profile = AsyncMock(return_value=profile or [])
+
+    client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+    client_instance.__aexit__ = AsyncMock(return_value=None)
+    return client_instance
+
+
+# ---------------------------------------------------------------------------
+# _resolve_since: cursor logic
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSince:
+    def test_first_sync_uses_initial_window(self):
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        since = _resolve_since(None, 7, now)
+        assert since == now - timedelta(days=7)
+
+    def test_subsequent_sync_uses_last_synced_at(self):
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        last = datetime(2026, 5, 10, 11, 0, tzinfo=UTC)
+        assert _resolve_since(last, 7, now) == last
+
+    def test_zero_window_means_unbounded_for_uncapped_call(self):
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        assert _resolve_since(None, 0, now) is None
+
+    def test_zero_window_with_cap_uses_cap(self):
+        """devicestatus path: 0 means 'all available' but cap_days bounds it."""
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        since = _resolve_since(None, 0, now, cap_days=30)
+        assert since == now - timedelta(days=30)
+
+    def test_window_larger_than_cap_clamps_to_cap(self):
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        since = _resolve_since(None, 90, now, cap_days=30)
+        assert since == now - timedelta(days=30)
+
+
+# ---------------------------------------------------------------------------
+# sync_nightscout_for_connection: outcome paths
+# ---------------------------------------------------------------------------
+
+
+class TestSyncOutcome:
+    @pytest.mark.asyncio
+    async def test_successful_sync_advances_cursor(self, sync_ctx):
+        session, conn = sync_ctx
+
+        client_mock = _mk_client_mock(
+            entries=[
+                {
+                    "_id": "fixture-entry-1",
+                    "type": "sgv",
+                    "sgv": 120,
+                    "dateString": "2026-05-10T12:00:00.000Z",
+                    "device": "xdrip",
+                }
+            ],
+        )
+        before = datetime.now(UTC)
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            result = await sync_nightscout_for_connection(session, conn)
+        after = datetime.now(UTC)
+
+        assert result.status == NightscoutSyncStatus.OK
+        assert result.entries_inserted == 1
+        # Cursor advanced
+        assert conn.last_synced_at is not None
+        assert before <= conn.last_synced_at <= after
+        # Status persisted
+        assert conn.last_sync_status == NightscoutSyncStatus.OK
+        assert conn.last_sync_error is None
+
+    @pytest.mark.asyncio
+    async def test_auth_error_maps_to_auth_failed_and_keeps_cursor(self, sync_ctx):
+        """Cursor MUST NOT advance on failure."""
+        session, conn = sync_ctx
+        original_cursor = conn.last_synced_at  # None on first run
+
+        client_mock = _mk_client_mock(
+            fetch_exception=NightscoutAuthError("401 unauthorized", status_code=401),
+        )
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            result = await sync_nightscout_for_connection(session, conn)
+
+        assert result.status == NightscoutSyncStatus.AUTH_FAILED
+        assert result.error == "401 unauthorized"
+        assert conn.last_synced_at is original_cursor  # unchanged
+        assert conn.last_sync_status == NightscoutSyncStatus.AUTH_FAILED
+        assert conn.last_sync_error == "401 unauthorized"
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_maps_to_rate_limited(self, sync_ctx):
+        session, conn = sync_ctx
+        client_mock = _mk_client_mock(
+            fetch_exception=NightscoutRateLimitError("429 too many requests")
+        )
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            result = await sync_nightscout_for_connection(session, conn)
+        assert result.status == NightscoutSyncStatus.RATE_LIMITED
+
+    @pytest.mark.asyncio
+    async def test_network_error_maps_to_network(self, sync_ctx):
+        session, conn = sync_ctx
+        client_mock = _mk_client_mock(
+            fetch_exception=NightscoutNetworkError("connection reset")
+        )
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            result = await sync_nightscout_for_connection(session, conn)
+        assert result.status == NightscoutSyncStatus.NETWORK
+
+    @pytest.mark.asyncio
+    async def test_idempotent_resync(self, sync_ctx):
+        """Running the same sync twice -- second call inserts nothing."""
+        session, conn = sync_ctx
+
+        # Fixed data; same payload both calls.
+        entries = [
+            {
+                "_id": f"idem-entry-{i}",
+                "type": "sgv",
+                "sgv": 110 + i,
+                "dateString": f"2026-05-10T12:0{i}:00.000Z",
+                "device": "xdrip",
+            }
+            for i in range(3)
+        ]
+        client_mock = _mk_client_mock(entries=entries)
+
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            first = await sync_nightscout_for_connection(session, conn)
+            second = await sync_nightscout_for_connection(session, conn)
+
+        assert first.entries_inserted == 3
+        assert second.entries_inserted == 0
+        # Both passes still landed on OK (i.e., dedupe is a skip, not an error).
+        assert first.status == NightscoutSyncStatus.OK
+        assert second.status == NightscoutSyncStatus.OK
+
+        rows = (
+            (
+                await session.execute(
+                    select(GlucoseReading).where(GlucoseReading.user_id == conn.user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 3

--- a/apps/web/__tests__/settings/offline-state.test.tsx
+++ b/apps/web/__tests__/settings/offline-state.test.tsx
@@ -74,6 +74,12 @@ jest.mock("../../src/lib/api", () => {
     disconnectDexcom: jest.fn().mockRejectedValue(networkError),
     connectTandem: jest.fn().mockRejectedValue(networkError),
     disconnectTandem: jest.fn().mockRejectedValue(networkError),
+    // Nightscout (third-party integration -- new in PR #575)
+    listNightscoutConnections: jest.fn().mockRejectedValue(networkError),
+    createNightscoutConnection: jest.fn().mockRejectedValue(networkError),
+    testNightscoutConnection: jest.fn().mockRejectedValue(networkError),
+    syncNightscoutConnection: jest.fn().mockRejectedValue(networkError),
+    deleteNightscoutConnection: jest.fn().mockRejectedValue(networkError),
     // Telegram
     getTelegramStatus: jest.fn().mockRejectedValue(networkError),
     generateTelegramCode: jest.fn().mockRejectedValue(networkError),

--- a/apps/web/__tests__/smoke-test-pages.test.tsx
+++ b/apps/web/__tests__/smoke-test-pages.test.tsx
@@ -93,11 +93,17 @@ jest.mock("@/lib/api", () => ({
   updateProfile: jest.fn().mockResolvedValue({}),
   changePassword: jest.fn().mockResolvedValue({}),
   // Integrations
-  listIntegrations: jest.fn().mockResolvedValue({ dexcom: { connected: false }, tandem: { connected: false } }),
+  listIntegrations: jest.fn().mockResolvedValue({ integrations: [] }),
   connectDexcom: jest.fn().mockResolvedValue({}),
   disconnectDexcom: jest.fn().mockResolvedValue(undefined),
   connectTandem: jest.fn().mockResolvedValue({}),
   disconnectTandem: jest.fn().mockResolvedValue(undefined),
+  // Nightscout (third-party integration -- new in PR #575)
+  listNightscoutConnections: jest.fn().mockResolvedValue({ connections: [] }),
+  createNightscoutConnection: jest.fn().mockResolvedValue({}),
+  testNightscoutConnection: jest.fn().mockResolvedValue({ ok: true }),
+  syncNightscoutConnection: jest.fn().mockResolvedValue({}),
+  deleteNightscoutConnection: jest.fn().mockResolvedValue(undefined),
   // Caregivers
   listLinkedCaregivers: jest.fn().mockResolvedValue({ caregivers: [] }),
   listCaregiverInvitations: jest.fn().mockResolvedValue({ invitations: [] }),

--- a/apps/web/src/app/dashboard/settings/integrations/page.tsx
+++ b/apps/web/src/app/dashboard/settings/integrations/page.tsx
@@ -23,11 +23,19 @@ import {
   disconnectDexcom,
   connectTandem,
   disconnectTandem,
+  listNightscoutConnections,
+  createNightscoutConnection,
+  deleteNightscoutConnection,
+  testNightscoutConnection,
+  syncNightscoutConnection,
   type IntegrationResponse,
+  type NightscoutConnectionCreate,
+  type NightscoutConnectionResponse,
 } from "@/lib/api";
 import { OfflineBanner } from "@/components/ui/offline-banner";
 import { PumpIntegrationsSection } from "@/components/integrations/pump-integrations-section";
 import { CGMIntegrationsSection } from "@/components/integrations/cgm-integrations-section";
+import { NightscoutIntegrationsSection } from "@/components/integrations/nightscout-integrations-section";
 
 export default function IntegrationsPage() {
   const [isLoading, setIsLoading] = useState(true);
@@ -38,6 +46,9 @@ export default function IntegrationsPage() {
   // Integration state
   const [dexcom, setDexcom] = useState<IntegrationResponse | null>(null);
   const [tandem, setTandem] = useState<IntegrationResponse | null>(null);
+  const [nightscoutConnections, setNightscoutConnections] = useState<
+    NightscoutConnectionResponse[]
+  >([]);
 
   // Dexcom form
   const [dexcomEmail, setDexcomEmail] = useState("");
@@ -60,7 +71,10 @@ export default function IntegrationsPage() {
   const fetchIntegrations = useCallback(async () => {
     try {
       setError(null);
-      const data = await listIntegrations();
+      const [data, ns] = await Promise.all([
+        listIntegrations(),
+        listNightscoutConnections(),
+      ]);
 
       const dexcomInt = data.integrations.find(
         (i) => i.integration_type === "dexcom"
@@ -71,6 +85,7 @@ export default function IntegrationsPage() {
 
       setDexcom(dexcomInt || null);
       setTandem(tandemInt || null);
+      setNightscoutConnections(ns.connections);
       setIsOffline(false);
     } catch (err) {
       if (!(err instanceof Error && err.message.includes("401"))) {
@@ -154,6 +169,102 @@ export default function IntegrationsPage() {
       );
     } finally {
       setIsTandemConnecting(false);
+    }
+  };
+
+  const refetchNightscoutConnections = useCallback(async () => {
+    const ns = await listNightscoutConnections();
+    setNightscoutConnections(ns.connections);
+  }, []);
+
+  const handleCreateNightscout = async (body: NightscoutConnectionCreate) => {
+    setError(null);
+    setSuccess(null);
+    try {
+      const result = await createNightscoutConnection(body);
+      // Refetch is best-effort: even if the list endpoint blips, the
+      // create succeeded server-side and the success banner should
+      // still appear so the user knows their save landed.
+      try {
+        await refetchNightscoutConnections();
+      } catch {
+        // intentional: don't suppress the success message just because
+        // the follow-up list fetch failed; next refresh will reconcile.
+      }
+      if (result.test.ok) {
+        setSuccess("Nightscout connection saved and verified");
+      } else {
+        setSuccess(
+          "Nightscout connection saved (initial test did not validate auth — check the connection's status)"
+        );
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to create Nightscout connection"
+      );
+      // Re-raise so the section's local create-form error display fires too.
+      throw err;
+    }
+  };
+
+  const handleDeleteNightscout = async (connectionId: string) => {
+    setError(null);
+    setSuccess(null);
+    try {
+      await deleteNightscoutConnection(connectionId);
+      // Refetch — the server soft-deletes (is_active=false) so the row
+      // stays in DB; the GET endpoint filters those out.
+      await refetchNightscoutConnections();
+      setSuccess("Nightscout connection removed");
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to delete Nightscout connection"
+      );
+    }
+  };
+
+  const handleTestNightscout = async (connectionId: string) => {
+    try {
+      const result = await testNightscoutConnection(connectionId);
+      // Refresh is best-effort so a transient list-fetch failure
+      // doesn't mask the actual test outcome the caller will render.
+      try {
+        await refetchNightscoutConnections();
+      } catch {
+        // intentional: don't lose the test result on refetch failure.
+      }
+      return result;
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to test Nightscout connection"
+      );
+      // Re-raise: the section component renders the failure inline.
+      throw err;
+    }
+  };
+
+  const handleSyncNightscout = async (connectionId: string) => {
+    try {
+      const result = await syncNightscoutConnection(connectionId);
+      try {
+        await refetchNightscoutConnections();
+      } catch {
+        // best-effort refetch -- sync result is the user-visible outcome.
+      }
+      return result;
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to sync Nightscout connection"
+      );
+      throw err;
     }
   };
 
@@ -267,6 +378,18 @@ export default function IntegrationsPage() {
           onDexcomPasswordChange={setDexcomPassword}
           onConnectDexcom={handleConnectDexcom}
           onDisconnectDexcom={handleDisconnectDexcom}
+        />
+      )}
+
+      {/* Third-Party Integrations (Nightscout) */}
+      {!isLoading && (
+        <NightscoutIntegrationsSection
+          connections={nightscoutConnections}
+          isOffline={isOffline}
+          onCreate={handleCreateNightscout}
+          onDelete={handleDeleteNightscout}
+          onTest={handleTestNightscout}
+          onSync={handleSyncNightscout}
         />
       )}
 

--- a/apps/web/src/app/dashboard/settings/integrations/page.tsx
+++ b/apps/web/src/app/dashboard/settings/integrations/page.tsx
@@ -69,31 +69,47 @@ export default function IntegrationsPage() {
   }, [success]);
 
   const fetchIntegrations = useCallback(async () => {
-    try {
-      setError(null);
-      const [data, ns] = await Promise.all([
-        listIntegrations(),
-        listNightscoutConnections(),
-      ]);
+    setError(null);
+    // Settled so a Nightscout endpoint blip doesn't take down the
+    // Dexcom/Tandem sections (and vice versa). The "offline" banner
+    // only fires when BOTH calls fail (i.e. the API itself is
+    // unreachable), not when one section's endpoint 4xx/5xx's.
+    const [integrationsResult, nightscoutResult] = await Promise.allSettled([
+      listIntegrations(),
+      listNightscoutConnections(),
+    ]);
 
-      const dexcomInt = data.integrations.find(
-        (i) => i.integration_type === "dexcom"
+    if (integrationsResult.status === "fulfilled") {
+      const data = integrationsResult.value;
+      setDexcom(
+        data.integrations.find((i) => i.integration_type === "dexcom") || null
       );
-      const tandemInt = data.integrations.find(
-        (i) => i.integration_type === "tandem"
+      setTandem(
+        data.integrations.find((i) => i.integration_type === "tandem") || null
       );
-
-      setDexcom(dexcomInt || null);
-      setTandem(tandemInt || null);
-      setNightscoutConnections(ns.connections);
-      setIsOffline(false);
-    } catch (err) {
-      if (!(err instanceof Error && err.message.includes("401"))) {
-        setIsOffline(true);
-      }
-    } finally {
-      setIsLoading(false);
     }
+    if (nightscoutResult.status === "fulfilled") {
+      setNightscoutConnections(nightscoutResult.value.connections);
+    }
+
+    const integrationsFailed = integrationsResult.status === "rejected";
+    const nightscoutFailed = nightscoutResult.status === "rejected";
+    const isAuthError = (err: unknown) =>
+      err instanceof Error && err.message.includes("401");
+
+    if (
+      integrationsFailed &&
+      nightscoutFailed &&
+      !isAuthError(integrationsResult.reason) &&
+      !isAuthError(nightscoutResult.reason)
+    ) {
+      // Both endpoints failed -- API itself is unreachable.
+      setIsOffline(true);
+    } else {
+      setIsOffline(false);
+    }
+
+    setIsLoading(false);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/components/integrations/nightscout-integrations-section.tsx
+++ b/apps/web/src/components/integrations/nightscout-integrations-section.tsx
@@ -1,0 +1,679 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import {
+  Cloud,
+  Link2,
+  Unlink,
+  Loader2,
+  Wifi,
+  AlertTriangle,
+  Check,
+  Eye,
+  EyeOff,
+  RefreshCw,
+} from "lucide-react";
+import clsx from "clsx";
+import { CollapsibleSection } from "@/components/ui/collapsible-section";
+import type {
+  NightscoutApiVersion,
+  NightscoutAuthType,
+  NightscoutConnectionCreate,
+  NightscoutConnectionResponse,
+  NightscoutConnectionTestResult,
+  NightscoutManualSyncResponse,
+  NightscoutSyncStatus,
+} from "@/lib/api";
+
+const SYNC_STATUS_LABEL: Record<NightscoutSyncStatus, string> = {
+  ok: "Connected",
+  error: "Error",
+  auth_failed: "Auth Failed",
+  rate_limited: "Rate Limited",
+  network: "Network Error",
+  unknown: "Pending",
+};
+
+const SYNC_STATUS_COLOR: Record<NightscoutSyncStatus, string> = {
+  ok: "text-green-400 bg-green-500/10",
+  error: "text-red-400 bg-red-500/10",
+  auth_failed: "text-red-400 bg-red-500/10",
+  rate_limited: "text-amber-400 bg-amber-500/10",
+  network: "text-amber-400 bg-amber-500/10",
+  unknown: "text-slate-500 bg-slate-500/10",
+};
+
+function SyncStatusBadge({ status }: { status: NightscoutSyncStatus }) {
+  return (
+    <span
+      className={clsx(
+        "ml-2 text-xs font-medium px-2 py-0.5 rounded-full",
+        SYNC_STATUS_COLOR[status]
+      )}
+    >
+      {SYNC_STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "never";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "unknown";
+  // floor not round so 59 minutes stays "59m ago" instead of jumping to "1h"
+  const minutes = Math.floor((Date.now() - then) / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+interface NightscoutIntegrationsSectionProps {
+  connections: NightscoutConnectionResponse[];
+  isOffline: boolean;
+  onCreate: (body: NightscoutConnectionCreate) => Promise<void>;
+  onDelete: (connectionId: string) => Promise<void>;
+  onTest: (connectionId: string) => Promise<NightscoutConnectionTestResult>;
+  onSync: (connectionId: string) => Promise<NightscoutManualSyncResponse>;
+}
+
+export function NightscoutIntegrationsSection({
+  connections,
+  isOffline,
+  onCreate,
+  onDelete,
+  onTest,
+  onSync,
+}: NightscoutIntegrationsSectionProps) {
+  const [name, setName] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [credential, setCredential] = useState("");
+  const [credentialVisible, setCredentialVisible] = useState(false);
+  const [authType, setAuthType] = useState<NightscoutAuthType>("auto");
+  const [apiVersion, setApiVersion] = useState<NightscoutApiVersion>("auto");
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [syncingId, setSyncingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [perConnectionResult, setPerConnectionResult] = useState<
+    Record<string, { ok: boolean; message: string }>
+  >({});
+
+  const handleCreate = async (e: FormEvent) => {
+    e.preventDefault();
+    if (isCreating) return;
+    setCreateError(null);
+    if (!name.trim() || !baseUrl.trim() || !credential.trim()) {
+      setCreateError("Name, base URL, and credential are all required");
+      return;
+    }
+    setIsCreating(true);
+    try {
+      await onCreate({
+        name: name.trim(),
+        base_url: baseUrl.trim(),
+        credential,
+        auth_type: authType,
+        api_version: apiVersion,
+      });
+      setName("");
+      setBaseUrl("");
+      setCredential("");
+      setAuthType("auto");
+      setApiVersion("auto");
+    } catch (err) {
+      setCreateError(
+        err instanceof Error ? err.message : "Failed to create connection"
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleTest = async (connectionId: string) => {
+    setTestingId(connectionId);
+    setPerConnectionResult((prev) => {
+      const { [connectionId]: _drop, ...rest } = prev;
+      return rest;
+    });
+    try {
+      const result = await onTest(connectionId);
+      setPerConnectionResult((prev) => ({
+        ...prev,
+        [connectionId]: {
+          ok: result.ok,
+          message: result.ok
+            ? `Connected${result.server_version ? ` (Nightscout ${result.server_version})` : ""}`
+            : result.error || "Connection test failed",
+        },
+      }));
+    } catch (err) {
+      setPerConnectionResult((prev) => ({
+        ...prev,
+        [connectionId]: {
+          ok: false,
+          message: err instanceof Error ? err.message : "Test failed",
+        },
+      }));
+    } finally {
+      setTestingId(null);
+    }
+  };
+
+  const handleSync = async (connectionId: string) => {
+    setSyncingId(connectionId);
+    setPerConnectionResult((prev) => {
+      const { [connectionId]: _drop, ...rest } = prev;
+      return rest;
+    });
+    try {
+      const result = await onSync(connectionId);
+      const inserted =
+        result.entries_inserted +
+        result.treatments_inserted_pump +
+        result.treatments_inserted_glucose +
+        result.devicestatuses_inserted;
+      const failed =
+        result.entries_failed +
+        result.treatments_failed +
+        result.devicestatuses_failed;
+      const buildSuccess = () => {
+        const parts = [
+          inserted > 0
+            ? `${inserted} new row${inserted === 1 ? "" : "s"}`
+            : "already up to date",
+        ];
+        if (failed > 0) {
+          parts.push(`${failed} record${failed === 1 ? "" : "s"} rejected`);
+        }
+        return `Synced — ${parts.join("; ")} (${result.duration_ms}ms)`;
+      };
+      setPerConnectionResult((prev) => ({
+        ...prev,
+        [connectionId]: {
+          ok: result.status === "ok" && failed === 0,
+          message:
+            result.status === "ok"
+              ? buildSuccess()
+              : result.error || `Sync failed (${result.status})`,
+        },
+      }));
+    } catch (err) {
+      setPerConnectionResult((prev) => ({
+        ...prev,
+        [connectionId]: {
+          ok: false,
+          message: err instanceof Error ? err.message : "Sync failed",
+        },
+      }));
+    } finally {
+      setSyncingId(null);
+    }
+  };
+
+  const handleDelete = async (connectionId: string) => {
+    setDeletingId(connectionId);
+    try {
+      await onDelete(connectionId);
+      // Drop any in-memory test result for the deleted connection so the
+      // entry doesn't leak in component state until unmount.
+      setPerConnectionResult((prev) => {
+        const { [connectionId]: _drop, ...rest } = prev;
+        return rest;
+      });
+      setConfirmDeleteId(null);
+    } catch (err) {
+      // Surface the failure inline so the user knows the row did NOT
+      // go away. The card stays visible (no refetch happened yet) and
+      // the confirm dialog stays open so they can retry without
+      // re-opening it.
+      setPerConnectionResult((prev) => ({
+        ...prev,
+        [connectionId]: {
+          ok: false,
+          message:
+            err instanceof Error
+              ? err.message
+              : "Failed to delete connection",
+        },
+      }));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <CollapsibleSection title="Third-Party Integrations" icon={Cloud}>
+      <div className="space-y-4">
+        <CollapsibleSection
+          title="Nightscout"
+          variant="subsection"
+          badge={
+            <span className="ml-2 text-xs font-medium text-slate-500">
+              {connections.length} connection
+              {connections.length === 1 ? "" : "s"}
+            </span>
+          }
+        >
+          <div className="space-y-4">
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Nightscout is an independent open-source project, not a
+              GlycemicGPT product. If you already self-host (or use a hosted)
+              Nightscout instance, you can point GlycemicGPT at it to pull
+              glucose readings, insulin events, and pump data. Multiple
+              connections are supported (e.g. one per family member or per
+              uploader).
+            </p>
+
+            {connections.length > 0 && (
+              <ul
+                role="list"
+                aria-label="Nightscout connections"
+                className="space-y-3"
+                data-testid="nightscout-connections-list"
+              >
+                {connections.map((conn) => {
+                  const result = perConnectionResult[conn.id];
+                  const showConfirm = confirmDeleteId === conn.id;
+                  return (
+                    <li
+                      key={conn.id}
+                      data-testid={`nightscout-connection-${conn.id}`}
+                      className="bg-white dark:bg-slate-900 rounded-lg p-4 border border-slate-200 dark:border-slate-800"
+                    >
+                      <div className="flex items-start justify-between gap-4 flex-wrap">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <Wifi className="h-4 w-4 text-slate-500 shrink-0" />
+                            <span className="font-medium text-slate-700 dark:text-slate-200 truncate">
+                              {conn.name}
+                            </span>
+                            <SyncStatusBadge status={conn.last_sync_status} />
+                          </div>
+                          <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 truncate">
+                            {conn.base_url}
+                          </p>
+                          <div className="text-xs text-slate-500 dark:text-slate-400 mt-1 flex gap-3 flex-wrap">
+                            <span>
+                              Last sync:{" "}
+                              {conn.last_synced_at ? (
+                                <time
+                                  dateTime={conn.last_synced_at}
+                                  title={new Date(
+                                    conn.last_synced_at
+                                  ).toLocaleString()}
+                                >
+                                  {formatRelative(conn.last_synced_at)}
+                                </time>
+                              ) : (
+                                "never"
+                              )}
+                            </span>
+                            <span>Every {conn.sync_interval_minutes} min</span>
+                            <span>
+                              {conn.api_version === "auto"
+                                ? "Auto API"
+                                : `API ${conn.api_version}`}
+                            </span>
+                          </div>
+                          {conn.last_sync_error && (
+                            <p
+                              className="text-xs text-red-400 mt-1"
+                              role="status"
+                            >
+                              {conn.last_sync_error}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex gap-2 shrink-0">
+                          <button
+                            type="button"
+                            onClick={() => handleSync(conn.id)}
+                            disabled={isOffline || syncingId === conn.id}
+                            data-testid={`nightscout-sync-${conn.id}`}
+                            className={clsx(
+                              "px-3 py-1.5 rounded-lg text-xs font-medium",
+                              "border border-blue-500/30 text-blue-400",
+                              "hover:bg-blue-500/10",
+                              "disabled:opacity-50 disabled:cursor-not-allowed",
+                              "transition-colors flex items-center gap-1"
+                            )}
+                          >
+                            {syncingId === conn.id ? (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                              <RefreshCw className="h-3 w-3" />
+                            )}
+                            Sync now
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleTest(conn.id)}
+                            disabled={isOffline || testingId === conn.id}
+                            data-testid={`nightscout-test-${conn.id}`}
+                            className={clsx(
+                              "px-3 py-1.5 rounded-lg text-xs font-medium",
+                              "border border-slate-300 dark:border-slate-700",
+                              "text-slate-700 dark:text-slate-300",
+                              "hover:bg-slate-100 dark:hover:bg-slate-800",
+                              "disabled:opacity-50 disabled:cursor-not-allowed",
+                              "transition-colors flex items-center gap-1"
+                            )}
+                          >
+                            {testingId === conn.id ? (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                              <Link2 className="h-3 w-3" />
+                            )}
+                            Test
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmDeleteId(conn.id)}
+                            disabled={isOffline || deletingId === conn.id}
+                            data-testid={`nightscout-delete-${conn.id}`}
+                            className={clsx(
+                              "px-3 py-1.5 rounded-lg text-xs font-medium",
+                              "border border-red-500/30 text-red-400",
+                              "hover:bg-red-500/10",
+                              "disabled:opacity-50 disabled:cursor-not-allowed",
+                              "transition-colors flex items-center gap-1"
+                            )}
+                          >
+                            {deletingId === conn.id ? (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                              <Unlink className="h-3 w-3" />
+                            )}
+                            Delete
+                          </button>
+                        </div>
+                      </div>
+
+                      {showConfirm && (
+                        <div
+                          role="alertdialog"
+                          aria-label={`Confirm delete connection ${conn.name}`}
+                          className="mt-3 px-3 py-3 rounded-lg bg-red-500/5 border border-red-500/30"
+                        >
+                          <p className="text-xs text-slate-700 dark:text-slate-200 mb-3">
+                            Delete <strong>{conn.name}</strong>? Historical data
+                            already imported is preserved; only future syncs
+                            stop.
+                          </p>
+                          <div className="flex gap-2">
+                            <button
+                              type="button"
+                              onClick={() => handleDelete(conn.id)}
+                              disabled={deletingId === conn.id}
+                              data-testid={`nightscout-confirm-delete-${conn.id}`}
+                              className={clsx(
+                                "px-3 py-1.5 rounded-lg text-xs font-medium",
+                                "bg-red-500 text-white hover:bg-red-400",
+                                "disabled:opacity-50 disabled:cursor-not-allowed",
+                                "transition-colors flex items-center gap-1"
+                              )}
+                            >
+                              {deletingId === conn.id ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              ) : null}
+                              Delete connection
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setConfirmDeleteId(null)}
+                              disabled={deletingId === conn.id}
+                              className={clsx(
+                                "px-3 py-1.5 rounded-lg text-xs font-medium",
+                                "border border-slate-300 dark:border-slate-700",
+                                "text-slate-700 dark:text-slate-300",
+                                "hover:bg-slate-100 dark:hover:bg-slate-800",
+                                "disabled:opacity-50 disabled:cursor-not-allowed",
+                                "transition-colors"
+                              )}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Always-mounted live region so screen readers
+                          register it before the first async insertion. */}
+                      <div
+                        role="status"
+                        aria-live="polite"
+                        aria-atomic="true"
+                        className={clsx(
+                          result &&
+                            "mt-3 px-3 py-2 rounded-lg text-xs flex items-center gap-2",
+                          result?.ok && "bg-green-500/10 text-green-400",
+                          result && !result.ok && "bg-red-500/10 text-red-400"
+                        )}
+                      >
+                        {result && (
+                          <>
+                            {result.ok ? (
+                              <Check className="h-3 w-3 shrink-0" />
+                            ) : (
+                              <AlertTriangle className="h-3 w-3 shrink-0" />
+                            )}
+                            <span>{result.message}</span>
+                          </>
+                        )}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+
+            <form
+              onSubmit={handleCreate}
+              className="bg-slate-50 dark:bg-slate-900 rounded-lg p-4 border border-slate-200 dark:border-slate-800"
+              aria-label="Add a Nightscout connection"
+            >
+              <h4 className="text-sm font-medium text-slate-700 dark:text-slate-200 mb-3">
+                Add a Nightscout connection
+              </h4>
+              <div className="space-y-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label
+                      htmlFor="ns-name"
+                      className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
+                    >
+                      Name
+                    </label>
+                    <input
+                      id="ns-name"
+                      type="text"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      disabled={isCreating}
+                      placeholder="e.g. Home Loop, Spouse, ..."
+                      className={clsx(
+                        "w-full rounded-lg border px-3 py-2 text-sm",
+                        "bg-white dark:bg-slate-800",
+                        "border-slate-300 dark:border-slate-700",
+                        "text-slate-700 dark:text-slate-200",
+                        "placeholder:text-slate-400 dark:placeholder:text-slate-500",
+                        "focus:outline-none focus:ring-2 focus:ring-blue-500",
+                        "disabled:opacity-50 disabled:cursor-not-allowed"
+                      )}
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="ns-url"
+                      className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
+                    >
+                      Nightscout URL
+                    </label>
+                    <input
+                      id="ns-url"
+                      type="url"
+                      value={baseUrl}
+                      onChange={(e) => setBaseUrl(e.target.value)}
+                      disabled={isCreating}
+                      placeholder="https://my-ns.example.com"
+                      autoComplete="off"
+                      className={clsx(
+                        "w-full rounded-lg border px-3 py-2 text-sm",
+                        "bg-white dark:bg-slate-800",
+                        "border-slate-300 dark:border-slate-700",
+                        "text-slate-700 dark:text-slate-200",
+                        "placeholder:text-slate-400 dark:placeholder:text-slate-500",
+                        "focus:outline-none focus:ring-2 focus:ring-blue-500",
+                        "disabled:opacity-50 disabled:cursor-not-allowed"
+                      )}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label
+                    htmlFor="ns-credential"
+                    className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
+                  >
+                    API_SECRET or bearer token
+                  </label>
+                  <div className="relative">
+                    <input
+                      id="ns-credential"
+                      type={credentialVisible ? "text" : "password"}
+                      value={credential}
+                      onChange={(e) => setCredential(e.target.value)}
+                      disabled={isCreating}
+                      // Not a browser/OS login credential — opt out of
+                      // password-manager autofill and OS keychain capture.
+                      autoComplete="off"
+                      spellCheck={false}
+                      data-1p-ignore=""
+                      data-lpignore="true"
+                      className={clsx(
+                        "w-full rounded-lg border px-3 py-2 pr-10 text-sm",
+                        "bg-slate-100 dark:bg-slate-800",
+                        "border-slate-300 dark:border-slate-700",
+                        "text-slate-700 dark:text-slate-200",
+                        "focus:outline-none focus:ring-2 focus:ring-blue-500",
+                        "disabled:opacity-50 disabled:cursor-not-allowed"
+                      )}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setCredentialVisible(!credentialVisible)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-slate-500 dark:text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+                      aria-label={
+                        credentialVisible
+                          ? "Hide credential"
+                          : "Show credential"
+                      }
+                    >
+                      {credentialVisible ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                  <p className="text-xs text-slate-500 mt-1">
+                    Use the Nightscout API_SECRET (the longer string from your
+                    instance config) or a bearer token issued by your Nightscout
+                    deployment.
+                  </p>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label
+                      htmlFor="ns-auth-type"
+                      className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
+                    >
+                      Credential type
+                    </label>
+                    <select
+                      id="ns-auth-type"
+                      value={authType}
+                      onChange={(e) =>
+                        setAuthType(e.target.value as NightscoutAuthType)
+                      }
+                      disabled={isCreating}
+                      className={clsx(
+                        "w-full rounded-lg border px-3 py-2 text-sm",
+                        "bg-white dark:bg-slate-800",
+                        "border-slate-300 dark:border-slate-700",
+                        "text-slate-700 dark:text-slate-200",
+                        "focus:outline-none focus:ring-2 focus:ring-blue-500",
+                        "disabled:opacity-50 disabled:cursor-not-allowed"
+                      )}
+                    >
+                      <option value="auto">Auto-detect</option>
+                      <option value="secret">API_SECRET</option>
+                      <option value="token">Bearer token</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="ns-api-version"
+                      className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
+                    >
+                      Nightscout API version
+                    </label>
+                    <select
+                      id="ns-api-version"
+                      value={apiVersion}
+                      onChange={(e) =>
+                        setApiVersion(e.target.value as NightscoutApiVersion)
+                      }
+                      disabled={isCreating}
+                      className={clsx(
+                        "w-full rounded-lg border px-3 py-2 text-sm",
+                        "bg-white dark:bg-slate-800",
+                        "border-slate-300 dark:border-slate-700",
+                        "text-slate-700 dark:text-slate-200",
+                        "focus:outline-none focus:ring-2 focus:ring-blue-500",
+                        "disabled:opacity-50 disabled:cursor-not-allowed"
+                      )}
+                    >
+                      <option value="auto">Auto-detect</option>
+                      <option value="v1">v1</option>
+                      <option value="v3">v3</option>
+                    </select>
+                  </div>
+                </div>
+                {createError && (
+                  <div
+                    className="bg-red-500/10 rounded-lg p-2 px-3 text-xs text-red-400 flex items-center gap-2"
+                    role="alert"
+                  >
+                    <AlertTriangle className="h-3 w-3 shrink-0" />
+                    {createError}
+                  </div>
+                )}
+                <button
+                  type="submit"
+                  disabled={isOffline || isCreating}
+                  className={clsx(
+                    "w-full sm:w-auto px-4 py-2 rounded-lg text-sm font-medium",
+                    "bg-blue-600 text-white hover:bg-blue-500",
+                    "disabled:opacity-50 disabled:cursor-not-allowed",
+                    "transition-colors flex items-center justify-center gap-2"
+                  )}
+                >
+                  {isCreating ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Link2 className="h-4 w-4" />
+                  )}
+                  Connect Nightscout
+                </button>
+              </div>
+            </form>
+          </div>
+        </CollapsibleSection>
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/apps/web/src/components/integrations/nightscout-integrations-section.tsx
+++ b/apps/web/src/components/integrations/nightscout-integrations-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useState, type Dispatch, type FormEvent, type SetStateAction } from "react";
 import {
   Cloud,
   Link2,
@@ -26,21 +26,23 @@ import type {
 } from "@/lib/api";
 
 const SYNC_STATUS_LABEL: Record<NightscoutSyncStatus, string> = {
+  never: "Pending",
   ok: "Connected",
   error: "Error",
   auth_failed: "Auth Failed",
   rate_limited: "Rate Limited",
   network: "Network Error",
-  unknown: "Pending",
+  unreachable: "Unreachable",
 };
 
 const SYNC_STATUS_COLOR: Record<NightscoutSyncStatus, string> = {
+  never: "text-slate-500 bg-slate-500/10",
   ok: "text-green-400 bg-green-500/10",
   error: "text-red-400 bg-red-500/10",
   auth_failed: "text-red-400 bg-red-500/10",
   rate_limited: "text-amber-400 bg-amber-500/10",
   network: "text-amber-400 bg-amber-500/10",
-  unknown: "text-slate-500 bg-slate-500/10",
+  unreachable: "text-red-400 bg-red-500/10",
 };
 
 function SyncStatusBadge({ status }: { status: NightscoutSyncStatus }) {
@@ -94,10 +96,35 @@ export function NightscoutIntegrationsSection({
   const [apiVersion, setApiVersion] = useState<NightscoutApiVersion>("auto");
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
-  const [testingId, setTestingId] = useState<string | null>(null);
-  const [syncingId, setSyncingId] = useState<string | null>(null);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
+  // Per-connection busy state. Sets (not single IDs) so two concurrent
+  // actions on different connections don't clobber each other's spinners.
+  const [testingIds, setTestingIds] = useState<Set<string>>(() => new Set());
+  const [syncingIds, setSyncingIds] = useState<Set<string>>(() => new Set());
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(() => new Set());
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  // True when ANY action is in flight on this connection -- used to
+  // disable the row's other action buttons too. Avoids "test while
+  // syncing" or "delete while testing" foot-guns.
+  const isBusy = (connectionId: string) =>
+    testingIds.has(connectionId) ||
+    syncingIds.has(connectionId) ||
+    deletingIds.has(connectionId);
+
+  const addToSet =
+    (setter: Dispatch<SetStateAction<Set<string>>>) => (id: string) =>
+      setter((prev) => {
+        const next = new Set(prev);
+        next.add(id);
+        return next;
+      });
+  const removeFromSet =
+    (setter: Dispatch<SetStateAction<Set<string>>>) => (id: string) =>
+      setter((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
   const [perConnectionResult, setPerConnectionResult] = useState<
     Record<string, { ok: boolean; message: string }>
   >({});
@@ -134,7 +161,7 @@ export function NightscoutIntegrationsSection({
   };
 
   const handleTest = async (connectionId: string) => {
-    setTestingId(connectionId);
+    addToSet(setTestingIds)(connectionId);
     setPerConnectionResult((prev) => {
       const { [connectionId]: _drop, ...rest } = prev;
       return rest;
@@ -159,12 +186,12 @@ export function NightscoutIntegrationsSection({
         },
       }));
     } finally {
-      setTestingId(null);
+      removeFromSet(setTestingIds)(connectionId);
     }
   };
 
   const handleSync = async (connectionId: string) => {
-    setSyncingId(connectionId);
+    addToSet(setSyncingIds)(connectionId);
     setPerConnectionResult((prev) => {
       const { [connectionId]: _drop, ...rest } = prev;
       return rest;
@@ -210,12 +237,12 @@ export function NightscoutIntegrationsSection({
         },
       }));
     } finally {
-      setSyncingId(null);
+      removeFromSet(setSyncingIds)(connectionId);
     }
   };
 
   const handleDelete = async (connectionId: string) => {
-    setDeletingId(connectionId);
+    addToSet(setDeletingIds)(connectionId);
     try {
       await onDelete(connectionId);
       // Drop any in-memory test result for the deleted connection so the
@@ -241,7 +268,7 @@ export function NightscoutIntegrationsSection({
         },
       }));
     } finally {
-      setDeletingId(null);
+      removeFromSet(setDeletingIds)(connectionId);
     }
   };
 
@@ -332,7 +359,7 @@ export function NightscoutIntegrationsSection({
                           <button
                             type="button"
                             onClick={() => handleSync(conn.id)}
-                            disabled={isOffline || syncingId === conn.id}
+                            disabled={isOffline || isBusy(conn.id)}
                             data-testid={`nightscout-sync-${conn.id}`}
                             className={clsx(
                               "px-3 py-1.5 rounded-lg text-xs font-medium",
@@ -342,7 +369,7 @@ export function NightscoutIntegrationsSection({
                               "transition-colors flex items-center gap-1"
                             )}
                           >
-                            {syncingId === conn.id ? (
+                            {syncingIds.has(conn.id) ? (
                               <Loader2 className="h-3 w-3 animate-spin" />
                             ) : (
                               <RefreshCw className="h-3 w-3" />
@@ -352,7 +379,7 @@ export function NightscoutIntegrationsSection({
                           <button
                             type="button"
                             onClick={() => handleTest(conn.id)}
-                            disabled={isOffline || testingId === conn.id}
+                            disabled={isOffline || isBusy(conn.id)}
                             data-testid={`nightscout-test-${conn.id}`}
                             className={clsx(
                               "px-3 py-1.5 rounded-lg text-xs font-medium",
@@ -363,7 +390,7 @@ export function NightscoutIntegrationsSection({
                               "transition-colors flex items-center gap-1"
                             )}
                           >
-                            {testingId === conn.id ? (
+                            {testingIds.has(conn.id) ? (
                               <Loader2 className="h-3 w-3 animate-spin" />
                             ) : (
                               <Link2 className="h-3 w-3" />
@@ -373,7 +400,7 @@ export function NightscoutIntegrationsSection({
                           <button
                             type="button"
                             onClick={() => setConfirmDeleteId(conn.id)}
-                            disabled={isOffline || deletingId === conn.id}
+                            disabled={isOffline || isBusy(conn.id)}
                             data-testid={`nightscout-delete-${conn.id}`}
                             className={clsx(
                               "px-3 py-1.5 rounded-lg text-xs font-medium",
@@ -383,7 +410,7 @@ export function NightscoutIntegrationsSection({
                               "transition-colors flex items-center gap-1"
                             )}
                           >
-                            {deletingId === conn.id ? (
+                            {deletingIds.has(conn.id) ? (
                               <Loader2 className="h-3 w-3 animate-spin" />
                             ) : (
                               <Unlink className="h-3 w-3" />
@@ -408,7 +435,7 @@ export function NightscoutIntegrationsSection({
                             <button
                               type="button"
                               onClick={() => handleDelete(conn.id)}
-                              disabled={deletingId === conn.id}
+                              disabled={deletingIds.has(conn.id)}
                               data-testid={`nightscout-confirm-delete-${conn.id}`}
                               className={clsx(
                                 "px-3 py-1.5 rounded-lg text-xs font-medium",
@@ -417,7 +444,7 @@ export function NightscoutIntegrationsSection({
                                 "transition-colors flex items-center gap-1"
                               )}
                             >
-                              {deletingId === conn.id ? (
+                              {deletingIds.has(conn.id) ? (
                                 <Loader2 className="h-3 w-3 animate-spin" />
                               ) : null}
                               Delete connection
@@ -425,7 +452,7 @@ export function NightscoutIntegrationsSection({
                             <button
                               type="button"
                               onClick={() => setConfirmDeleteId(null)}
-                              disabled={deletingId === conn.id}
+                              disabled={deletingIds.has(conn.id)}
                               className={clsx(
                                 "px-3 py-1.5 rounded-lg text-xs font-medium",
                                 "border border-slate-300 dark:border-slate-700",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1884,13 +1884,17 @@ export async function disconnectTandem(): Promise<void> {
 
 export type NightscoutAuthType = "auto" | "secret" | "token";
 export type NightscoutApiVersion = "auto" | "v1" | "v3";
+// Mirrors `apps/api/src/models/nightscout_connection.py::NightscoutSyncStatus`.
+// `never` is the default for a newly-created connection (no sync attempted
+// yet); `unreachable` is set after repeated failures pause polling.
 export type NightscoutSyncStatus =
+  | "never"
   | "ok"
   | "error"
   | "auth_failed"
   | "rate_limited"
   | "network"
-  | "unknown";
+  | "unreachable";
 
 export interface NightscoutConnectionResponse {
   id: string;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1879,6 +1879,166 @@ export async function disconnectTandem(): Promise<void> {
 }
 
 // ============================================================================
+// Story 43.x: Nightscout Cloud-Mediated Integration
+// ============================================================================
+
+export type NightscoutAuthType = "auto" | "secret" | "token";
+export type NightscoutApiVersion = "auto" | "v1" | "v3";
+export type NightscoutSyncStatus =
+  | "ok"
+  | "error"
+  | "auth_failed"
+  | "rate_limited"
+  | "network"
+  | "unknown";
+
+export interface NightscoutConnectionResponse {
+  id: string;
+  name: string;
+  base_url: string;
+  auth_type: NightscoutAuthType;
+  api_version: NightscoutApiVersion;
+  is_active: boolean;
+  has_credential: boolean;
+  sync_interval_minutes: number;
+  initial_sync_window_days: number;
+  last_sync_status: NightscoutSyncStatus;
+  last_synced_at: string | null;
+  last_sync_error: string | null;
+  // Shape varies per uploader; treat as opaque and narrow at the consumer.
+  detected_uploaders_json: unknown;
+  last_evaluated_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface NightscoutConnectionListResponse {
+  connections: NightscoutConnectionResponse[];
+}
+
+export interface NightscoutConnectionTestResult {
+  ok: boolean;
+  server_version: string | null;
+  api_version_detected: NightscoutApiVersion | null;
+  auth_validated: boolean;
+  error: string | null;
+}
+
+export interface NightscoutConnectionCreatedResponse {
+  connection: NightscoutConnectionResponse;
+  test: NightscoutConnectionTestResult;
+}
+
+export interface NightscoutConnectionCreate {
+  name: string;
+  base_url: string;
+  auth_type?: NightscoutAuthType;
+  credential: string;
+  api_version?: NightscoutApiVersion;
+  sync_interval_minutes?: number;
+  initial_sync_window_days?: number;
+}
+
+export async function listNightscoutConnections(): Promise<NightscoutConnectionListResponse> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/integrations/nightscout`
+  );
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to list Nightscout connections: ${response.status}`
+    );
+  }
+  return response.json();
+}
+
+export async function createNightscoutConnection(
+  body: NightscoutConnectionCreate
+): Promise<NightscoutConnectionCreatedResponse> {
+  const response = await apiFetch(`${API_BASE_URL}/api/integrations/nightscout`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to create Nightscout connection: ${response.status}`
+    );
+  }
+  return response.json();
+}
+
+export async function testNightscoutConnection(
+  connectionId: string
+): Promise<NightscoutConnectionTestResult> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/integrations/nightscout/${encodeURIComponent(
+      connectionId
+    )}/test`,
+    { method: "POST" }
+  );
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to test Nightscout connection: ${response.status}`
+    );
+  }
+  return response.json();
+}
+
+export interface NightscoutManualSyncResponse {
+  connection_id: string;
+  status: NightscoutSyncStatus;
+  entries_inserted: number;
+  entries_skipped: number;
+  entries_failed: number;
+  treatments_inserted_pump: number;
+  treatments_inserted_glucose: number;
+  treatments_failed: number;
+  devicestatuses_inserted: number;
+  devicestatuses_failed: number;
+  profile_synced: boolean;
+  duration_ms: number;
+  error: string | null;
+}
+
+export async function syncNightscoutConnection(
+  connectionId: string
+): Promise<NightscoutManualSyncResponse> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/integrations/nightscout/${encodeURIComponent(
+      connectionId
+    )}/sync`,
+    { method: "POST" }
+  );
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to sync Nightscout connection: ${response.status}`
+    );
+  }
+  return response.json();
+}
+
+export async function deleteNightscoutConnection(
+  connectionId: string
+): Promise<void> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/integrations/nightscout/${encodeURIComponent(
+      connectionId
+    )}`,
+    { method: "DELETE" }
+  );
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to delete Nightscout connection: ${response.status}`
+    );
+  }
+}
+
+// ============================================================================
 // Story 18.3: Tandem Cloud Upload
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Two related pieces that together let a user configure a Nightscout connection from the web app, run a sync on demand, and watch the data show up on the dashboard. This unblocks visual derisk before the background sync scheduler lands.

- **Backend (commit `318ab0a`)**: new `POST /api/integrations/nightscout/{id}/sync` endpoint + a per-connection `sync_nightscout_for_connection` service that drives the existing translator (PR #572) end-to-end. Synchronous from the user's POV; bounded by a 20s `wait_for` timeout. Only advances `last_synced_at` on full success; classifies typed `NightscoutError` exceptions into the existing `NightscoutSyncStatus`. Per-connection asyncio lock prevents races.
- **Frontend (commit `80a0302`)**: new "Third-Party Integrations" section on `/dashboard/settings/integrations` with a Nightscout subsection. Add / Test / Sync now / Delete, with inline confirm dialog, password-manager-suppressed credential field, ARIA-live status banner, list refetch after every mutation.

## What this is NOT

- The background sync scheduler (queued in the next story). This PR adds the manual button + the service the scheduler will reuse.
- Sync interval picker / dashboard freshness widget — those land with the scheduler.
- Mobile NS plugin — separate later piece.

## Architecture decisions

- **Cursor: all-or-nothing.** `last_synced_at` advances only when all four `translate_*` calls return without raising. Partial failure leaves the cursor put so the next run re-fetches. The translator's partial unique indexes make replay cheap. Considered per-collection cursors; rejected as premature.
- **`devicestatus` initial backfill capped at 30 days** regardless of `initial_sync_window_days`. High-volume tables on busy uploaders can have tens of thousands of rows per day; the cap bounds blast radius without preventing later catch-up via incremental syncs.
- **Soft-deleted connections are 404'd on test / sync.** `_load_owned(require_active=True)` for both side-effect endpoints. The connection row is preserved (per existing soft-delete design) so the `nightscout:<id>` source attribution on canonical-table rows stays meaningful, but you can't reanimate sync activity by re-using a stale ID.
- **Synchronous endpoint with timeout.** `asyncio.wait_for(..., 20s)` bounds the request thread so a slow / unresponsive user-controlled NS URL can't pin a worker. Timeout rolls back any partial flush, records `NETWORK` status, returns 504.
- **Credential field opts out of password managers.** `autoComplete="off"`, `spellCheck={false}`, `data-1p-ignore`, `data-lpignore="true"` — Nightscout API_SECRET is not a browser/OS login credential. The shared `PasswordInput` hardcodes `current-password` which would otherwise capture it.

## Verification

- 251 backend tests pass (10 new in `test_nightscout_sync.py`).
- ESLint + `tsc --noEmit` clean on the new + modified frontend files.
- End-to-end against local Nightscout (1137 entries + 14 treatments fixture):
  - Add via UI → connection persists, list updates.
  - Test → green "Connected (Nightscout 15.0.8)" banner.
  - **Sync now** → 1683 rows inserted in 2.9s, dashboard AGP count goes 4,816 → 5,658, "Last sync" updates to "just now".
  - Re-sync → 0 rows inserted (dedupe holds).
  - Soft-deleted connection → 404 on `POST /sync` attempt.
- Adversarial review + CodeRabbit CLI run on the staged diff. Critical / major / minor findings addressed in the same diff (`require_active` filter, timeout rollback, `treatments_failed` summing both glucose+pump outcomes, `encodeURIComponent` on path params, in-flight lock eviction, exception-catch tightening, full error handling on all four mutation handlers).
- Security review on staged diff: PASS (SSRF guard intact via `NightscoutClient.create()`; no secrets in test fixtures; cross-tenant returns 404; data-1p-ignore directionality verified correct).

## Test plan

- [x] Migration: no migration in this PR.
- [x] `ruff format --check` + `ruff check` clean for changed Python files.
- [x] `npx eslint` + `npx tsc --noEmit` clean for changed TypeScript files.
- [x] Full nightscout subset: 251 passed / 13 skipped.
- [x] Visual: add / test / sync / delete flow exercised end-to-end via Playwright.
- [x] Visual: dashboard renders Nightscout-sourced glucose readings post-sync.
- [x] Defense: soft-deleted connection rejected from sync (404).

## Follow-ups (filed / noted)

- Background sync scheduler — queued as the next story.
- Sync interval picker UI — lands with the scheduler.
- Per-source freshness widget on the dashboard — lands with the scheduler.
- "Sync now" button currently shows result but no failure-row breakdown beyond the count; consider drilling deeper if users see persistent partial failures.
- Issue #574 (dashboard insulin/bolus widgets ignore NS-sourced pump events) — separate follow-up; not blocked by or blocking this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual sync capability for Nightscout connections with detailed sync results and status tracking
  * Introduced Nightscout integrations section in dashboard settings for creating, testing, and managing connections
  * Added sync status indicators and per-operation results display with human-readable error messages
  * Implemented 20-second timeout protection for sync operations with graceful error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->