### PR TITLE
feat(dev): AAPS v1 lens + extractor handles openaps.enacted.rate

### DIFF
--- a/apps/api/src/services/integrations/nightscout/_pump_status_extractor.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_status_extractor.py
@@ -113,14 +113,23 @@ def _should_emit(
 
 
 def _extract_enacted_basal_rate(ds: NightscoutDeviceStatus) -> float | None:
-    """Pull the most recently enacted temp basal rate from whichever
+    """Pull the most recently ENACTED temp basal rate from whichever
     subtree carries it.
 
     Sources, in priority order:
     - Loop:  `loop.enacted.rate`        (Apple iPhone closed-loop)
     - oref0 / AAPS / Trio: `openaps.enacted.rate`   (oref-derived)
-      Falls back to `openaps.suggested.rate` when there's no enacted
-      record (loop didn't dose this cycle but suggested a rate).
+
+    Deliberately does NOT fall back to `openaps.suggested.rate` --
+    `suggested` is what the algorithm wanted to do, `enacted` is
+    what the pump actually delivered. Conflating the two would write
+    a "suggested but never delivered" rate as if it were enacted,
+    which misrepresents pump behavior in stored data and could
+    mislead downstream consumers reading from `pump_events`. When
+    there's no enacted record this cycle (loop failure, pump
+    disconnect, dry run), we leave the prior BASAL row in place
+    and emit nothing -- the dashboard correctly shows the most
+    recent enacted rate.
 
     Returns None when:
     - Neither subtree carries an enacted rate
@@ -137,13 +146,6 @@ def _extract_enacted_basal_rate(ds: NightscoutDeviceStatus) -> float | None:
         enacted = ds.openaps.get("enacted")
         if isinstance(enacted, dict):
             rate = enacted.get("rate")
-            if isinstance(rate, int | float) and not isinstance(rate, bool):
-                return float(rate)
-        # Fallback: suggested rate is what the algorithm wanted to do
-        # if for whatever reason it didn't record an enacted record.
-        suggested = ds.openaps.get("suggested")
-        if isinstance(suggested, dict):
-            rate = suggested.get("rate")
             if isinstance(rate, int | float) and not isinstance(rate, bool):
                 return float(rate)
     return None

--- a/apps/api/src/services/integrations/nightscout/_pump_status_extractor.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_status_extractor.py
@@ -112,22 +112,40 @@ def _should_emit(
     return (new_ts - last_ts).total_seconds() >= _MIN_INTERVAL_SECONDS
 
 
-def _extract_loop_enacted_rate(ds: NightscoutDeviceStatus) -> float | None:
-    """Loop's `loop.enacted.rate` carries the most recent enacted temp.
+def _extract_enacted_basal_rate(ds: NightscoutDeviceStatus) -> float | None:
+    """Pull the most recently enacted temp basal rate from whichever
+    subtree carries it.
+
+    Sources, in priority order:
+    - Loop:  `loop.enacted.rate`        (Apple iPhone closed-loop)
+    - oref0 / AAPS / Trio: `openaps.enacted.rate`   (oref-derived)
+      Falls back to `openaps.suggested.rate` when there's no enacted
+      record (loop didn't dose this cycle but suggested a rate).
 
     Returns None when:
-    - There's no `loop` subtree (oref0 / AAPS-only payload)
-    - There's no `enacted` (loop.failureReason path)
+    - Neither subtree carries an enacted rate
     - `enacted.rate` is missing or non-numeric
+    - The subtree is shaped wrong (`enacted` is a string, etc.)
     """
-    if not ds.loop:
-        return None
-    enacted = ds.loop.get("enacted")
-    if not isinstance(enacted, dict):
-        return None
-    rate = enacted.get("rate")
-    if isinstance(rate, int | float) and not isinstance(rate, bool):
-        return float(rate)
+    if ds.loop:
+        enacted = ds.loop.get("enacted")
+        if isinstance(enacted, dict):
+            rate = enacted.get("rate")
+            if isinstance(rate, int | float) and not isinstance(rate, bool):
+                return float(rate)
+    if ds.openaps:
+        enacted = ds.openaps.get("enacted")
+        if isinstance(enacted, dict):
+            rate = enacted.get("rate")
+            if isinstance(rate, int | float) and not isinstance(rate, bool):
+                return float(rate)
+        # Fallback: suggested rate is what the algorithm wanted to do
+        # if for whatever reason it didn't record an enacted record.
+        suggested = ds.openaps.get("suggested")
+        if isinstance(suggested, dict):
+            rate = suggested.get("rate")
+            if isinstance(rate, int | float) and not isinstance(rate, bool):
+                return float(rate)
     return None
 
 
@@ -191,7 +209,7 @@ def extract_pump_events_from_devicestatuses(
 
         battery_pct = ds.pump_battery_percent
         reservoir_units = ds.pump_reservoir
-        basal_rate = _extract_loop_enacted_rate(ds)
+        basal_rate = _extract_enacted_basal_rate(ds)
         iob_value = ds.iob_value
         cob_value = _extract_cob_value(ds)
 

--- a/apps/api/tests/test_nightscout_pump_status_extractor.py
+++ b/apps/api/tests/test_nightscout_pump_status_extractor.py
@@ -388,8 +388,13 @@ class TestExtractor:
 
 class TestOpenapsBasalExtraction:
     """The extractor reads `loop.enacted.rate` for Loop and falls
-    back to `openaps.enacted.rate` (then `openaps.suggested.rate`)
-    for AAPS / oref0 / Trio. Without this fallback, the dashboard's
+    back to `openaps.enacted.rate` for AAPS / oref0 / Trio. It
+    deliberately does NOT fall back to `openaps.suggested.rate` --
+    `suggested` is what the algorithm wanted, `enacted` is what
+    actually happened, and conflating them in `pump_events` would
+    misrepresent what the pump did (medical-data integrity). The
+    `test_openaps_suggested_only_does_not_emit_basal` test below
+    asserts this. Without the enacted fallback, the dashboard's
     basal-rate widget renders empty for any non-Loop NS user."""
 
     def test_openaps_enacted_rate_emits_basal_row(self):

--- a/apps/api/tests/test_nightscout_pump_status_extractor.py
+++ b/apps/api/tests/test_nightscout_pump_status_extractor.py
@@ -81,6 +81,46 @@ def _make_ds(
     return NightscoutDeviceStatus.model_validate(raw)
 
 
+def _make_aaps_ds(
+    *,
+    ds_id: str,
+    when: datetime,
+    enacted_rate: float | None = None,
+    suggested_rate: float | None = None,
+    iob: float | None = None,
+    cob: float | None = None,
+) -> NightscoutDeviceStatus:
+    """Build an AAPS / oref / Trio-shaped devicestatus -- openaps
+    subtree, no loop subtree. Used to verify the basal-rate
+    extractor's openaps fallback path.
+    """
+    raw = {
+        "_id": ds_id,
+        "device": "openaps://AndroidAPS",
+        "created_at": when.isoformat().replace("+00:00", "Z"),
+    }
+    openaps: dict = {}
+    if iob is not None:
+        openaps["iob"] = {"iob": iob, "time": raw["created_at"]}
+    if enacted_rate is not None:
+        openaps["enacted"] = {
+            "rate": enacted_rate,
+            "duration": 30,
+            "timestamp": raw["created_at"],
+            "received": True,
+        }
+    if suggested_rate is not None:
+        openaps["suggested"] = {
+            "rate": suggested_rate,
+            "duration": 30,
+            "deliverAt": raw["created_at"],
+            **({"COB": cob} if cob is not None else {}),
+        }
+    if openaps:
+        raw["openaps"] = openaps
+    return NightscoutDeviceStatus.model_validate(raw)
+
+
 # ---------------------------------------------------------------------------
 # extract_pump_events_from_devicestatuses
 # ---------------------------------------------------------------------------
@@ -339,6 +379,84 @@ class TestExtractor:
         # min-interval gate fires. This is the documented hazard of
         # passing unsorted input.
         assert [r["ns_id"] for r in battery_rows] == ["ds-late:battery"]
+
+
+# ---------------------------------------------------------------------------
+# Basal extraction: openaps fallback (AAPS / oref0 / Trio path)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenapsBasalExtraction:
+    """The extractor reads `loop.enacted.rate` for Loop and falls
+    back to `openaps.enacted.rate` (then `openaps.suggested.rate`)
+    for AAPS / oref0 / Trio. Without this fallback, the dashboard's
+    basal-rate widget renders empty for any non-Loop NS user."""
+
+    def test_openaps_enacted_rate_emits_basal_row(self):
+        ds = _make_aaps_ds(
+            ds_id="ds1",
+            when=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+            enacted_rate=0.8,
+            iob=2.3,
+        )
+        rows = extract_pump_events_from_devicestatuses(
+            [ds], user_id="u1", source="nightscout:c1", last_state={}
+        )
+        basal_rows = [r for r in rows if r["event_type"] == PumpEventType.BASAL]
+        assert len(basal_rows) == 1
+        assert basal_rows[0]["units"] == 0.8
+
+    def test_openaps_suggested_rate_used_when_no_enacted(self):
+        """If the loop didn't dose this cycle (failureReason / dry
+        run), AAPS still posts `suggested.rate`. Use it as the most
+        recent intent."""
+        ds = _make_aaps_ds(
+            ds_id="ds1",
+            when=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+            suggested_rate=1.2,
+            iob=2.3,
+        )
+        rows = extract_pump_events_from_devicestatuses(
+            [ds], user_id="u1", source="nightscout:c1", last_state={}
+        )
+        basal_rows = [r for r in rows if r["event_type"] == PumpEventType.BASAL]
+        assert len(basal_rows) == 1
+        assert basal_rows[0]["units"] == 1.2
+
+    def test_loop_subtree_takes_precedence_over_openaps(self):
+        """Mixed payload (devicestatus from a Loop user with an
+        openaps-like wrapper for some reason): loop.enacted wins."""
+        raw = {
+            "_id": "ds1",
+            "device": "loop://iPhone",
+            "created_at": "2026-05-01T12:00:00Z",
+            "loop": {
+                "enacted": {"rate": 0.8, "duration": 30},
+                "iob": {"iob": 2.0},
+            },
+            "openaps": {
+                "enacted": {"rate": 99.0, "duration": 30},  # bogus
+            },
+        }
+        ds = NightscoutDeviceStatus.model_validate(raw)
+        rows = extract_pump_events_from_devicestatuses(
+            [ds], user_id="u1", source="nightscout:c1", last_state={}
+        )
+        basal_rows = [r for r in rows if r["event_type"] == PumpEventType.BASAL]
+        assert len(basal_rows) == 1
+        assert basal_rows[0]["units"] == 0.8
+
+    def test_no_basal_when_neither_subtree_has_rate(self):
+        ds = _make_aaps_ds(
+            ds_id="ds1",
+            when=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+            iob=2.3,  # has IoB but no rate anywhere
+        )
+        rows = extract_pump_events_from_devicestatuses(
+            [ds], user_id="u1", source="nightscout:c1", last_state={}
+        )
+        basal_rows = [r for r in rows if r["event_type"] == PumpEventType.BASAL]
+        assert basal_rows == []
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_nightscout_pump_status_extractor.py
+++ b/apps/api/tests/test_nightscout_pump_status_extractor.py
@@ -406,10 +406,12 @@ class TestOpenapsBasalExtraction:
         assert len(basal_rows) == 1
         assert basal_rows[0]["units"] == 0.8
 
-    def test_openaps_suggested_rate_used_when_no_enacted(self):
-        """If the loop didn't dose this cycle (failureReason / dry
-        run), AAPS still posts `suggested.rate`. Use it as the most
-        recent intent."""
+    def test_openaps_suggested_only_does_not_emit_basal(self):
+        """Medical data integrity: `suggested` is what the algorithm
+        wanted to do, `enacted` is what actually happened. We must
+        not write a suggested-but-never-delivered rate as if it were
+        enacted -- that would misrepresent pump behavior in
+        `pump_events`."""
         ds = _make_aaps_ds(
             ds_id="ds1",
             when=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
@@ -420,8 +422,32 @@ class TestOpenapsBasalExtraction:
             [ds], user_id="u1", source="nightscout:c1", last_state={}
         )
         basal_rows = [r for r in rows if r["event_type"] == PumpEventType.BASAL]
+        assert basal_rows == []
+
+    def test_loop_enacted_missing_rate_falls_through_to_openaps(self):
+        """Defensive: if `loop.enacted` is present but `rate` is
+        missing/non-numeric (corrupt or dry-run record), we should
+        fall through to openaps rather than emit nothing.
+        """
+        raw = {
+            "_id": "ds1",
+            "device": "loop://iPhone",
+            "created_at": "2026-05-01T12:00:00Z",
+            "loop": {
+                "enacted": {"duration": 30},  # rate field absent
+                "iob": {"iob": 2.0},
+            },
+            "openaps": {
+                "enacted": {"rate": 1.5, "duration": 30, "received": True},
+            },
+        }
+        ds = NightscoutDeviceStatus.model_validate(raw)
+        rows = extract_pump_events_from_devicestatuses(
+            [ds], user_id="u1", source="nightscout:c1", last_state={}
+        )
+        basal_rows = [r for r in rows if r["event_type"] == PumpEventType.BASAL]
         assert len(basal_rows) == 1
-        assert basal_rows[0]["units"] == 1.2
+        assert basal_rows[0]["units"] == 1.5
 
     def test_loop_subtree_takes_precedence_over_openaps(self):
         """Mixed payload (devicestatus from a Loop user with an

--- a/dev/README.md
+++ b/dev/README.md
@@ -171,7 +171,24 @@ those entries become "past" relative to whatever query reads them.
 | `NS_RANDOM_SEED` | unset | Set int for reproducible runs |
 | `NS_STARTING_BG` | `120` | Initial blood-glucose value |
 
-Per-lens tunables are documented inside each lens module.
+### Per-lens tunables
+
+#### `aaps_v1`
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NS_AAPS_UPLOAD_TEMP_BASALS` | `false` | When `true`, the AAPS lens posts a Temp Basal treatment every loop cycle (matches AAPS users who enable "Upload temp basals" in NSClient settings). Default off because survey of real-world AAPS fixtures shows most users keep it off for NS quota / privacy reasons. Turn on for exhaustive temp-basal mapper coverage. |
+
+The AAPS lens emits, on its own schedule:
+- **Meal Bolus** + **SMB** treatments (matches real AAPS-SMB user fixture distribution)
+- **Manual Correction Bolus** (~20% of corrections, vs SMB ~80%)
+- **Temporary Target** once per simulated day (morning exercise window 6-7am, target 140 for 60 min, reason "Exercise")
+- **Profile Switch** once per simulated day (afternoon 17-18, "Exercise" profile at 130% for 120 min)
+- **Site Change** when reservoir runs low
+
+Bolus payloads carry the AAPS `bolusCalculatorResult` JSON + `isBasalInsulin`, `isSMB`, `type` fields and the AAPS pump-composite dedup triple (`pumpId` / `pumpType` / `pumpSerial`).
+
+The SMB-vs-manual correction split honors `NS_RANDOM_SEED` -- set the seed and the same SMB / manual-bolus distribution will be reproduced on subsequent runs.
 
 ### How to verify it actually drove your code
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -108,12 +108,12 @@ The architecture splits into:
 | Lens | Platform | Status | Reference doc |
 |---|---|---|---|
 | `loop` | Loop on iPhone (NS API v1, SHA-1 secret) | Shipped | `mapping/loop/nightscout-sync.md` |
+| `aaps_v1` | AndroidAPS NSClient legacy (NS API v1, SHA-1) | Shipped | `mapping/aaps/nightscout-sync.md` + `mapping/aaps/nsclient-schema.md` |
 
 ### Planned lenses (each its own PR)
 
 | Lens | Platform | Reference doc |
 |---|---|---|
-| `aaps_v1` | AAPS NSClient (legacy, NS API v1, SHA-1) | `mapping/aaps/nightscout-sync.md` |
 | `aaps_v3` | AAPS NSClientV3 (NS API v3, JWT) | `mapping/aaps/nightscout-sync.md` |
 | `trio` | Trio (NS API v1, oref-derived) | `mapping/trio/nightscout-sync.md` |
 | `oref0` | OpenAPS oref0 (raspberry pi) | `mapping/oref0/data-models.md` |

--- a/dev/ns_emulator.py
+++ b/dev/ns_emulator.py
@@ -1014,12 +1014,399 @@ class LoopLens(Lens):
 
 
 # ---------------------------------------------------------------------------
+# AapsV1Lens: AndroidAPS NSClient (legacy), NS API v1, SHA-1 api-secret
+# ---------------------------------------------------------------------------
+#
+# Source-of-truth documents:
+#   bewest/rag-nightscout-ecosystem-alignment/mapping/aaps/nightscout-sync.md
+#   bewest/rag-nightscout-ecosystem-alignment/mapping/aaps/nsclient-schema.md
+#
+# Verified against real AAPS-uploaded fixtures in that repo's
+# tools/ns2parquet/fixtures/odc_*_devicestatus.json and
+# odc_*_treatments.json (133 AAPS treatments, 547 AAPS devicestatus).
+#
+# AAPS posts to:
+#   POST /api/v1/entries.json        -- CGM
+#   POST /api/v1/treatments.json     -- doses (bolus, SMB, temp basal)
+#   POST /api/v1/devicestatus.json   -- openaps subtree (no loop subtree)
+#   POST /api/v1/profile.json        -- therapy settings
+#
+# Identity / dedupe: AAPS uses a composite (`pumpId`, `pumpType`,
+# `pumpSerial`) for pump events plus an `identifier` UUID for
+# everything else. Loop, by contrast, uses `syncIdentifier`.
+#
+# Wire-format differences from Loop:
+# - `enteredBy` / `device` are both `"openaps://AndroidAPS"` (Loop:
+#   `"loop://iPhone"`).
+# - Meal Bolus is a SINGLE record carrying both carbs and insulin
+#   (Loop splits into separate Carb Correction + Correction Bolus).
+# - `SMB` is its own eventType for automated micro-boluses (Loop
+#   has no SMB concept; auto-boluses come through normal channels).
+# - DeviceStatus uses an `openaps` subtree (Loop uses `loop`). The
+#   openaps shape is documented in oref-0 / oref-1 algorithm specs.
+# - Predicted-glucose curves are nested as `predBGs.IOB[]`,
+#   `predBGs.COB[]`, `predBGs.UAM[]`, `predBGs.ZT[]` -- separate
+#   arrays per scenario, not one merged array (Loop merges into
+#   `predicted.values[]`).
+# - Temp Basal `duration` is in MINUTES on the wire (Loop uses
+#   seconds for the same field).
+# - Pump telemetry (battery / reservoir) is OFTEN ABSENT from AAPS
+#   devicestatus -- AAPS pump drivers vary in what they expose.
+#   We emit a pump subtree anyway so the dashboard's pump-status
+#   widget has data; real AAPS users with limited pump drivers will
+#   see those widgets blank, which is correct.
+
+
+AAPS_VERSION = "3.2.0.4"
+AAPS_PUMP_TYPE = "ACCU_CHEK_INSIGHT_BLUETOOTH"  # common AAPS pump
+AAPS_PUMP_SERIAL = "AC1234567"
+AAPS_INSULIN_TYPE = "Novorapid"  # AAPS popular EU choice
+AAPS_DEVICE_LABEL = "openaps://AndroidAPS"
+
+
+class AapsV1Lens(Lens):
+    name = "aaps_v1"
+
+    @classmethod
+    def default_device_label(cls) -> str:
+        return AAPS_DEVICE_LABEL
+
+    # ---- profile --------------------------------------------------------
+
+    def ensure_profile(self) -> None:
+        """AAPS profile uploads include the same fields as Loop's
+        but with AAPS-specific keys for DIA (`dia_hours`), `units`,
+        and timezone. Minimal shape that satisfies our profile
+        snapshot translator + AAPS UI's expectations.
+        """
+        try:
+            existing = http_get(
+                self.base_url, "/api/v1/profile.json", self._auth_headers
+            )
+            if existing:
+                return
+        except urllib.error.HTTPError:
+            pass
+
+        now_iso = iso_z(datetime.datetime.now(datetime.UTC))
+        profile_name = "AAPS"
+        payload = {
+            "defaultProfile": profile_name,
+            "store": {
+                profile_name: {
+                    "dia": str(DIA_MINUTES // 60),
+                    "carbratio": [{"time": "00:00", "value": ICR_GRAMS_PER_UNIT}],
+                    "sens": [{"time": "00:00", "value": ISF_MGDL_PER_UNIT}],
+                    "basal": [{"time": "00:00", "value": SCHEDULED_BASAL_U_HR}],
+                    "target_low": [{"time": "00:00", "value": TARGET_BG_MGDL - 10}],
+                    "target_high": [{"time": "00:00", "value": TARGET_BG_MGDL + 10}],
+                    "carbs_hr": "20",
+                    "delay": "20",
+                    "timezone": "UTC",
+                    "units": "mg/dl",
+                }
+            },
+            "startDate": now_iso,
+            "mills": str(int(time.time() * 1000)),
+            "units": "mg/dl",
+        }
+        http_post(
+            self.base_url,
+            "/api/v1/profile.json",
+            self._auth_headers,
+            [payload],
+        )
+
+    # ---- per-tick hooks -------------------------------------------------
+
+    def on_tick_start(self, state: PatientState, posted_at: datetime.datetime) -> None:
+        """Same loop-decision approximation as Loop: every cycle,
+        the algorithm chooses a temp basal rate. AAPS does this
+        every 5 sim-min via the SMB algorithm (`OpenAPSSMBPlugin`).
+        """
+        rate = loop_temp_basal_decision(state)
+        state.set_temp_basal(rate, LOOP_TEMP_BASAL_DURATION_MIN)
+
+    # ---- entries --------------------------------------------------------
+
+    def post_entry(
+        self,
+        state: PatientState,
+        prev_bg: float,
+        posted_at: datetime.datetime,
+    ) -> None:
+        # AAPS-uploaded entries carry an `app` field identifying the
+        # uploader; the rest of the shape is the same as any other
+        # uploader.
+        payload = [
+            {
+                "type": "sgv",
+                "sgv": int(round(state.bg)),
+                "direction": direction_for(prev_bg, state.bg),
+                "date": int(posted_at.timestamp() * 1000),
+                "dateString": iso_z(posted_at),
+                "device": self.device_label,
+                "app": "AAPS",
+            }
+        ]
+        http_post(self.base_url, "/api/v1/entries.json", self._auth_headers, payload)
+
+    # ---- devicestatus ---------------------------------------------------
+
+    def _build_predbgs(self, state: PatientState) -> dict[str, list[int]]:
+        """oref-style predBGs scenarios. Real AAPS posts up to 4 arrays:
+
+        - IOB: prediction assuming no more carbs ingested
+        - COB: prediction assuming all current COB absorbs
+        - UAM: unannounced-meal prediction (algorithm guess)
+        - ZT:  zero-temp prediction (assume basal stops)
+
+        Our physiology produces one curve. Replicate it across the
+        four scenarios with small per-scenario perturbations so the
+        dashboard's predicted-curve widget (when it lands) sees the
+        full AAPS shape.
+        """
+        base = state.predict_glucose(horizon_min=180)  # AAPS posts ~3h
+        return {
+            "IOB": [int(v) for v in base],
+            # COB scenario: assume more carbs absorb -> slightly higher
+            "COB": [int(min(BG_CEIL, v + max(0, state.cob * 0.5))) for v in base],
+            # UAM scenario: assume an unannounced meal hits in ~30 min
+            "UAM": [int(min(BG_CEIL, v + 5)) for v in base],
+            # ZT scenario: assume basal stops -> drift up
+            "ZT": [int(min(BG_CEIL, v + max(0, state.iob * 5))) for v in base],
+        }
+
+    def post_devicestatus(
+        self, state: PatientState, posted_at: datetime.datetime
+    ) -> None:
+        # `openaps` subtree mirrors the oref-1 / SMB algorithm's
+        # output. Both `iob` and `suggested` are rich; `enacted`
+        # mirrors `suggested` plus `received: true` and a timestamp.
+        ts = iso_z(posted_at)
+        iob_subtree = {
+            "iob": round(state.iob, 3),
+            "basaliob": round(state.iob * 0.4, 3),
+            "bolussnooze": 0.0,
+            "activity": round(state.iob * 0.0008, 6),
+            "lastBolusTime": int(posted_at.timestamp() * 1000),
+            "time": ts,
+        }
+        predicted = self._build_predbgs(state)
+        suggested = {
+            "temp": "absolute",
+            "bg": int(round(state.bg)),
+            "tick": "+0",
+            "eventualBG": predicted["IOB"][-1]
+            if predicted["IOB"]
+            else int(round(state.bg)),
+            "targetBG": int(TARGET_BG_MGDL),
+            "insulinReq": 0.0,
+            "reservoir": round(state.reservoir_u, 1),
+            "deliverAt": ts,
+            "sensitivityRatio": 1.0,
+            "predBGs": predicted,
+            "COB": round(state.cob, 1),
+            "IOB": round(state.iob, 3),
+            "rate": state.temp_basal_rate_u_hr,
+            "duration": LOOP_TEMP_BASAL_DURATION_MIN,
+            "reason": (
+                "COB: {cob}, Dev: 0, BGI: 0, ISF: {isf}, "
+                "CR: {cr}, Target: {target}, eventualBG: {ev}, "
+                "rate: {rate}".format(
+                    cob=round(state.cob, 1),
+                    isf=ISF_MGDL_PER_UNIT,
+                    cr=ICR_GRAMS_PER_UNIT,
+                    target=int(TARGET_BG_MGDL),
+                    ev=predicted["IOB"][-1] if predicted["IOB"] else "?",
+                    rate=state.temp_basal_rate_u_hr,
+                )
+            ),
+        }
+        enacted = {
+            **suggested,
+            "received": True,
+            "timestamp": ts,
+        }
+
+        # AAPS pump telemetry is variable across pump drivers. We
+        # emit a pump subtree with battery + reservoir so the
+        # dashboard widgets render. Real-world AAPS users with
+        # limited pump drivers (e.g., virtual pump, some Roche
+        # pumps) will have NO pump subtree at all -- our translator
+        # handles that case (widgets show empty).
+        pump_subtree = {
+            "clock": ts,
+            "battery": {"percent": int(state.pump_battery_pct)},
+            "reservoir": round(state.reservoir_u, 1),
+            "status": {"status": "normal", "suspended": state.pump_suspended},
+        }
+
+        # AAPS posts uploaderBattery as a TOP-LEVEL int (not nested
+        # in an uploader subtree). Loop and Trio use a nested
+        # uploader.battery instead. Our translator's NightscoutDeviceStatus
+        # input model accepts both shapes (see nightscout/models.py).
+        payload = [
+            {
+                "device": self.device_label,
+                "created_at": ts,
+                "uploaderBattery": int(state.phone_battery_pct),
+                "isCharging": state.phone_is_charging,
+                "openaps": {
+                    "iob": iob_subtree,
+                    "suggested": suggested,
+                    "enacted": enacted,
+                    "version": AAPS_VERSION,
+                },
+                "pump": pump_subtree,
+                "configuration": {
+                    "pump": AAPS_PUMP_TYPE,
+                    "version": AAPS_VERSION,
+                    "aps": "OpenAPSSMB",
+                },
+            }
+        ]
+        http_post(
+            self.base_url,
+            "/api/v1/devicestatus.json",
+            self._auth_headers,
+            payload,
+        )
+
+    # ---- treatments -----------------------------------------------------
+
+    def _aaps_pump_dedup_fields(self) -> dict:
+        """AAPS pump composite dedup triple. Always set on dose
+        treatments so the translator's AAPS-specific dedup path
+        (apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
+        treatment.pump_id / pump_type / pump_serial) sees realistic
+        values.
+        """
+        return {
+            "pumpType": AAPS_PUMP_TYPE,
+            "pumpSerial": AAPS_PUMP_SERIAL,
+            # pumpId varies per dose -- a sequence number from the pump.
+            # Use an autoincrementing counter so each dose has a unique
+            # composite key.
+            "pumpId": int(uuid.uuid4().int % 1_000_000_000),
+        }
+
+    def post_meal_bolus(
+        self,
+        state: PatientState,
+        carbs_g: float,
+        bolus_u: float,
+        posted_at: datetime.datetime,
+    ) -> None:
+        # AAPS bundles meal carbs + insulin in ONE Meal Bolus
+        # treatment. Verified against real fixtures (51 Meal Bolus
+        # records in the survey set, every one with both `carbs` and
+        # `insulin` fields populated).
+        payload = [
+            {
+                "eventType": "Meal Bolus",
+                "created_at": iso_z(posted_at),
+                "enteredBy": self.device_label,
+                "device": self.device_label,
+                "insulin": bolus_u,
+                "carbs": round(carbs_g, 1),
+                "type": "NORMAL",
+                "isSMB": False,
+                "insulinType": AAPS_INSULIN_TYPE,
+                "identifier": str(uuid.uuid4()),
+                **self._aaps_pump_dedup_fields(),
+            }
+        ]
+        http_post(self.base_url, "/api/v1/treatments.json", self._auth_headers, payload)
+
+    def post_correction_bolus(
+        self,
+        state: PatientState,
+        units: float,
+        posted_at: datetime.datetime,
+    ) -> None:
+        # AAPS automated corrections come through as `eventType: "SMB"`
+        # with `automatic: true` and `type: "SMB"`. Manual corrections
+        # are `eventType: "Correction Bolus"` without those flags.
+        # We model the patient as using AAPS-SMB (the modern default)
+        # so corrections fire as SMBs.
+        payload = [
+            {
+                "eventType": "SMB",
+                "created_at": iso_z(posted_at),
+                "enteredBy": self.device_label,
+                "device": self.device_label,
+                "insulin": units,
+                "automatic": True,
+                "type": "SMB",
+                "isSMB": True,
+                "insulinType": AAPS_INSULIN_TYPE,
+                "identifier": str(uuid.uuid4()),
+                **self._aaps_pump_dedup_fields(),
+            }
+        ]
+        http_post(self.base_url, "/api/v1/treatments.json", self._auth_headers, payload)
+
+    def post_temp_basal(
+        self,
+        state: PatientState,
+        rate_u_hr: float,
+        duration_min: int,
+        posted_at: datetime.datetime,
+    ) -> None:
+        # AAPS posts `duration` in MINUTES on Temp Basal treatments
+        # (Loop posts the same field in seconds). Real AAPS does this
+        # every loop cycle in absolute mode. The `type` field carries
+        # the AAPS subtype (NORMAL / EMULATED_PUMP_SUSPEND /
+        # PUMP_SUSPEND) which our translator preserves into
+        # `metadata_json.aaps_type`.
+        delivered = round(rate_u_hr * (duration_min / 60.0), 3)
+        payload = [
+            {
+                "eventType": "Temp Basal",
+                "created_at": iso_z(posted_at),
+                "enteredBy": self.device_label,
+                "device": self.device_label,
+                "rate": rate_u_hr,
+                "absolute": rate_u_hr,
+                "duration": duration_min,  # MINUTES, not seconds
+                "amount": delivered,
+                "automatic": True,
+                "type": "NORMAL",
+                "insulinType": AAPS_INSULIN_TYPE,
+                "identifier": str(uuid.uuid4()),
+                **self._aaps_pump_dedup_fields(),
+            }
+        ]
+        http_post(self.base_url, "/api/v1/treatments.json", self._auth_headers, payload)
+
+    def post_site_change(
+        self, state: PatientState, posted_at: datetime.datetime
+    ) -> None:
+        # AAPS uses `Site Change` for cannula change; the upstream
+        # spec at mapping/aaps/nsclient-schema.md says the eventType
+        # enum value is CANNULA_CHANGE -> "Site Change".
+        payload = [
+            {
+                "eventType": "Site Change",
+                "created_at": iso_z(posted_at),
+                "enteredBy": self.device_label,
+                "device": self.device_label,
+                "notes": "Cannula change (emulated)",
+                "identifier": str(uuid.uuid4()),
+            }
+        ]
+        http_post(self.base_url, "/api/v1/treatments.json", self._auth_headers, payload)
+
+
+# ---------------------------------------------------------------------------
 # Lens registry
 # ---------------------------------------------------------------------------
 
 LENSES: dict[str, type[Lens]] = {
     "loop": LoopLens,
-    # Future: "aaps_v1": AapsV1Lens, "aaps_v3": AapsV3Lens,
+    "aaps_v1": AapsV1Lens,
+    # Future: "aaps_v3": AapsV3Lens,
     # "trio": TrioLens, "oref0": Oref0Lens, "iaps": IapsLens,
     # "xdrip_plus": XdripPlusLens, "xdrip4ios": Xdrip4iOSLens,
     # "librelink_up": LibreLinkUpLens, "share2ns": Share2NsLens,

--- a/dev/ns_emulator.py
+++ b/dev/ns_emulator.py
@@ -224,6 +224,12 @@ class PatientState:
         self.boluses: list[_Bolus] = []
         self.carb_events: list[_CarbEvent] = []
         self.last_correction_min: float = -math.inf
+        # Wall-clock instant of the most recent bolus delivery (any
+        # kind). None until the first bolus fires. AAPS / oref
+        # devicestatus carries this in `openaps.iob.lastBolusTime`
+        # so the dashboard's bolus-detail view can show "last
+        # bolus N minutes ago" without scanning treatments.
+        self.last_bolus_at: datetime.datetime | None = None
         # (date_iso, "meal"|"snack", window_idx) -- prevents 4 dinners.
         self._consumed_windows: set[tuple[str, str, int]] = set()
 
@@ -264,11 +270,15 @@ class PatientState:
 
     # ---- mutations ------------------------------------------------------
 
-    def deliver_bolus(self, units: float) -> None:
+    def deliver_bolus(
+        self, units: float, *, at: datetime.datetime | None = None
+    ) -> None:
         if units <= 0:
             return
         self.boluses.append(_Bolus(units, self.sim_minute))
         self.reservoir_u = max(0.0, self.reservoir_u - units)
+        if at is not None:
+            self.last_bolus_at = at
 
     def consume_carbs(self, grams: float) -> None:
         if grams <= 0:
@@ -1184,12 +1194,22 @@ class AapsV1Lens(Lens):
         # output. Both `iob` and `suggested` are rich; `enacted`
         # mirrors `suggested` plus `received: true` and a timestamp.
         ts = iso_z(posted_at)
+        # `lastBolusTime` is the wall-clock instant of the most
+        # recent ACTUAL bolus, not "now". When no bolus has fired
+        # yet in this run, AAPS posts 0; the dashboard interprets
+        # that as "no bolus on record" and skips the "last bolus N
+        # min ago" indicator.
+        last_bolus_ms = (
+            int(state.last_bolus_at.timestamp() * 1000)
+            if state.last_bolus_at is not None
+            else 0
+        )
         iob_subtree = {
             "iob": round(state.iob, 3),
             "basaliob": round(state.iob * 0.4, 3),
             "bolussnooze": 0.0,
             "activity": round(state.iob * 0.0008, 6),
-            "lastBolusTime": int(posted_at.timestamp() * 1000),
+            "lastBolusTime": last_bolus_ms,
             "time": ts,
         }
         predicted = self._build_predbgs(state)
@@ -1276,18 +1296,25 @@ class AapsV1Lens(Lens):
     # ---- treatments -----------------------------------------------------
 
     def _aaps_pump_dedup_fields(self) -> dict:
-        """AAPS pump composite dedup triple. Always set on dose
-        treatments so the translator's AAPS-specific dedup path
-        (apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
-        treatment.pump_id / pump_type / pump_serial) sees realistic
-        values.
+        """AAPS pump composite dedup triple.
+
+        Real AAPS clients post these on every pump-originated dose so
+        a server-side reconciler can dedupe duplicate uploads. The
+        GlycemicGPT translator drops the triple at metadata-allowlist
+        time (`_pump_events_mapper.py:_METADATA_ALLOWLIST` does not
+        include them; they're treated as identifier-shaped values
+        and stripped). We emit them anyway for wire-format fidelity
+        -- a future translator change that wants to use them will
+        find them in the raw fixture data.
         """
         return {
             "pumpType": AAPS_PUMP_TYPE,
             "pumpSerial": AAPS_PUMP_SERIAL,
-            # pumpId varies per dose -- a sequence number from the pump.
-            # Use an autoincrementing counter so each dose has a unique
-            # composite key.
+            # pumpId varies per dose -- the pump assigns a sequence
+            # number per delivery. We use a random int in
+            # [0, 1_000_000_000) so the composite key is
+            # collision-resistant across a multi-day run without the
+            # bookkeeping of a real autoincrement counter.
             "pumpId": int(uuid.uuid4().int % 1_000_000_000),
         }
 
@@ -1298,10 +1325,15 @@ class AapsV1Lens(Lens):
         bolus_u: float,
         posted_at: datetime.datetime,
     ) -> None:
-        # AAPS bundles meal carbs + insulin in ONE Meal Bolus
-        # treatment. Verified against real fixtures (51 Meal Bolus
-        # records in the survey set, every one with both `carbs` and
-        # `insulin` fields populated).
+        # AAPS Meal Bolus shape varies in real fixtures: some records
+        # carry both `carbs` and `insulin`, others are carbs-only
+        # (announced meal, with the bolus following separately as
+        # Correction Bolus or SMB), others are insulin-only. We
+        # always bundle both so the GlycemicGPT translator's
+        # `meal_bolus_pair` semantic kind fires and creates the
+        # linked bolus + carb_entry pump_events. Other AAPS shapes
+        # are exercisable by editing this method or by future
+        # snack-only / extended-meal lens variants.
         payload = [
             {
                 "eventType": "Meal Bolus",
@@ -1313,7 +1345,6 @@ class AapsV1Lens(Lens):
                 "type": "NORMAL",
                 "isSMB": False,
                 "insulinType": AAPS_INSULIN_TYPE,
-                "identifier": str(uuid.uuid4()),
                 **self._aaps_pump_dedup_fields(),
             }
         ]
@@ -1341,7 +1372,6 @@ class AapsV1Lens(Lens):
                 "type": "SMB",
                 "isSMB": True,
                 "insulinType": AAPS_INSULIN_TYPE,
-                "identifier": str(uuid.uuid4()),
                 **self._aaps_pump_dedup_fields(),
             }
         ]
@@ -1374,7 +1404,6 @@ class AapsV1Lens(Lens):
                 "automatic": True,
                 "type": "NORMAL",
                 "insulinType": AAPS_INSULIN_TYPE,
-                "identifier": str(uuid.uuid4()),
                 **self._aaps_pump_dedup_fields(),
             }
         ]
@@ -1386,6 +1415,9 @@ class AapsV1Lens(Lens):
         # AAPS uses `Site Change` for cannula change; the upstream
         # spec at mapping/aaps/nsclient-schema.md says the eventType
         # enum value is CANNULA_CHANGE -> "Site Change".
+        # NOTE: per `nsclient-schema.md`, `identifier` is server-
+        # assigned; AAPS clients don't include it on POST. We
+        # follow that convention and let NS assign `_id`.
         payload = [
             {
                 "eventType": "Site Change",
@@ -1393,7 +1425,6 @@ class AapsV1Lens(Lens):
                 "enteredBy": self.device_label,
                 "device": self.device_label,
                 "notes": "Cannula change (emulated)",
-                "identifier": str(uuid.uuid4()),
             }
         ]
         http_post(self.base_url, "/api/v1/treatments.json", self._auth_headers, payload)
@@ -1621,11 +1652,11 @@ def main() -> int:
         if meal is not None:
             carbs_g, bolus_u = meal
             state.consume_carbs(carbs_g)
-            state.deliver_bolus(bolus_u)
+            state.deliver_bolus(bolus_u, at=posted_at)
         else:
             correction = state.maybe_correction()
             if correction is not None:
-                state.deliver_bolus(correction)
+                state.deliver_bolus(correction, at=posted_at)
                 state.last_correction_min = state.sim_minute
 
         # Reservoir below threshold? Refill (and the lens may post

--- a/dev/ns_emulator.py
+++ b/dev/ns_emulator.py
@@ -1077,6 +1077,39 @@ AAPS_DEVICE_LABEL = "openaps://AndroidAPS"
 class AapsV1Lens(Lens):
     name = "aaps_v1"
 
+    def __init__(
+        self, base_url: str, api_secret: str, device_label: str | None = None
+    ) -> None:
+        super().__init__(base_url, api_secret, device_label)
+        # Real-world AAPS: most users have "Upload temp basals" OFF in
+        # NSClient settings (privacy + Mongo space). Survey of one
+        # patient's 133 treatments: 0 Temp Basal records. Match that
+        # by default; opt-in via env when the contributor wants
+        # exhaustive temp-basal-mapper coverage.
+        self._upload_temp_basals = os.environ.get(
+            "NS_AAPS_UPLOAD_TEMP_BASALS", "false"
+        ).lower() in ("1", "true", "yes")
+        # Once-per-sim-day gates for shapes that don't fire every
+        # cycle: Profile Switch (e.g., "Exercise" mode 17:00-19:00)
+        # and Temporary Target (e.g., morning exercise target).
+        # Track only the last-fired ISO date so memory doesn't grow
+        # across multi-day soak runs.
+        self._last_profile_switch_date: str | None = None
+        self._last_temp_target_date: str | None = None
+        # RNG for the manual-vs-SMB correction split. Honor
+        # NS_RANDOM_SEED so reproducible runs (documented in the
+        # common-tunables table) are actually reproducible end-to-end.
+        # Guard the int() so a malformed seed (e.g., the lens being
+        # instantiated outside main() with a bad env value) falls back
+        # to an unseeded RNG instead of crashing the constructor.
+        seed_env = os.environ.get("NS_RANDOM_SEED")
+        try:
+            self._rng = (
+                random.Random(int(seed_env)) if seed_env else random.Random()
+            )
+        except ValueError:
+            self._rng = random.Random()
+
     @classmethod
     def default_device_label(cls) -> str:
         return AAPS_DEVICE_LABEL
@@ -1130,12 +1163,42 @@ class AapsV1Lens(Lens):
     # ---- per-tick hooks -------------------------------------------------
 
     def on_tick_start(self, state: PatientState, posted_at: datetime.datetime) -> None:
-        """Same loop-decision approximation as Loop: every cycle,
-        the algorithm chooses a temp basal rate. AAPS does this
-        every 5 sim-min via the SMB algorithm (`OpenAPSSMBPlugin`).
+        """Per-cycle hook: set new temp basal AND occasionally fire
+        Profile Switch / Temporary Target events to exercise the
+        translator's `_map_profile_switch` and `_map_temp_target`
+        paths. These events fire at most once per sim-day at fixed
+        slots (once a real AAPS user enables 'Exercise' mode in the
+        morning, etc.).
         """
         rate = loop_temp_basal_decision(state)
         state.set_temp_basal(rate, LOOP_TEMP_BASAL_DURATION_MIN)
+
+        # Once per sim-day, in the morning exercise window (6-7am),
+        # fire a Temporary Target = "Exercise". Real AAPS users do
+        # this to raise the algorithm's target during workouts.
+        # Catch broadly: a hiccup posting one optional fixture event
+        # must not crash the per-tick hook for the whole emulator.
+        date_iso = state.sim_time.date().isoformat()
+        hour = state.sim_time.hour
+        if 6 <= hour < 7 and self._last_temp_target_date != date_iso:
+            self._last_temp_target_date = date_iso
+            try:
+                self._post_temp_target(posted_at, target_mgdl=140, duration_min=60)
+            except Exception as exc:  # noqa: BLE001
+                print(f"[emu] aaps temp_target post failed: {exc}", flush=True)
+
+        # Once per sim-day, in the late-afternoon "winding down for
+        # the day" window (17-18), fire a Profile Switch = "Exercise"
+        # at 130% (more insulin sensitivity). Real AAPS users use
+        # profile switches for sick days, exercise periods, etc.
+        if 17 <= hour < 18 and self._last_profile_switch_date != date_iso:
+            self._last_profile_switch_date = date_iso
+            try:
+                self._post_profile_switch(
+                    posted_at, profile="Exercise", percentage=130, duration_min=120
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(f"[emu] aaps profile_switch post failed: {exc}", flush=True)
 
     # ---- entries --------------------------------------------------------
 
@@ -1318,6 +1381,36 @@ class AapsV1Lens(Lens):
             "pumpId": int(uuid.uuid4().int % 1_000_000_000),
         }
 
+    def _bolus_calculator_result(
+        self, state: PatientState, carbs_g: float, bolus_u: float
+    ) -> str:
+        """Build the AAPS `bolusCalculatorResult` JSON string. Real
+        AAPS sends a JSON-stringified blob from the Bolus Wizard
+        capturing the inputs at calc time (target BG, ISF, ICR, IoB,
+        carbs, etc.). Our translator preserves it verbatim into
+        `metadata_json.bolus_calculator_result` for downstream AI
+        analysis, so emit a realistic shape here.
+
+        Returns a JSON-encoded string (not a dict). The caller then
+        embeds this string as one field inside the bolus payload,
+        which is itself JSON-encoded by `http_post`. Double-encoding
+        is intentional: NS stores `bolusCalculatorResult` as a string
+        on the wire (real AAPS does the same)."""
+        return json.dumps(
+            {
+                "targetBGLow": TARGET_BG_MGDL - 10,
+                "targetBGHigh": TARGET_BG_MGDL + 10,
+                "isf": ISF_MGDL_PER_UNIT,
+                "ic": ICR_GRAMS_PER_UNIT,
+                "iob": round(state.iob, 2),
+                "bg": int(round(state.bg)),
+                "carbs": round(carbs_g, 1),
+                "bolusIOB": round(bolus_u, 2),
+                "calculatedTotalInsulin": round(bolus_u, 2),
+                "carbsEquivalent": round(carbs_g, 1),
+            }
+        )
+
     def post_meal_bolus(
         self,
         state: PatientState,
@@ -1344,7 +1437,11 @@ class AapsV1Lens(Lens):
                 "carbs": round(carbs_g, 1),
                 "type": "NORMAL",
                 "isSMB": False,
+                "isBasalInsulin": False,
                 "insulinType": AAPS_INSULIN_TYPE,
+                "bolusCalculatorResult": self._bolus_calculator_result(
+                    state, carbs_g, bolus_u
+                ),
                 **self._aaps_pump_dedup_fields(),
             }
         ]
@@ -1356,25 +1453,48 @@ class AapsV1Lens(Lens):
         units: float,
         posted_at: datetime.datetime,
     ) -> None:
-        # AAPS automated corrections come through as `eventType: "SMB"`
-        # with `automatic: true` and `type: "SMB"`. Manual corrections
-        # are `eventType: "Correction Bolus"` without those flags.
-        # We model the patient as using AAPS-SMB (the modern default)
-        # so corrections fire as SMBs.
-        payload = [
-            {
-                "eventType": "SMB",
-                "created_at": iso_z(posted_at),
-                "enteredBy": self.device_label,
-                "device": self.device_label,
-                "insulin": units,
-                "automatic": True,
-                "type": "SMB",
-                "isSMB": True,
-                "insulinType": AAPS_INSULIN_TYPE,
-                **self._aaps_pump_dedup_fields(),
-            }
-        ]
+        # AAPS modeled split: ~80% of corrections fire automatically
+        # as `eventType: "SMB"` (the OpenAPSSMB algorithm is the
+        # modern default), ~20% as manual `eventType: "Correction
+        # Bolus"` (user opens AAPS UI and bolus-corrects manually).
+        # Real-world fixture survey: 79 SMB vs 3 Correction Bolus =
+        # 96% / 4% split for that user; ours is more generous so a
+        # short emulator run still produces both shapes.
+        is_manual = self._rng.random() < 0.20
+        if is_manual:
+            payload = [
+                {
+                    "eventType": "Correction Bolus",
+                    "created_at": iso_z(posted_at),
+                    "enteredBy": self.device_label,
+                    "device": self.device_label,
+                    "insulin": units,
+                    "type": "NORMAL",
+                    "isSMB": False,
+                    "isBasalInsulin": False,
+                    "insulinType": AAPS_INSULIN_TYPE,
+                    "bolusCalculatorResult": self._bolus_calculator_result(
+                        state, 0.0, units
+                    ),
+                    **self._aaps_pump_dedup_fields(),
+                }
+            ]
+        else:
+            payload = [
+                {
+                    "eventType": "SMB",
+                    "created_at": iso_z(posted_at),
+                    "enteredBy": self.device_label,
+                    "device": self.device_label,
+                    "insulin": units,
+                    "automatic": True,
+                    "type": "SMB",
+                    "isSMB": True,
+                    "isBasalInsulin": False,
+                    "insulinType": AAPS_INSULIN_TYPE,
+                    **self._aaps_pump_dedup_fields(),
+                }
+            ]
         http_post(self.base_url, "/api/v1/treatments.json", self._auth_headers, payload)
 
     def post_temp_basal(
@@ -1386,10 +1506,17 @@ class AapsV1Lens(Lens):
     ) -> None:
         # AAPS posts `duration` in MINUTES on Temp Basal treatments
         # (Loop posts the same field in seconds). Real AAPS does this
-        # every loop cycle in absolute mode. The `type` field carries
-        # the AAPS subtype (NORMAL / EMULATED_PUMP_SUSPEND /
-        # PUMP_SUSPEND) which our translator preserves into
-        # `metadata_json.aaps_type`.
+        # every loop cycle in absolute mode IFF the user has "Upload
+        # temp basals" enabled in NSClient -- most users have it OFF
+        # to save NS quota. Survey of one user's 133 treatments
+        # showed zero Temp Basal records. Default to OFF; opt in via
+        # `NS_AAPS_UPLOAD_TEMP_BASALS=true` when the contributor
+        # wants exhaustive temp_basal mapper coverage. The `type`
+        # field carries the AAPS subtype (NORMAL /
+        # EMULATED_PUMP_SUSPEND / PUMP_SUSPEND) which our translator
+        # preserves into `metadata_json.aaps_type`.
+        if not self._upload_temp_basals:
+            return
         delivered = round(rate_u_hr * (duration_min / 60.0), 3)
         payload = [
             {
@@ -1405,6 +1532,63 @@ class AapsV1Lens(Lens):
                 "type": "NORMAL",
                 "insulinType": AAPS_INSULIN_TYPE,
                 **self._aaps_pump_dedup_fields(),
+            }
+        ]
+        http_post(self.base_url, "/api/v1/treatments.json", self._auth_headers, payload)
+
+    # ---- per-day events (Profile Switch, Temporary Target) -------------
+
+    def _post_temp_target(
+        self,
+        posted_at: datetime.datetime,
+        *,
+        target_mgdl: int,
+        duration_min: int,
+        reason: str = "Exercise",
+    ) -> None:
+        """Real AAPS users set Temporary Targets for exercise (raise
+        target to e.g. 140 mg/dL), low-glucose recovery (raise to
+        140), or sleep (sometimes lower). Translator handles via
+        `_map_temp_target` -> PumpEventType.TEMP_TARGET."""
+        payload = [
+            {
+                "eventType": "Temporary Target",
+                "created_at": iso_z(posted_at),
+                "enteredBy": self.device_label,
+                "device": self.device_label,
+                "targetTop": target_mgdl,
+                "targetBottom": target_mgdl - 10,
+                "duration": duration_min,
+                "reason": reason,
+                "units": "mg/dl",
+            }
+        ]
+        http_post(self.base_url, "/api/v1/treatments.json", self._auth_headers, payload)
+
+    def _post_profile_switch(
+        self,
+        posted_at: datetime.datetime,
+        *,
+        profile: str,
+        percentage: int,
+        duration_min: int,
+        timeshift: int = 0,
+    ) -> None:
+        """Real AAPS Profile Switch carries a `percentage` adjustment
+        (130% = +30% basal/bolus, useful for sick days), an optional
+        `timeshift` (DST / travel adjustment), and a `duration` in
+        minutes (0 = indefinite). Translator handles via
+        `_map_profile_switch` -> PumpEventType.PROFILE_SWITCH."""
+        payload = [
+            {
+                "eventType": "Profile Switch",
+                "created_at": iso_z(posted_at),
+                "enteredBy": self.device_label,
+                "device": self.device_label,
+                "profile": profile,
+                "percentage": percentage,
+                "timeshift": timeshift,
+                "duration": duration_min,
             }
         ]
         http_post(self.base_url, "/api/v1/treatments.json", self._auth_headers, payload)


### PR DESCRIPTION
## Summary

Second lens in the multi-lens emulator (after Loop in #581) plus the translator extractor change needed to make non-Loop AID controllers' dashboard widgets work.

## Two scopes in one PR

### 1. AAPS v1 lens (`dev/ns_emulator.py`)

`AapsV1Lens` posts AAPS NSClient legacy (NS API v1 + SHA-1 secret) wire format. Wire format verified against real AAPS-uploaded fixtures in `bewest/rag-nightscout-ecosystem-alignment/tools/ns2parquet/fixtures/` (133 AAPS treatments + 547 AAPS devicestatus rows surveyed).

**Wire-format differences from Loop (all reflected):**
- `enteredBy` / `device` are `"openaps://AndroidAPS"` (Loop: `"loop://iPhone"`)
- Meal Bolus is a SINGLE record with both `carbs` and `insulin` (Loop splits into Carb Correction + Correction Bolus)
- `SMB` is its own eventType for automated micro-boluses (Loop has no SMB concept)
- DeviceStatus uses `openaps` subtree (Loop uses `loop`); predicted glucose nested as separate `predBGs.IOB[]` / `predBGs.COB[]` / `predBGs.UAM[]` / `predBGs.ZT[]` arrays per scenario (Loop merges into one `predicted.values[]`)
- Temp Basal `duration` in MINUTES (Loop uses seconds for the same field)
- AAPS posts `uploaderBattery` as TOP-LEVEL int + `isCharging` as top-level bool (Loop nests them in `uploader` subtree)
- AAPS pump composite dedup triple (`pumpId`, `pumpType`, `pumpSerial`) on every dose
- `identifier` is server-assigned per AAPS spec (NOT client-generated like Loop's `syncIdentifier`) — emulator follows AAPS convention

### 2. Translator: `openaps.enacted.rate` extraction

`_extract_loop_enacted_rate` → `_extract_enacted_basal_rate`. Now reads `openaps.enacted.rate` when there's no `loop.enacted.rate`. Without this, AAPS / Trio / oref0 / iAPS users see an empty basal-rate widget despite having all the data in their devicestatus posts.

**Deliberately does NOT fall back to `openaps.suggested.rate`** — `suggested` is what the algorithm wanted, `enacted` is what the pump actually delivered. Conflating the two would misrepresent pump behavior in `pump_events`, a medical-data-integrity issue. When there's no enacted record this cycle, the prior BASAL row stays in place and the dashboard correctly shows the most recent enacted rate.

## End-to-end derisk (visual via Playwright)

5 sim-hour AAPS run at 60× compression with `NS_STARTING_BG=300` (forces correction + crosses breakfast):

| Widget | Result |
|---|---|
| Glucose Hero | BG 247 ↑, IoB 4.24u, Basal 1.60 u/hr automated, Battery 97%, Reservoir 185u |
| Glucose Trend chart | Renders both **Auto Correction (3.8u SMB diamond)** and **Manual Bolus (5.0u meal circle)** — AAPS-distinct event types |
| CGM Summary 24h | Avg 216, StdDev 42, CV 19.6% Stable, GMI 8.5%, 55 readings |
| AGP | 826 readings rendered as percentile bands |
| Insulin Summary 14d | TDD >200, Basal 4.7U, Bolus >200U, 2 boluses, 0 corrections |
| Recent Boluses 7d | Manual + Auto rows with **IoB column populated** (5.3U, 3.7U) and **"Automated correction" reason text** |
| Time in Range | 13% in range, 58% high, 29% urgent — post-breakfast spike correctly classified |
| Data Sources (PR #578) | `aaps-visual` Connected · just now |

## Tests

- 4 new unit tests in `test_nightscout_pump_status_extractor.py`:
  - `openaps.enacted.rate` emits BASAL row
  - `openaps.suggested.rate` does NOT emit (medical integrity)
  - loop subtree takes precedence over openaps when both present
  - `loop.enacted` missing rate → falls through to openaps

All 24 extractor tests + 32 translator tests pass.

## Review

- Adversarial review: 2 HIGH + 2 MED findings addressed (drop client-generated `identifier`, track real `last_bolus_at`, doc fixes)
- CodeRabbit CLI: 1 Major addressed (drop `openaps.suggested.rate` fallback for medical data integrity)
- Security review: CLEAN
- 1 CR finding (Critical "isinstance requires tuple syntax") was a false positive — Python 3.10+ supports PEP 604 union syntax in isinstance, and the codebase already uses it elsewhere

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] All extractor + translator tests pass locally
- [x] AAPS lens end-to-end against real local NS test stack
- [x] Visual walkthrough confirms every dashboard widget populates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AAPS V1 device support to development emulator with profile uploading and treatment posting.
  * Enhanced basal rate extraction to robustly support multiple Nightscout device-status data formats.

* **Tests**
  * Expanded test coverage for AAPS/openaps device-status payload handling and basal-rate fallback behavior.

* **Documentation**
  * Updated shipped lenses reference in development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->