### PR TITLE
feat: sync interval picker + per-source freshness card

### DIFF
--- a/apps/web/__tests__/accessibility/dashboard.test.tsx
+++ b/apps/web/__tests__/accessibility/dashboard.test.tsx
@@ -87,7 +87,11 @@ describe("Dashboard Page Accessibility", () => {
       const h3s = screen.getAllByRole("heading", { level: 3 });
       expect(h3s.length).toBeGreaterThanOrEqual(2);
       expect(h3s.some(h => h.textContent?.includes("Time in Range"))).toBe(true);
-      expect(h3s.some(h => h.textContent?.includes("Last Updated"))).toBe(true);
+      // The old single-row "Last Updated" card was replaced by the
+      // multi-source "Data Sources" card in Story 43.5 phase 3. Both
+      // the populated card and its empty-state fallback render an h3
+      // with this text.
+      expect(h3s.some(h => h.textContent?.includes("Data Sources"))).toBe(true);
     });
   });
 
@@ -128,12 +132,18 @@ describe("Dashboard Page Accessibility", () => {
       expect(tirValue).toBeInTheDocument();
     });
 
-    it("provides accessible label for last updated value", () => {
+    it("renders a Data Sources card with discoverable content", () => {
       render(<DashboardPage />, { wrapper: LayoutWrapper });
 
-      // When no data, should show "No data"
-      const lastUpdated = screen.getByLabelText(/last updated/i);
-      expect(lastUpdated).toBeInTheDocument();
+      // The new Data Sources card replaces the old "Last Updated"
+      // card. With no integrations configured (the test fixture
+      // returns empty lists), the empty-state fallback renders the
+      // h3 + an actionable hint pointing to Settings → Integrations.
+      const heading = screen.getByRole("heading", {
+        level: 3,
+        name: /data sources/i,
+      });
+      expect(heading).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/__tests__/components/dashboard/data-sources-freshness-card.test.tsx
+++ b/apps/web/__tests__/components/dashboard/data-sources-freshness-card.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * Tests for DataSourcesFreshnessCard.
+ *
+ * Story 43.5 phase 3: per-source freshness widget on the dashboard.
+ * The component is a pure projection of the parent's data into rows
+ * + status pills + relative timestamps -- no fetches of its own,
+ * no internal timers -- so the tests just feed props.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { DataSourcesFreshnessCard } from "../../../src/components/dashboard/data-sources-freshness-card";
+import type {
+  IntegrationResponse,
+  NightscoutConnectionResponse,
+  NightscoutSyncStatus,
+} from "../../../src/lib/api";
+
+const NOW_MS = new Date("2026-05-08T12:00:00.000Z").getTime();
+
+function nsConn(overrides: Partial<NightscoutConnectionResponse> = {}): NightscoutConnectionResponse {
+  return {
+    id: "ns-1",
+    name: "Test NS",
+    base_url: "https://example.com",
+    auth_type: "secret",
+    api_version: "v1",
+    is_active: true,
+    has_credential: true,
+    sync_interval_minutes: 5,
+    initial_sync_window_days: 7,
+    last_sync_status: "ok" as NightscoutSyncStatus,
+    last_synced_at: new Date(NOW_MS - 60_000).toISOString(), // 1 min ago
+    last_sync_error: null,
+    detected_uploaders_json: null,
+    last_evaluated_at: null,
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function dexcomIntegration(
+  overrides: Partial<IntegrationResponse> = {}
+): IntegrationResponse {
+  return {
+    id: "int-dex",
+    integration_type: "dexcom",
+    status: "connected",
+    last_sync_at: new Date(NOW_MS - 5 * 60_000).toISOString(), // 5m ago
+    last_error: null,
+    has_credentials: true,
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("DataSourcesFreshnessCard", () => {
+  it("returns null when no sources are configured", () => {
+    const { container } = render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[]}
+        dexcom={null}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a single NS connection inside its 2x interval as Connected (green)", () => {
+    render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[
+          nsConn({
+            sync_interval_minutes: 5,
+            last_synced_at: new Date(NOW_MS - 3 * 60_000).toISOString(),
+          }),
+        ]}
+        dexcom={null}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Test NS")).toBeInTheDocument();
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(screen.getByText("3m ago")).toBeInTheDocument();
+  });
+
+  it("renders Lagging (amber) between 2x and 5x interval", () => {
+    render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[
+          nsConn({
+            sync_interval_minutes: 5,
+            last_synced_at: new Date(NOW_MS - 15 * 60_000).toISOString(), // 15m ago, 3x interval
+          }),
+        ]}
+        dexcom={null}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Lagging")).toBeInTheDocument();
+  });
+
+  it("renders Stale (red) past 5x interval", () => {
+    render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[
+          nsConn({
+            sync_interval_minutes: 5,
+            last_synced_at: new Date(NOW_MS - 35 * 60_000).toISOString(), // 35m ago, 7x
+          }),
+        ]}
+        dexcom={null}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Stale")).toBeInTheDocument();
+  });
+
+  it("renders Pending when last_sync_status is 'never'", () => {
+    render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[
+          nsConn({
+            last_sync_status: "never",
+            last_synced_at: null,
+          }),
+        ]}
+        dexcom={null}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.getByText("never")).toBeInTheDocument();
+  });
+
+  it("auth_failed forces Stale regardless of last_synced_at recency", () => {
+    render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[
+          nsConn({
+            last_sync_status: "auth_failed",
+            // Synced 30 seconds ago — would be "fresh" by recency, but
+            // auth_failed means the connection is broken.
+            last_synced_at: new Date(NOW_MS - 30_000).toISOString(),
+          }),
+        ]}
+        dexcom={null}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Stale")).toBeInTheDocument();
+  });
+
+  it("rate_limited and network statuses force Lagging", () => {
+    const { rerender } = render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[
+          nsConn({ last_sync_status: "rate_limited" }),
+        ]}
+        dexcom={null}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Lagging")).toBeInTheDocument();
+
+    rerender(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[
+          nsConn({ last_sync_status: "network" }),
+        ]}
+        dexcom={null}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Lagging")).toBeInTheDocument();
+  });
+
+  it("excludes inactive (soft-deleted) NS connections from the list", () => {
+    render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[
+          nsConn({ name: "Active NS", is_active: true }),
+          nsConn({
+            id: "ns-2",
+            name: "Deleted NS",
+            is_active: false,
+          }),
+        ]}
+        dexcom={null}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Active NS")).toBeInTheDocument();
+    expect(screen.queryByText("Deleted NS")).not.toBeInTheDocument();
+  });
+
+  it("renders multi-source mixed states (Dexcom fresh + NS stale)", () => {
+    render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[
+          nsConn({
+            sync_interval_minutes: 5,
+            last_synced_at: new Date(NOW_MS - 35 * 60_000).toISOString(), // 7x → Stale
+          }),
+        ]}
+        dexcom={dexcomIntegration({
+          last_sync_at: new Date(NOW_MS - 5 * 60_000).toISOString(), // 5m, well under 15m threshold
+        })}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Dexcom")).toBeInTheDocument();
+    expect(screen.getByText("Test NS")).toBeInTheDocument();
+    // Both pills present, in different bands.
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(screen.getByText("Stale")).toBeInTheDocument();
+  });
+
+  it("Dexcom integration: 15m threshold → Lagging, 60m threshold → Stale", () => {
+    const { rerender } = render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[]}
+        dexcom={dexcomIntegration({
+          last_sync_at: new Date(NOW_MS - 20 * 60_000).toISOString(),
+        })}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Lagging")).toBeInTheDocument();
+
+    rerender(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[]}
+        dexcom={dexcomIntegration({
+          last_sync_at: new Date(NOW_MS - 90 * 60_000).toISOString(),
+        })}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    expect(screen.getByText("Stale")).toBeInTheDocument();
+  });
+
+  it("disconnected direct integration is hidden", () => {
+    render(
+      <DataSourcesFreshnessCard
+        nightscoutConnections={[]}
+        dexcom={dexcomIntegration({ status: "disconnected" })}
+        tandem={null}
+        now={NOW_MS}
+      />
+    );
+    // No Dexcom row -> no sources -> null render.
+    expect(screen.queryByText("Dexcom")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/settings/offline-state.test.tsx
+++ b/apps/web/__tests__/settings/offline-state.test.tsx
@@ -80,6 +80,7 @@ jest.mock("../../src/lib/api", () => {
     testNightscoutConnection: jest.fn().mockRejectedValue(networkError),
     syncNightscoutConnection: jest.fn().mockRejectedValue(networkError),
     deleteNightscoutConnection: jest.fn().mockRejectedValue(networkError),
+    patchNightscoutConnection: jest.fn().mockRejectedValue(networkError),
     // Telegram
     getTelegramStatus: jest.fn().mockRejectedValue(networkError),
     generateTelegramCode: jest.fn().mockRejectedValue(networkError),

--- a/apps/web/__tests__/smoke-test-pages.test.tsx
+++ b/apps/web/__tests__/smoke-test-pages.test.tsx
@@ -104,6 +104,7 @@ jest.mock("@/lib/api", () => ({
   testNightscoutConnection: jest.fn().mockResolvedValue({ ok: true }),
   syncNightscoutConnection: jest.fn().mockResolvedValue({}),
   deleteNightscoutConnection: jest.fn().mockResolvedValue(undefined),
+  patchNightscoutConnection: jest.fn().mockResolvedValue({}),
   // Caregivers
   listLinkedCaregivers: jest.fn().mockResolvedValue({ caregivers: [] }),
   listCaregiverInvitations: jest.fn().mockResolvedValue({ invitations: [] }),

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -19,7 +19,13 @@
 
 import { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Activity, Clock } from "lucide-react";
+import { Activity } from "lucide-react";
+import {
+  listIntegrations,
+  listNightscoutConnections,
+  type IntegrationResponse,
+  type NightscoutConnectionResponse,
+} from "@/lib/api";
 import { AnimatedCard } from "@/components/ui/animated-card";
 import { PageTransition } from "@/components/ui/page-transition";
 
@@ -32,6 +38,7 @@ import {
   AgpChart,
   InsulinSummaryStats,
   BolusReviewTable,
+  DataSourcesFreshnessCard,
   PERIOD_LABELS,
 } from "@/components/dashboard";
 import { useGlucoseStreamContext, useUserContext } from "@/providers";
@@ -74,6 +81,58 @@ export default function DashboardPage() {
   // Fetch latest pump status (basal, battery, reservoir) for hero card
   const pumpStatus = usePumpStatus(chartRefreshKey);
 
+  // Per-source freshness for the "Data Sources" card. Fetched once on
+  // mount + every 30s after that, with `freshnessNow` advancing every
+  // 30s so relative-time labels walk forward without a refetch. 30s
+  // (not 60s) so the worst-case "lagging" flash before the 1-min
+  // scheduler tick is bounded.
+  const [nightscoutConnections, setNightscoutConnections] = useState<
+    NightscoutConnectionResponse[]
+  >([]);
+  const [dexcomIntegration, setDexcomIntegration] =
+    useState<IntegrationResponse | null>(null);
+  const [tandemIntegration, setTandemIntegration] =
+    useState<IntegrationResponse | null>(null);
+  const [freshnessNow, setFreshnessNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    let cancelled = false;
+    const refetch = async () => {
+      try {
+        const [integrationsResult, nsResult] = await Promise.allSettled([
+          listIntegrations(),
+          listNightscoutConnections(),
+        ]);
+        if (cancelled) return;
+        if (integrationsResult.status === "fulfilled") {
+          const data = integrationsResult.value;
+          setDexcomIntegration(
+            data.integrations.find((i) => i.integration_type === "dexcom") ||
+              null
+          );
+          setTandemIntegration(
+            data.integrations.find((i) => i.integration_type === "tandem") ||
+              null
+          );
+        }
+        if (nsResult.status === "fulfilled") {
+          setNightscoutConnections(nsResult.value.connections);
+        }
+      } catch {
+        // Best-effort: leaving stale state during a transient API blip
+        // is preferable to clobbering the rendered freshness rows.
+      }
+    };
+    void refetch();
+    const refetchInterval = setInterval(() => void refetch(), 30_000);
+    const tickInterval = setInterval(() => setFreshnessNow(Date.now()), 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(refetchInterval);
+      clearInterval(tickInterval);
+    };
+  }, []);
+
   // Redirect caregivers to the caregiver-specific dashboard (Story 8.3)
   useEffect(() => {
     if (user?.role === "caregiver") {
@@ -109,22 +168,6 @@ export default function DashboardPage() {
   const glucoseValue = glucose?.value ?? null;
   const glucoseTrend = glucose?.trend ?? "Unknown";
   const iob = glucose?.iob?.current ?? null;
-  const minutesAgo = glucose?.minutes_ago ?? null;
-  const isStale = glucose?.is_stale ?? false;
-
-  // Format "last updated" text
-  const getLastUpdatedText = (): string => {
-    if (minutesAgo === null) return "No data";
-    if (minutesAgo < 1) return "Just now";
-    if (minutesAgo === 1) return "1m ago";
-    return `${minutesAgo}m ago`;
-  };
-
-  const getFreshnessText = (): string => {
-    if (!isLive) return "Connecting...";
-    if (isStale) return "Data is stale";
-    return "Data is fresh";
-  };
 
   // Derive in-range pct from detail stats for the metrics card
   const inRangePct = tirStats?.buckets?.find(
@@ -212,19 +255,39 @@ export default function DashboardPage() {
               <p className="text-slate-500 text-xs mt-1">Target: {targetRange}</p>
             </article>
 
-            {/* Last Updated Card */}
-            <article className="bg-white dark:bg-slate-900 rounded-xl p-6 border border-slate-200 dark:border-slate-800">
-              <div className="flex items-center gap-3 mb-2">
-                <div className="p-2 bg-emerald-500/10 rounded-lg">
-                  <Clock className="h-5 w-5 text-emerald-400" aria-hidden="true" />
-                </div>
-                <h3 className="text-slate-500 dark:text-slate-400 text-sm">Last Updated</h3>
-              </div>
-              <p className="text-3xl font-bold text-emerald-400" aria-label={`Last updated: ${getLastUpdatedText()}`}>
-                {getLastUpdatedText()}
-              </p>
-              <p className="text-slate-500 text-xs mt-1">{getFreshnessText()}</p>
-            </article>
+            {/* Data Sources card -- per-source freshness with status
+                pills. Replaces the old single-row "Last Updated" card.
+                Returns null when the user has zero configured sources,
+                in which case the parent grid silently shrinks. */}
+            <DataSourcesFreshnessCard
+              nightscoutConnections={nightscoutConnections}
+              dexcom={dexcomIntegration}
+              tandem={tandemIntegration}
+              now={freshnessNow}
+            />
+            {/* When no sources are configured, fall back to the
+                glucose-stream freshness signal so the grid slot
+                isn't empty during initial onboarding. */}
+            {nightscoutConnections.length === 0 &&
+              !dexcomIntegration &&
+              !tandemIntegration && (
+                <article className="bg-white dark:bg-slate-900 rounded-xl p-6 border border-slate-200 dark:border-slate-800">
+                  <h3 className="text-slate-500 dark:text-slate-400 text-sm mb-2">
+                    Data Sources
+                  </h3>
+                  <p className="text-sm text-slate-500">
+                    No data sources configured yet. Connect a CGM, pump, or
+                    Nightscout instance from{" "}
+                    <a
+                      href="/dashboard/settings/integrations"
+                      className="text-blue-400 hover:underline"
+                    >
+                      Settings → Integrations
+                    </a>
+                    .
+                  </p>
+                </article>
+              )}
           </div>
         </section>
       </AnimatedCard>

--- a/apps/web/src/app/dashboard/settings/integrations/page.tsx
+++ b/apps/web/src/app/dashboard/settings/integrations/page.tsx
@@ -28,8 +28,10 @@ import {
   deleteNightscoutConnection,
   testNightscoutConnection,
   syncNightscoutConnection,
+  patchNightscoutConnection,
   type IntegrationResponse,
   type NightscoutConnectionCreate,
+  type NightscoutConnectionUpdate,
   type NightscoutConnectionResponse,
 } from "@/lib/api";
 import { OfflineBanner } from "@/components/ui/offline-banner";
@@ -284,6 +286,32 @@ export default function IntegrationsPage() {
     }
   };
 
+  const handleUpdateNightscout = async (
+    connectionId: string,
+    patch: NightscoutConnectionUpdate
+  ) => {
+    try {
+      const result = await patchNightscoutConnection(connectionId, patch);
+      // Refetch so the canonical column value replaces any optimistic
+      // override the section component is holding.
+      try {
+        await refetchNightscoutConnections();
+      } catch {
+        // best-effort
+      }
+      return result;
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to update Nightscout connection"
+      );
+      // Re-raise: the section's interval picker rolls back the
+      // optimistic value when this throws.
+      throw err;
+    }
+  };
+
   const handleDisconnectTandem = async () => {
     setError(null);
     setSuccess(null);
@@ -406,6 +434,7 @@ export default function IntegrationsPage() {
           onDelete={handleDeleteNightscout}
           onTest={handleTestNightscout}
           onSync={handleSyncNightscout}
+          onUpdate={handleUpdateNightscout}
         />
       )}
 

--- a/apps/web/src/components/dashboard/data-sources-freshness-card.tsx
+++ b/apps/web/src/components/dashboard/data-sources-freshness-card.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+/**
+ * Multi-source freshness card for the dashboard.
+ *
+ * Replaces the old single-row "Last Updated" card. Renders one row
+ * per active data source (Nightscout connection, Dexcom integration,
+ * Tandem integration) with its `last_synced_at` relative time + a
+ * status pill colored by recency-vs-cadence.
+ *
+ * Color thresholds:
+ * - Slate (Pending): never synced yet (NS `last_sync_status === "never"`
+ *   or no `last_sync_at` for direct integrations).
+ * - Green (Connected): within 2x sync interval. One missed tick is
+ *   tolerated -- the scheduler tick is 1-min granularity + jitter.
+ * - Amber (Lagging): 2x to 5x interval, OR `rate_limited` / `network`.
+ * - Red (Stale/Error): >5x interval, OR `auth_failed` / `unreachable` /
+ *   `error`.
+ *
+ * Direct integrations (Dexcom, Tandem) don't have a per-source
+ * `sync_interval_minutes` -- they use a flat 15m amber / 60m red.
+ *
+ * Returns null when the user has no data sources configured -- no
+ * orphan empty card on the dashboard.
+ */
+
+import { Database } from "lucide-react";
+import clsx from "clsx";
+import type {
+  IntegrationResponse,
+  NightscoutConnectionResponse,
+  NightscoutSyncStatus,
+} from "@/lib/api";
+
+type StaleBand = "pending" | "fresh" | "lagging" | "stale";
+
+const BAND_COLORS: Record<StaleBand, string> = {
+  pending: "text-slate-500 bg-slate-500/10",
+  fresh: "text-green-400 bg-green-500/10",
+  lagging: "text-amber-400 bg-amber-500/10",
+  stale: "text-red-400 bg-red-500/10",
+};
+
+const BAND_LABELS: Record<StaleBand, string> = {
+  pending: "Pending",
+  fresh: "Connected",
+  lagging: "Lagging",
+  stale: "Stale",
+};
+
+// Direct-integration thresholds (no per-source interval available).
+const DIRECT_INTEGRATION_AMBER_MIN = 15;
+const DIRECT_INTEGRATION_RED_MIN = 60;
+
+function formatRelative(iso: string | null, now: number): string {
+  if (!iso) return "never";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "unknown";
+  const minutes = Math.floor((now - then) / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function nightscoutBand(
+  status: NightscoutSyncStatus,
+  lastSyncedIso: string | null,
+  syncIntervalMinutes: number,
+  now: number
+): StaleBand {
+  if (status === "never") return "pending";
+  if (status === "auth_failed" || status === "unreachable" || status === "error") {
+    return "stale";
+  }
+  if (!lastSyncedIso) return "pending";
+  const elapsedMin = (now - new Date(lastSyncedIso).getTime()) / 60_000;
+  if (Number.isNaN(elapsedMin)) return "pending";
+  if (status === "rate_limited" || status === "network") {
+    // Network glitches -- amber regardless of recency.
+    return "lagging";
+  }
+  if (elapsedMin > 5 * syncIntervalMinutes) return "stale";
+  if (elapsedMin > 2 * syncIntervalMinutes) return "lagging";
+  return "fresh";
+}
+
+function directBand(
+  integration: IntegrationResponse,
+  now: number
+): StaleBand {
+  if (integration.status === "error") return "stale";
+  if (integration.status === "pending" || !integration.last_sync_at) {
+    return "pending";
+  }
+  const elapsedMin =
+    (now - new Date(integration.last_sync_at).getTime()) / 60_000;
+  if (Number.isNaN(elapsedMin)) return "pending";
+  if (elapsedMin > DIRECT_INTEGRATION_RED_MIN) return "stale";
+  if (elapsedMin > DIRECT_INTEGRATION_AMBER_MIN) return "lagging";
+  return "fresh";
+}
+
+function StatusPill({ band }: { band: StaleBand }) {
+  return (
+    <span
+      className={clsx(
+        "text-xs font-medium px-2 py-0.5 rounded-full",
+        BAND_COLORS[band]
+      )}
+    >
+      {BAND_LABELS[band]}
+    </span>
+  );
+}
+
+interface DataSourcesFreshnessCardProps {
+  nightscoutConnections: NightscoutConnectionResponse[];
+  dexcom: IntegrationResponse | null;
+  tandem: IntegrationResponse | null;
+  /**
+   * Wall-clock "now" passed in from the parent. Hoisting this up
+   * lets the parent advance it on a setInterval so the component
+   * re-renders without needing to re-fetch from the server.
+   */
+  now: number;
+}
+
+export function DataSourcesFreshnessCard({
+  nightscoutConnections,
+  dexcom,
+  tandem,
+  now,
+}: DataSourcesFreshnessCardProps) {
+  // Only render NS connections that are active (the list endpoint
+  // also returns deactivated rows for history -- those shouldn't
+  // count as freshness sources).
+  const activeNs = nightscoutConnections.filter((c) => c.is_active);
+
+  const directRows: { key: string; label: string; band: StaleBand; relative: string; iso: string | null }[] = [];
+  if (dexcom && dexcom.status !== "disconnected") {
+    directRows.push({
+      key: "dexcom",
+      label: "Dexcom",
+      band: directBand(dexcom, now),
+      relative: formatRelative(dexcom.last_sync_at, now),
+      iso: dexcom.last_sync_at,
+    });
+  }
+  if (tandem && tandem.status !== "disconnected") {
+    directRows.push({
+      key: "tandem",
+      label: "Tandem",
+      band: directBand(tandem, now),
+      relative: formatRelative(tandem.last_sync_at, now),
+      iso: tandem.last_sync_at,
+    });
+  }
+
+  const totalSources = directRows.length + activeNs.length;
+  if (totalSources === 0) {
+    // No configured sources -- don't render an orphan empty card.
+    return null;
+  }
+
+  return (
+    <article
+      className="bg-white dark:bg-slate-900 rounded-xl p-6 border border-slate-200 dark:border-slate-800"
+      aria-label="Data sources"
+    >
+      <div className="flex items-center gap-3 mb-3">
+        <div className="p-2 bg-emerald-500/10 rounded-lg">
+          <Database className="h-5 w-5 text-emerald-400" aria-hidden="true" />
+        </div>
+        <h3 className="text-slate-500 dark:text-slate-400 text-sm">
+          Data Sources
+        </h3>
+      </div>
+      <ul role="list" className="space-y-2">
+        {directRows.map((row) => (
+          <li
+            key={row.key}
+            data-testid={`freshness-row-${row.key}`}
+            className="flex items-center justify-between gap-3 text-sm"
+          >
+            <span className="font-medium text-slate-700 dark:text-slate-200 truncate">
+              {row.label}
+            </span>
+            <div className="flex items-center gap-2 shrink-0">
+              <StatusPill band={row.band} />
+              <span
+                className="text-xs text-slate-500 dark:text-slate-400"
+                title={row.iso ? new Date(row.iso).toLocaleString() : undefined}
+              >
+                {row.relative}
+              </span>
+            </div>
+          </li>
+        ))}
+        {activeNs.map((conn) => {
+          const band = nightscoutBand(
+            conn.last_sync_status,
+            conn.last_synced_at,
+            conn.sync_interval_minutes,
+            now
+          );
+          return (
+            <li
+              key={conn.id}
+              data-testid={`freshness-row-nightscout-${conn.id}`}
+              className="flex items-center justify-between gap-3 text-sm"
+            >
+              <span className="font-medium text-slate-700 dark:text-slate-200 truncate">
+                {conn.name}
+                <span className="ml-1 text-xs text-slate-500 dark:text-slate-400 font-normal">
+                  (Nightscout)
+                </span>
+              </span>
+              <div className="flex items-center gap-2 shrink-0">
+                <StatusPill band={band} />
+                <span
+                  className="text-xs text-slate-500 dark:text-slate-400"
+                  title={
+                    conn.last_synced_at
+                      ? new Date(conn.last_synced_at).toLocaleString()
+                      : undefined
+                  }
+                >
+                  {formatRelative(conn.last_synced_at, now)}
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </article>
+  );
+}

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -83,3 +83,5 @@ export {
   type BolusReviewTableProps,
 } from "./bolus-review-table";
 
+export { DataSourcesFreshnessCard } from "./data-sources-freshness-card";
+

--- a/apps/web/src/components/integrations/nightscout-integrations-section.tsx
+++ b/apps/web/src/components/integrations/nightscout-integrations-section.tsx
@@ -19,11 +19,23 @@ import type {
   NightscoutApiVersion,
   NightscoutAuthType,
   NightscoutConnectionCreate,
+  NightscoutConnectionCreatedResponse,
   NightscoutConnectionResponse,
   NightscoutConnectionTestResult,
+  NightscoutConnectionUpdate,
   NightscoutManualSyncResponse,
   NightscoutSyncStatus,
 } from "@/lib/api";
+
+// Preset cadences. Below 5 min offers diminishing returns (NS
+// uploaders themselves typically push every 5 min); above 60 min is
+// the territory of "low-priority backup connection." Power users who
+// genuinely need a 7-min cadence can hit the API directly.
+const SYNC_INTERVAL_PRESETS_MINUTES = [1, 5, 15, 30, 60] as const;
+
+function formatInterval(minutes: number): string {
+  return minutes < 60 ? `${minutes}m` : `${minutes / 60}h`;
+}
 
 const SYNC_STATUS_LABEL: Record<NightscoutSyncStatus, string> = {
   never: "Pending",
@@ -78,6 +90,10 @@ interface NightscoutIntegrationsSectionProps {
   onDelete: (connectionId: string) => Promise<void>;
   onTest: (connectionId: string) => Promise<NightscoutConnectionTestResult>;
   onSync: (connectionId: string) => Promise<NightscoutManualSyncResponse>;
+  onUpdate: (
+    connectionId: string,
+    patch: NightscoutConnectionUpdate
+  ) => Promise<NightscoutConnectionCreatedResponse>;
 }
 
 export function NightscoutIntegrationsSection({
@@ -87,6 +103,7 @@ export function NightscoutIntegrationsSection({
   onDelete,
   onTest,
   onSync,
+  onUpdate,
 }: NightscoutIntegrationsSectionProps) {
   const [name, setName] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
@@ -101,7 +118,17 @@ export function NightscoutIntegrationsSection({
   const [testingIds, setTestingIds] = useState<Set<string>>(() => new Set());
   const [syncingIds, setSyncingIds] = useState<Set<string>>(() => new Set());
   const [deletingIds, setDeletingIds] = useState<Set<string>>(() => new Set());
+  const [updatingIds, setUpdatingIds] = useState<Set<string>>(() => new Set());
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  // Optimistic override of `sync_interval_minutes` per connection.
+  // Click reflects the chosen chip immediately; on PATCH success we
+  // clear the override (parent will refetch with the canonical value);
+  // on failure we clear the override + surface the error in the live
+  // region. Map keyed by connection id so cross-row clicks don't race.
+  const [intervalOverride, setIntervalOverride] = useState<
+    Record<string, number>
+  >({});
 
   // True when ANY action is in flight on this connection -- used to
   // disable the row's other action buttons too. Avoids "test while
@@ -109,7 +136,8 @@ export function NightscoutIntegrationsSection({
   const isBusy = (connectionId: string) =>
     testingIds.has(connectionId) ||
     syncingIds.has(connectionId) ||
-    deletingIds.has(connectionId);
+    deletingIds.has(connectionId) ||
+    updatingIds.has(connectionId);
 
   const addToSet =
     (setter: Dispatch<SetStateAction<Set<string>>>) => (id: string) =>
@@ -272,6 +300,48 @@ export function NightscoutIntegrationsSection({
     }
   };
 
+  const handleIntervalChange = async (
+    connectionId: string,
+    minutes: number
+  ) => {
+    // Optimistic: reflect chosen chip immediately so the click feels
+    // instant. Roll back if the PATCH fails.
+    setIntervalOverride((prev) => ({ ...prev, [connectionId]: minutes }));
+    addToSet(setUpdatingIds)(connectionId);
+    setPerConnectionResult((prev) => {
+      const { [connectionId]: _drop, ...rest } = prev;
+      return rest;
+    });
+    try {
+      await onUpdate(connectionId, { sync_interval_minutes: minutes });
+      // Parent refetches the list; canonical interval will replace the
+      // override on next render. Clear the override so the row falls
+      // back to the server-sourced value.
+      setIntervalOverride((prev) => {
+        const { [connectionId]: _drop, ...rest } = prev;
+        return rest;
+      });
+    } catch (err) {
+      // Roll back the optimistic value.
+      setIntervalOverride((prev) => {
+        const { [connectionId]: _drop, ...rest } = prev;
+        return rest;
+      });
+      setPerConnectionResult((prev) => ({
+        ...prev,
+        [connectionId]: {
+          ok: false,
+          message:
+            err instanceof Error
+              ? err.message
+              : "Failed to update sync interval",
+        },
+      }));
+    } finally {
+      removeFromSet(setUpdatingIds)(connectionId);
+    }
+  };
+
   return (
     <CollapsibleSection title="Third-Party Integrations" icon={Cloud}>
       <div className="space-y-4">
@@ -339,12 +409,59 @@ export function NightscoutIntegrationsSection({
                                 "never"
                               )}
                             </span>
-                            <span>Every {conn.sync_interval_minutes} min</span>
                             <span>
                               {conn.api_version === "auto"
                                 ? "Auto API"
                                 : `API ${conn.api_version}`}
                             </span>
+                          </div>
+
+                          <div className="mt-2 flex items-center gap-2 flex-wrap">
+                            <span
+                              className="text-xs text-slate-500 dark:text-slate-400"
+                              id={`ns-interval-label-${conn.id}`}
+                            >
+                              Sync every:
+                            </span>
+                            <div
+                              role="radiogroup"
+                              aria-labelledby={`ns-interval-label-${conn.id}`}
+                              className="flex gap-1 flex-wrap"
+                            >
+                              {SYNC_INTERVAL_PRESETS_MINUTES.map((m) => {
+                                const current =
+                                  intervalOverride[conn.id] ??
+                                  conn.sync_interval_minutes;
+                                const selected = current === m;
+                                const updating = updatingIds.has(conn.id);
+                                return (
+                                  <button
+                                    key={m}
+                                    type="button"
+                                    role="radio"
+                                    aria-checked={selected}
+                                    onClick={() =>
+                                      !selected &&
+                                      handleIntervalChange(conn.id, m)
+                                    }
+                                    disabled={isOffline || updating || selected}
+                                    data-testid={`nightscout-interval-${conn.id}-${m}`}
+                                    className={clsx(
+                                      "px-2 py-0.5 rounded-full text-xs font-medium transition-colors",
+                                      "border",
+                                      selected
+                                        ? "border-blue-500/50 bg-blue-500/10 text-blue-400"
+                                        : "border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800",
+                                      "disabled:cursor-not-allowed",
+                                      !selected &&
+                                        "disabled:opacity-50"
+                                    )}
+                                  >
+                                    {formatInterval(m)}
+                                  </button>
+                                );
+                              })}
+                            </div>
                           </div>
                           {conn.last_sync_error && (
                             <p

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2042,6 +2042,46 @@ export async function deleteNightscoutConnection(
   }
 }
 
+// PATCH body for `update_connection`. The backend re-tests the
+// connection ONLY when url / credential / auth_type / api_version
+// change (see apps/api/src/routers/nightscout.py:292). Sending only
+// `sync_interval_minutes` (the picker's payload) is a fast in-place
+// update with no network round-trip to the user's NS instance --
+// safe to fire on every chip click.
+export interface NightscoutConnectionUpdate {
+  name?: string;
+  base_url?: string;
+  auth_type?: NightscoutAuthType;
+  credential?: string;
+  api_version?: NightscoutApiVersion;
+  is_active?: boolean;
+  sync_interval_minutes?: number;
+  initial_sync_window_days?: number;
+}
+
+export async function patchNightscoutConnection(
+  connectionId: string,
+  body: NightscoutConnectionUpdate
+): Promise<NightscoutConnectionCreatedResponse> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/integrations/nightscout/${encodeURIComponent(
+      connectionId
+    )}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to update Nightscout connection: ${response.status}`
+    );
+  }
+  return response.json();
+}
+
 // ============================================================================
 // Story 18.3: Tandem Cloud Upload
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes the final pieces of the Nightscout setup-wizard UX:

1. **Sync interval picker** on each connection card — 5 preset chips (1m / 5m / 15m / 30m / 1h). Pre-PR, `sync_interval_minutes` was stuck at the 5-min default unless edited via PATCH directly.
2. **Per-source "Data Sources" card** on the dashboard, replacing the old single-row "Last Updated" card. One row per active integration with a status pill colored by recency-vs-cadence so users with multiple data sources can spot which one is stale.

## Architecture decisions

**Picker**: chip-style radiogroup, optimistic save on click, rolls back to server value on error. Mirrors the existing Test/Sync/Delete pattern. Backend re-tests the upstream NS instance only when URL/credential/auth/api_version change (verified at `routers/nightscout.py:292`), so a `sync_interval_minutes`-only PATCH is a fast in-place update.

**Freshness card**: pure projection of props. Parent dashboard owns the fetch + a `freshnessNow` state advanced every 30s — the card itself has no timers or network calls. 30s (not 60s) so the worst-case "lagging" flash before the 1-min scheduler fires is bounded.

| Status | Threshold | Color |
|---|---|---|
| Pending | `last_sync_status === "never"` | Slate |
| Connected | `< 2× sync_interval_minutes` (NS) or `< 15m` (Dexcom/Tandem) | Green |
| Lagging | `2×-5× interval` OR `rate_limited` / `network` | Amber |
| Stale | `> 5× interval` OR `auth_failed` / `unreachable` / `error`, or `> 60m` for direct integrations | Red |

Hidden when zero sources are configured; an empty-state fallback in the dashboard grid points users to Settings → Integrations so the slot isn't visually empty during onboarding.

## Verification

- **790 passing / 0 failed** (full Jest suite, 38 suites)
- **11 new tests** in `data-sources-freshness-card.test.tsx` cover every stale band, the `auth_failed` / `rate_limited` / `network` status overrides, inactive NS exclusion, multi-source mixed states, direct-integration thresholds, and the empty-state null render.
- **2 dashboard accessibility tests** updated for "Data Sources" h3 + region in place of "Last Updated".
- **2 settings test mocks** updated so the integrations page renders without a missing `patchNightscoutConnection` export.
- **ESLint + tsc** clean across changed files.
- **API round-trip verified**: created an NS connection, PATCH'd `sync_interval_minutes` from 5 to 15, confirmed via subsequent GET that the column updated. Endpoint returns 200 without re-testing the upstream connection.

## Test plan

- [x] `npx tsc --noEmit` clean for changed files
- [x] `npx eslint` clean for changed files
- [x] Full Jest suite: 790 / 0 / 0
- [x] API round-trip for the picker payload

## Risks / known caveats

1. **30s refresh racing the 1-min scheduler tick.** A user could see "Lagging" flash for ~30s right before the scheduler fires. Acceptable; converges within one refresh.
2. **Cross-tab optimistic conflicts on the picker.** Tab A picks 5m, Tab B picks 30m a moment later — both PATCH, last write wins, A's display is wrong until next refetch. Both tabs converge on next list-fetch; backend state is correct.
3. **Picker disabled during any in-flight row action.** Adds friction if a user wants to change interval *during* a sync. Trade-off accepted — avoids dispatching a PATCH while a sync is mutating `last_synced_at`.

## Closes

Story 43.5 phase 3 (final pieces). Story 43.5 is now fully complete (phase 1: connection management UI in #575; phase 3: this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard now displays a "Data Sources" card showing freshness status for each configured integration (Nightscout, Dexcom, Tandem) with real-time sync indicators (Connected, Lagging, Stale, Pending).
  * Users can now update Nightscout sync intervals directly from the Integrations settings page using preset options.

* **Tests**
  * Added comprehensive test coverage for data source freshness tracking and offline integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->