### PR TITLE
fix(nightscout): scheduler tick wall budget + test fixture hardening

### DIFF
--- a/apps/api/src/services/integrations/nightscout/scheduler.py
+++ b/apps/api/src/services/integrations/nightscout/scheduler.py
@@ -72,6 +72,19 @@ _PAUSED_STATUSES = frozenset({NightscoutSyncStatus.AUTH_FAILED})
 # also indirectly bound DB-pool and FD pressure.
 _MAX_PARALLEL_SYNCS = 8
 
+# Hard ceiling on how long a single scheduler tick may spend in the
+# parallel sync phase. APScheduler is configured with `coalesce=True`
+# and `max_instances=1`, so a tick that runs longer than its base
+# interval (default 60s) silently delays the next tick. This budget
+# is the contract: at this many seconds, in-flight syncs are
+# cancelled and the tick returns. The cancelled connections will be
+# re-discovered as due on the next tick (their `last_synced_at` is
+# only updated on success), so no data is lost.
+#
+# Set below the default 60s tick interval so even a maximally slow
+# tick doesn't push past the next scheduled fire.
+_TICK_WALL_BUDGET_SECONDS = 45.0
+
 
 async def run_nightscout_sync_all_users() -> None:
     """One tick of the scheduler.
@@ -129,10 +142,52 @@ async def run_nightscout_sync_all_users() -> None:
         async with sem:
             return await _sync_one(session_maker, conn_id, user_id)
 
-    statuses = await asyncio.gather(
-        *(_bounded(cid, uid) for (cid, uid) in due_ids),
-        return_exceptions=False,
-    )
+    gather_started = datetime.now(UTC)
+    try:
+        statuses = await asyncio.wait_for(
+            asyncio.gather(
+                *(_bounded(cid, uid) for (cid, uid) in due_ids),
+                return_exceptions=False,
+            ),
+            timeout=_TICK_WALL_BUDGET_SECONDS,
+        )
+    except TimeoutError:
+        # Past the wall budget. Cancellation propagates to every
+        # in-flight `_sync_one` via the gather; any partial DB writes
+        # roll back when their session context exits. Each cancelled
+        # connection's `last_synced_at` was not advanced, so the next
+        # tick will pick it up again -- no data lost, just a missed
+        # cycle. Don't raise: APScheduler would log + skip the next
+        # tick as a side-effect.
+        #
+        # Trade-off: a `_sync_one` that already classified a real
+        # failure (e.g. AUTH_FAILED) and was about to commit a
+        # `last_sync_status` update can have that write rolled back
+        # by cancellation. The next tick re-runs the same connection
+        # and is expected to reproduce the same failure classification,
+        # so the status field self-heals on the next cycle.
+        gather_duration_ms = int(
+            (datetime.now(UTC) - gather_started).total_seconds() * 1000
+        )
+        logger.warning(
+            "nightscout_scheduler_tick_budget_exceeded",
+            due_count=len(due_ids),
+            budget_seconds=_TICK_WALL_BUDGET_SECONDS,
+            gather_duration_ms=gather_duration_ms,
+            tick_duration_ms=int((datetime.now(UTC) - started).total_seconds() * 1000),
+        )
+        # Always emit `tick_completed` so dashboards / alerting that
+        # count one per tick don't see a gap on overrun.
+        logger.info(
+            "nightscout_scheduler_tick_completed",
+            due_count=len(due_ids),
+            success=0,
+            failures=0,
+            cancelled=len(due_ids),
+            partial=True,
+            duration_ms=int((datetime.now(UTC) - started).total_seconds() * 1000),
+        )
+        return
 
     success = sum(1 for s in statuses if s is True)
     failures = sum(1 for s in statuses if s is False)

--- a/apps/api/tests/test_nightscout_scheduler.py
+++ b/apps/api/tests/test_nightscout_scheduler.py
@@ -92,8 +92,15 @@ class TestClampedInterval:
 async def scheduler_ctx() -> AsyncGenerator[tuple[AsyncSession, uuid.UUID], None]:
     """Provide a session + a user that owns several test connections.
 
-    Mirrors the pattern used by other Nightscout test files -- own
-    session_maker so cross-loop teardown noise stays cosmetic.
+    Cleanup uses a *fresh* session from the session_maker rather than
+    reusing the test's session: a poisoned session from a cross-loop
+    teardown would silently swallow the DELETEs otherwise, leaving
+    @example.com user rows + their connections accumulating in the
+    dev DB. Each leaked row then shows up in the scheduler's
+    discovery query on every tick, dilating wall-clock tick duration.
+    Cleanup failures here surface loudly via re-raise so future
+    leaks are caught at the source instead of masquerading as a
+    slow scheduler.
     """
     session_maker = get_session_maker()
     session = session_maker()
@@ -103,28 +110,28 @@ async def scheduler_ctx() -> AsyncGenerator[tuple[AsyncSession, uuid.UUID], None
     await session.flush()
     user_id = user.id
     await session.commit()
+
     try:
         yield session, user_id
     finally:
+        # Close the test's session first. A close-failure here is
+        # benign (it usually means the test's loop already shut down)
+        # so we swallow it. The DELETE/COMMIT path below uses a fresh
+        # session and is NOT swallowed -- a real cleanup failure must
+        # surface so future leaks don't silently accumulate.
         try:
-            await session.rollback()
-            await session.execute(
+            await session.close()
+        except Exception:
+            pass
+
+        async with session_maker() as cleanup:
+            await cleanup.execute(
                 delete(NightscoutConnection).where(
                     NightscoutConnection.user_id == user_id
                 )
             )
-            await session.execute(delete(User).where(User.id == user_id))
-            await session.commit()
-        except Exception:
-            # Broad catch on cleanup: a SQLAlchemy / asyncpg cross-loop
-            # error here would otherwise mask the real test failure.
-            # Cosmetic noise during teardown is the price.
-            pass
-        finally:
-            try:
-                await session.close()
-            except Exception:
-                pass
+            await cleanup.execute(delete(User).where(User.id == user_id))
+            await cleanup.commit()
 
 
 def _mk_connection(
@@ -314,6 +321,65 @@ class TestRunNightscoutSyncAllUsers:
             await run_nightscout_sync_all_users()
 
         assert synced_ok_for_test_user == {a_id, c_id}
+
+    @pytest.mark.asyncio
+    async def test_tick_budget_exceeded_cancels_in_flight_syncs(
+        self, scheduler_ctx, monkeypatch
+    ):
+        """Slow upstream cannot extend a tick past the wall budget.
+
+        APScheduler is configured `coalesce=True, max_instances=1`,
+        so a tick that runs longer than its base interval delays
+        every subsequent tick by the overrun. The budget cap
+        prevents a slow upstream from silently dilating the
+        scheduler.
+        """
+        import asyncio as _asyncio
+
+        from src.services.integrations.nightscout import scheduler as sched_mod
+
+        # 2.0s gives discovery + `_sync_one`'s refetch generous
+        # headroom even on a slow CI runner before fake_sync's sleep
+        # traps. fake_sync sleeps 10s so the budget still fires
+        # comfortably in the middle.
+        monkeypatch.setattr(sched_mod, "_TICK_WALL_BUDGET_SECONDS", 2.0)
+
+        session, user_id = scheduler_ctx
+        slow = _mk_connection(user_id, name="slow-conn")
+        session.add(slow)
+        await session.commit()
+        slow_id = slow.id
+
+        entered_fake_sync = _asyncio.Event()
+        cancelled_for_test_user: list[uuid.UUID] = []
+        completed_for_test_user: list[uuid.UUID] = []
+
+        async def fake_sync(_session, conn):
+            if conn.user_id != user_id:
+                return _ok_result(conn.id)
+            entered_fake_sync.set()
+            try:
+                await _asyncio.sleep(10.0)  # well past the budget
+                completed_for_test_user.append(conn.id)
+                return _ok_result(conn.id)
+            except _asyncio.CancelledError:
+                cancelled_for_test_user.append(conn.id)
+                raise
+
+        with patch(
+            "src.services.integrations.nightscout.scheduler.sync_nightscout_for_connection",
+            side_effect=fake_sync,
+        ):
+            # Must NOT raise -- budget exceedance is logged + swallowed.
+            await run_nightscout_sync_all_users()
+
+        # If fake_sync was reached at all, the slow path must have been
+        # cancelled (never completed).
+        assert entered_fake_sync.is_set(), (
+            "fake_sync was never entered; widen the budget so the test exercises cancellation"
+        )
+        assert slow_id in cancelled_for_test_user
+        assert slow_id not in completed_for_test_user
 
     @pytest.mark.asyncio
     async def test_no_connections_for_test_user_means_no_call(self, scheduler_ctx):

--- a/apps/api/tests/test_nightscout_scheduler.py
+++ b/apps/api/tests/test_nightscout_scheduler.py
@@ -338,11 +338,11 @@ class TestRunNightscoutSyncAllUsers:
 
         from src.services.integrations.nightscout import scheduler as sched_mod
 
-        # 2.0s gives discovery + `_sync_one`'s refetch generous
-        # headroom even on a slow CI runner before fake_sync's sleep
-        # traps. fake_sync sleeps 10s so the budget still fires
-        # comfortably in the middle.
-        monkeypatch.setattr(sched_mod, "_TICK_WALL_BUDGET_SECONDS", 2.0)
+        # 5s budget gives discovery + `_sync_one`'s refetch wide
+        # headroom on slow CI before fake_sync's sleep traps. The 6x
+        # gap to the 30s sleep ensures the budget fires comfortably
+        # mid-sleep.
+        monkeypatch.setattr(sched_mod, "_TICK_WALL_BUDGET_SECONDS", 5.0)
 
         session, user_id = scheduler_ctx
         slow = _mk_connection(user_id, name="slow-conn")
@@ -359,7 +359,7 @@ class TestRunNightscoutSyncAllUsers:
                 return _ok_result(conn.id)
             entered_fake_sync.set()
             try:
-                await _asyncio.sleep(10.0)  # well past the budget
+                await _asyncio.sleep(30.0)  # well past the budget
                 completed_for_test_user.append(conn.id)
                 return _ok_result(conn.id)
             except _asyncio.CancelledError:


### PR DESCRIPTION
## Summary

The Nightscout sync scheduler tick was running 70+ seconds in dev because 72 stale `@example.com` test connections had accumulated in the DB across many test runs. Each leaked row appeared as "due" in every tick, hammering `example.com` (the test fixture's `base_url`) and dilating wall-clock duration of the discovery + sync phases. Two fixes here so this can't recur.

### 1. Wall-clock budget cap on the parallel sync phase

`run_nightscout_sync_all_users` now wraps the parallel `asyncio.gather` in `asyncio.wait_for(..., timeout=45)`. If the budget is exceeded, in-flight syncs are cancelled and the tick returns. Cancelled connections re-sync on the next tick because their `last_synced_at` is only advanced on success — no data lost, just a missed cycle.

- Budget set to 45s, comfortably below the default 60s tick interval. APScheduler is configured `coalesce=True / max_instances=1`, so a tick exceeding its base interval would otherwise silently delay every subsequent tick.
- On overrun: emits both a `nightscout_scheduler_tick_budget_exceeded` warning (with separate `gather_duration_ms` and `tick_duration_ms` so dashboards can distinguish discovery overhead from sync overhead) AND a `nightscout_scheduler_tick_completed` info event with `partial=true, cancelled=N`. Anything counting one `tick_completed` per scheduled tick continues to see one.
- Trade-off documented in code: a `_sync_one` that already classified a real upstream failure (e.g. AUTH_FAILED) and was about to commit a `last_sync_status` update can have that write rolled back by cancellation. The next tick re-runs the same connection and is expected to reproduce the same failure classification, so the status field self-heals on the next cycle.

### 2. Test fixture hardening for `scheduler_ctx`

Cleanup now opens a fresh session from the `session_maker` rather than reusing the test's session. A poisoned session from cross-loop teardown would have silently swallowed the DELETE under the previous `try/except Exception: pass` pattern — that is exactly how the leak originally formed. DELETE / COMMIT failures here now re-raise so any future leak surfaces immediately at test time instead of slowly poisoning the dev DB.

The test's `session.close()` swallow remains (a closed-loop close-failure is benign), but is the only swallow on the cleanup path and is documented as such.

### Test coverage

New test `test_tick_budget_exceeded_cancels_in_flight_syncs` exercises the budget cap with a monkeypatched 5s budget and a 30s `fake_sync` sleep. The 6× ratio gives slow CI runners ample headroom for DB discovery + `_sync_one` refetch before the cancellation path fires. All 14 existing tests in `test_nightscout_scheduler.py` continue to pass; broader 54-test Nightscout suite (`test_nightscout_scheduler` + `test_nightscout_sync` + `test_nightscout_connection`) green.

## Test plan

- [x] `pytest apps/api/tests/test_nightscout_scheduler.py` — 15/15 pass
- [x] `pytest apps/api/tests/test_nightscout_sync.py apps/api/tests/test_nightscout_connection.py` — 39/39 pass
- [x] `ruff check` + `ruff format --check` clean
- [x] Manual scheduler observation: dev DB cleaned up; subsequent ticks complete in <100ms
- [x] Cancellation path verified: budget overrun logs both `_budget_exceeded` (warning) and `_completed` (info, `partial=true`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Nightscout synchronization scheduler now enforces a configurable time limit to prevent long-running syncs from blocking future scheduled cycles. If a sync cycle exceeds the timeout, in-flight operations are automatically cancelled and a warning is logged.

* **Tests**
  * Added test coverage to verify the scheduler properly cancels long-running sync operations when they exceed the configured time budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->