### PR TITLE
feat(dev): tconnectsync lens — Tandem t:connect cloud → NS bridge (pump-side)

### DIFF
--- a/apps/api/src/services/integrations/nightscout/models.py
+++ b/apps/api/src/services/integrations/nightscout/models.py
@@ -666,10 +666,25 @@ class NightscoutTreatment(BaseModel):
         """Combo Bolus / extended-emulated TBR detection.
 
         Two shapes:
-        1. eventType == "Combo Bolus" (Care Portal, AAPS Combo Bolus)
+        1. eventType == "Combo Bolus" WITH split data (split_now /
+           split_ext) OR a duration -- the legitimate AAPS / Care
+           Portal combo bolus (some-now, some-extended-over-time).
         2. eventType == "Temp Basal" with non-empty `extendedEmulated`
            subtree carrying bolus fields (AAPS extended-bolus emulating
            TBR).
+
+        Bare eventType == "Combo Bolus" with NO split / extended /
+        duration is NOT a true combo -- it is upstream's catch-all
+        naming convention for plain boluses (per
+        `jwoglom/tconnectsync` `process_bolus.py`, which collapses
+        every Tandem bolus -- meal, correction, override -- into the
+        single `"Combo Bolus"` eventType with the distinction in the
+        `notes` field). Falling through to the field-presence
+        routing (meal_bolus_pair / bolus) yields a `BOLUS`
+        event_type that the Insulin Summary / Recent Boluses /
+        IoB / safety / brief widgets actually consume; routing
+        these to `COMBO_BOLUS` would orphan them from every
+        downstream bolus read path.
 
         We require the eventType to be either of those forms; an
         incidental `extendedEmulated` field on a Note or Site Change
@@ -677,7 +692,14 @@ class NightscoutTreatment(BaseModel):
         """
         et = self.normalized_event_type
         if et == "combo bolus":
-            return True
+            # Real combo iff it carries split or duration data. A
+            # plain "Combo Bolus" without those is upstream-naming-
+            # only and should be classified by field presence.
+            return (
+                self.split_now is not None
+                or self.split_ext is not None
+                or self.duration is not None
+            )
         # AAPS extended bolus emulating TBR -- only fires under a Temp
         # Basal envelope with a non-empty payload that carries bolus
         # data (insulin/amount). Empty `{}` and unrelated eventTypes

--- a/apps/api/tests/test_nightscout_models.py
+++ b/apps/api/tests/test_nightscout_models.py
@@ -924,6 +924,66 @@ class TestAdversarialRegressions:
         assert t.is_combo_bolus is True
         assert t.semantic_kind == "combo_bolus"
 
+    # H5b: tconnectsync emits ALL Tandem boluses (meal, correction,
+    # override) as eventType "Combo Bolus" with the meal/correction
+    # distinction stuffed into `notes` -- per upstream `jwoglom/
+    # tconnectsync/sync/tandemsource/process_bolus.py`. These have
+    # NO splitNow / splitExt / duration -- the eventType is just
+    # upstream's catch-all naming. Routing them to COMBO_BOLUS
+    # would orphan them from every downstream bolus read path
+    # (Insulin Summary, Recent Boluses, IoB, safety). Field-presence
+    # routing (meal_bolus_pair / bolus) yields BOLUS event_type so
+    # they actually surface in the dashboard.
+    def test_h5_tconnectsync_meal_combo_bolus_routes_to_meal_bolus_pair(self):
+        t = NightscoutTreatment.model_validate(
+            {
+                "eventType": "Combo Bolus",
+                "insulin": 4.16,
+                "carbs": 41.6,
+                "notes": "Meal Bolus",
+                "enteredBy": "Pump (tconnectsync)",
+                "created_at": "2026-05-09T07:40:38Z",
+            }
+        )
+        # Not a real combo (no split / extended / duration) --
+        # field-presence routing produces meal_bolus_pair (BOLUS
+        # + CARBS rows).
+        assert t.is_combo_bolus is False
+        assert t.semantic_kind == "meal_bolus_pair"
+
+    def test_h5_tconnectsync_correction_combo_bolus_routes_to_bolus(self):
+        t = NightscoutTreatment.model_validate(
+            {
+                "eventType": "Combo Bolus",
+                "insulin": 2.07,
+                "notes": "Correction Bolus",
+                "enteredBy": "Pump (tconnectsync)",
+                "created_at": "2026-05-09T07:45:19Z",
+            }
+        )
+        assert t.is_combo_bolus is False
+        # No carbs -> field-presence routing yields plain bolus
+        # (BOLUS event_type).
+        assert t.semantic_kind == "bolus"
+
+    def test_h5_careportal_combo_bolus_with_split_still_routes_combo(self):
+        # Pre-existing Care Portal / AAPS combo bolus with explicit
+        # split MUST still classify as combo_bolus -- the narrow
+        # "no split = not combo" rule preserves real combo semantics.
+        t = NightscoutTreatment.model_validate(
+            {
+                "eventType": "Combo Bolus",
+                "insulin": 6.0,
+                "carbs": 75,
+                "splitNow": 60,
+                "splitExt": 40,
+                "duration": 120,
+                "created_at": "2026-05-06T19:00:00Z",
+            }
+        )
+        assert t.is_combo_bolus is True
+        assert t.semantic_kind == "combo_bolus"
+
     # H6: device events were eaten by carb/bolus routing
     def test_h6_site_change_with_carbs_field_is_still_device_event(self):
         # A Care Portal Site Change with an incidental carbs field

--- a/dev/README.md
+++ b/dev/README.md
@@ -116,13 +116,13 @@ The architecture splits into:
 | `xdrip_plus` | xDrip+ (Android, pure-CGM uploader) | Shipped | `mapping/xdrip-android/` + upstream `NightscoutFoundation/xDrip` |
 | `librelink_up` | LibreLinkUp (Abbott cloud → NS bridge) | Shipped | `mapping/nightscout-librelink-up/` + upstream `timoschlueter/nightscout-librelink-up` |
 | `share2ns` | share2nightscout-bridge (Dexcom Share cloud → NS) | Shipped | `mapping/share2nightscout-bridge/` + upstream `nightscout/share2nightscout-bridge` |
+| `tconnectsync` | tconnectsync (Tandem t:connect cloud → NS) | Shipped | `mapping/tconnectsync/` + upstream `jwoglom/tconnectsync` |
 
 ### Planned lenses (each its own PR)
 
 | Lens | Platform | Reference doc |
 |---|---|---|
 | `iaps` | iAPS (Trio's predecessor) | `mapping/trio/nightscout-sync.md` |
-| `tconnectsync` | tconnectsync (Tandem t:connect → NS) | `mapping/tconnectsync/` |
 | `manual` | Direct Nightscout web UI entry | `mapping/cgm-remote-monitor/` |
 
 The reference repo is reference, not authoritative — when its claims
@@ -550,6 +550,98 @@ Cross-checked against upstream `nightscout/share2nightscout-bridge`:
 - `index.js` (the entire bridge is a single JS file -- entry
   mapping at lines 226-230, devicestatus at lines 265-273,
   `matchTrend()` at lines 56-66)
+
+#### `tconnectsync`
+
+The tconnectsync lens emits the **Tandem t:connect cloud →
+Nightscout bridge** wire format. tconnectsync (`jwoglom/tconnectsync`,
+Python, MIT) is a server-side bridge that polls Tandem's t:connect
+cloud (the cloud that t:slim X2 / Mobi pumps batch-upload to) and
+forwards pump events to Nightscout. Architecturally distinct from
+every prior cloud-bridge lens: where LibreLinkUp / share2ns forward
+**CGM-only** data from a sensor cloud, tconnectsync forwards
+**pump-side therapy data** -- boluses, basals, site changes,
+battery state -- alongside CGM (Dexcom paired with the pump).
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NS_TCONNECTSYNC_DEVICE` | `Pump (tconnectsync)` | The `device` / `enteredBy` string stamped on every record. Per upstream `tconnectsync/parser/nightscout.py`'s `ENTERED_BY` constant. The local RAG document claims `"tconnectsync"` (no parens) -- per the repo memory rule, upstream wins; the RAG is stale. |
+
+**Top divergences vs every prior lens:**
+
+- **Identity is `"Pump (tconnectsync)"`** -- literal string with
+  parentheses + space. Stamped on every treatment, entry, AND
+  devicestatus record (no other lens uses this exact form).
+- **`pump_event_id` field on every record**: monotonic pump
+  sequence number (e.g., `"100123"`). Used by tconnectsync for
+  client-side dedupe queries against NS. AAPS uses
+  `pumpId/pumpType/pumpSerial`; Trio uses `id` (UUID); oref0 has
+  no client dedupe; tconnectsync has its own.
+- **All boluses are `"Combo Bolus"`**: meal, correction, extended,
+  override, declined-correction -- ALL map to a single eventType
+  with the distinction stuffed into the `notes` field (`"Meal
+  Bolus"`, `"Correction Bolus"`, ...). Carbs are bundled into the
+  same record (no separate `Carb Correction`). Hard divergence
+  from every other lens.
+- **Temp Basal carries a `reason` field** describing Control-IQ's
+  rationale: `"Control-IQ"` (algorithm-controlled, no specific
+  intent), `"Helping with Trend"` (BG dropping), `"Correcting
+  High"`. Per upstream `process_basal.py`'s `changetype`-bitmask
+  reason extraction. AAPS / Trio temp basals have no comparable
+  field.
+- **Entries OMIT `direction`**: t:connect's CGM API doesn't expose
+  the trend arrow. Real divergence -- LibreLinkUp / share2ns /
+  xDrip-family all include direction; tconnectsync cannot.
+- **Devicestatus is MINIMAL `pump.battery` only**: voltage (volts,
+  not millivolts) + percent + a human-readable string like
+  `"85%"`. NO `openaps` / `loop` / `uploader` subtrees. NO
+  reservoir level (real upstream gap -- t:connect API doesn't
+  expose it).
+- **Profile uploads a Tandem-pump schedule**: full basal / ICR /
+  ISF / target schedule. Control-IQ default target is a NARROW
+  110/110 mg/dL band (single-value, not a wide range). AAPS / Trio
+  use a wider target_low/target_high split; this narrow band is a
+  Tandem-specific signal.
+- **Site Change for cartridge / cannula / tubing fills**: per
+  upstream `process_cartridge.py`, all three fill types map to
+  eventType `"Site Change"` with a `notes` field shaped
+  `"Cartridge Filled (<n>u filled)"` (volume in units in
+  parentheses) -- our reservoir-refill trigger emits the same
+  format with the actual reservoir volume so downstream
+  volume-extraction regex paths get exercised.
+
+**Real-world latency**: t:connect cloud is **60-90 minutes behind
+the pump** because Tandem batches uploads. Our emulator posts at
+5-min sim cadence (matching the rest of the emulator's tick rate)
+-- documented divergence; modeling true 60-90 min batched-upload
+latency would require buffering and is orthogonal to NS wire-format
+coverage.
+
+**Translator-side note**: `detect_uploader` doesn't recognize
+`"Pump (tconnectsync)"` as a known uploader (no substring match for
+`tandem` or `tconnect`). Real tconnectsync deployments hit this
+same gap. No functional impact -- no code paths branch on
+`uploader == "tconnectsync"`. Documented for the future translator
+improvement: `enteredBy == "Pump (tconnectsync)"` could be a
+recognition signal.
+
+Cross-checked against upstream `jwoglom/tconnectsync`:
+- `tconnectsync/parser/nightscout.py` (`ENTERED_BY` constant,
+  `NightscoutEntry` builders for bolus / basal / devicestatus /
+  entry / profile)
+- `tconnectsync/nightscout.py` (NS API v1 + SHA-1 auth)
+- `tconnectsync/sync/tandemsource/process_bolus.py` (Combo Bolus
+  + carbs bundling + notes)
+- `tconnectsync/sync/tandemsource/process_basal.py` (Temp Basal +
+  reason from `changetype` bitmask)
+- `tconnectsync/sync/tandemsource/process_cartridge.py` (Site
+  Change for cartridge / cannula / tubing fills)
+- `tconnectsync/sync/tandemsource/process_device_status.py`
+  (`pump.battery` shape: voltage + percent + status)
+- `tconnectsync/sync/tandemsource/process_cgm_reading.py` (entry
+  shape: no `direction`)
+- `tconnectsync/sync/tandemsource/update_profiles.py` (profile
+  schedule shape with narrow Control-IQ target band)
 
 ### How to verify it actually drove your code
 

--- a/dev/ns_emulator.py
+++ b/dev/ns_emulator.py
@@ -4485,6 +4485,478 @@ class Share2NsLens(Lens):
 
 
 # ---------------------------------------------------------------------------
+# tconnectsync lens (Tandem t:connect cloud → Nightscout bridge, pump-side)
+# ---------------------------------------------------------------------------
+#
+# `jwoglom/tconnectsync` (Python, MIT) is the third cloud-bridge lens
+# (after `librelink_up` / `share2ns`) but it is the ARCHITECTURAL
+# OPPOSITE of those two: where LibreLinkUp / share2ns forward CGM-only
+# data from a sensor cloud, tconnectsync forwards PUMP-SIDE THERAPY
+# data from Tandem's t:connect cloud (the cloud that t:slim X2 / Mobi
+# pumps batch-upload to). It is the user's actual real-world data
+# path, since they are a Tandem user.
+#
+# Polls Tandem's t:connect ControlIQ API on a schedule (typically
+# `--auto-update` continuous mode, default ~every few minutes) and
+# converts pump events to NS treatments + entries + devicestatus +
+# profile. Real-world latency: t:connect cloud is 60-90 minutes
+# behind the pump because Tandem batches uploads on the pump side.
+# Our emulator posts at 5-min sim cadence (matching the rest of the
+# emulator's tick rate) -- documented divergence; modeling true
+# 60-90 min batched-upload latency would require buffering and is
+# orthogonal to what we want to test (NS wire-format coverage).
+#
+# Architecturally distinct from EVERY prior lens:
+#
+# - **Identity**: every record stamps `enteredBy: "Pump
+#   (tconnectsync)"` (literal string with parentheses + space).
+#   Per upstream `tconnectsync/parser/nightscout.py`'s `ENTERED_BY`
+#   constant. The local RAG document claims `ENTERED_BY =
+#   "tconnectsync"` -- per the repo memory rule, upstream wins; the
+#   RAG is stale on this field.
+#
+# - **`pump_event_id` field**: every treatment, entry, AND
+#   devicestatus carries a `pump_event_id` -- the pump's sequence
+#   number (e.g., `"12345"` for a single basal event, or
+#   `"12345,12346,12347"` for paired Exercise Mode start/stop
+#   events). Per upstream `process_*.py` helpers. tconnectsync uses
+#   this for client-side dedupe queries against NS. No prior lens
+#   uses this exact field name -- AAPS uses `pumpId/pumpType/
+#   pumpSerial`, Trio uses `id` (UUID), oref0 has no client dedupe
+#   at all.
+#
+# - **Boluses are ALL `"Combo Bolus"`**: per upstream
+#   `process_bolus.py`, every Tandem bolus -- meal, correction,
+#   extended, dual-wave, override, declined-correction -- maps to
+#   the SINGLE eventType `"Combo Bolus"`. Carbs are bundled into
+#   the same record when present. Distinguishing Meal vs Correction
+#   only happens via the `notes` field (e.g., `"Meal Bolus"`,
+#   `"Correction Bolus"`, `"(Override)"`). NO `"Meal Bolus"` /
+#   `"Correction Bolus"` / `"Bolus"` / `"SMB"` event types ever
+#   appear -- a hard divergence from every other lens.
+#
+# - **Temp Basal carries a `reason` field** with Control-IQ
+#   metadata: `"Control-IQ"`, `"Helping with Trend"`, `"Correcting
+#   High"`, `"User Requested"`, etc. Per upstream `process_basal.py`
+#   which extracts the reason from the pump event's `changetype`
+#   bitmask. AAPS/Trio temp basals have no comparable field.
+#
+# - **Site Change for cartridge / cannula / tubing fills**: per
+#   upstream `process_cartridge.py`, all three fill types map to
+#   eventType `"Site Change"` (despite "cartridge change" being a
+#   pump-side different operation than "infusion set change").
+#   Matches our emulator's reservoir-refill trigger.
+#
+# - **Devicestatus is MINIMAL pump.battery only**: per upstream
+#   `process_device_status.py`:
+#     `{ device, created_at, pump: { clock, battery: { voltage,
+#        percent, status: "<n>%" } }, pump_event_id }`
+#   NO `openaps` subtree, NO `loop` subtree, NO uploader subtree.
+#   Battery has BOTH voltage (in volts, not millivolts) AND percent
+#   AND a human-readable string. NO reservoir level on devicestatus
+#   (t:connect API doesn't expose it -- a real upstream gap, not a
+#   lens defect).
+#
+# - **Entries have NO `direction` field**: per upstream
+#   `process_cgm_reading.py`, t:connect's CGM API does not expose
+#   the trend arrow -- only the raw glucose value. So tconnectsync
+#   posts entries with `sgv` only, no `direction`. This is a real
+#   wire-format divergence vs LibreLinkUp / share2ns (both of which
+#   include direction).
+#
+# - **Profile upload is FULL pump-side schedule**: tconnectsync
+#   uploads basal / ICR / ISF / target_low / target_high schedules
+#   from the pump's active settings. Per upstream
+#   `update_profiles.py`. LibreLinkUp / share2ns do NOT upload
+#   profiles. AAPS / Trio / Loop / oref0 upload theirs but those
+#   come from app settings; tconnectsync's come from PUMP settings
+#   (Control-IQ targets are typically 110 mg/dL fixed).
+#
+# Translator-side note: `detect_uploader` does not recognize "Pump
+# (tconnectsync)" as a known uploader (no substring match for
+# `tandem` or `tconnect`). Real tconnectsync deployments hit this
+# same translator gap -- no functional impact since no code paths
+# branch on `uploader == "tconnectsync"`. Documented for the future
+# translator improvement: `enteredBy == "Pump (tconnectsync)"`
+# could be a recognition signal.
+#
+# Source-of-truth files cross-checked:
+#   - `mapping/tconnectsync/`
+#   - upstream `jwoglom/tconnectsync/tconnectsync/parser/nightscout.py`
+#     (`ENTERED_BY = "Pump (tconnectsync)"`, NightscoutEntry builders)
+#   - upstream `tconnectsync/nightscout.py` (SHA-1 auth, NS API v1)
+#   - upstream `tconnectsync/sync/tandemsource/process_bolus.py`
+#     (Combo Bolus, notes field)
+#   - upstream `process_basal.py` (Temp Basal + reason)
+#   - upstream `process_cartridge.py` (Site Change for cartridge/cannula)
+#   - upstream `process_device_status.py` (pump.battery shape)
+#   - upstream `process_cgm_reading.py` (entry: no direction)
+#   - upstream `update_profiles.py` (profile schedule shape)
+
+
+TCONNECTSYNC_ENTERED_BY = "Pump (tconnectsync)"
+# Default Control-IQ target on the t:slim X2 / Mobi pumps is a
+# narrow 110 mg/dL band -- tconnectsync uploads this literally per
+# upstream `update_profiles.py`. (Sleep mode lowers it to 112.5;
+# Exercise raises to 140-160. We model only the default band.)
+TCONNECTSYNC_CIQ_TARGET_MGDL = 110
+
+
+class TconnectsyncLens(Lens):
+    """tconnectsync (Tandem t:connect cloud → NS) lens. See
+    architecture comment block above for full divergence vs every
+    prior lens. Pump-side data: Combo Bolus treatments, Temp Basals
+    with Control-IQ reasons, pump.battery devicestatus, entries
+    WITHOUT direction, full profile schedule."""
+
+    name = "tconnectsync"
+
+    def __init__(
+        self, base_url: str, api_secret: str, device_label: str | None = None
+    ) -> None:
+        super().__init__(base_url, api_secret, device_label)
+        # Monotonic pump event sequence number. Real Tandem pumps
+        # use a hardware counter that increments with every pump
+        # event; tconnectsync extracts it from the event payload
+        # and stamps it as `pump_event_id` on every NS record. Our
+        # counter starts at a plausible mid-range value (matches
+        # what a pump that has been running for a few months
+        # would emit) so dashboards see realistic 6-digit ids.
+        self._next_seqnum = 100000
+
+    @classmethod
+    def default_device_label(cls) -> str:
+        return os.environ.get("NS_TCONNECTSYNC_DEVICE", TCONNECTSYNC_ENTERED_BY)
+
+    # ---- helpers --------------------------------------------------------
+
+    def _seqnum(self) -> str:
+        """Issue the next pump-event sequence number as a string
+        (per upstream's `pump_event_id` typing). Monotonic across
+        every record this lens emits."""
+        n = self._next_seqnum
+        self._next_seqnum += 1
+        return str(n)
+
+    # ---- profile --------------------------------------------------------
+
+    def ensure_profile(self) -> None:
+        """tconnectsync uploads a full Tandem-pump profile via
+        `update_profiles.py`: basal schedule, ICR, ISF, target
+        bands. The Control-IQ default target is a narrow 110 mg/dL
+        band (110-110); we expose it that way to match real-world
+        t:connect uploads.
+
+        Emulator simplification: this is an ENSURE-ONCE check (same
+        as every other lens in this file). Real tconnectsync runs a
+        diff between pump_settings and the existing NS profile and
+        re-POSTs whenever they drift -- per upstream
+        `update_profiles.py:54-77` (`add` vs `replace` mode). Our
+        single-tick emulator doesn't model pump-side schedule
+        changes, so a diff loop would be dead code. If a profile
+        already exists, skip; otherwise POST a baseline.
+
+        `enteredBy` on the profile record is the tconnectsync
+        identity string (NOT `"openaps"` -- this lens does author
+        a profile on behalf of the user)."""
+        try:
+            existing = http_get(
+                self.base_url, "/api/v1/profile.json", self._auth_headers
+            )
+            if existing:
+                return
+        except urllib.error.HTTPError:
+            pass
+
+        now_iso = iso_z(datetime.datetime.now(datetime.UTC))
+        profile_name = "Default"
+        ciq_target = TCONNECTSYNC_CIQ_TARGET_MGDL
+        payload = {
+            "defaultProfile": profile_name,
+            "store": {
+                profile_name: {
+                    "dia": str(DIA_MINUTES // 60),
+                    "carbratio": [{"time": "00:00", "value": ICR_GRAMS_PER_UNIT}],
+                    "sens": [{"time": "00:00", "value": ISF_MGDL_PER_UNIT}],
+                    "basal": [{"time": "00:00", "value": SCHEDULED_BASAL_U_HR}],
+                    # Control-IQ posts a SINGLE-VALUE target band
+                    # (110/110), not a wide range. AAPS/Trio/Loop
+                    # use a wider target_low/target_high split; this
+                    # narrow band is a Tandem-specific signal.
+                    "target_low": [{"time": "00:00", "value": ciq_target}],
+                    "target_high": [{"time": "00:00", "value": ciq_target}],
+                    "carbs_hr": "20",
+                    "delay": "20",
+                    "timezone": "UTC",
+                    "units": "mg/dl",
+                }
+            },
+            "startDate": now_iso,
+            "mills": int(time.time() * 1000),
+            "units": "mg/dl",
+            "enteredBy": TCONNECTSYNC_ENTERED_BY,
+        }
+        http_post(
+            self.base_url, "/api/v1/profile.json", self._auth_headers, [payload]
+        )
+
+    # ---- per-tick hook --------------------------------------------------
+
+    def on_tick_start(
+        self, state: PatientState, posted_at: datetime.datetime
+    ) -> None:
+        """Control-IQ runs ON THE PUMP every 5 min; tconnectsync
+        observes the resulting basal adjustments via cloud upload.
+        We model that here by running the same `loop_temp_basal_
+        decision` the Loop / Trio / AAPS lenses use, which gives the
+        patient realistic basal modulation. The reason string is
+        stamped on the resulting Temp Basal treatment in
+        `post_temp_basal` below."""
+        rate = loop_temp_basal_decision(state)
+        state.set_temp_basal(rate, LOOP_TEMP_BASAL_DURATION_MIN)
+
+    # ---- entries --------------------------------------------------------
+
+    def post_entry(
+        self,
+        state: PatientState,
+        prev_bg: float,
+        posted_at: datetime.datetime,
+    ) -> None:
+        """tconnectsync entries OMIT `direction` -- t:connect's CGM
+        API doesn't expose the trend arrow. Per upstream
+        `process_cgm_reading.py`. Big divergence vs LibreLinkUp /
+        share2ns / xDrip-family which all include direction.
+
+        Shape per upstream:
+            { type: 'sgv', sgv, date, dateString, device,
+              pump_event_id }
+
+        Note: `prev_bg` parameter is unused -- tconnectsync has no
+        trend data so prior BG is irrelevant for the wire payload.
+        Kept for Lens contract compatibility."""
+        sgv = int(round(state.bg))
+        payload = [
+            {
+                "type": "sgv",
+                "sgv": sgv,
+                "date": int(posted_at.timestamp() * 1000),
+                "dateString": iso_z(posted_at),
+                "device": self.device_label,
+                "pump_event_id": self._seqnum(),
+            }
+        ]
+        http_post(
+            self.base_url, "/api/v1/entries.json", self._auth_headers, payload
+        )
+
+    # ---- devicestatus ---------------------------------------------------
+
+    def post_devicestatus(
+        self, state: PatientState, posted_at: datetime.datetime
+    ) -> None:
+        """tconnectsync devicestatus is MINIMAL: just `pump.battery`
+        with voltage (volts, not millivolts), percent, and a human-
+        readable status string. NO openaps / loop / uploader
+        subtrees. NO reservoir level (t:connect API doesn't expose
+        it -- a real upstream gap). Per upstream
+        `process_device_status.py`.
+
+        Real Tandem pump batteries are 3.7V Li-ion; we map the
+        patient-state percent to a plausible voltage range
+        (3.5V dead, 4.2V full).
+        """
+        ts = iso_z(posted_at)
+        pct = int(state.pump_battery_pct)
+        # Linear pct→voltage mapping in the 3.5V (0%) to 4.2V (100%)
+        # range a real 3.7V Li-ion shows. tconnectsync passes raw
+        # volts through; we round to 2 decimals to keep the wire
+        # payload tidy and to mirror the precision a real pump
+        # reports.
+        voltage = round(3.5 + (4.2 - 3.5) * (pct / 100.0), 2)
+        battery = {
+            "voltage": voltage,
+            "percent": pct,
+            "status": f"{pct}%",
+        }
+        payload = [
+            {
+                "device": self.device_label,
+                "created_at": ts,
+                "pump": {
+                    "clock": ts,
+                    "battery": battery,
+                },
+                "pump_event_id": self._seqnum(),
+            }
+        ]
+        http_post(
+            self.base_url,
+            "/api/v1/devicestatus.json",
+            self._auth_headers,
+            payload,
+        )
+
+    # ---- treatments -----------------------------------------------------
+
+    def post_meal_bolus(
+        self,
+        state: PatientState,
+        carbs_g: float,
+        bolus_u: float,
+        posted_at: datetime.datetime,
+    ) -> None:
+        """Per upstream `process_bolus.py`, ALL Tandem boluses are
+        emitted as eventType `"Combo Bolus"` with the meal/correction
+        distinction stuffed into the `notes` field. Carbs are bundled
+        in the SAME record (not a separate Carb Correction). One
+        record per meal-bolus event."""
+        payload = [
+            {
+                "eventType": "Combo Bolus",
+                "created_at": iso_z(posted_at),
+                "enteredBy": TCONNECTSYNC_ENTERED_BY,
+                "insulin": bolus_u,
+                "carbs": round(carbs_g, 1),
+                "notes": "Meal Bolus",
+                "pump_event_id": self._seqnum(),
+            }
+        ]
+        http_post(
+            self.base_url,
+            "/api/v1/treatments.json",
+            self._auth_headers,
+            payload,
+        )
+
+    def post_correction_bolus(
+        self,
+        state: PatientState,
+        units: float,
+        posted_at: datetime.datetime,
+    ) -> None:
+        """Same `"Combo Bolus"` event type as meal boluses; only the
+        `notes` field distinguishes the two. NO carbs on a correction-
+        only bolus. NO `"SMB"` event type (Tandem doesn't have SMBs;
+        Control-IQ adjusts BASAL, not bolus, for between-meal
+        corrections)."""
+        payload = [
+            {
+                "eventType": "Combo Bolus",
+                "created_at": iso_z(posted_at),
+                "enteredBy": TCONNECTSYNC_ENTERED_BY,
+                "insulin": units,
+                "notes": "Correction Bolus",
+                "pump_event_id": self._seqnum(),
+            }
+        ]
+        http_post(
+            self.base_url,
+            "/api/v1/treatments.json",
+            self._auth_headers,
+            payload,
+        )
+
+    def post_temp_basal(
+        self,
+        state: PatientState,
+        rate_u_hr: float,
+        duration_min: int,
+        posted_at: datetime.datetime,
+    ) -> None:
+        """Tandem Control-IQ adjusts basal continuously; tconnectsync
+        forwards every adjustment as a `"Temp Basal"` treatment with
+        a `reason` field describing WHY Control-IQ made the change.
+        Per upstream `process_basal.py`'s `changetype`-bitmask reason
+        extraction (which calls `bitmask_to_list(event.changetype)`
+        and joins the resulting enum-label list).
+
+        Emulator-friendly reasons (NOT verbatim upstream enum
+        labels): we synthesize one of three human-readable strings
+        based on rate vs scheduled basal:
+        - rate < scheduled -> "Helping with Trend" (low/dropping BG)
+        - rate > scheduled -> "Correcting High"
+        - rate == scheduled -> "Control-IQ" (algorithm-controlled,
+          no specific corrective intent)
+
+        Real tconnectsync emits the underlying `Changetype` /
+        `CommandedRateSource` enum labels which can read e.g.
+        `BG_HIGH, INDUCED_LOW` -- the exact string set varies by
+        pump firmware and is hard to enumerate exhaustively. The
+        three aliases above cover the operationally meaningful
+        intent that downstream readers care about (was this
+        adjustment correcting up, correcting down, or steady-
+        state) without claiming verbatim upstream fidelity.
+        """
+        if rate_u_hr < SCHEDULED_BASAL_U_HR - 0.01:
+            reason = "Helping with Trend"
+        elif rate_u_hr > SCHEDULED_BASAL_U_HR + 0.01:
+            reason = "Correcting High"
+        else:
+            reason = "Control-IQ"
+        payload = [
+            {
+                "eventType": "Temp Basal",
+                "created_at": iso_z(posted_at),
+                "enteredBy": TCONNECTSYNC_ENTERED_BY,
+                "rate": rate_u_hr,
+                "absolute": rate_u_hr,
+                "duration": duration_min,
+                "reason": reason,
+                "pump_event_id": self._seqnum(),
+            }
+        ]
+        http_post(
+            self.base_url,
+            "/api/v1/treatments.json",
+            self._auth_headers,
+            payload,
+        )
+
+    def post_site_change(
+        self, state: PatientState, posted_at: datetime.datetime
+    ) -> None:
+        """tconnectsync emits Site Change for ALL three Tandem fill
+        types (cartridge, cannula, tubing) per upstream
+        `process_cartridge.py`. Our reservoir-refill trigger maps to
+        cartridge fill (the fill that signals an insulin reservoir
+        replacement) -- the most common Site Change source on real
+        Tandem pumps.
+
+        Notes shape matches upstream `process_cartridge.py`:
+        `"Cartridge Filled (<int>u filled)"` -- fill volume in
+        units appended in parentheses. Real downstream readers
+        (translators, AI consumers) parse this regex to extract
+        the volume; emitting the bare string would silently drop
+        coverage for that read path.
+
+        The volume is the POST-refill reservoir level. On real
+        Tandem pumps a Cartridge Filled event fires after a fresh
+        cartridge load + priming, and the logged "filled" amount
+        is the volume in the new cartridge -- which equals
+        capacity for a clean swap (Mobi 200U / X2 300U). Reading
+        `state.reservoir_u` post-refill (200U) matches this
+        upstream semantic exactly: it is the volume of the new
+        cartridge, not the delta from the prior level."""
+        reservoir_u = int(round(state.reservoir_u))
+        payload = [
+            {
+                "eventType": "Site Change",
+                "created_at": iso_z(posted_at),
+                "enteredBy": TCONNECTSYNC_ENTERED_BY,
+                "notes": f"Cartridge Filled ({reservoir_u}u filled)",
+                "pump_event_id": self._seqnum(),
+            }
+        ]
+        http_post(
+            self.base_url,
+            "/api/v1/treatments.json",
+            self._auth_headers,
+            payload,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Lens registry
 # ---------------------------------------------------------------------------
 
@@ -4498,8 +4970,8 @@ LENSES: dict[str, type[Lens]] = {
     "xdrip_plus": XdripPlusLens,
     "librelink_up": LibreLinkUpLens,
     "share2ns": Share2NsLens,
-    # Future: "iaps": IapsLens, "tconnectsync": TConnectSyncLens,
-    # "manual": ManualLens.
+    "tconnectsync": TconnectsyncLens,
+    # Future: "iaps": IapsLens, "manual": ManualLens.
 }
 
 


### PR DESCRIPTION
## Summary

Adds the 10th lens in the multi-lens Nightscout emulator at `dev/ns_emulator.py`. tconnectsync (`jwoglom/tconnectsync`, Python) is the **architectural inverse** of the two prior cloud-bridge lenses (`librelink_up`, `share2ns`):

- LibreLinkUp / share2ns: CGM-only sensor cloud → NS (entries only)
- tconnectsync: **pump-side therapy data** (boluses, basals, site changes, pump battery) + CGM, from Tandem's t:connect cloud → NS

This is the real-world data path for Tandem t:slim X2 / Mobi pump users.

## Wire-format coverage (cross-checked against upstream `jwoglom/tconnectsync`)

- **`enteredBy: "Pump (tconnectsync)"`** literal (`parser/nightscout.py`'s `ENTERED_BY` constant). The local RAG had a stale `"tconnectsync"` no-parens claim — upstream wins per the repo's memory rule.
- **All boluses → `"Combo Bolus"`** with meal/correction distinction in the `notes` field; carbs bundled in the same record (`process_bolus.py`). Hard divergence from every other lens — no `"Meal Bolus"` / `"Correction Bolus"` / `"SMB"` event types appear.
- **Temp Basal carries a `reason` field** with one of three Control-IQ aliases (`"Helping with Trend"`, `"Correcting High"`, `"Control-IQ"`) derived from rate vs scheduled basal. Emulator-friendly synthesis of upstream's `changetype`-bitmask reasons (whose exact enum-label set varies by firmware).
- **Entries OMIT `direction`** (`process_cgm_reading.py` — t:connect's CGM API doesn't expose the trend arrow). Real divergence vs every other CGM-emitting lens.
- **Devicestatus is minimal `pump.battery` only** — voltage (volts, not millivolts) + percent + status string. No `openaps`/`loop`/`uploader` subtrees, no reservoir (real upstream gap).
- **Profile uses a narrow 110/110 mg/dL Control-IQ target band** — Tandem-specific signal (AAPS/Trio/Loop use a wider `target_low`/`target_high` split).
- **Site Change emits `"Cartridge Filled (<n>u filled)"`** notes matching `process_cartridge.py`'s shape.
- **`pump_event_id`** (monotonic int) stamped on every entry, treatment, and devicestatus record. AAPS uses `pumpId/pumpType/pumpSerial`; Trio uses `id` (UUID); oref0 has no client dedupe; tconnectsync has its own.

## Verification (60× compression, 30 sim-hr, `NS_RANDOM_SEED=42`)

- **488** glucose readings extracted by the GlycemicGPT translator (`trend = not_computable`, the expected outcome for direction-less entries).
- **223** Temp Basal records (with reasons) + **5** Combo Bolus + 1 Site Change posted.
- Dashboard renders BG hero (with `?` trend, correct for tconnectsync-without-direction), basal rate, pump battery percent. IOB and reservoir correctly show `--` — upstream tconnectsync gaps faithfully reproduced.
- Cartridge Filled notes shape verified end-to-end via targeted `post_site_change` invocation.

## Reviews

- Adversarial review run on the lens code; HIGH/MED/LOW findings addressed (ensure-once docstring tightened, Site Change notes shape fixed to include fill volume, temp-basal reason strings documented as emulator-friendly aliases, `del state` lines removed for cross-lens consistency).
- CodeRabbit CLI review run on the uncommitted diff. The one remaining `dev/ns_emulator.py` finding (post-refill reservoir level reads as capacity) was reviewed and skipped with an in-code clarifying note: for Tandem, a fresh cartridge fill IS the capacity, matching upstream's "filled" semantic. The other CR findings were on `mempalace.yaml` (unrelated, untracked).
- Security review on the staged diff: PASS, no findings.

## Test plan

- [x] `python3 dev/ns_emulator.py --help` lists the new `tconnectsync` platform alongside the prior 9 lenses
- [x] 30 sim-hr run posts entries / treatments / devicestatus / profile records to the local NS test stack
- [x] Translator extracts glucose readings with `trend = not_computable`
- [x] Dashboard renders correctly (BG hero, basal rate, battery percent; IOB and reservoir show `--` per tconnectsync upstream gaps)
- [x] Cartridge Filled note shape matches upstream `"Cartridge Filled (<n>u filled)"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tandem t:connect platform bridge integration and made the new platform selectable in the test emulator.

* **Documentation**
  * Expanded platform documentation with a dedicated t:connect section, wire-format details, configuration notes, and uploader behavior caveats.

* **Bug Fixes**
  * Refined Combo Bolus classification to avoid misclassifying plain boluses encoded as "Combo Bolus."

* **Tests**
  * Added regression tests covering Combo Bolus routing and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/591)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->