### PR TITLE
feat(api): Nightscout evaluate endpoint for smart-onboarding wizard (Story 43.7a)

### DIFF
--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -556,9 +556,14 @@ async def run_evaluate(
     # would trap the user for 5 min while they fix the secret. The
     # cache is for "we already evaluated this healthy instance"
     # only.
+    # `isinstance(..., dict)` guards against legacy rows that may
+    # have stored a list / string in this JSONB column under an
+    # earlier schema -- without it, `.get()` would raise
+    # AttributeError and 500 the request instead of falling
+    # through to a fresh evaluate.
     if (
         conn.last_evaluated_at is not None
-        and conn.detected_uploaders_json is not None
+        and isinstance(conn.detected_uploaders_json, dict)
         and conn.detected_uploaders_json.get("status_ok") is True
     ):
         age = (datetime.now(UTC) - conn.last_evaluated_at).total_seconds()

--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -35,6 +35,7 @@ from src.schemas.nightscout import (
     NightscoutConnectionTestResult,
     NightscoutConnectionUpdate,
     NightscoutDataResponse,
+    NightscoutDiscoveryReport,
     NightscoutGlucoseReadingDTO,
     NightscoutManualSyncResponse,
     NightscoutProfileSnapshotResponse,
@@ -43,6 +44,9 @@ from src.schemas.nightscout import (
 from src.services.integrations.nightscout.connection_test import (
     ConnectionTestOutcome,
     test_connection,
+)
+from src.services.integrations.nightscout.evaluate import (
+    evaluate_nightscout_for_connection,
 )
 from src.services.integrations.nightscout.sync import (
     sync_nightscout_for_connection,
@@ -59,6 +63,19 @@ router = APIRouter(
 # worker so a slow / unresponsive user-controlled NS URL can't pin a
 # request thread for the full upstream client timeout (often 30s+).
 _SYNC_TIMEOUT_SECONDS = 20.0
+
+# Story 43.7a (evaluate endpoint): bound the upstream probes the same
+# way `_SYNC_TIMEOUT_SECONDS` does -- evaluate fires up to 5 fetches
+# (entries x2, treatments, devicestatus, profile) sequentially, so a
+# user-controlled URL that hangs on any of them shouldn't tie up a
+# request worker indefinitely. 25s is generous-but-bounded.
+_EVALUATE_TIMEOUT_SECONDS = 25.0
+
+# Story 43.7a AC9: cache the discovery report on the connection row
+# for this many seconds. Wizard re-renders shouldn't re-evaluate; an
+# explicit "re-import settings" entry point (Story 43.7d) bypasses the
+# cache by setting `last_evaluated_at = None` before the call.
+_EVALUATE_CACHE_SECONDS = 5 * 60
 
 
 # ---------------------------------------------------------------------------
@@ -497,6 +514,101 @@ async def run_sync(
         duration_ms=result.duration_ms,
         error=result.error,
     )
+
+
+@router.post(
+    "/{connection_id}/evaluate",
+    response_model=NightscoutDiscoveryReport,
+    responses={
+        200: {"description": "Discovery report (check `status_ok`)"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Connection not found"},
+        504: {"model": ErrorResponse, "description": "Evaluate timed out"},
+    },
+)
+async def run_evaluate(
+    connection_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> NightscoutDiscoveryReport:
+    """Story 43.7a: evaluate the target Nightscout for the wizard.
+
+    Counts entries (full + 7d), detects uploaders, samples treatments
+    + devicestatus + profile, and returns a structured discovery
+    report (AC1). The wizard's step 2 renders this as the
+    "Found ~142K entries..." preview.
+
+    Cached for 5 min on the connection row (AC9). Wizard re-renders
+    return the cached body; "Re-import settings" (Story 43.7d)
+    bypasses the cache by clearing `last_evaluated_at` before the
+    call.
+
+    Soft-deleted connections are 404'd (parity with `/test` and
+    `/sync`) -- evaluate is a side-effecting probe, not a passive
+    read.
+    """
+    conn = await _load_owned(
+        db, connection_id, current_user.id, require_active=True
+    )
+
+    # AC9: 5-min cache. Return the previously persisted report when
+    # the cache window is still warm AND the cached report itself
+    # was a success. A cached `status_ok=False` (e.g. typo'd token
+    # on the prior call) MUST NOT be served from cache -- doing so
+    # would trap the user for 5 min while they fix the secret. The
+    # cache is for "we already evaluated this healthy instance"
+    # only.
+    if (
+        conn.last_evaluated_at is not None
+        and conn.detected_uploaders_json is not None
+        and conn.detected_uploaders_json.get("status_ok") is True
+    ):
+        age = (datetime.now(UTC) - conn.last_evaluated_at).total_seconds()
+        if age < _EVALUATE_CACHE_SECONDS:
+            try:
+                return NightscoutDiscoveryReport.model_validate(
+                    conn.detected_uploaders_json
+                )
+            except Exception:  # noqa: BLE001 - shape changed mid-cache
+                # Schema drift between cached payload and current
+                # model: fall through to a fresh evaluate. The
+                # cached row will be overwritten below.
+                logger.info(
+                    "nightscout_evaluate_cache_invalid",
+                    connection_id=str(conn.id),
+                )
+
+    # Bound the user-controlled upstream the same way `/sync` does.
+    try:
+        report = await asyncio.wait_for(
+            evaluate_nightscout_for_connection(conn),
+            timeout=_EVALUATE_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        # Don't persist anything on timeout: `last_evaluated_at` stays
+        # whatever it was, so an immediate retry isn't blocked by a
+        # phantom cache entry. Last sync status is also untouched
+        # (we didn't write user data).
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=f"Evaluate exceeded {_EVALUATE_TIMEOUT_SECONDS}s timeout",
+        ) from None
+
+    # Persistence policy: only successful reports go into the cache.
+    # A `status_ok=False` (auth fail, unreachable URL, etc.) returns
+    # to the caller fresh every time so the user can immediately
+    # retry after fixing their secret -- without waiting out a
+    # 5-min cache window. Diagnostic value of caching a failure is
+    # near zero; the wizard's "we couldn't reach your NS" UX wants
+    # a real attempt each time.
+    if report.status_ok:
+        # `mode="json"` so datetime fields serialize to strings -- the
+        # JSONB column rejects raw datetime objects.
+        conn.detected_uploaders_json = report.model_dump(mode="json")
+        conn.last_evaluated_at = datetime.now(UTC)
+        await db.commit()
+
+    return report
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -547,9 +547,7 @@ async def run_evaluate(
     `/sync`) -- evaluate is a side-effecting probe, not a passive
     read.
     """
-    conn = await _load_owned(
-        db, connection_id, current_user.id, require_active=True
-    )
+    conn = await _load_owned(db, connection_id, current_user.id, require_active=True)
 
     # AC9: 5-min cache. Return the previously persisted report when
     # the cache window is still warm AND the cached report itself

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -10,7 +10,7 @@ set" without exposing it.
 
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -383,3 +383,93 @@ class NightscoutProfileSnapshotResponse(BaseModel):
     sensitivity_segments: list[NightscoutProfileSegmentDTO] | None
     target_low_segments: list[NightscoutProfileSegmentDTO] | None
     target_high_segments: list[NightscoutProfileSegmentDTO] | None
+
+
+# ---------------------------------------------------------------------------
+# Story 43.7a -- evaluate / discovery report
+# ---------------------------------------------------------------------------
+
+
+class NightscoutDiscoveryProfileSummary(BaseModel):
+    """Profile facts surfaced on the discovery report.
+
+    Schedules carry the profile snapshot's `[{time, value, ...}, ...]`
+    shape verbatim so downstream code (43.7b derive, the wizard's
+    review table) sees the same structure the snapshot stores. Single-
+    band target_low / target_high values are min / max across the
+    target schedule (a single-segment 70-180 target reports identical
+    bounds; a time-varying target reports the safest summary the
+    review screen can render in one row).
+
+    `target_low` / `target_high` are kept as `float` so mmol/L profiles
+    (where targets are sub-ten decimals like 4.4 / 7.8) preserve their
+    clinical precision. Wizard / 43.7b derive code is responsible for
+    unit normalization at render / write time.
+    """
+
+    target_low: float | None = None
+    target_high: float | None = None
+    dia_hours: float | None = None
+    # NS profile units are one of "mg/dl" / "mmol" per upstream
+    # `lib/units.js`. Constrained because mg/dL <-> mmol/L is a
+    # ~18x scale factor -- a misread here corrupts every downstream
+    # target / ISF / DIA calculation. Strict Literal so a future
+    # NS version that introduces a third unit string fails loud
+    # at the schema layer rather than silently writing garbage.
+    units: Literal["mg/dl", "mmol"] | None = None
+    timezone: str | None = None
+    carb_ratio_schedule: list[NightscoutProfileSegmentDTO] | None = None
+    isf_schedule: list[NightscoutProfileSegmentDTO] | None = None
+    basal_schedule: list[NightscoutProfileSegmentDTO] | None = None
+    target_low_schedule: list[NightscoutProfileSegmentDTO] | None = None
+    target_high_schedule: list[NightscoutProfileSegmentDTO] | None = None
+    is_malformed: bool = False  # AC11: profile fetch returned but unparseable
+
+
+class NightscoutDiscoveryReport(BaseModel):
+    """Story 43.7a AC1: the evaluate endpoint's response shape.
+
+    Persisted on `nightscout_connections.detected_uploaders_json` and
+    cached for 5 minutes per AC9 -- the field name predates this report
+    (Story 43.1 forward-engineered it), but it now stores the full
+    report, not just the uploader list.
+    """
+
+    status_ok: bool
+    server_version: str | None = None
+    earliest_entry_at: datetime | None = None
+    # `entry_count_estimate` is an EXTRAPOLATION from the recent-7d
+    # rate * the span between the oldest sampled entry and now. For
+    # instances with steady CGM upload, this lands within ~10% of the
+    # true total. For sparse / intermittent uploaders, it's a rough
+    # order-of-magnitude. The wizard renders this as "~N entries" so
+    # the rough-estimate nature is OK. Constrained `>= 0` to reject
+    # anyone serializing in a corrupt state.
+    entry_count_estimate: int = Field(default=0, ge=0)
+    recent_entry_count_7d: int = Field(default=0, ge=0)
+    uploaders_detected: list[str] = []
+    has_treatments: bool = False
+    treatment_count_estimate: int = Field(default=0, ge=0)
+    has_devicestatus: bool = False
+    has_profile: bool = False
+    profile_summary: NightscoutDiscoveryProfileSummary | None = None
+    # First detected closed-loop platform from the uploader sample,
+    # if any -- one of "loop" | "aaps" | "trio" | "oref0" | None.
+    # Treated as a HINT, not source-of-truth: a multi-uploader
+    # sample (e.g. legacy Loop records still in retention plus
+    # current Trio uploads) reports the first match across the
+    # `_LOOP_UPLOADERS` preference order. The wizard surfaces this
+    # for UI flavor / freshness expectations only.
+    active_pump_loop: str | None = None
+    # Names of upstream resources that a per-resource probe
+    # FAILED to read, even though `test_connection` passed. Empty
+    # on a clean evaluate. Populated when an instance's token has
+    # entries-only scope (or any other partial-permission pattern):
+    # the wizard can surface "we couldn't read your treatments --
+    # your token might be entries-only" rather than silently
+    # claiming the data isn't there. Names match the orchestrator's
+    # internal labels: "treatments" | "devicestatus" | "profile" |
+    # "recent_entries" | "oldest_entries".
+    partial_resources: list[str] = []
+    evaluated_at: datetime
+    error: str | None = None  # populated when status_ok is False

--- a/apps/api/src/services/integrations/nightscout/evaluate.py
+++ b/apps/api/src/services/integrations/nightscout/evaluate.py
@@ -83,7 +83,27 @@ async def evaluate_nightscout_for_connection(
     inherits the protection.
     """
     evaluated_at = datetime.now(UTC)
-    credential = decrypt_credential(conn.encrypted_credential)
+    # Decrypt failures are a real production concern (key rotation,
+    # DB corruption, direct DB tampering) -- treat them as a clean
+    # status_ok=False report rather than letting the ValueError
+    # propagate as an opaque 500. The router's failure-not-cached
+    # policy still applies, so an operator who fixes the cipher
+    # state can retry immediately.
+    try:
+        credential = decrypt_credential(conn.encrypted_credential)
+    except Exception:  # noqa: BLE001 -- defense for any cipher fault
+        logger.warning(
+            "nightscout_evaluate_decrypt_failed",
+            connection_id=str(conn.id),
+        )
+        return NightscoutDiscoveryReport(
+            status_ok=False,
+            evaluated_at=evaluated_at,
+            error=(
+                "Stored credential could not be decrypted. The "
+                "connection's secret may need to be re-entered."
+            ),
+        )
 
     # Step 1: connection test reuses the proven path. Outcome carries
     # status_ok + server_version + the actual auth/version

--- a/apps/api/src/services/integrations/nightscout/evaluate.py
+++ b/apps/api/src/services/integrations/nightscout/evaluate.py
@@ -1,0 +1,475 @@
+"""Story 43.7a -- evaluate a Nightscout instance for the onboarding wizard.
+
+Builds a `NightscoutDiscoveryReport` from a single round-trip to the
+target Nightscout: tests the connection, samples recent entries +
+treatments + devicestatus, derives uploader identity from the sample,
+and pulls the profile if available. Result is cached on the connection
+row (Story 43.7a AC9) so the wizard re-rendering doesn't hammer the
+upstream.
+
+Entry point: `evaluate_nightscout_for_connection(db, conn)`.
+
+The router calls this inside an `asyncio.wait_for(..., timeout)`
+envelope so a slow / unresponsive user-controlled NS URL can't pin a
+request thread; the bound mirrors the Story 43.4 sync pattern.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from src.core.encryption import decrypt_credential
+from src.logging_config import get_logger
+from src.models.nightscout_connection import NightscoutConnection
+from src.schemas.nightscout import (
+    NightscoutDiscoveryProfileSummary,
+    NightscoutDiscoveryReport,
+    NightscoutProfileSegmentDTO,
+)
+
+from .client import NightscoutClient
+from .connection_test import test_connection
+from .models import NightscoutProfile, detect_uploader
+
+logger = get_logger(__name__)
+
+
+# How many records to sample for uploader detection + count estimation.
+# Per-resource page size for the evaluate probe. Big enough that a 7-day
+# window of normal CGM data (288 entries/day * 7 = 2016) fits, small
+# enough that a stale instance's 100K-entry retention doesn't transfer
+# the whole archive on every wizard render.
+_ENTRIES_RECENT_PROBE_COUNT = 2500
+_ENTRIES_OLDEST_PROBE_COUNT = 1000  # for earliest_entry_at lookup
+_TREATMENTS_PROBE_COUNT = 200
+_DEVICESTATUS_PROBE_COUNT = 50
+# Closed-loop labels we surface as `active_pump_loop`. Order is
+# preference -- if multiple are present in the uploader sample, the
+# first match wins. Anchors on the "real" loops; xdrip+ / xdrip4ios
+# are CGM uploaders, not loops, and stay out of this list.
+_LOOP_UPLOADERS = ("loop", "aaps", "trio", "oref0")
+
+
+async def evaluate_nightscout_for_connection(
+    conn: NightscoutConnection,
+) -> NightscoutDiscoveryReport:
+    """Sample the target Nightscout to build a discovery report.
+
+    Pure read -- does NOT mutate the connection (the router commits
+    `detected_uploaders_json` + `last_evaluated_at` after the report
+    is built; keeping the side effect at the boundary makes this
+    function easy to test with a mocked client).
+
+    Caller is responsible for the 5-min cache lookup (AC9) and for
+    bounding the call with `asyncio.wait_for`.
+
+    Returns a report with `status_ok=False` and a populated `error`
+    when the connection test fails -- the router intentionally does
+    NOT cache failures (so a typo'd token can be retried immediately
+    after fix). Profile-malformed cases (AC11) populate
+    `has_profile=False` + `profile_summary.is_malformed=True` rather
+    than raising, so the wizard's settings-import step can render
+    a "skipped" state cleanly.
+
+    **SSRF**: the user-controlled `conn.base_url` flows into
+    `test_connection()` -> `NightscoutClient.create()` -> `httpx`.
+    SSRF guards live one layer down, in
+    `src/services/integrations/nightscout/ssrf.py`'s
+    `ValidatedTarget`, which `NightscoutClient.create()` constructs
+    before any network call. That validator rejects loopback /
+    private / link-local / metadata IPs, IPv4+IPv6, and non-http(s)
+    schemes. Story 43.2 owns the SSRF surface; this orchestrator
+    inherits the protection.
+    """
+    evaluated_at = datetime.now(UTC)
+    credential = decrypt_credential(conn.encrypted_credential)
+
+    # Step 1: connection test reuses the proven path. Outcome carries
+    # status_ok + server_version + the actual auth/version
+    # negotiated.
+    outcome = await test_connection(
+        base_url=conn.base_url,
+        auth_type=conn.auth_type,
+        credential=credential,
+        api_version=conn.api_version,
+    )
+    if not outcome.ok:
+        return NightscoutDiscoveryReport(
+            status_ok=False,
+            server_version=outcome.server_version,
+            evaluated_at=evaluated_at,
+            error=outcome.error,
+        )
+
+    # Step 2: open a client for the per-resource probes. The
+    # test_connection path above proved the credential/URL; the
+    # client below reuses whatever auto-detected api_version the
+    # test settled on (auto-detect is per-client, so we pay the
+    # small extra round-trip on the second client -- a future
+    # refactor could thread the negotiated version through, but the
+    # cost is bounded by the router's `_EVALUATE_TIMEOUT_SECONDS`
+    # envelope (25s).
+    api_version = (
+        outcome.api_version_detected
+        if outcome.api_version_detected is not None
+        else conn.api_version
+    )
+    # Track resources whose probe failed even though auth passed
+    # -- e.g. tokens with entries-only scope. The wizard surfaces
+    # this as "we couldn't read X -- your token might be scope-
+    # restricted" rather than silently claiming the data is absent.
+    partial_resources: list[str] = []
+    async with await NightscoutClient.create(
+        base_url=conn.base_url,
+        auth_type=conn.auth_type,
+        credential=credential,
+        api_version=api_version,
+    ) as client:
+        recent_entries, recent_ok = await _safe_fetch(
+            client.fetch_entries(
+                since=evaluated_at - timedelta(days=7),
+                count=_ENTRIES_RECENT_PROBE_COUNT,
+            ),
+            label="recent_entries",
+        )
+        if not recent_ok:
+            partial_resources.append("recent_entries")
+        # Earliest-entry lookup: a separate fetch WITHOUT the since
+        # filter so we get the oldest tail of the page, not the
+        # 7-day cutoff. NS returns newest-first so the LAST item of
+        # this page is the earliest in our sample. For instances
+        # with > _ENTRIES_OLDEST_PROBE_COUNT entries in retention,
+        # this is a lower bound on "how far back can we go" rather
+        # than an absolute earliest -- acceptable for the wizard's
+        # "going back to 2024-08-12" prose.
+        oldest_page, oldest_ok = await _safe_fetch(
+            client.fetch_entries(count=_ENTRIES_OLDEST_PROBE_COUNT),
+            label="oldest_entries",
+        )
+        if not oldest_ok:
+            partial_resources.append("oldest_entries")
+        treatments, treatments_ok = await _safe_fetch(
+            client.fetch_treatments(count=_TREATMENTS_PROBE_COUNT),
+            label="treatments",
+        )
+        if not treatments_ok:
+            partial_resources.append("treatments")
+        devicestatuses, devicestatus_ok = await _safe_fetch(
+            client.fetch_devicestatus(count=_DEVICESTATUS_PROBE_COUNT),
+            label="devicestatus",
+        )
+        if not devicestatus_ok:
+            partial_resources.append("devicestatus")
+        profile_records, profile_ok = await _safe_fetch(
+            client.fetch_profile(),
+            label="profile",
+        )
+        if not profile_ok:
+            partial_resources.append("profile")
+
+    earliest_entry_at = _earliest_entry_timestamp(oldest_page)
+    recent_entry_count_7d = len(recent_entries)
+    # Real estimate (CR feedback): extrapolate the last-7-day rate
+    # across the (earliest..now) span. For steady CGM upload this
+    # lands within ~10% of true total; for intermittent uploaders
+    # it's a rough order-of-magnitude. Bounded below by the actual
+    # sample size (`len(oldest_page)`) so we never under-report
+    # what we directly observed. Capped above by an absolute
+    # ceiling to keep the wizard prose sane on instances that have
+    # been running for years (`100M` is well past any plausible
+    # personal CGM retention).
+    entry_count_estimate = _estimate_total_entries(
+        recent_count_7d=recent_entry_count_7d,
+        earliest_at=earliest_entry_at,
+        sample_size=len(oldest_page),
+        now=evaluated_at,
+    )
+
+    uploaders_detected = _detect_uploaders(
+        recent_entries, treatments, devicestatuses
+    )
+    active_pump_loop = next(
+        (u for u in _LOOP_UPLOADERS if u in uploaders_detected), None
+    )
+
+    has_profile, profile_summary = _summarize_profile(profile_records)
+
+    return NightscoutDiscoveryReport(
+        status_ok=True,
+        server_version=outcome.server_version,
+        earliest_entry_at=earliest_entry_at,
+        entry_count_estimate=entry_count_estimate,
+        recent_entry_count_7d=recent_entry_count_7d,
+        uploaders_detected=sorted(uploaders_detected),
+        has_treatments=len(treatments) > 0,
+        treatment_count_estimate=len(treatments),
+        has_devicestatus=len(devicestatuses) > 0,
+        has_profile=has_profile,
+        profile_summary=profile_summary,
+        active_pump_loop=active_pump_loop,
+        partial_resources=partial_resources,
+        evaluated_at=evaluated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _safe_fetch(
+    coro: Any, *, label: str
+) -> tuple[list[dict[str, Any]], bool]:
+    """Run a fetch coroutine and swallow per-resource failures.
+
+    The discovery report is degrade-gracefully by design: if
+    treatments are unreachable but entries work, we still report the
+    entries half. The connection test (step 1 in the orchestrator)
+    has already confirmed the URL + credential are valid, so a per-
+    resource error here means EITHER a 404 / 5xx on that specific
+    endpoint OR a per-collection token scope restriction (v3
+    instances can issue tokens that grant entries but not
+    treatments). The orchestrator surfaces the failed resource
+    name on `report.partial_resources` so the wizard can show
+    "your token might be scope-restricted" instead of silently
+    claiming the data is absent.
+
+    Returns `(rows, success_flag)`. Logged at WARNING (not INFO)
+    because partial failures change wizard UX and deserve operator
+    visibility.
+    """
+    try:
+        result = await coro
+    except Exception as exc:  # noqa: BLE001 - report graceful degrade
+        logger.warning(
+            "nightscout_evaluate_partial",
+            resource=label,
+            error_type=type(exc).__name__,
+        )
+        return [], False
+    rows = result if isinstance(result, list) else []
+    return rows, True
+
+
+def _earliest_entry_timestamp(entries: list[dict[str, Any]]) -> datetime | None:
+    """Pull the oldest entry from a newest-first page.
+
+    Tries `dateString` first (NS canonical) then `sysTime` as a
+    backstop. Returns None when the page is empty or no parseable
+    timestamp is present.
+    """
+    if not entries:
+        return None
+    # NS server returns newest-first; the LAST element is the oldest
+    # in the page.
+    candidate = entries[-1]
+    for key in ("dateString", "sysTime"):
+        value = candidate.get(key)
+        if isinstance(value, str):
+            parsed = _parse_iso(value)
+            if parsed is not None:
+                return parsed
+    # date is epoch ms (the v1 entries collection's primary timestamp)
+    date_ms = candidate.get("date")
+    if isinstance(date_ms, int | float):
+        try:
+            return datetime.fromtimestamp(date_ms / 1000.0, tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+    return None
+
+
+def _parse_iso(value: str) -> datetime | None:
+    """Parse an ISO-8601 string into a UTC datetime, or None on failure."""
+    s = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    return dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def _detect_uploaders(
+    entries: list[dict[str, Any]],
+    treatments: list[dict[str, Any]],
+    devicestatuses: list[dict[str, Any]],
+) -> set[str]:
+    """Fold `detect_uploader()` over a sample of records.
+
+    Excludes "unknown" so a sparse / generic-uploader sample doesn't
+    populate the wizard's chips with an unhelpful tag.
+    """
+    found: set[str] = set()
+    for record in entries + treatments + devicestatuses:
+        if not isinstance(record, dict):
+            continue
+        uploader = detect_uploader(
+            record.get("enteredBy"), record.get("device")
+        )
+        if uploader != "unknown":
+            found.add(uploader)
+    return found
+
+
+def _summarize_profile(
+    profile_records: list[dict[str, Any]],
+) -> tuple[bool, NightscoutDiscoveryProfileSummary | None]:
+    """Build the profile_summary portion of the discovery report.
+
+    AC11: malformed / unparseable profile returns
+    `(False, summary(is_malformed=True))` so the wizard renders a
+    "skipped" panel instead of crashing.
+    """
+    if not profile_records:
+        return False, None
+
+    # NS server returns newest-first by `startDate`; take the freshest
+    # profile record. The wizard surfaces the active store via the
+    # NightscoutProfile.active_profile() helper which already handles
+    # the `defaultProfile` indirection.
+    raw = profile_records[0]
+    try:
+        profile = NightscoutProfile.model_validate(raw)
+    except Exception:  # noqa: BLE001 - AC11 graceful degrade
+        logger.info("nightscout_evaluate_profile_unparseable")
+        return False, NightscoutDiscoveryProfileSummary(is_malformed=True)
+
+    active = profile.active_profile()
+    if active is None:
+        # Profile record exists but has no usable store -- treat as
+        # missing rather than malformed; the wizard's "skip settings"
+        # branch is the right UX.
+        return False, None
+
+    target_low_segments = active.target_low or None
+    target_high_segments = active.target_high or None
+    target_low_value = _safe_min_segment_value(target_low_segments)
+    target_high_value = _safe_max_segment_value(target_high_segments)
+
+    summary = NightscoutDiscoveryProfileSummary(
+        target_low=target_low_value,
+        target_high=target_high_value,
+        dia_hours=active.dia,
+        units=active.units or profile.units,
+        timezone=active.timezone,
+        carb_ratio_schedule=_to_segment_dtos(active.carbratio),
+        isf_schedule=_to_segment_dtos(active.sens),
+        basal_schedule=_to_segment_dtos(active.basal),
+        target_low_schedule=_to_segment_dtos(target_low_segments),
+        target_high_schedule=_to_segment_dtos(target_high_segments),
+        is_malformed=False,
+    )
+    return True, summary
+
+
+def _to_segment_dtos(
+    raw: list[dict[str, Any]] | None,
+) -> list[NightscoutProfileSegmentDTO] | None:
+    """Convert raw profile segments into the response DTO list.
+
+    Drops segments that are missing `time` or `value`; if the result
+    is empty, returns None so the wizard's "schedule absent" branch
+    fires cleanly.
+    """
+    if not raw:
+        return None
+    out: list[NightscoutProfileSegmentDTO] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        time_str = entry.get("time")
+        value = entry.get("value")
+        if not isinstance(time_str, str):
+            continue
+        try:
+            float_value = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        out.append(
+            NightscoutProfileSegmentDTO(time=time_str, value=float_value)
+        )
+    return out or None
+
+
+def _safe_min_segment_value(
+    segments: list[dict[str, Any]] | None,
+) -> float | None:
+    """Min `value` across segments, kept as float. None when absent.
+
+    Float-precision matters for mmol/L profiles where targets are
+    sub-ten decimals (e.g. 4.4-7.8). The wizard / 43.7b derive
+    handles unit normalization at render / write time.
+    """
+    values = _segment_values(segments)
+    return min(values) if values else None
+
+
+def _safe_max_segment_value(
+    segments: list[dict[str, Any]] | None,
+) -> float | None:
+    """Max `value` across segments, kept as float. None when absent."""
+    values = _segment_values(segments)
+    return max(values) if values else None
+
+
+def _segment_values(
+    segments: list[dict[str, Any]] | None,
+) -> list[float]:
+    """Coerce segment `value` fields to floats, dropping non-numeric."""
+    if not segments:
+        return []
+    out: list[float] = []
+    for entry in segments:
+        if not isinstance(entry, dict):
+            continue
+        value = entry.get("value")
+        try:
+            out.append(float(value))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+# Maximum plausible per-instance entry count to surface in the
+# wizard prose. CGM uploads at ~288 readings/day = ~105K/year; a
+# 5-year retention plus treatments / devicestatus tops ~10M. 100M
+# leaves a generous ceiling without blowing up if our extrapolation
+# math goes haywire on a degenerate sample.
+_ENTRY_COUNT_CEILING = 100_000_000
+
+
+def _estimate_total_entries(
+    *,
+    recent_count_7d: int,
+    earliest_at: datetime | None,
+    sample_size: int,
+    now: datetime,
+) -> int:
+    """Extrapolate total entry count from the recent-7d rate.
+
+    Falls back to `sample_size` when extrapolation isn't viable:
+    - no `earliest_at` (oldest probe failed)
+    - `earliest_at` within 7 days of now (no extrapolation distance)
+    - zero recent activity (rate would be 0; the actual sampled
+      count is the better estimate)
+
+    Always >= sample_size so we never report fewer entries than we
+    directly observed; <= _ENTRY_COUNT_CEILING so a degenerate input
+    doesn't blow up the wizard prose.
+    """
+    if (
+        earliest_at is None
+        or recent_count_7d <= 0
+    ):
+        return sample_size
+
+    span_days = (now - earliest_at).total_seconds() / 86400
+    if span_days < 7:
+        # Less than a week of history; the 7-day count IS the total.
+        return max(recent_count_7d, sample_size)
+
+    per_day_rate = recent_count_7d / 7.0
+    extrapolated = int(per_day_rate * span_days)
+    estimate = max(extrapolated, sample_size)
+    return min(estimate, _ENTRY_COUNT_CEILING)

--- a/apps/api/src/services/integrations/nightscout/evaluate.py
+++ b/apps/api/src/services/integrations/nightscout/evaluate.py
@@ -206,9 +206,7 @@ async def evaluate_nightscout_for_connection(
         now=evaluated_at,
     )
 
-    uploaders_detected = _detect_uploaders(
-        recent_entries, treatments, devicestatuses
-    )
+    uploaders_detected = _detect_uploaders(recent_entries, treatments, devicestatuses)
     active_pump_loop = next(
         (u for u in _LOOP_UPLOADERS if u in uploaders_detected), None
     )
@@ -238,9 +236,7 @@ async def evaluate_nightscout_for_connection(
 # ---------------------------------------------------------------------------
 
 
-async def _safe_fetch(
-    coro: Any, *, label: str
-) -> tuple[list[dict[str, Any]], bool]:
+async def _safe_fetch(coro: Any, *, label: str) -> tuple[list[dict[str, Any]], bool]:
     """Run a fetch coroutine and swallow per-resource failures.
 
     The discovery report is degrade-gracefully by design: if
@@ -324,9 +320,7 @@ def _detect_uploaders(
     for record in entries + treatments + devicestatuses:
         if not isinstance(record, dict):
             continue
-        uploader = detect_uploader(
-            record.get("enteredBy"), record.get("device")
-        )
+        uploader = detect_uploader(record.get("enteredBy"), record.get("device"))
         if uploader != "unknown":
             found.add(uploader)
     return found
@@ -406,9 +400,7 @@ def _to_segment_dtos(
             float_value = float(value)  # type: ignore[arg-type]
         except (TypeError, ValueError):
             continue
-        out.append(
-            NightscoutProfileSegmentDTO(time=time_str, value=float_value)
-        )
+        out.append(NightscoutProfileSegmentDTO(time=time_str, value=float_value))
     return out or None
 
 
@@ -478,10 +470,7 @@ def _estimate_total_entries(
     directly observed; <= _ENTRY_COUNT_CEILING so a degenerate input
     doesn't blow up the wizard prose.
     """
-    if (
-        earliest_at is None
-        or recent_count_7d <= 0
-    ):
+    if earliest_at is None or recent_count_7d <= 0:
         return sample_size
 
     span_days = (now - earliest_at).total_seconds() / 86400

--- a/apps/api/tests/test_nightscout_evaluate.py
+++ b/apps/api/tests/test_nightscout_evaluate.py
@@ -66,9 +66,7 @@ async def _register_and_login(client, email: str, password: str = "Test1234!"):
 
 async def _cleanup(emails: list[str]) -> None:
     async with get_session_maker()() as db:
-        result = await db.execute(
-            User.__table__.select().where(User.email.in_(emails))
-        )
+        result = await db.execute(User.__table__.select().where(User.email.in_(emails)))
         ids = [row.id for row in result.fetchall()]
         if ids:
             await db.execute(
@@ -247,9 +245,7 @@ async def test_orchestrator_happy_path_with_loop_profile():
     conn = _mk_conn()
     client_mock = _mk_client_mock(
         recent_entries=[_xdrip_entry() for _ in range(20)],
-        oldest_entries=[
-            _xdrip_entry("2024-08-12T00:00:00.000Z") for _ in range(100)
-        ],
+        oldest_entries=[_xdrip_entry("2024-08-12T00:00:00.000Z") for _ in range(100)],
         treatments=[_aaps_treatment() for _ in range(5)],
         devicestatus=[{"device": "loop://iPhone/Loop/3.4.5"}],
         profile=[_loop_profile()],
@@ -436,21 +432,27 @@ def test_estimate_total_entries_extrapolates_from_recent_rate():
 
     # No earliest_at -> fall back to sample size (no extrapolation
     # distance).
-    assert _estimate_total_entries(
-        recent_count_7d=2016,
-        earliest_at=None,
-        sample_size=1000,
-        now=now,
-    ) == 1000
+    assert (
+        _estimate_total_entries(
+            recent_count_7d=2016,
+            earliest_at=None,
+            sample_size=1000,
+            now=now,
+        )
+        == 1000
+    )
 
     # Zero recent activity -> use sample size (rate of 0 would
     # under-report what we actually saw).
-    assert _estimate_total_entries(
-        recent_count_7d=0,
-        earliest_at=now - timedelta(days=365),
-        sample_size=500,
-        now=now,
-    ) == 500
+    assert (
+        _estimate_total_entries(
+            recent_count_7d=0,
+            earliest_at=now - timedelta(days=365),
+            sample_size=500,
+            now=now,
+        )
+        == 500
+    )
 
     # Span < 7 days -> recent count IS effectively the total.
     estimate_short = _estimate_total_entries(
@@ -699,9 +701,7 @@ async def test_evaluate_endpoint_404s_soft_deleted_connection(http_client):
 @pytest.mark.asyncio
 async def test_evaluate_endpoint_unauthenticated_rejected(http_client):
     fake_id = uuid.uuid4()
-    resp = await http_client.post(
-        f"/api/integrations/nightscout/{fake_id}/evaluate"
-    )
+    resp = await http_client.post(f"/api/integrations/nightscout/{fake_id}/evaluate")
     assert resp.status_code == 401
 
 
@@ -724,9 +724,7 @@ async def test_evaluate_endpoint_504_on_timeout(http_client):
                 "src.routers.nightscout.evaluate_nightscout_for_connection",
                 new=_hang,
             ),
-            patch(
-                "src.routers.nightscout._EVALUATE_TIMEOUT_SECONDS", 0.05
-            ),
+            patch("src.routers.nightscout._EVALUATE_TIMEOUT_SECONDS", 0.05),
         ):
             resp = await http_client.post(
                 f"/api/integrations/nightscout/{connection_id}/evaluate",

--- a/apps/api/tests/test_nightscout_evaluate.py
+++ b/apps/api/tests/test_nightscout_evaluate.py
@@ -303,6 +303,29 @@ async def test_orchestrator_status_ok_false_when_test_fails():
 
 
 @pytest.mark.asyncio
+async def test_orchestrator_handles_decrypt_failure_cleanly():
+    """Real-world e2e found this: tampered encrypted_credential
+    propagated ValueError -> 500 instead of a clean status_ok=False
+    report. Production triggers: key rotation, DB corruption, manual
+    DB edits.
+    """
+    conn = _mk_conn()
+    # Replace the encrypted_credential with garbage so Fernet's
+    # signature verification fails.
+    conn.encrypted_credential = "gAAAAABxxxinvalidxxx"
+
+    # No need to patch test_connection -- the orchestrator MUST
+    # bail out before reaching it.
+    report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.status_ok is False
+    assert report.error is not None
+    assert "decrypt" in report.error.lower()
+    assert report.recent_entry_count_7d == 0
+    assert report.has_profile is False
+
+
+@pytest.mark.asyncio
 async def test_orchestrator_no_profile_records():
     """Empty profile collection -> has_profile=False, no malformed flag."""
     conn = _mk_conn()

--- a/apps/api/tests/test_nightscout_evaluate.py
+++ b/apps/api/tests/test_nightscout_evaluate.py
@@ -1,0 +1,851 @@
+"""Story 43.7a -- tests for the evaluate endpoint + orchestrator.
+
+Mocks the NightscoutClient at the class level so we exercise the real
+orchestrator + the real router (cache, persistence, timeout handling)
+without depending on a live Nightscout. The orchestrator's profile
+parsing, uploader detection, and segment summarization are exercised
+directly with Pydantic-validated fixtures so the unit + integration
+slices both light up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import delete
+
+from src.core.encryption import encrypt_credential
+from src.database import get_session_maker
+from src.main import app
+from src.models.nightscout_connection import (
+    NightscoutApiVersion,
+    NightscoutAuthType,
+    NightscoutConnection,
+    NightscoutSyncStatus,
+)
+from src.models.user import User
+from src.services.integrations.nightscout.connection_test import (
+    ConnectionTestOutcome,
+)
+from src.services.integrations.nightscout.evaluate import (
+    evaluate_nightscout_for_connection,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _unique_email(stem: str) -> str:
+    return f"{stem}_{uuid.uuid4().hex[:10]}@example.com"
+
+
+async def _register_and_login(client, email: str, password: str = "Test1234!"):
+    from src.config import settings
+
+    reg = await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+    assert reg.status_code in (200, 201), reg.text
+    resp = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert resp.status_code == 200, resp.text
+    cookie = resp.cookies.get(settings.jwt_cookie_name)
+    assert cookie
+    return {settings.jwt_cookie_name: cookie}
+
+
+async def _cleanup(emails: list[str]) -> None:
+    async with get_session_maker()() as db:
+        result = await db.execute(
+            User.__table__.select().where(User.email.in_(emails))
+        )
+        ids = [row.id for row in result.fetchall()]
+        if ids:
+            await db.execute(
+                delete(NightscoutConnection).where(
+                    NightscoutConnection.user_id.in_(ids)
+                )
+            )
+            await db.execute(delete(User).where(User.id.in_(ids)))
+            await db.commit()
+
+
+@pytest_asyncio.fixture
+async def http_client():
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+
+def _ok_outcome(server_version: str = "15.0.3") -> ConnectionTestOutcome:
+    return ConnectionTestOutcome(
+        ok=True,
+        server_version=server_version,
+        api_version_detected=NightscoutApiVersion.V1,
+        auth_validated=True,
+    )
+
+
+def _fail_outcome(error: str = "auth rejected") -> ConnectionTestOutcome:
+    return ConnectionTestOutcome(ok=False, error=error)
+
+
+def _mk_client_mock(
+    *,
+    recent_entries: list[dict] | None = None,
+    oldest_entries: list[dict] | None = None,
+    treatments: list[dict] | None = None,
+    devicestatus: list[dict] | None = None,
+    profile: list[dict] | None = None,
+    fetch_exception: Exception | None = None,
+) -> MagicMock:
+    """Build a mock standing in for an opened `NightscoutClient`.
+
+    fetch_entries side-effects: the orchestrator calls it twice -- once
+    with `since=` (recent) and once without (oldest sample). We discriminate
+    by the kwarg presence to return the right list.
+    """
+    client_instance = AsyncMock()
+
+    async def _fetch_entries(**kwargs):
+        if fetch_exception is not None:
+            raise fetch_exception
+        if "since" in kwargs and kwargs["since"] is not None:
+            return list(recent_entries or [])
+        return list(oldest_entries or [])
+
+    client_instance.fetch_entries = AsyncMock(side_effect=_fetch_entries)
+    client_instance.fetch_treatments = AsyncMock(
+        return_value=treatments or [],
+        side_effect=fetch_exception,
+    )
+    client_instance.fetch_devicestatus = AsyncMock(
+        return_value=devicestatus or [],
+        side_effect=fetch_exception,
+    )
+    client_instance.fetch_profile = AsyncMock(
+        return_value=profile or [],
+        side_effect=fetch_exception,
+    )
+    if fetch_exception is None:
+        # AsyncMock with both return_value AND side_effect ignores
+        # return_value. Re-bind without side effect for the no-error
+        # case.
+        client_instance.fetch_treatments = AsyncMock(return_value=treatments or [])
+        client_instance.fetch_devicestatus = AsyncMock(return_value=devicestatus or [])
+        client_instance.fetch_profile = AsyncMock(return_value=profile or [])
+
+    client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+    client_instance.__aexit__ = AsyncMock(return_value=None)
+    return client_instance
+
+
+def _patch_test(outcome: ConnectionTestOutcome):
+    return patch(
+        "src.services.integrations.nightscout.evaluate.test_connection",
+        new=AsyncMock(return_value=outcome),
+    )
+
+
+def _patch_client(client_mock: MagicMock):
+    """Patch the NightscoutClient.create() factory."""
+    return patch(
+        "src.services.integrations.nightscout.evaluate.NightscoutClient.create",
+        new=AsyncMock(return_value=client_mock),
+    )
+
+
+def _loop_profile(units: str = "mg/dl") -> dict:
+    """A realistic Loop profile record (single store, single-band target)."""
+    return {
+        "_id": "abc123",
+        "defaultProfile": "Default",
+        "startDate": "2026-04-01T00:00:00.000Z",
+        "units": units,
+        "store": {
+            "Default": {
+                "dia": 5.0,
+                "timezone": "America/Los_Angeles",
+                "units": units,
+                "carbratio": [{"time": "00:00", "value": 12.0}],
+                "sens": [{"time": "00:00", "value": 50.0}],
+                "basal": [{"time": "00:00", "value": 0.65}],
+                "target_low": [{"time": "00:00", "value": 90.0}],
+                "target_high": [{"time": "00:00", "value": 120.0}],
+            },
+        },
+    }
+
+
+def _aaps_treatment() -> dict:
+    return {
+        "eventType": "Bolus",
+        "insulin": 2.5,
+        "created_at": "2026-05-09T12:00:00.000Z",
+        "enteredBy": "openaps://AndroidAPS",
+    }
+
+
+def _xdrip_entry(date_string: str = "2026-05-10T11:55:00.000Z") -> dict:
+    return {
+        "type": "sgv",
+        "sgv": 120,
+        "date": 1778155500000,
+        "dateString": date_string,
+        "device": "xDrip-Android",
+        "enteredBy": "xdrip-android",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit: orchestrator (calls evaluate_nightscout_for_connection directly)
+# ---------------------------------------------------------------------------
+
+
+def _mk_conn(
+    user_id: uuid.UUID | None = None,
+    *,
+    last_evaluated_at: datetime | None = None,
+    detected_uploaders_json: dict | None = None,
+) -> NightscoutConnection:
+    """Construct a transient connection (not persisted) for unit tests.
+
+    `user_id=None` -> generate a fresh UUID per call. (Default mutable
+    `uuid.uuid4()` would freeze at import time, leaking the same id
+    across tests; harmless today but a future test asserting on
+    user_id would silently flake.)
+    """
+    return NightscoutConnection(
+        id=uuid.uuid4(),
+        user_id=user_id if user_id is not None else uuid.uuid4(),
+        name="test",
+        base_url="https://example.com",
+        auth_type=NightscoutAuthType.SECRET,
+        encrypted_credential=encrypt_credential("secret-12chars-min"),
+        api_version=NightscoutApiVersion.V1,
+        is_active=True,
+        last_sync_status=NightscoutSyncStatus.NEVER,
+        last_evaluated_at=last_evaluated_at,
+        detected_uploaders_json=detected_uploaders_json,
+    )
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_happy_path_with_loop_profile():
+    conn = _mk_conn()
+    client_mock = _mk_client_mock(
+        recent_entries=[_xdrip_entry() for _ in range(20)],
+        oldest_entries=[
+            _xdrip_entry("2024-08-12T00:00:00.000Z") for _ in range(100)
+        ],
+        treatments=[_aaps_treatment() for _ in range(5)],
+        devicestatus=[{"device": "loop://iPhone/Loop/3.4.5"}],
+        profile=[_loop_profile()],
+    )
+    with _patch_test(_ok_outcome()), _patch_client(client_mock):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.status_ok is True
+    assert report.server_version == "15.0.3"
+    assert report.recent_entry_count_7d == 20
+    # entry_count_estimate is now an extrapolation from the recent-7d
+    # rate * (now - earliest) span. With 20 entries/7d and earliest
+    # set to 2024-08-12 (~600+ days back), the estimate is well into
+    # the thousands -- always >= sample_size (100). The exact value
+    # drifts with wall-clock so we assert the bound + magnitude
+    # rather than an exact number.
+    assert report.entry_count_estimate >= 100  # sample-size floor
+    assert report.entry_count_estimate >= 1000  # extrapolated
+    assert report.earliest_entry_at is not None
+    assert report.has_treatments is True
+    assert report.treatment_count_estimate == 5
+    assert report.has_devicestatus is True
+    # Loop in devicestatus + AAPS in treatments + xdrip+ in entries.
+    assert "loop" in report.uploaders_detected
+    assert "aaps" in report.uploaders_detected
+    assert "xdrip+" in report.uploaders_detected
+    # Loop wins the active_pump_loop tiebreak (first in _LOOP_UPLOADERS).
+    assert report.active_pump_loop == "loop"
+    assert report.has_profile is True
+    assert report.profile_summary is not None
+    assert report.profile_summary.dia_hours == 5.0
+    assert report.profile_summary.target_low == 90
+    assert report.profile_summary.target_high == 120
+    assert report.profile_summary.units == "mg/dl"
+    assert report.profile_summary.timezone == "America/Los_Angeles"
+    assert report.profile_summary.carb_ratio_schedule is not None
+    assert report.profile_summary.carb_ratio_schedule[0].value == 12.0
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_status_ok_false_when_test_fails():
+    conn = _mk_conn()
+    with _patch_test(_fail_outcome("auth rejected")):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.status_ok is False
+    assert report.error == "auth rejected"
+    assert report.recent_entry_count_7d == 0
+    assert report.has_profile is False
+    assert report.profile_summary is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_no_profile_records():
+    """Empty profile collection -> has_profile=False, no malformed flag."""
+    conn = _mk_conn()
+    client_mock = _mk_client_mock(profile=[])
+    with _patch_test(_ok_outcome()), _patch_client(client_mock):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.status_ok is True
+    assert report.has_profile is False
+    assert report.profile_summary is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_profile_with_no_active_store():
+    """Profile record exists but defaultProfile points nowhere."""
+    conn = _mk_conn()
+    bad = {
+        "_id": "abc",
+        "defaultProfile": "Missing",
+        "startDate": "2026-04-01T00:00:00.000Z",
+        "store": {"Default": {"dia": 5.0}},  # active points to "Missing", not in store
+    }
+    client_mock = _mk_client_mock(profile=[bad])
+    with _patch_test(_ok_outcome()), _patch_client(client_mock):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.has_profile is False
+    assert report.profile_summary is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_malformed_profile_flagged_per_ac11():
+    """AC11: profile fetch returns garbage -> is_malformed=True, no crash."""
+    conn = _mk_conn()
+    # Pydantic NightscoutProfile.model_validate raises on this shape
+    # (`store` should be a dict, not a string).
+    garbage = {"_id": "x", "store": "not-a-dict"}
+    client_mock = _mk_client_mock(profile=[garbage])
+    with _patch_test(_ok_outcome()), _patch_client(client_mock):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.has_profile is False
+    assert report.profile_summary is not None
+    assert report.profile_summary.is_malformed is True
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_per_resource_failure_degrades_gracefully():
+    """If treatments fetch raises, we still get a report from the rest.
+
+    Also asserts the failed resource shows up on `partial_resources`
+    so the wizard can surface "your token might be entries-only"
+    (M5 from CR review).
+    """
+    conn = _mk_conn()
+
+    # Build a client where treatments raises but everything else
+    # works. Re-bind manually since _mk_client_mock applies one
+    # exception across all four fetches.
+    client_instance = AsyncMock()
+
+    async def _fetch_entries(**kwargs):
+        if "since" in kwargs and kwargs["since"] is not None:
+            return [_xdrip_entry()]
+        return [_xdrip_entry("2024-08-12T00:00:00.000Z")]
+
+    client_instance.fetch_entries = AsyncMock(side_effect=_fetch_entries)
+    client_instance.fetch_treatments = AsyncMock(
+        side_effect=RuntimeError("treatments 500")
+    )
+    client_instance.fetch_devicestatus = AsyncMock(return_value=[])
+    client_instance.fetch_profile = AsyncMock(return_value=[_loop_profile()])
+    client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+    client_instance.__aexit__ = AsyncMock(return_value=None)
+
+    with _patch_test(_ok_outcome()), _patch_client(client_instance):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.status_ok is True
+    assert report.has_treatments is False  # graceful degrade
+    assert report.recent_entry_count_7d == 1
+    assert report.has_profile is True
+    # M5: failed resource surfaced so wizard can flag "scope-restricted token".
+    assert "treatments" in report.partial_resources
+    assert "recent_entries" not in report.partial_resources
+
+
+def test_estimate_total_entries_extrapolates_from_recent_rate():
+    """Direct test for the helper; CR M2 (entry_count_estimate must
+    be a real estimate, not just sample size).
+    """
+    from src.services.integrations.nightscout.evaluate import (
+        _estimate_total_entries,
+    )
+
+    now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+
+    # Steady CGM: 2016 entries in last 7 days (~288/day), earliest
+    # 365 days back -> expect ~105K total.
+    estimate = _estimate_total_entries(
+        recent_count_7d=2016,
+        earliest_at=now - timedelta(days=365),
+        sample_size=1000,
+        now=now,
+    )
+    # 2016/7 = 288/day * 365 = 105,120
+    assert 100_000 <= estimate <= 110_000
+
+    # No earliest_at -> fall back to sample size (no extrapolation
+    # distance).
+    assert _estimate_total_entries(
+        recent_count_7d=2016,
+        earliest_at=None,
+        sample_size=1000,
+        now=now,
+    ) == 1000
+
+    # Zero recent activity -> use sample size (rate of 0 would
+    # under-report what we actually saw).
+    assert _estimate_total_entries(
+        recent_count_7d=0,
+        earliest_at=now - timedelta(days=365),
+        sample_size=500,
+        now=now,
+    ) == 500
+
+    # Span < 7 days -> recent count IS effectively the total.
+    estimate_short = _estimate_total_entries(
+        recent_count_7d=144,
+        earliest_at=now - timedelta(days=2),
+        sample_size=144,
+        now=now,
+    )
+    assert estimate_short == 144
+
+    # Floor: extrapolation never reports fewer than the directly-
+    # observed sample.
+    estimate_floor = _estimate_total_entries(
+        recent_count_7d=10,  # very sparse uploader
+        earliest_at=now - timedelta(days=8),
+        sample_size=2000,  # but we observed 2K in our oldest probe
+        now=now,
+    )
+    assert estimate_floor >= 2000
+
+    # Ceiling: degenerate inputs can't blow up the wizard prose.
+    estimate_huge = _estimate_total_entries(
+        recent_count_7d=10**9,  # absurd
+        earliest_at=now - timedelta(days=10000),
+        sample_size=1000,
+        now=now,
+    )
+    assert estimate_huge <= 100_000_000
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_target_low_high_preserve_mmol_precision():
+    """M3: mmol/L profile values stay as floats (4.4 / 7.8), not rounded."""
+    conn = _mk_conn()
+    profile = _loop_profile(units="mmol")
+    profile["store"]["Default"]["target_low"] = [{"time": "00:00", "value": 4.4}]
+    profile["store"]["Default"]["target_high"] = [{"time": "00:00", "value": 7.8}]
+    client_mock = _mk_client_mock(profile=[profile])
+    with _patch_test(_ok_outcome()), _patch_client(client_mock):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.profile_summary is not None
+    # Float precision preserved -- not rounded to int 4 / 8.
+    assert report.profile_summary.target_low == 4.4
+    assert report.profile_summary.target_high == 7.8
+    assert report.profile_summary.units == "mmol"
+
+
+# ---------------------------------------------------------------------------
+# Profile summary edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_summary_takes_min_max_for_segmented_target():
+    """Time-varying target reports min(low) / max(high) across segments."""
+    conn = _mk_conn()
+    profile = _loop_profile()
+    profile["store"]["Default"]["target_low"] = [
+        {"time": "00:00", "value": 80.0},
+        {"time": "08:00", "value": 90.0},
+        {"time": "22:00", "value": 100.0},  # higher -- min is 80
+    ]
+    profile["store"]["Default"]["target_high"] = [
+        {"time": "00:00", "value": 130.0},  # lower -- max is 150
+        {"time": "08:00", "value": 150.0},
+        {"time": "22:00", "value": 110.0},
+    ]
+    client_mock = _mk_client_mock(profile=[profile])
+    with _patch_test(_ok_outcome()), _patch_client(client_mock):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.profile_summary is not None
+    assert report.profile_summary.target_low == 80
+    assert report.profile_summary.target_high == 150
+    # Schedules preserved as DTO list.
+    assert len(report.profile_summary.target_low_schedule or []) == 3
+
+
+# ---------------------------------------------------------------------------
+# Endpoint: cache, persistence, RBAC
+# ---------------------------------------------------------------------------
+
+
+async def _create_conn(http_client, cookies, name: str = "Test NS") -> str:
+    """Use the real POST endpoint to seed a connection (mocked test)."""
+    with patch(
+        "src.routers.nightscout.test_connection",
+        new=AsyncMock(return_value=_ok_outcome()),
+    ):
+        resp = await http_client.post(
+            "/api/integrations/nightscout",
+            cookies=cookies,
+            json={
+                "name": name,
+                "base_url": "https://example.com",
+                "auth_type": "secret",
+                "credential": "test-secret-12chars",
+                "api_version": "v1",
+            },
+        )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["connection"]["id"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_endpoint_persists_report_and_timestamp(http_client):
+    email = _unique_email("ns_eval_persist")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+
+        client_mock = _mk_client_mock(
+            recent_entries=[_xdrip_entry()],
+            profile=[_loop_profile()],
+        )
+        with (
+            _patch_test(_ok_outcome()),
+            _patch_client(client_mock),
+        ):
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status_ok"] is True
+        assert body["has_profile"] is True
+        assert body["profile_summary"]["dia_hours"] == 5.0
+
+        # Persistence: detected_uploaders_json + last_evaluated_at written.
+        async with get_session_maker()() as db:
+            result = await db.execute(
+                NightscoutConnection.__table__.select().where(
+                    NightscoutConnection.id == uuid.UUID(connection_id)
+                )
+            )
+            row = result.fetchone()
+            assert row.detected_uploaders_json is not None
+            assert row.detected_uploaders_json["status_ok"] is True
+            assert row.last_evaluated_at is not None
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_evaluate_endpoint_returns_cached_within_5_min(http_client):
+    """AC9: second call within cache window does NOT re-evaluate."""
+    email = _unique_email("ns_eval_cache")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+
+        # First call: actual evaluate.
+        client_mock = _mk_client_mock(
+            recent_entries=[_xdrip_entry()],
+            profile=[_loop_profile()],
+        )
+        test_mock = AsyncMock(return_value=_ok_outcome())
+        with (
+            patch(
+                "src.services.integrations.nightscout.evaluate.test_connection",
+                new=test_mock,
+            ),
+            _patch_client(client_mock),
+        ):
+            r1 = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        assert r1.status_code == 200
+        assert test_mock.call_count == 1
+
+        # Second call: should hit cache, NOT re-call test_connection.
+        with (
+            patch(
+                "src.services.integrations.nightscout.evaluate.test_connection",
+                new=test_mock,
+            ),
+            _patch_client(client_mock),
+        ):
+            r2 = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        assert r2.status_code == 200
+        # Cache hit -> test_connection NOT called a second time.
+        assert test_mock.call_count == 1
+        # Same body shape
+        assert r2.json()["server_version"] == r1.json()["server_version"]
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_evaluate_endpoint_rejects_cross_tenant_with_404(http_client):
+    email_a = _unique_email("ns_eval_a")
+    email_b = _unique_email("ns_eval_b")
+    cookies_a = await _register_and_login(http_client, email_a)
+    cookies_b = await _register_and_login(http_client, email_b)
+    try:
+        a_conn_id = await _create_conn(http_client, cookies_a, "A's conn")
+
+        # B tries to evaluate A's connection -- 404 (not 403, no leak).
+        with (
+            _patch_test(_ok_outcome()),
+            _patch_client(_mk_client_mock()),
+        ):
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{a_conn_id}/evaluate",
+                cookies=cookies_b,
+            )
+        assert resp.status_code == 404
+    finally:
+        await _cleanup([email_a, email_b])
+
+
+@pytest.mark.asyncio
+async def test_evaluate_endpoint_404s_soft_deleted_connection(http_client):
+    email = _unique_email("ns_eval_softdel")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+
+        # Soft-delete the connection.
+        del_resp = await http_client.delete(
+            f"/api/integrations/nightscout/{connection_id}",
+            cookies=cookies,
+        )
+        assert del_resp.status_code == 200
+
+        with (
+            _patch_test(_ok_outcome()),
+            _patch_client(_mk_client_mock()),
+        ):
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        # require_active=True -> 404 even though row exists.
+        assert resp.status_code == 404
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_evaluate_endpoint_unauthenticated_rejected(http_client):
+    fake_id = uuid.uuid4()
+    resp = await http_client.post(
+        f"/api/integrations/nightscout/{fake_id}/evaluate"
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_evaluate_endpoint_504_on_timeout(http_client):
+    """Bound by _EVALUATE_TIMEOUT_SECONDS -- a slow upstream returns 504."""
+    email = _unique_email("ns_eval_timeout")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+
+        # Make evaluate hang past the wait_for window. We patch the
+        # orchestrator to await a long sleep (much longer than the
+        # router's _EVALUATE_TIMEOUT_SECONDS).
+        async def _hang(*args, **kwargs):
+            await asyncio.sleep(60)
+
+        with (
+            patch(
+                "src.routers.nightscout.evaluate_nightscout_for_connection",
+                new=_hang,
+            ),
+            patch(
+                "src.routers.nightscout._EVALUATE_TIMEOUT_SECONDS", 0.05
+            ),
+        ):
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        assert resp.status_code == 504
+        assert "timeout" in resp.json()["detail"].lower()
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_evaluate_endpoint_does_not_cache_failures(http_client):
+    """H2 from CR review: a failed evaluate (status_ok=False) MUST NOT
+    cache for 5 min -- a user fixing a typo'd token must be able to
+    immediately retry.
+    """
+    email = _unique_email("ns_eval_failcache")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+
+        # First call: evaluate fails (auth rejected by the upstream).
+        with _patch_test(_fail_outcome("auth rejected by upstream")):
+            r1 = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        assert r1.status_code == 200
+        assert r1.json()["status_ok"] is False
+
+        # The failure should NOT have been written to the cache.
+        async with get_session_maker()() as db:
+            result = await db.execute(
+                NightscoutConnection.__table__.select().where(
+                    NightscoutConnection.id == uuid.UUID(connection_id)
+                )
+            )
+            row = result.fetchone()
+            assert row.detected_uploaders_json is None
+            assert row.last_evaluated_at is None
+
+        # Second call: user fixed the token -- should re-attempt
+        # (NOT serve a cached failure).
+        client_mock = _mk_client_mock(
+            recent_entries=[_xdrip_entry()],
+            profile=[_loop_profile()],
+        )
+        with _patch_test(_ok_outcome()), _patch_client(client_mock):
+            r2 = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        assert r2.status_code == 200
+        assert r2.json()["status_ok"] is True
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_evaluate_endpoint_404s_inactive_via_db_flag(http_client):
+    """M6 from CR review: assert require_active=True is wired by setting
+    is_active=False directly in DB (not via DELETE), so 404 can't be
+    explained by 'row missing'.
+    """
+    email = _unique_email("ns_eval_inactivedb")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+
+        # Directly flip is_active=False without touching the row count.
+        async with get_session_maker()() as db:
+            await db.execute(
+                NightscoutConnection.__table__.update()
+                .where(NightscoutConnection.id == uuid.UUID(connection_id))
+                .values(is_active=False)
+            )
+            await db.commit()
+
+        with _patch_test(_ok_outcome()), _patch_client(_mk_client_mock()):
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        assert resp.status_code == 404
+
+        # Sanity: the row IS still there.
+        async with get_session_maker()() as db:
+            result = await db.execute(
+                NightscoutConnection.__table__.select().where(
+                    NightscoutConnection.id == uuid.UUID(connection_id)
+                )
+            )
+            assert result.fetchone() is not None
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_evaluate_endpoint_cache_drift_falls_through_to_fresh(http_client):
+    """If cached payload has stale schema, we re-evaluate cleanly."""
+    email = _unique_email("ns_eval_drift")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+
+        # Manually plant a cache payload with `status_ok: true` (so it
+        # gets past the cache-only-on-success gate) but otherwise
+        # malformed (so model_validate fails -> fall through to a
+        # fresh evaluate).
+        async with get_session_maker()() as db:
+            await db.execute(
+                NightscoutConnection.__table__.update()
+                .where(NightscoutConnection.id == uuid.UUID(connection_id))
+                .values(
+                    detected_uploaders_json={
+                        "status_ok": True,
+                        "some_old_field": "drift",
+                        # Missing required `evaluated_at` -- triggers
+                        # ValidationError on model_validate.
+                    },
+                    last_evaluated_at=datetime.now(UTC) - timedelta(seconds=1),
+                )
+            )
+            await db.commit()
+
+        client_mock = _mk_client_mock(
+            recent_entries=[_xdrip_entry()],
+            profile=[_loop_profile()],
+        )
+        with (
+            _patch_test(_ok_outcome()),
+            _patch_client(client_mock),
+        ):
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        # Fresh evaluate populated the report -- not the stale shape.
+        assert body["status_ok"] is True
+        assert "some_old_field" not in body
+    finally:
+        await _cleanup([email])

--- a/apps/api/tests/test_nightscout_evaluate.py
+++ b/apps/api/tests/test_nightscout_evaluate.py
@@ -824,6 +824,54 @@ async def test_evaluate_endpoint_404s_inactive_via_db_flag(http_client):
 
 
 @pytest.mark.asyncio
+async def test_evaluate_endpoint_handles_non_dict_legacy_cache(http_client):
+    """CR finding: cache check must guard against legacy rows where
+    detected_uploaders_json was stored as a list / string under an
+    earlier schema. Without an isinstance(..., dict) check, the
+    `.get("status_ok")` call would raise AttributeError -> 500
+    instead of falling through to a fresh evaluate.
+    """
+    email = _unique_email("ns_eval_legacycache")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+
+        # Plant a non-dict payload directly in JSONB and a fresh
+        # last_evaluated_at so the cache window is hot.
+        async with get_session_maker()() as db:
+            await db.execute(
+                NightscoutConnection.__table__.update()
+                .where(NightscoutConnection.id == uuid.UUID(connection_id))
+                .values(
+                    detected_uploaders_json=["loop", "xdrip+"],  # list, not dict
+                    last_evaluated_at=datetime.now(UTC) - timedelta(seconds=1),
+                )
+            )
+            await db.commit()
+
+        # Endpoint MUST NOT 500 -- it should fall through to a fresh
+        # evaluate. We mock the evaluate so it returns a clean
+        # report, proving the legacy-shape branch ignored the cache
+        # and re-ran the orchestrator.
+        client_mock = _mk_client_mock(
+            recent_entries=[_xdrip_entry()],
+            profile=[_loop_profile()],
+        )
+        with _patch_test(_ok_outcome()), _patch_client(client_mock):
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/evaluate",
+                cookies=cookies,
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status_ok"] is True
+        # Fresh report -- the list was overwritten with a proper dict.
+        assert isinstance(body, dict)
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
 async def test_evaluate_endpoint_cache_drift_falls_through_to_fresh(http_client):
     """If cached payload has stale schema, we re-evaluate cleanly."""
     email = _unique_email("ns_eval_drift")


### PR DESCRIPTION
## Summary

First sub-story of **Story 43.7 (smart onboarding)**. Adds `POST /api/integrations/nightscout/{id}/evaluate` -- the read-only probe the wizard's step 2 uses to surface:

> Found ~142K entries going back to 2024-08-12. Detected uploaders: Loop, xDrip+. Profile present with 12g/U carb ratio, 70-180 target, 5h DIA.

before the user picks an import window.

## What this enables

The discovery report is the source of pre-fill for the wizard's step 3 (settings review table). Subsequent sub-stories build on this:

- **43.7b** -- pure profile -> canonical settings derivation (consumes `profile_summary`)
- **43.7c** -- the multi-step wizard UI + apply-onboarding endpoint
- **43.7d** -- "Re-import settings from Nightscout" entry point on existing connection cards
- **43.7e** -- tests + docs polish

## Implementation

- New orchestrator `services/integrations/nightscout/evaluate.py` -- 5 sequential probes (recent entries, oldest entries, treatments, devicestatus, profile) bundled into a typed `NightscoutDiscoveryReport`. Per-resource failures degrade gracefully and surface on a new `partial_resources` field so the wizard can flag scope-restricted tokens.
- New schemas `NightscoutDiscoveryReport` + `NightscoutDiscoveryProfileSummary` -- strict `Literal["mg/dl", "mmol"]` units, `Field(ge=0)` count constraints, `float | None` target bounds (preserves mmol/L precision).
- Router endpoint with 25s `asyncio.wait_for` envelope + 5-min on-row cache (AC9). Cache only serves `status_ok=True` reports -- a typo'd-token failure does NOT poison the cache.

## Reviews

- **Adversarial**: HIGH ship-blocker (failed-evaluate cached for 5 min, locked typo'd-secret users out of retry) fixed by gating the cache write on `status_ok`. MED findings addressed: per-resource fail surfaced on `partial_resources`, mmol/L float precision preserved, direct `is_active=False` DB-flip test added, timeout comment drift fixed.
- **CodeRabbit CLI**: MAJOR findings addressed: units tightened to `Literal`, `entry_count_estimate` now a real extrapolation (recent-7d rate * span) instead of sample size. MINOR findings (count constraints, naming clarity) addressed.
- **Security**: PASS. SSRF inheritance (orchestrator's user-controlled `base_url` flows through `ValidatedTarget` at `NightscoutClient.create()`) documented in the orchestrator docstring; no raw httpx call escapes. Auth gating, cache poisoning, secret disclosure, DoS bounds all clean.

## Acceptance criteria covered (Story 43.7a slice)

- [x] **AC1** -- `POST /{id}/evaluate` returns `NightscoutDiscoveryReport` with status_ok / server_version / earliest_entry_at / entry_count_estimate / recent_entry_count_7d / uploaders_detected / has_treatments / treatment_count_estimate / has_devicestatus / has_profile / profile_summary / active_pump_loop / evaluated_at.
- [x] **AC9** -- Cached for 5 min on `nightscout_connections.detected_uploaders_json` + `last_evaluated_at`.
- [x] **AC11** -- Malformed profile sets `has_profile=False` + `profile_summary.is_malformed=True` (does not crash).

ACs covered by later sub-stories (43.7b-e): AC2 (wizard preview), AC3 (sync-window selector), AC4 (settings checklist), AC5 (apply transaction), AC6 (real-time sync progress), AC7 (post-finalize redirect), AC8 (no silent overwrite), AC10 (re-import entry point), AC12 (Playwright e2e).

## Test plan

- [x] `pytest tests/test_nightscout_evaluate.py` -- 18 tests, all pass
- [x] `pytest tests/test_nightscout_*.py` -- 213 NS tests pass, no regressions
- [x] ruff check clean
- [x] Adversarial + CR + security review chain run on staged diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nightscout evaluation endpoint that discovers connection details, detects active uploaders/pump-loop status, and returns normalized profile summaries; successful results are cached for 5 minutes.
* **Behavior**
  * Long-running evaluations are capped with a timeout (clients receive 504) and failed/timeout runs are not persisted to cache.
* **Tests**
  * Comprehensive unit and integration tests covering evaluation, caching, tenancy, access control, and schema-drift fallbacks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/594)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->