### PR TITLE
fix: source-agnostic Insulin Summary + Recent Boluses widgets

### DIFF
--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -1809,9 +1809,6 @@ _MAX_BASAL_RATE = 15.0
 # and should not accumulate phantom insulin.
 _BASAL_MAX_GAP_HOURS = 2.0
 
-# Source priority for aggregation: mobile BLE > tandem cloud. Never use 'test'.
-_SOURCE_PRIORITY = ("mobile", "tandem")
-
 
 def _boundary_aligned_cutoff(
     days: int,
@@ -1852,37 +1849,6 @@ def _boundary_aligned_cutoff(
     # days=7 means "since 6 days before the effective boundary".
     # Convert back to UTC for DB queries.
     return (effective_boundary - timedelta(days=max(days - 1, 0))).astimezone(UTC)
-
-
-async def _best_source(
-    db: AsyncSession,
-    user_id: uuid.UUID,
-    cutoff: datetime,
-    event_types: list[PumpEventType],
-    now: datetime | None = None,
-) -> str | None:
-    """Return the highest-priority source that has data in the time window.
-
-    Uses a single query to fetch all sources present, then picks the best.
-    """
-    upper = now or datetime.now(UTC)
-    result = await db.execute(
-        select(PumpEvent.source)
-        .select_from(PumpEvent)
-        .where(
-            PumpEvent.user_id == user_id,
-            PumpEvent.event_timestamp >= cutoff,
-            PumpEvent.event_timestamp <= upper,
-            PumpEvent.source.in_(_SOURCE_PRIORITY),
-            PumpEvent.event_type.in_(event_types),
-        )
-        .distinct()
-    )
-    sources = {row[0] for row in result.all()}
-    for src in _SOURCE_PRIORITY:
-        if src in sources:
-            return src
-    return None
 
 
 def _compute_percentile(data: list[float], pct: float) -> float:
@@ -2144,19 +2110,17 @@ async def get_insulin_summary(
             raise HTTPException(status_code=422, detail=str(e)) from e
         period_days = days
 
-    # Determine best data source for bolus/correction events.
-    bolus_source = await _best_source(
-        db,
-        current_user.id,
-        cutoff,
-        [PumpEventType.BOLUS, PumpEventType.CORRECTION],
-        now=now,
-    )
-
-    # Bolus/correction: dedup CTE collapses mobile dual-creation records
-    # (same delivery stored as both 'bolus' and 'correction' at same timestamp).
-    # GROUP BY (event_timestamp, units) merges duplicates; bool_or picks
-    # the more specific 'correction' label when both exist.
+    # Bolus/correction: dedup CTE collapses dual-creation records
+    # (same delivery stored as both 'bolus' and 'correction' at the same
+    # timestamp+units). `GROUP BY (event_timestamp, units)` is the dedupe
+    # key; `bool_or(... = correction)` picks the more specific label
+    # when both exist for the same delivery. The grouping naturally
+    # handles cross-source duplicates too (e.g. one row from mobile BLE
+    # + one from Tandem cloud + one from Nightscout — same ts and units
+    # → merged into one delivery). No source filter, by design: this
+    # widget renders any bolus the canonical table holds, regardless of
+    # which integration wrote it. See issue #574 / source-agnostic-
+    # widgets discussion.
     _bolus_table = PumpEvent.__tablename__
     _bolus_val = PumpEventType.BOLUS.value
     _correction_val = PumpEventType.CORRECTION.value
@@ -2169,7 +2133,6 @@ async def get_insulin_summary(
             WHERE user_id = :user_id
               AND event_timestamp >= :cutoff AND event_timestamp <= :now
               AND event_type IN (:bolus_type, :correction_type)
-              AND source = :source
               AND units IS NOT NULL AND units >= 0 AND units <= :max_bolus
             GROUP BY event_timestamp, units
         )
@@ -2180,33 +2143,34 @@ async def get_insulin_summary(
         GROUP BY is_correction
     """
     )
-    if bolus_source is not None:
-        bolus_result = await db.execute(
-            bolus_query,
-            {
-                "user_id": str(current_user.id),
-                "cutoff": cutoff,
-                "now": now,
-                "bolus_type": _bolus_val,
-                "correction_type": _correction_val,
-                "source": bolus_source,
-                "max_bolus": float(_MAX_BOLUS_UNITS),
-            },
-        )
-        bolus_rows = bolus_result.all()
-    else:
-        bolus_rows = []
-
-    # Determine best data source for basal events (independent of bolus source).
-    basal_source = await _best_source(
-        db, current_user.id, cutoff, [PumpEventType.BASAL], now=now
+    bolus_result = await db.execute(
+        bolus_query,
+        {
+            "user_id": str(current_user.id),
+            "cutoff": cutoff,
+            "now": now,
+            "bolus_type": _bolus_val,
+            "correction_type": _correction_val,
+            "max_bolus": float(_MAX_BOLUS_UNITS),
+        },
     )
+    bolus_rows = bolus_result.all()
 
-    # Basal: time-weighted rate integration using SQL LEAD() window function.
-    # Each basal record stores units = rate in U/hr (not delivered amount).
-    # We compute actual delivery as rate * time_until_next_record, capped at
-    # _BASAL_MAX_GAP_HOURS to handle pump disconnections/gaps.
-    # Uses PostgreSQL EXTRACT(EPOCH) and LEAST() -- not portable to SQLite.
+    # Basal: time-weighted rate integration using SQL LEAD() window
+    # function. Each basal record stores units = rate in U/hr (not
+    # delivered amount). Actual delivery = rate * time_until_next_record,
+    # capped at _BASAL_MAX_GAP_HOURS to handle pump disconnections/gaps.
+    # Uses PostgreSQL EXTRACT(EPOCH) and LEAST() -- not portable to
+    # SQLite.
+    #
+    # No source filter: any integration that writes basal-rate-change
+    # events to the canonical table contributes. Cross-source overlap
+    # (rare in practice -- a user with both Tandem cloud and Loop-via-
+    # NS reporting the same pump) produces same-timestamp rows that the
+    # LEAD ordering folds into zero-duration intervals, so the
+    # integrated total is approximately correct without explicit
+    # row-level dedupe. A precise dedupe scheme would land at write
+    # time, not in this read query.
     _table = PumpEvent.__tablename__
     _basal_val = PumpEventType.BASAL.value
     basal_query = text(  # nosemgrep: avoid-sqlalchemy-text
@@ -2216,7 +2180,6 @@ async def get_insulin_summary(
             FROM {_table}
             WHERE user_id = :user_id
               AND event_type = :event_type
-              AND source = :source
               AND units IS NOT NULL
               AND units >= 0
               AND units <= :max_rate
@@ -2229,7 +2192,6 @@ async def get_insulin_summary(
             FROM {_table}
             WHERE user_id = :user_id
               AND event_type = :event_type
-              AND source = :source
               AND units IS NOT NULL
               AND units >= 0
               AND units <= :max_rate
@@ -2262,22 +2224,18 @@ async def get_insulin_summary(
             > GREATEST(event_timestamp, :cutoff)
     """
     )
-    if basal_source is not None:
-        basal_result = await db.execute(
-            basal_query,
-            {
-                "user_id": str(current_user.id),
-                "cutoff": cutoff,
-                "now": now,
-                "event_type": _basal_val,
-                "source": basal_source,
-                "max_rate": float(_MAX_BASAL_RATE),
-                "max_gap": float(_BASAL_MAX_GAP_HOURS),
-            },
-        )
-        basal_units = float(basal_result.scalar() or 0.0)
-    else:
-        basal_units = 0.0
+    basal_result = await db.execute(
+        basal_query,
+        {
+            "user_id": str(current_user.id),
+            "cutoff": cutoff,
+            "now": now,
+            "event_type": _basal_val,
+            "max_rate": float(_MAX_BASAL_RATE),
+            "max_gap": float(_BASAL_MAX_GAP_HOURS),
+        },
+    )
+    basal_units = float(basal_result.scalar() or 0.0)
 
     bolus_units = 0.0
     correction_units = 0.0
@@ -2373,58 +2331,36 @@ async def get_bolus_review(
             raise HTTPException(status_code=422, detail=str(e)) from e
         period_days = days
 
-    # Determine best source to avoid cross-source duplicates.
-    review_source = await _best_source(
-        db,
-        current_user.id,
-        cutoff,
-        [PumpEventType.BOLUS, PumpEventType.CORRECTION],
-        now=now,
-    )
-
-    if review_source is None:
-        return BolusReviewResponse(
-            boluses=[], total_count=0, period_days=max(1, round(period_days))
-        )
+    # No source filter: render any bolus / correction in the time
+    # window regardless of which integration wrote it (Tandem direct,
+    # mobile BLE, Nightscout-relayed Loop / AAPS / OmniPod, future
+    # Tidepool, etc.). Cross-source duplicate suppression at the row
+    # level is its own piece of work (write-time content-hash dedupe);
+    # for the table view, displaying both rows with their distinct
+    # source labels is an acceptable interim. See issue #574.
+    bolus_filter = [
+        PumpEvent.user_id == current_user.id,
+        PumpEvent.event_timestamp >= cutoff,
+        PumpEvent.event_timestamp <= now,
+        PumpEvent.units.is_not(None),
+        PumpEvent.units >= 0,
+        PumpEvent.units <= _MAX_BOLUS_UNITS,
+        PumpEvent.event_type.in_(
+            [
+                PumpEventType.BOLUS,
+                PumpEventType.CORRECTION,
+            ]
+        ),
+    ]
 
     # Count total
-    count_result = await db.execute(
-        select(func.count()).where(
-            PumpEvent.user_id == current_user.id,
-            PumpEvent.event_timestamp >= cutoff,
-            PumpEvent.event_timestamp <= now,
-            PumpEvent.units.is_not(None),
-            PumpEvent.units >= 0,
-            PumpEvent.units <= _MAX_BOLUS_UNITS,
-            PumpEvent.event_type.in_(
-                [
-                    PumpEventType.BOLUS,
-                    PumpEventType.CORRECTION,
-                ]
-            ),
-            PumpEvent.source == review_source,
-        )
-    )
+    count_result = await db.execute(select(func.count()).where(*bolus_filter))
     total = count_result.scalar() or 0
 
     # Fetch page
     result = await db.execute(
         select(PumpEvent)
-        .where(
-            PumpEvent.user_id == current_user.id,
-            PumpEvent.event_timestamp >= cutoff,
-            PumpEvent.event_timestamp <= now,
-            PumpEvent.units.is_not(None),
-            PumpEvent.units >= 0,
-            PumpEvent.units <= _MAX_BOLUS_UNITS,
-            PumpEvent.event_type.in_(
-                [
-                    PumpEventType.BOLUS,
-                    PumpEventType.CORRECTION,
-                ]
-            ),
-            PumpEvent.source == review_source,
-        )
+        .where(*bolus_filter)
         .order_by(PumpEvent.event_timestamp.desc(), PumpEvent.id.desc())
         .offset(offset)
         .limit(limit)

--- a/apps/api/tests/test_aggregate_stats.py
+++ b/apps/api/tests/test_aggregate_stats.py
@@ -798,6 +798,234 @@ class TestBolusReview:
 
 
 @pytest.mark.asyncio
+class TestInsulinSummarySourceAgnostic:
+    """Insulin Summary must render data from ANY integration that
+    writes to `pump_events`, not just Tandem / Mobile.
+
+    Pre-PR behavior (issue #574): a `_best_source` filter selected
+    one of `("mobile", "tandem")` and ignored Nightscout-sourced
+    rows entirely. Now that the filter is gone, an NS-only user
+    sees their boluses + basal in the widget like every other user.
+    """
+
+    async def test_only_nightscout_pump_events_rendered(self):
+        """User has zero Tandem/Mobile rows but full Nightscout
+        coverage -- the widget must populate."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie, user_id = await register_and_login(client)
+
+            # Per-test unique source so the partial unique index on
+            # `(source, ns_id) WHERE ns_id IS NOT NULL` (PR #572)
+            # doesn't conflict with leftover rows from prior test runs.
+            run_token = uuid.uuid4().hex[:12]
+            ns_source = f"nightscout:{uuid.uuid4()}"
+
+            async for db in get_db():
+                uid = uuid.UUID(user_id)
+                cutoff = _boundary_cutoff(days=7)
+
+                # 144 basal events (1/hr for 6 complete days), all NS
+                for h in range(144):
+                    ts = cutoff + timedelta(hours=h + 1)
+                    db.add(
+                        PumpEvent(
+                            user_id=uid,
+                            event_type=PumpEventType.BASAL,
+                            event_timestamp=ts,
+                            units=0.7,
+                            is_automated=True,
+                            received_at=ts,
+                            source=ns_source,
+                            ns_id=f"basal-{run_token}-{h}",
+                        )
+                    )
+                # 18 boluses (3/day * 6 days) at 4.0U each, all NS
+                for d in range(6):
+                    day_start = cutoff + timedelta(days=d)
+                    for meal_h in [8, 12, 18]:
+                        ts = day_start + timedelta(hours=meal_h)
+                        db.add(
+                            PumpEvent(
+                                user_id=uid,
+                                event_type=PumpEventType.BOLUS,
+                                event_timestamp=ts,
+                                units=4.0,
+                                is_automated=False,
+                                received_at=ts,
+                                source=ns_source,
+                                ns_id=f"bolus-{run_token}-{d}-{meal_h}",
+                            )
+                        )
+                await db.commit()
+                break
+
+            resp = await client.get(
+                "/api/integrations/insulin/summary?days=7",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Pre-PR: this would all be 0 because _best_source filtered out
+        # the NS rows. Post-PR: the widget renders the real numbers.
+        assert data["bolus_count"] == 18, f"NS-only boluses didn't render: {data}"
+        assert data["basal_units"] > 0, f"NS-only basal didn't render: {data}"
+        assert data["tdd"] > 0
+
+    async def test_mixed_sources_both_contribute(self):
+        """User with both Tandem AND Nightscout boluses sees both."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie, user_id = await register_and_login(client)
+
+            run_token = uuid.uuid4().hex[:12]
+            ns_source = f"nightscout:{uuid.uuid4()}"
+
+            async for db in get_db():
+                uid = uuid.UUID(user_id)
+                cutoff = _boundary_cutoff(days=7)
+
+                # 1 Tandem bolus on day 0
+                db.add(
+                    PumpEvent(
+                        user_id=uid,
+                        event_type=PumpEventType.BOLUS,
+                        event_timestamp=cutoff + timedelta(days=0, hours=12),
+                        units=3.0,
+                        is_automated=False,
+                        received_at=cutoff + timedelta(days=0, hours=12),
+                        source="tandem",
+                    )
+                )
+                # 1 Nightscout bolus on day 1 (different timestamp -- not a
+                # cross-source duplicate, a separate delivery)
+                db.add(
+                    PumpEvent(
+                        user_id=uid,
+                        event_type=PumpEventType.BOLUS,
+                        event_timestamp=cutoff + timedelta(days=1, hours=12),
+                        units=2.0,
+                        is_automated=False,
+                        received_at=cutoff + timedelta(days=1, hours=12),
+                        source=ns_source,
+                        ns_id=f"ns-bolus-{run_token}",
+                    )
+                )
+                await db.commit()
+                break
+
+            resp = await client.get(
+                "/api/integrations/insulin/summary?days=7",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Both deliveries counted: 2 bolus events, 5.0 U total bolus
+        assert data["bolus_count"] == 2
+
+    async def test_cross_source_duplicate_at_same_ts_units_deduped(self):
+        """Two sources reporting the SAME bolus (same timestamp + units)
+        get folded into one delivery by the GROUP BY in the bolus CTE.
+        This is the natural dedupe boundary for non-divergent reports."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie, user_id = await register_and_login(client)
+
+            run_token = uuid.uuid4().hex[:12]
+            ns_source = f"nightscout:{uuid.uuid4()}"
+
+            async for db in get_db():
+                uid = uuid.UUID(user_id)
+                cutoff = _boundary_cutoff(days=7)
+                ts = cutoff + timedelta(days=2, hours=12)
+                # Same delivery, two source rows
+                db.add(
+                    PumpEvent(
+                        user_id=uid,
+                        event_type=PumpEventType.BOLUS,
+                        event_timestamp=ts,
+                        units=4.0,
+                        is_automated=False,
+                        received_at=ts,
+                        source="tandem",
+                    )
+                )
+                db.add(
+                    PumpEvent(
+                        user_id=uid,
+                        event_type=PumpEventType.BOLUS,
+                        event_timestamp=ts,
+                        units=4.0,
+                        is_automated=False,
+                        received_at=ts,
+                        source=ns_source,
+                        ns_id=f"dup-bolus-{run_token}",
+                    )
+                )
+                await db.commit()
+                break
+
+            resp = await client.get(
+                "/api/integrations/insulin/summary?days=7",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Same-ts + same-units across two sources = one delivery
+        # (the GROUP BY collapses them).
+        assert data["bolus_count"] == 1
+
+
+@pytest.mark.asyncio
+class TestBolusReviewSourceAgnostic:
+    """Recent Boluses table must render rows from any integration."""
+
+    async def test_only_nightscout_boluses_rendered(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie, user_id = await register_and_login(client)
+
+            run_token = uuid.uuid4().hex[:12]
+            ns_source = f"nightscout:{uuid.uuid4()}"
+
+            async for db in get_db():
+                uid = uuid.UUID(user_id)
+                cutoff = _boundary_cutoff(days=7)
+                # 5 NS boluses in window
+                for i in range(5):
+                    ts = cutoff + timedelta(days=i, hours=12)
+                    db.add(
+                        PumpEvent(
+                            user_id=uid,
+                            event_type=PumpEventType.BOLUS,
+                            event_timestamp=ts,
+                            units=3.0 + i * 0.1,
+                            is_automated=False,
+                            received_at=ts,
+                            source=ns_source,
+                            ns_id=f"bolus-{run_token}-{i}",
+                        )
+                    )
+                await db.commit()
+                break
+
+            resp = await client.get(
+                "/api/integrations/bolus/review?days=7&limit=10",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Pre-PR: total_count would be 0 because _best_source filtered
+        # NS out. Post-PR: all 5 render.
+        assert data["total_count"] == 5
+        assert len(data["boluses"]) == 5
+
+
+@pytest.mark.asyncio
 class TestCrossUserIsolation:
     """Verify users cannot see each other's data across all endpoints."""
 
@@ -1113,10 +1341,22 @@ class TestTirDetail:
 
 @pytest.mark.asyncio
 class TestSourceFilteringAndDedup:
-    """Story 30.10: source filtering and bolus/correction dedup tests."""
+    """Bolus/correction dedup tests.
 
-    async def test_source_test_excluded(self):
-        """Events with source='test' should be excluded from insulin summary."""
+    Note: the original Story 30.10 source-priority filtering (mobile >
+    tandem; exclude 'test') was removed when widgets became
+    source-agnostic. The dedup CTE in the bolus query is what now
+    handles same-timestamp same-units cross-source duplicates; the
+    `source` column is treated as attribution metadata only.
+    """
+
+    async def test_arbitrary_source_strings_are_rendered(self):
+        """The widget renders rows regardless of source value.
+
+        Pre-PR: `source='test'` was excluded by `_best_source`'s
+        priority filter. Post-PR: `source` has no semantic meaning at
+        the read layer -- whatever's in pump_events renders.
+        """
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
         ) as client:
@@ -1127,7 +1367,6 @@ class TestSourceFilteringAndDedup:
                 uid = uuid.UUID(user_id)
                 cutoff = _boundary_cutoff(days=1)
                 ts = cutoff + timedelta(hours=1)
-                # Insert bolus and basal with source='test' -- should be ignored
                 db.add(
                     PumpEvent(
                         user_id=uid,
@@ -1159,8 +1398,8 @@ class TestSourceFilteringAndDedup:
             )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["tdd"] == 0.0
-        assert data["bolus_count"] == 0
+        assert data["bolus_count"] == 1
+        assert data["tdd"] > 0
 
     async def test_bolus_correction_dedup(self):
         """Same delivery stored as both bolus and correction should be counted once."""
@@ -1212,8 +1451,19 @@ class TestSourceFilteringAndDedup:
         # correction_units is daily avg (3.0 / 1 day = 3.0)
         assert abs(data["correction_units"] - 3.0) < 0.5
 
-    async def test_cross_source_prefers_mobile(self):
-        """When both mobile and tandem have data, only mobile is aggregated."""
+    async def test_cross_source_distinct_timestamps_both_count(self):
+        """Two sources reporting bolus at DIFFERENT timestamps count as
+        separate deliveries.
+
+        The bolus CTE dedupes by `(event_timestamp, units)`. Two rows
+        with different timestamps don't share a group, so they
+        contribute two distinct deliveries. This is the right answer
+        for "two sources, two physically different boluses."
+
+        Cross-source duplicates AT THE SAME timestamp+units are
+        deduped naturally (covered by `test_bolus_correction_dedup`
+        and the source-agnostic dedupe test).
+        """
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
         ) as client:
@@ -1223,7 +1473,6 @@ class TestSourceFilteringAndDedup:
                 now = datetime.now(UTC)
                 uid = uuid.UUID(user_id)
                 ts = _stable_test_ts(days=1)
-                # Mobile bolus
                 db.add(
                     PumpEvent(
                         user_id=uid,
@@ -1235,7 +1484,6 @@ class TestSourceFilteringAndDedup:
                         source="mobile",
                     )
                 )
-                # Tandem bolus at slightly different timestamp (cloud sync)
                 db.add(
                     PumpEvent(
                         user_id=uid,
@@ -1256,9 +1504,8 @@ class TestSourceFilteringAndDedup:
             )
         assert resp.status_code == 200
         data = resp.json()
-        # Only the mobile bolus (4.0 U) should be counted, not both
-        assert data["bolus_count"] == 1
-        assert abs(data["bolus_units"] - 4.0) < 0.5
+        # Different timestamps => two distinct deliveries.
+        assert data["bolus_count"] == 2
 
     async def test_tandem_fallback_when_no_mobile(self):
         """When only tandem data exists, it should be used for aggregation."""
@@ -1317,8 +1564,9 @@ class TestSourceFilteringAndDedup:
         assert data["bolus_count"] == 1
         assert data["basal_units"] > 0
 
-    async def test_bolus_review_excludes_test_source(self):
-        """Bolus review endpoint should exclude source='test' events."""
+    async def test_bolus_review_renders_all_sources(self):
+        """Bolus review renders rows from any source -- the table is
+        a literal projection of pump_events by event_type + window."""
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
         ) as client:
@@ -1328,7 +1576,6 @@ class TestSourceFilteringAndDedup:
                 now = datetime.now(UTC)
                 uid = uuid.UUID(user_id)
                 ts = _stable_test_ts(days=1)
-                # One mobile bolus (should appear) and one test bolus (excluded)
                 db.add(
                     PumpEvent(
                         user_id=uid,
@@ -1360,7 +1607,6 @@ class TestSourceFilteringAndDedup:
             )
         assert resp.status_code == 200
         data = resp.json()
-        # Only the mobile bolus should appear
-        assert data["total_count"] == 1
-        assert len(data["boluses"]) == 1
-        assert abs(data["boluses"][0]["units"] - 3.0) < 0.01
+        # Both rows render -- source no longer filters at the read layer.
+        assert data["total_count"] == 2
+        assert len(data["boluses"]) == 2


### PR DESCRIPTION
## Summary

Drops the `_best_source` helper that filtered Insulin Summary / Recent Boluses to `("mobile", "tandem")`-only and silently hid Nightscout-relayed pump events. Closes #574.

After this PR every dashboard widget renders data regardless of which integration wrote it. Per the architecture intent: the `source` column is attribution metadata only, never a read-time filter. Per-user isolation (`user_id` predicate) remains the only authorization boundary and is unchanged.

## What changed

- **`integrations.py`**: removed `_SOURCE_PRIORITY` constant, removed `_best_source()` helper, removed `AND source = :source` clauses from the bolus/correction CTE, the basal LEAD-window query, and the bolus-review count + page queries.
- **The bolus dedupe CTE** (`GROUP BY event_timestamp, units`) is unchanged and now does double duty — it folds intra-source dual-creation pairs (the original purpose) AND cross-source duplicates that share the same `(timestamp, units)`.
- **Tests**: 3 pre-existing tests asserting the old "exclude source='test' / prefer mobile over tandem" behavior were updated to assert the new agnostic semantics (those behaviors were band-aids over the absent cross-source dedupe and don't make sense post-PR). 4 new tests added covering the NS-only / mixed-source / same-ts-same-units-deduped scenarios.

## Architecture decisions

- **Why drop the filter rather than extend `_SOURCE_PRIORITY` to include nightscout?** Read-time filtering is the wrong abstraction layer for cross-source dedupe. The right answer is write-time content-hash uniqueness; that's queued as a separate piece of work. In the meantime, "show everything" matches the platform-vision principle that widgets work with whatever the user has, regardless of integration.
- **Cross-source same-`(timestamp, units)` duplicates** fold via the existing dedupe CTE — this is the natural boundary for non-divergent reports. Documented in code comments.
- **Cross-source DIVERGENT reports** (e.g. Loop's 2.5U recommendation vs Tandem's 2.4U delivery for the same physical bolus) currently render as two distinct deliveries. Not great, but better than the pre-PR behavior of silently hiding the Nightscout one entirely. Proper write-time dedupe is queued.

## Verification

- **1789 / 0 / 14** (full `:api` suite)
- **End-to-end** on local Nightscout: dev account wiped clean → NS connection configured via UI → synthetic uploader pushed live entries + 6 treatments → all dashboard widgets populated from NS-only data:
  - BG hero: **110 mg/dL** (was stale 261 from removed Dexcom)
  - Glucose Trend: live readings + bolus markers (4.5U / 3.2U / 1.2U / 2.8U / 0.8U)
  - CGM Summary: avg 122, GMI 6.2%, 47 readings
  - AGP: 1,630 readings
  - **Insulin Summary**: TDD 7.3 U/day, **bolus_count 23** (was 0 pre-PR)
  - **Recent Boluses**: 5+ entries visible (was empty pre-PR)
  - TIR 24H: 100%, Last Updated "Just now"
- **Adversarial review** + **security review** + **CodeRabbit CLI**: clean.

## Test plan

- [x] `ruff format --check` + `ruff check` clean
- [x] `tests/test_aggregate_stats.py` — 46 passing (4 new + 3 updated + 39 unchanged)
- [x] Full :api suite — 1789 passing, 0 failed
- [x] Visual: BG hero / chart / Insulin Summary / Recent Boluses / AGP / TIR / CGM Summary all populate from NS-only source

## Follow-ups (filed)

These came up during the derisk and are queued as separate pieces of work:

1. **Cross-source CGM dedupe + primary-source preference** — for users with both Dexcom Share AND Loop-via-NS posting the same readings to `glucose_readings`. Settings UI picker for "primary CGM source" + read-time filter.
2. **Cross-source pump-event dedupe (write-time content hash)** — for users with both Tandem cloud + Loop-via-NS reporting the same physical bolus with marginally different units / timestamps. New `pump_events.dedupe_hash` column + partial unique index.
3. **Closed-loop UI surfaces** — Loop status badge, predictive BG overlay, override-active indicator, COB display. Reads from existing `device_status_snapshots.{loop,openaps}_subtree_json` columns we already populate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Insulin analytics and bolus review now include data from all pump integration sources, providing more comprehensive reporting.

* **Tests**
  * Expanded test coverage for multi-source insulin data aggregation and deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->