### PR TITLE
feat: Nightscout background sync scheduler

### DIFF
--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -77,7 +77,13 @@ class Settings(BaseSettings):
     # Per-connection cadence is honored via the column on the connection
     # row, not via the global tick.
     nightscout_sync_enabled: bool = True
-    nightscout_sync_tick_interval_minutes: int = 1
+    # Bounded so a misconfigured env var (0 / negative / absurdly
+    # large) can't crash APScheduler at startup or starve the
+    # scheduler entirely. 1 minute = the per-connection minimum the
+    # connection model already enforces; 60 minutes ceiling on the
+    # global tick is generous (per-connection cadence is what users
+    # actually tune).
+    nightscout_sync_tick_interval_minutes: int = Field(default=1, ge=1, le=60)
 
     # Predictive Alert Engine (Story 6.2)
     alert_check_interval_minutes: int = 5  # Run alert engine every 5 minutes

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -70,6 +70,15 @@ class Settings(BaseSettings):
     tandem_sync_enabled: bool = True  # Enable/disable automatic sync
     tandem_sync_hours_back: int = 24  # Hours of history to fetch per sync
 
+    # Nightscout Sync Configuration (Story 43.4)
+    # The scheduler ticks on a fixed interval; on each tick it scans
+    # nightscout_connections and runs the per-connection sync for any
+    # row whose `last_synced_at + sync_interval_minutes <= now()`.
+    # Per-connection cadence is honored via the column on the connection
+    # row, not via the global tick.
+    nightscout_sync_enabled: bool = True
+    nightscout_sync_tick_interval_minutes: int = 1
+
     # Predictive Alert Engine (Story 6.2)
     alert_check_interval_minutes: int = 5  # Run alert engine every 5 minutes
     alert_check_enabled: bool = True  # Enable/disable automatic alert checking

--- a/apps/api/src/services/integrations/nightscout/scheduler.py
+++ b/apps/api/src/services/integrations/nightscout/scheduler.py
@@ -1,0 +1,219 @@
+"""Story 43.4: Background Nightscout sync scheduler.
+
+The single global APScheduler job ticks on `nightscout_sync_tick_interval_minutes`
+(default 1 min) and scans `nightscout_connections` for rows whose
+per-connection cadence has elapsed. Due connections are synced in
+parallel (bounded by `_MAX_PARALLEL_SYNCS`) -- one slow upstream NS
+instance does not block other users.
+
+Why one global tick instead of one APScheduler job per connection:
+- Matches the existing Dexcom / Tandem / research-scheduler pattern in
+  this codebase.
+- Settings changes (sync_interval_minutes) take effect at the next
+  tick automatically; no `reschedule_job` plumbing needed.
+- No job-lifecycle management on connection create / delete / soft-
+  delete; the discovery query is the source of truth.
+
+Per-connection isolation:
+- Each connection gets its own DB session via the shared
+  `get_session_maker()`.
+- A bare `try/except Exception` per row so one malformed connection
+  (corrupted credential, removed user, etc.) doesn't kill the tick.
+- `asyncio.Semaphore` bounds parallelism so we don't open hundreds of
+  upstream sockets simultaneously.
+
+Concurrency:
+- The scheduler decides "due" by reading `last_synced_at`. The
+  per-connection asyncio lock in `sync.py` prevents this tick's
+  sync from racing with a manual `POST /sync` triggered through
+  the UI.
+- With parallel syncs, individual connections complete at different
+  wall-clock instants; that's fine since each has its own session
+  and translator outcome is recorded per-row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from src.database import get_session_maker
+from src.logging_config import get_logger
+from src.models.nightscout_connection import (
+    SYNC_INTERVAL_MAX_MINUTES,
+    SYNC_INTERVAL_MIN_MINUTES,
+    NightscoutConnection,
+    NightscoutSyncStatus,
+)
+from src.services.integrations.nightscout.sync import (
+    sync_nightscout_for_connection,
+)
+
+logger = get_logger(__name__)
+
+
+# Statuses that exclude a connection from polling. AUTH_FAILED requires
+# user intervention (re-authenticate). Other failure modes (ERROR /
+# NETWORK / RATE_LIMITED) still get retried on the next tick.
+#
+# UNREACHABLE is intentionally NOT in this set: the model defines it
+# for a future "consecutive-failure circuit breaker" but no code path
+# currently sets it. Including it here would be dead code dressed up
+# as a working circuit breaker. When the breaker is wired (own PR),
+# add UNREACHABLE here.
+_PAUSED_STATUSES = frozenset({NightscoutSyncStatus.AUTH_FAILED})
+
+# Bound concurrent upstream connections. Most users will have 1-2
+# connections; this matters when many users have the same tick window.
+# Each parallel slot opens its own DB session + httpx client, so we
+# also indirectly bound DB-pool and FD pressure.
+_MAX_PARALLEL_SYNCS = 8
+
+
+async def run_nightscout_sync_all_users() -> None:
+    """One tick of the scheduler.
+
+    Discovers all active connections that are due for a sync (per their
+    own `sync_interval_minutes`), then syncs each in isolation, in
+    parallel up to `_MAX_PARALLEL_SYNCS`.
+
+    This function is the APScheduler callback. It must NOT raise --
+    APScheduler would log + skip the next tick. The per-connection
+    error handler in `_sync_one` ensures that.
+    """
+    started = datetime.now(UTC)
+
+    # Discover phase -- single short-lived session, slim SELECT.
+    # Pulling the encrypted_credential blob for every active connection
+    # would waste bandwidth at 1000s of rows; the refetch inside
+    # `_sync_one` will hydrate the full row only for due connections.
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        result = await session.execute(
+            select(
+                NightscoutConnection.id,
+                NightscoutConnection.user_id,
+                NightscoutConnection.sync_interval_minutes,
+                NightscoutConnection.last_synced_at,
+            ).where(
+                NightscoutConnection.is_active.is_(True),
+                NightscoutConnection.last_sync_status.notin_(list(_PAUSED_STATUSES)),
+            )
+        )
+        rows = result.all()
+
+    due_ids: list[tuple[uuid.UUID, uuid.UUID]] = []
+    for row in rows:
+        interval = _clamped_interval(row.sync_interval_minutes)
+        if _is_due(row.last_synced_at, interval, now=started):
+            due_ids.append((row.id, row.user_id))
+
+    if not due_ids:
+        logger.debug("nightscout_scheduler_tick_no_due_connections")
+        return
+
+    logger.info(
+        "nightscout_scheduler_tick_starting",
+        due_count=len(due_ids),
+    )
+
+    # Bounded parallelism: many users with the same tick window
+    # shouldn't open hundreds of upstream sockets at once, but a
+    # single slow upstream MUST NOT block all the others either.
+    sem = asyncio.Semaphore(_MAX_PARALLEL_SYNCS)
+
+    async def _bounded(conn_id: uuid.UUID, user_id: uuid.UUID) -> bool:
+        async with sem:
+            return await _sync_one(session_maker, conn_id, user_id)
+
+    statuses = await asyncio.gather(
+        *(_bounded(cid, uid) for (cid, uid) in due_ids),
+        return_exceptions=False,
+    )
+
+    success = sum(1 for s in statuses if s is True)
+    failures = sum(1 for s in statuses if s is False)
+
+    logger.info(
+        "nightscout_scheduler_tick_completed",
+        due_count=len(due_ids),
+        success=success,
+        failures=failures,
+        duration_ms=int((datetime.now(UTC) - started).total_seconds() * 1000),
+    )
+
+
+async def _sync_one(
+    session_maker, connection_id: uuid.UUID, user_id: uuid.UUID
+) -> bool:
+    """Run one connection's sync. Returns True on OK, False otherwise.
+
+    Refetches the connection inside this function's own session
+    because the discovery scan only pulled identifiers + cursor
+    columns. The refetch also picks up any mutation that happened
+    between discovery and now (e.g. user toggled `is_active=false`
+    via PATCH, or sync_interval_minutes changed). We deliberately
+    do NOT re-check `_is_due` here -- the contract is "what was due
+    at tick start gets synced," even if the user changed the
+    interval mid-tick.
+
+    Cooperative-shutdown signals propagate (CancelledError / SystemExit
+    / KeyboardInterrupt). Any other exception is logged with traceback
+    and reported as failure so the tick continues with the rest.
+    """
+    try:
+        async with session_maker() as user_session:
+            conn_result = await user_session.execute(
+                select(NightscoutConnection).where(
+                    NightscoutConnection.id == connection_id,
+                    NightscoutConnection.is_active.is_(True),
+                )
+            )
+            conn = conn_result.scalar_one_or_none()
+            if conn is None:
+                # Connection was deleted between discovery and now;
+                # silently skip (not a failure).
+                return True
+            outcome = await sync_nightscout_for_connection(user_session, conn)
+            return outcome.status == NightscoutSyncStatus.OK
+    except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
+        raise
+    except Exception:  # noqa: BLE001 - per-row isolation is the goal
+        logger.exception(
+            "nightscout_scheduler_per_row_failure",
+            connection_id=str(connection_id),
+            user_id=str(user_id),
+        )
+        return False
+
+
+def _is_due(
+    last_synced_at: datetime | None,
+    interval_minutes: int,
+    *,
+    now: datetime,
+) -> bool:
+    """Return True when this connection is due for another sync."""
+    if last_synced_at is None:
+        # Never synced -- always due.
+        return True
+    if last_synced_at.tzinfo is None:
+        # Treat naive timestamps as UTC; the column is `timezone=True`
+        # so we never expect this in practice, but be defensive.
+        last_synced_at = last_synced_at.replace(tzinfo=UTC)
+    return now - last_synced_at >= timedelta(minutes=interval_minutes)
+
+
+def _clamped_interval(value: int) -> int:
+    """Defensive clamp against out-of-range column values.
+
+    The Pydantic schema and DB constraint already bound this, but
+    if the column ever ended up out of range (manual SQL update,
+    older row pre-bound) we don't want a single bad row to either
+    blast upstream every tick (interval=0) or stall forever
+    (interval=1e9).
+    """
+    return max(SYNC_INTERVAL_MIN_MINUTES, min(SYNC_INTERVAL_MAX_MINUTES, value))

--- a/apps/api/src/services/scheduler.py
+++ b/apps/api/src/services/scheduler.py
@@ -20,6 +20,9 @@ from src.models.integration import (
     IntegrationType,
 )
 from src.services.dexcom_sync import DexcomSyncError, sync_dexcom_for_user
+from src.services.integrations.nightscout.scheduler import (
+    run_nightscout_sync_all_users,
+)
 from src.services.predictive_alerts import evaluate_alerts_for_user
 from src.services.tandem_sync import TandemSyncError, sync_tandem_for_user
 
@@ -444,6 +447,30 @@ def start_scheduler() -> AsyncIOScheduler:
         logger.info(
             "Scheduled Tandem sync job",
             interval_minutes=settings.tandem_sync_interval_minutes,
+        )
+
+    # Add Nightscout sync tick job if enabled (Story 43.4)
+    # Single global tick; the per-connection cadence is honored inside
+    # `run_nightscout_sync_all_users` by checking each row's
+    # `sync_interval_minutes` against `last_synced_at`.
+    if settings.nightscout_sync_enabled:
+        scheduler.add_job(
+            run_nightscout_sync_all_users,
+            trigger=IntervalTrigger(
+                minutes=settings.nightscout_sync_tick_interval_minutes
+            ),
+            id="nightscout_sync",
+            name="Nightscout Sync Tick",
+            replace_existing=True,
+            # max_instances=1 + coalesce: a long-running tick should
+            # not stack with the next one. Per-connection asyncio lock
+            # in sync.py protects against manual + scheduler races.
+            max_instances=1,
+            coalesce=True,
+        )
+        logger.info(
+            "Scheduled Nightscout sync tick job",
+            tick_interval_minutes=settings.nightscout_sync_tick_interval_minutes,
         )
 
     # Add predictive alert check job if enabled (Story 6.2)

--- a/apps/api/tests/test_nightscout_scheduler.py
+++ b/apps/api/tests/test_nightscout_scheduler.py
@@ -1,0 +1,343 @@
+"""Tests for the background Nightscout sync scheduler.
+
+Mocks `sync_nightscout_for_connection` at the module boundary so we
+exercise the real discovery query + per-row isolation logic without
+hitting an actual Nightscout instance. Live end-to-end coverage --
+"the scheduler tick triggers a real fetch + translate" -- is left to
+manual verification against the dev synthetic uploader (see
+`dev/ns_synthetic_uploader.py`); the unit-tested seam here is the
+"who's due, what happens when one fails" decision tree.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.encryption import encrypt_credential
+from src.database import get_session_maker
+from src.models.nightscout_connection import (
+    NightscoutAuthType,
+    NightscoutConnection,
+    NightscoutSyncStatus,
+)
+from src.models.user import User
+from src.services.integrations.nightscout.scheduler import (
+    _clamped_interval,
+    _is_due,
+    run_nightscout_sync_all_users,
+)
+from src.services.integrations.nightscout.sync import SyncResult
+
+# ---------------------------------------------------------------------------
+# _is_due: the discovery predicate
+# ---------------------------------------------------------------------------
+
+
+class TestIsDue:
+    def test_never_synced_is_always_due(self):
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        assert _is_due(None, 5, now=now) is True
+
+    def test_within_window_not_due(self):
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        last = now - timedelta(minutes=3)
+        assert _is_due(last, 5, now=now) is False
+
+    def test_at_exact_window_is_due(self):
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        last = now - timedelta(minutes=5)
+        assert _is_due(last, 5, now=now) is True
+
+    def test_well_past_window_is_due(self):
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        last = now - timedelta(hours=3)
+        assert _is_due(last, 5, now=now) is True
+
+    def test_naive_timestamp_is_treated_as_utc(self):
+        """Defensive: column is timezone=True so we shouldn't see this,
+        but if a naive datetime sneaks in we don't want a TypeError."""
+        now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+        last = datetime(2026, 5, 10, 11, 0)  # naive
+        assert _is_due(last, 5, now=now) is True
+
+
+class TestClampedInterval:
+    def test_in_range_passes_through(self):
+        assert _clamped_interval(60) == 60
+
+    def test_below_min_clamps(self):
+        # SYNC_INTERVAL_MIN_MINUTES = 1
+        assert _clamped_interval(0) == 1
+        assert _clamped_interval(-5) == 1
+
+    def test_above_max_clamps(self):
+        # SYNC_INTERVAL_MAX_MINUTES = 1440 (24h)
+        assert _clamped_interval(10000) == 1440
+
+
+# ---------------------------------------------------------------------------
+# Discovery + per-row isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def scheduler_ctx() -> AsyncGenerator[tuple[AsyncSession, uuid.UUID], None]:
+    """Provide a session + a user that owns several test connections.
+
+    Mirrors the pattern used by other Nightscout test files -- own
+    session_maker so cross-loop teardown noise stays cosmetic.
+    """
+    session_maker = get_session_maker()
+    session = session_maker()
+    email = f"sched_{uuid.uuid4().hex[:10]}@example.com"
+    user = User(email=email, hashed_password="not-a-real-hash")
+    session.add(user)
+    await session.flush()
+    user_id = user.id
+    await session.commit()
+    try:
+        yield session, user_id
+    finally:
+        try:
+            await session.rollback()
+            await session.execute(
+                delete(NightscoutConnection).where(
+                    NightscoutConnection.user_id == user_id
+                )
+            )
+            await session.execute(delete(User).where(User.id == user_id))
+            await session.commit()
+        except Exception:
+            # Broad catch on cleanup: a SQLAlchemy / asyncpg cross-loop
+            # error here would otherwise mask the real test failure.
+            # Cosmetic noise during teardown is the price.
+            pass
+        finally:
+            try:
+                await session.close()
+            except Exception:
+                pass
+
+
+def _mk_connection(
+    user_id: uuid.UUID,
+    *,
+    name: str,
+    interval_minutes: int = 5,
+    last_synced_at: datetime | None = None,
+    last_sync_status: NightscoutSyncStatus = NightscoutSyncStatus.NEVER,
+    is_active: bool = True,
+) -> NightscoutConnection:
+    return NightscoutConnection(
+        user_id=user_id,
+        name=name,
+        base_url="https://example.com",
+        auth_type=NightscoutAuthType.SECRET,
+        encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+        sync_interval_minutes=interval_minutes,
+        is_active=is_active,
+        last_synced_at=last_synced_at,
+        last_sync_status=last_sync_status,
+    )
+
+
+def _ok_result(connection_id: uuid.UUID) -> SyncResult:
+    return SyncResult(
+        connection_id=str(connection_id),
+        status=NightscoutSyncStatus.OK,
+        entries_inserted=1,
+        entries_skipped=0,
+        entries_failed=0,
+        treatments_inserted_pump=0,
+        treatments_inserted_glucose=0,
+        treatments_failed=0,
+        devicestatuses_inserted=0,
+        devicestatuses_failed=0,
+        profile_synced=False,
+        duration_ms=42,
+        error=None,
+    )
+
+
+class TestRunNightscoutSyncAllUsers:
+    @pytest.mark.asyncio
+    async def test_only_due_connections_get_synced(self, scheduler_ctx):
+        """Connections whose interval hasn't elapsed are skipped.
+
+        Filters synced IDs to this test's user so leftover rows from
+        prior interrupted runs don't pollute the assertion.
+        """
+        session, user_id = scheduler_ctx
+        now = datetime.now(UTC)
+        # Due (never synced)
+        a = _mk_connection(user_id, name="due-a", interval_minutes=5)
+        # Due (last synced 10m ago, interval=5)
+        b = _mk_connection(
+            user_id,
+            name="due-b",
+            interval_minutes=5,
+            last_synced_at=now - timedelta(minutes=10),
+            last_sync_status=NightscoutSyncStatus.OK,
+        )
+        # Not due (last synced 1m ago, interval=60)
+        c = _mk_connection(
+            user_id,
+            name="not-due",
+            interval_minutes=60,
+            last_synced_at=now - timedelta(minutes=1),
+            last_sync_status=NightscoutSyncStatus.OK,
+        )
+        session.add_all([a, b, c])
+        await session.commit()
+        a_id, b_id, c_id = a.id, b.id, c.id
+
+        synced_for_test_user: set[uuid.UUID] = set()
+
+        async def fake_sync(_session, conn):
+            if conn.user_id == user_id:
+                synced_for_test_user.add(conn.id)
+            return _ok_result(conn.id)
+
+        with patch(
+            "src.services.integrations.nightscout.scheduler.sync_nightscout_for_connection",
+            side_effect=fake_sync,
+        ):
+            await run_nightscout_sync_all_users()
+
+        assert synced_for_test_user == {a_id, b_id}
+        assert c_id not in synced_for_test_user
+
+    @pytest.mark.asyncio
+    async def test_inactive_connections_excluded(self, scheduler_ctx):
+        """Soft-deleted (is_active=false) rows are ignored."""
+        session, user_id = scheduler_ctx
+        active = _mk_connection(user_id, name="active")
+        inactive = _mk_connection(user_id, name="inactive", is_active=False)
+        session.add_all([active, inactive])
+        await session.commit()
+        active_id = active.id
+
+        synced_for_test_user: list[uuid.UUID] = []
+
+        async def fake_sync(_session, conn):
+            if conn.user_id == user_id:
+                synced_for_test_user.append(conn.id)
+            return _ok_result(conn.id)
+
+        with patch(
+            "src.services.integrations.nightscout.scheduler.sync_nightscout_for_connection",
+            side_effect=fake_sync,
+        ):
+            await run_nightscout_sync_all_users()
+
+        assert synced_for_test_user == [active_id]
+
+    @pytest.mark.asyncio
+    async def test_auth_failed_connection_excluded(self, scheduler_ctx):
+        """AUTH_FAILED is sticky -- requires user re-auth, no auto retry."""
+        session, user_id = scheduler_ctx
+        ok = _mk_connection(user_id, name="ok-conn")
+        broken = _mk_connection(
+            user_id,
+            name="auth-failed-conn",
+            last_sync_status=NightscoutSyncStatus.AUTH_FAILED,
+        )
+        session.add_all([ok, broken])
+        await session.commit()
+        ok_id = ok.id
+
+        synced_for_test_user: list[uuid.UUID] = []
+
+        async def fake_sync(_session, conn):
+            if conn.user_id == user_id:
+                synced_for_test_user.append(conn.id)
+            return _ok_result(conn.id)
+
+        with patch(
+            "src.services.integrations.nightscout.scheduler.sync_nightscout_for_connection",
+            side_effect=fake_sync,
+        ):
+            await run_nightscout_sync_all_users()
+
+        assert synced_for_test_user == [ok_id]
+
+    @pytest.mark.asyncio
+    async def test_paused_statuses_set_is_minimal(self):
+        """Pinned set for the discovery filter.
+
+        UNREACHABLE is intentionally NOT in `_PAUSED_STATUSES` yet --
+        the model defines it for a future "consecutive-failure circuit
+        breaker" that no code path currently writes. Adding it to the
+        exclusion now would advertise a circuit breaker that doesn't
+        exist. When the breaker is wired in its own PR, expand this
+        test alongside the new code.
+        """
+        from src.services.integrations.nightscout.scheduler import (
+            _PAUSED_STATUSES,
+        )
+
+        assert frozenset({NightscoutSyncStatus.AUTH_FAILED}) == _PAUSED_STATUSES
+
+    @pytest.mark.asyncio
+    async def test_one_connection_failing_does_not_block_others(self, scheduler_ctx):
+        """Per-connection isolation: a raise on one row doesn't kill the tick."""
+        session, user_id = scheduler_ctx
+        a = _mk_connection(user_id, name="a")
+        b = _mk_connection(user_id, name="b")
+        c = _mk_connection(user_id, name="c")
+        session.add_all([a, b, c])
+        await session.commit()
+        a_id, b_id, c_id = a.id, b.id, c.id
+
+        synced_ok_for_test_user: set[uuid.UUID] = set()
+
+        async def fake_sync(_session, conn):
+            if conn.id == b_id:
+                raise RuntimeError("simulated upstream blowup on conn-b")
+            if conn.user_id == user_id:
+                synced_ok_for_test_user.add(conn.id)
+            return _ok_result(conn.id)
+
+        with patch(
+            "src.services.integrations.nightscout.scheduler.sync_nightscout_for_connection",
+            side_effect=fake_sync,
+        ):
+            # Should NOT raise.
+            await run_nightscout_sync_all_users()
+
+        assert synced_ok_for_test_user == {a_id, c_id}
+
+    @pytest.mark.asyncio
+    async def test_no_connections_for_test_user_means_no_call(self, scheduler_ctx):
+        """Sanity: scheduler does not invoke sync for THIS test's user
+        when that user has zero connections.
+
+        We can't assert the global mock was never called -- the dev DB
+        may have leftover rows from prior interrupted test runs and the
+        scheduler scans all users. Scope the assertion to "no call
+        referenced one of OUR connections" to stay isolation-clean.
+        """
+        _session, user_id = scheduler_ctx
+
+        synced_for_test_user: list[uuid.UUID] = []
+
+        async def fake_sync(_session, conn):
+            if conn.user_id == user_id:
+                synced_for_test_user.append(conn.id)
+            return _ok_result(conn.id)
+
+        with patch(
+            "src.services.integrations.nightscout.scheduler.sync_nightscout_for_connection",
+            side_effect=fake_sync,
+        ):
+            await run_nightscout_sync_all_users()
+
+        assert synced_for_test_user == []

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,54 @@
+# Dev-only utilities
+
+Scripts and helpers that exist for local development workflows. None of
+this is shipped in any production image — these files live in the repo
+so they're reviewable and version-controlled, but they're never copied
+into a Dockerfile context.
+
+## `ns_synthetic_uploader.py`
+
+Continuously posts synthetic CGM entries to a local Nightscout instance
+so the GlycemicGPT scheduler / dashboard can be visually verified
+against "new data arriving in real time" instead of static fixture
+data. Useful for:
+
+- Watching the Story 43.4 sync scheduler tick → new rows land →
+  dashboard chart updates over a few minutes.
+- Demoing the full data flow without setting up a real Dexcom uploader.
+- Reproducing scheduler / dedupe edge cases that only show up when new
+  entries are arriving on a cadence.
+
+### Quick start
+
+```bash
+# Start the local Nightscout test stack first (lives outside this repo):
+cd ~/dev-test/nightscout && docker compose up -d
+
+# Then run the uploader from anywhere; it talks to NS over 127.0.0.1:1337
+python3 dev/ns_synthetic_uploader.py
+```
+
+Stops on Ctrl-C. No backfill — only posts forward in time.
+
+### Tunables (env vars)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NS_BASE_URL` | `http://127.0.0.1:1337` | Nightscout URL |
+| `NS_API_SECRET` | the dev-stack secret | Plaintext API_SECRET; SHA-1'd into the api-secret header |
+| `NS_CADENCE_SECONDS` | `60` | Seconds between entries |
+| `NS_BASELINE_MGDL` | `120` | Mean of the random walk |
+| `NS_VOLATILITY` | `5` | Per-step jitter (mg/dL) |
+| `NS_DEVICE_NAME` | `glycemicgpt-synthetic-uploader` | `device` field on each entry |
+
+### Implementation notes
+
+- Mean-reverting random walk biased by a 24-hour sine wave so the curve
+  doesn't drift in one direction.
+- Direction (trend arrow) computed from the per-step delta, mapped to
+  Dexcom's `DoubleUp` / `SingleUp` / `FortyFiveUp` / `Flat` /
+  `FortyFiveDown` / `SingleDown` / `DoubleDown` vocabulary.
+- Stdlib only (no httpx / requests) so the script runs from any
+  environment with Python 3.11+.
+- Errors are logged and swallowed — the loop never exits on a transient
+  upstream failure; it just retries on the next cadence tick.

--- a/dev/README.md
+++ b/dev/README.md
@@ -24,8 +24,10 @@ data. Useful for:
 # Start the local Nightscout test stack first (lives outside this repo):
 cd ~/dev-test/nightscout && docker compose up -d
 
-# Then run the uploader from anywhere; it talks to NS over 127.0.0.1:1337
-python3 dev/ns_synthetic_uploader.py
+# Then run the uploader. NS_API_SECRET is required -- whatever you
+# set as the API_SECRET env var on the NS container.
+NS_API_SECRET="<your-test-stack-secret>" \
+  python3 dev/ns_synthetic_uploader.py
 ```
 
 Stops on Ctrl-C. No backfill — only posts forward in time.
@@ -35,11 +37,18 @@ Stops on Ctrl-C. No backfill — only posts forward in time.
 | Variable | Default | Purpose |
 |---|---|---|
 | `NS_BASE_URL` | `http://127.0.0.1:1337` | Nightscout URL |
-| `NS_API_SECRET` | the dev-stack secret | Plaintext API_SECRET; SHA-1'd into the api-secret header |
+| `NS_API_SECRET` | **REQUIRED** (no default) | Plaintext API_SECRET; SHA-1'd into the api-secret header |
 | `NS_CADENCE_SECONDS` | `60` | Seconds between entries |
 | `NS_BASELINE_MGDL` | `120` | Mean of the random walk |
 | `NS_VOLATILITY` | `5` | Per-step jitter (mg/dL) |
 | `NS_DEVICE_NAME` | `glycemicgpt-synthetic-uploader` | `device` field on each entry |
+
+`NS_API_SECRET` is intentionally required (no default). Even though
+this script only talks to a local-only test instance, baking a
+secret-shaped string into source code is bad hygiene — it gets
+flagged by secret scanners, leaks into deploy contexts that
+shouldn't have dev-only constants, and obscures genuine
+misconfiguration.
 
 ### Implementation notes
 

--- a/dev/ns_synthetic_uploader.py
+++ b/dev/ns_synthetic_uploader.py
@@ -1,0 +1,220 @@
+"""Synthetic Nightscout uploader.
+
+Continuously POSTs CGM entries to a local Nightscout instance so the
+GlycemicGPT scheduler / dashboard can be visually verified against
+"new data arriving in real time" instead of static fixture data.
+
+NOT shipped in any production image. Lives in the repo so the script
+itself is reviewable + version-controlled, but it never enters a
+Dockerfile context.
+
+Usage:
+    # Default: post every 60 seconds to http://127.0.0.1:1337
+    python3 dev/ns_synthetic_uploader.py
+
+    # Faster cadence for active iteration
+    NS_CADENCE_SECONDS=10 python3 dev/ns_synthetic_uploader.py
+
+    # Different baseline / volatility
+    NS_BASELINE_MGDL=140 NS_VOLATILITY=8 python3 dev/ns_synthetic_uploader.py
+
+Environment:
+    NS_BASE_URL          base URL of the Nightscout instance
+                          (default http://127.0.0.1:1337)
+    NS_API_SECRET        plaintext API_SECRET; gets SHA-1 hashed in the
+                          api-secret header
+                          (default glycemicgpt-test-secret-min12chars)
+    NS_CADENCE_SECONDS   seconds between entries
+                          (default 60)
+    NS_BASELINE_MGDL     mean of the random walk
+                          (default 120)
+    NS_VOLATILITY        per-step jitter in mg/dL
+                          (default 5)
+    NS_DEVICE_NAME       value for the `device` field
+                          (default glycemicgpt-synthetic-uploader)
+
+Stops on Ctrl-C. Doesn't backfill -- only posts forward in time
+starting from `now()`.
+
+Requires only the stdlib + a Python 3.11+ interpreter (no httpx /
+requests). Curl-equivalent over urllib so the script can run from
+any environment that has Python.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import math
+import os
+import random
+import signal
+import socket
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def _hash_secret(secret: str) -> str:
+    return hashlib.sha1(secret.encode("utf-8")).hexdigest()
+
+
+def _direction_for(prev: int, curr: int) -> str:
+    """Map mg/dL delta to Nightscout's trend-arrow vocabulary.
+
+    Nightscout uses the Dexcom direction strings:
+      DoubleUp / SingleUp / FortyFiveUp / Flat
+      / FortyFiveDown / SingleDown / DoubleDown
+    Roughly: each step is 5 minutes, so a "rate" in mg/dL/min is
+    `delta / cadence_minutes`.
+    """
+    delta = curr - prev
+    if delta >= 15:
+        return "DoubleUp"
+    if delta >= 7:
+        return "SingleUp"
+    if delta >= 3:
+        return "FortyFiveUp"
+    if delta <= -15:
+        return "DoubleDown"
+    if delta <= -7:
+        return "SingleDown"
+    if delta <= -3:
+        return "FortyFiveDown"
+    return "Flat"
+
+
+def _post_entry(
+    base_url: str,
+    secret_hash: str,
+    sgv: int,
+    direction: str,
+    device: str,
+) -> None:
+    """POST one entry to /api/v1/entries.json.
+
+    Raises urllib.error.HTTPError on non-2xx; caller prints + continues.
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    payload = [
+        {
+            "type": "sgv",
+            "sgv": sgv,
+            "direction": direction,
+            "date": int(now.timestamp() * 1000),
+            "dateString": now.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            "device": device,
+        }
+    ]
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/api/v1/entries.json",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "api-secret": secret_hash,
+        },
+        method="POST",
+    )
+    # urlopen raises HTTPError for any non-2xx (the default
+    # HTTPErrorProcessor handles that for us); reaching the body of
+    # this `with` means we got a 2xx. Don't manually guard against
+    # specific 2xx codes -- treating 202/204 as errors would be wrong.
+    with urllib.request.urlopen(req, timeout=10):
+        pass
+
+
+def main() -> int:
+    base_url = os.environ.get("NS_BASE_URL", "http://127.0.0.1:1337")
+    secret = os.environ.get("NS_API_SECRET", "glycemicgpt-test-secret-min12chars")
+    cadence = float(os.environ.get("NS_CADENCE_SECONDS", "60"))
+    baseline = float(os.environ.get("NS_BASELINE_MGDL", "120"))
+    volatility = float(os.environ.get("NS_VOLATILITY", "5"))
+    device = os.environ.get("NS_DEVICE_NAME", "glycemicgpt-synthetic-uploader")
+
+    # Mean-reverting random walk with diurnal sine bias so the curve
+    # doesn't drift to one side. Bias adds +/- ~25 mg/dL over a 24h
+    # cycle so the dashboard doesn't render a flat line.
+    secret_hash = _hash_secret(secret)
+    sgv = max(40, min(400, int(baseline)))
+    prev_sgv = sgv
+    started_at = time.monotonic()
+
+    print(
+        f"[uploader] posting to {base_url} every {cadence}s "
+        f"(baseline {baseline}, volatility {volatility})",
+        flush=True,
+    )
+
+    stopping = False
+
+    def _on_signal(signum, _frame):  # type: ignore[no-untyped-def]
+        nonlocal stopping
+        print(f"\n[uploader] caught signal {signum}, stopping", flush=True)
+        stopping = True
+
+    signal.signal(signal.SIGINT, _on_signal)
+    signal.signal(signal.SIGTERM, _on_signal)
+
+    while not stopping:
+        elapsed = time.monotonic() - started_at
+        # Sine bias period of 24 hours; amplitude 25 mg/dL.
+        diurnal_bias = 25 * math.sin(elapsed * 2 * math.pi / 86400)
+        target = baseline + diurnal_bias
+        # Random step toward target plus jitter.
+        step = random.gauss(0, volatility) + 0.05 * (target - sgv)
+        sgv = max(40, min(400, int(round(sgv + step))))
+
+        direction = _direction_for(prev_sgv, sgv)
+        try:
+            _post_entry(base_url, secret_hash, sgv, direction, device)
+            print(
+                f"[uploader] sgv={sgv} direction={direction} "
+                f"(prev={prev_sgv}, target={target:.1f})",
+                flush=True,
+            )
+        except urllib.error.HTTPError as exc:
+            # 401 / 403 are permanent and won't recover by retrying;
+            # bail with a non-zero exit so the operator sees the
+            # misconfiguration immediately. Other HTTP codes (e.g.
+            # 5xx, 429) are usually transient -- log + retry.
+            if exc.code in (401, 403):
+                print(
+                    f"[uploader] FATAL: HTTP {exc.code} {exc.reason} -- "
+                    f"check NS_API_SECRET; aborting.",
+                    flush=True,
+                )
+                return 1
+            print(f"[uploader] HTTP {exc.code}: {exc.reason}", flush=True)
+        except urllib.error.URLError as exc:
+            # DNS / hostname failures are permanent for the lifetime
+            # of this process; transient TCP issues are not.
+            # `socket.gaierror` covers Linux ("Name or service not known"),
+            # macOS/BSD ("nodename nor servname"), and Windows
+            # ("getaddrinfo failed") uniformly without OS-specific string
+            # matching.
+            if isinstance(exc.reason, socket.gaierror):
+                print(
+                    f"[uploader] FATAL: cannot resolve {base_url!r} "
+                    f"({exc.reason}); aborting.",
+                    flush=True,
+                )
+                return 1
+            print(f"[uploader] network error: {exc.reason}", flush=True)
+        except Exception as exc:  # noqa: BLE001 - keep loop running
+            print(f"[uploader] unexpected error: {exc}", flush=True)
+
+        prev_sgv = sgv
+
+        # Sleep in 1-second chunks so SIGINT lands quickly.
+        slept = 0.0
+        while slept < cadence and not stopping:
+            time.sleep(min(1.0, cadence - slept))
+            slept += 1.0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/ns_synthetic_uploader.py
+++ b/dev/ns_synthetic_uploader.py
@@ -21,9 +21,10 @@ Usage:
 Environment:
     NS_BASE_URL          base URL of the Nightscout instance
                           (default http://127.0.0.1:1337)
-    NS_API_SECRET        plaintext API_SECRET; gets SHA-1 hashed in the
-                          api-secret header
-                          (default glycemicgpt-test-secret-min12chars)
+    NS_API_SECRET        REQUIRED. Plaintext API_SECRET for the
+                          target instance; gets SHA-1 hashed in the
+                          api-secret header. Whatever you set as the
+                          `API_SECRET` env on the NS container.
     NS_CADENCE_SECONDS   seconds between entries
                           (default 60)
     NS_BASELINE_MGDL     mean of the random walk
@@ -127,7 +128,20 @@ def _post_entry(
 
 def main() -> int:
     base_url = os.environ.get("NS_BASE_URL", "http://127.0.0.1:1337")
-    secret = os.environ.get("NS_API_SECRET", "glycemicgpt-test-secret-min12chars")
+    # Required: don't bake in a default secret value, even for a
+    # dev-only test stack. Forcing the operator to set it explicitly
+    # keeps a stray credential out of the repo and surfaces
+    # misconfiguration immediately rather than silently uploading
+    # to whatever instance happens to share the default secret.
+    secret = os.environ.get("NS_API_SECRET")
+    if not secret:
+        print(
+            "ERROR: NS_API_SECRET environment variable is required.\n"
+            "Set it to the plaintext API_SECRET of your target "
+            "Nightscout instance. See dev/README.md for usage.",
+            file=sys.stderr,
+        )
+        return 2
     cadence = float(os.environ.get("NS_CADENCE_SECONDS", "60"))
     baseline = float(os.environ.get("NS_BASELINE_MGDL", "120"))
     volatility = float(os.environ.get("NS_VOLATILITY", "5"))


### PR DESCRIPTION
## Summary

Wires the existing per-connection sync service (PR #575) into a single APScheduler tick that scans `nightscout_connections` and syncs due rows **in parallel** — bounded by a semaphore so one slow upstream doesn't block other users. Closes the loop: a user adds a connection in the UI, the scheduler picks it up at the next tick, data flows through the translator into the canonical tables, and the dashboard renders new readings without any manual intervention.

## What's in the box

**Backend (commit included)**
- `services/integrations/nightscout/scheduler.py` (new) — `run_nightscout_sync_all_users()` callback + per-connection `_sync_one` helper. Slim discovery SELECT (id + user_id + interval + last_synced_at). Refetches the full row in a fresh per-connection session so soft-delete-mid-tick is honored. Bounded parallelism via `asyncio.Semaphore(_MAX_PARALLEL_SYNCS=8)`.
- `services/scheduler.py` — registers the job with `IntervalTrigger(minutes=...)`, `max_instances=1`, `coalesce=True`.
- `config.py` — `nightscout_sync_enabled` (default true), `nightscout_sync_tick_interval_minutes` (default 1).
- 14 new tests in `tests/test_nightscout_scheduler.py`.

**Dev tooling**
- `dev/ns_synthetic_uploader.py` — continuously POSTs synthetic CGM entries to a local Nightscout so the scheduler is *visually* verifiable. Stdlib only. Random walk biased by 24h sine. Bails on permanent errors (HTTP 401/403, `socket.gaierror`). NOT shipped in any production image.
- `dev/README.md` — describes the dev/ directory + uploader usage.

## Architecture decisions

- **One global tick, not one APScheduler job per connection.** Matches existing Dexcom/Tandem/research-scheduler patterns. `sync_interval_minutes` changes pick up automatically at the next tick. No job-lifecycle plumbing on connection create/delete.
- **Parallel syncs (semaphore = 8).** Sequential per-connection-with-1s-sleep would let one slow upstream block all other users behind it. Each parallel slot opens its own DB session + httpx client; the semaphore indirectly bounds DB-pool and FD pressure.
- **`_PAUSED_STATUSES = {AUTH_FAILED}`.** UNREACHABLE is intentionally NOT in the set — the model defines it for a future "consecutive-failure circuit breaker" but no code path currently sets it. Adding it now would advertise a working circuit breaker that doesn't exist. Will be added in the breaker's own PR.
- **Slim discovery SELECT.** Pulling `encrypted_credential` for every active connection just to compute due-ness is wasteful; the per-connection refetch hydrates the full row only when needed.
- **Discovery → refetch race.** Between discovery (sees `is_active=True`) and refetch (re-asserts `is_active=True`), a connection could be soft-deleted; the refetch returns `None` and we skip silently. `sync_interval_minutes` could also change mid-tick — by design we honor "what was due at tick start gets synced," documented in `_sync_one`'s docstring.

## Verification

End-to-end with the synthetic uploader at 10s cadence + scheduler at 1-min tick:
- 3 consecutive successful ticks observed.
- Initial sync: 1633 entries + 39 treatments. Subsequent ticks: ~12 new entries each (matches uploader rate).
- Dashboard chart rendered live data with timestamps ending at the current minute.

Test suite:
- 265 nightscout backend tests pass (251 from prior PRs + 14 new).
- `ruff format` + `ruff check` clean across changed files.

Reviews on staged diff:
- Adversarial review: HIGH (parallelize, drop unreachable from paused set), MEDIUM (slim SELECT), LOW (uploader DNS portability) — all applied.
- CodeRabbit CLI: 4 minor findings — all applied (drop manual 2xx check that was treating 202/204 as errors; portable DNS detection via `socket.gaierror`; broaden teardown exception base from `RuntimeError` to `Exception`; user-scope assertions in tests so dev-DB pollution doesn't break them).
- Security review: PASS.

## Test plan

- [x] `ruff format --check` + `ruff check` clean for changed Python files.
- [x] 14 new scheduler tests pass; full nightscout subset 265 passed / 13 skipped.
- [x] Visual: scheduler tick observed every minute; new data flows through to dashboard.
- [x] Defensive: tests scoped to test-user IDs so leftover dev-DB rows don't cause spurious failures.

## Follow-ups (not in this PR)

- **Consecutive-failure circuit breaker** that sets `last_sync_status = UNREACHABLE` after N failures and adds it to `_PAUSED_STATUSES`. Out of scope here.
- **Sync interval picker UI** + **dashboard freshness widget** — final pieces of Story 43.5.
- **Real Dexcom G7 → Nightscout uploader** — pre-launch QA, not blocking.
- Dev DB cleanup helper / transaction-rollback test fixture pattern so cross-loop teardown errors don't leak rows. The current `try/except Exception: pass` teardown handles it cosmetically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Nightscout connections now sync automatically in the background at configurable intervals.
  * Added settings to enable/disable automatic syncing and adjust sync frequency.

* **Documentation**
  * Added developer documentation for the synthetic CGM data uploader tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->