### PR TITLE
feat(api): pure-function NS profile -> wizard proposals derive

### DIFF
--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -426,6 +426,105 @@ class NightscoutDiscoveryProfileSummary(BaseModel):
     is_malformed: bool = False  # AC11: profile fetch returned but unparseable
 
 
+class OnboardingScheduleSegment(BaseModel):
+    """Story 43.7b -- a single time-segmented entry in our canonical
+    schedule shape.
+
+    Difference from `NightscoutProfileSegmentDTO`: this carries
+    `start_minutes` (int, 0-1439) for direct insertion into our
+    `pump_profiles.segments` JSONB column and downstream math. The
+    NS source uses `time` as "HH:MM" + optional `timeAsSeconds`;
+    the derive module converts.
+    """
+
+    start_minutes: int = Field(ge=0, lt=24 * 60)
+    # Medical-safety guard: schedule values (basal U/hr, carb ratio
+    # g/U, ISF mg/dL/U) must always be strictly positive. A `0.0`
+    # basal would mean "infinitely no insulin" -- not a real profile
+    # segment shape (suspends are encoded separately, not as a 0
+    # basal segment). Negatives are physiologically impossible.
+    value: float = Field(gt=0)
+
+
+class OnboardingNumericFieldDerivation(BaseModel):
+    """Per-field proposal for a single-value setting (target_low,
+    target_high, dia_hours, ...).
+
+    The wizard renders one row per field in a diff table:
+    'Setting | Currently | From Nightscout | Use this? [checkbox]'.
+    `current_value` powers the "Currently" column, `proposed_value`
+    the "From Nightscout" column, `default_checked` the checkbox's
+    initial state per AC4 (checked iff the user's current value is
+    the platform default -- i.e. they haven't customized it).
+    `proposed_value=None` when NS has nothing to propose; the
+    wizard hides the row in that case.
+    """
+
+    field: str  # stable identifier: "target_low" | "target_high" | "dia_hours" | ...
+    # Medical-safety guard: glucose targets and DIA must be strictly
+    # positive. Optional (None when no current row / no NS proposal).
+    # Upper bounds are NOT enforced here -- the wizard's diff table
+    # surfaces unusual values for the user to confirm before write.
+    current_value: float | None = Field(default=None, gt=0)
+    proposed_value: float | None = Field(default=None, gt=0)
+    default_checked: bool = False
+
+
+class OnboardingScheduleFieldDerivation(BaseModel):
+    """Per-field proposal for a time-segmented schedule (basal,
+    carb_ratio, isf).
+
+    Same wizard contract as `OnboardingNumericFieldDerivation` but
+    the "current" / "proposed" values are lists of segments. The
+    wizard renders a "current vs proposed" preview; per the 43.7c
+    decision the user can opt the WHOLE schedule in/out (no
+    per-segment editing in v1). `proposed_segments=None` when the
+    NS profile doesn't carry this schedule.
+    """
+
+    field: str  # "basal_schedule" | "carb_ratio_schedule" | "isf_schedule"
+    current_segments: list[OnboardingScheduleSegment] | None = None
+    proposed_segments: list[OnboardingScheduleSegment] | None = None
+    default_checked: bool = False
+
+
+class OnboardingDerivation(BaseModel):
+    """Story 43.7b -- the wizard step 3 review-table source.
+
+    Returned by the `derive_onboarding_proposals()` pure function
+    given a Nightscout profile snapshot + the user's current
+    canonical settings. The wizard step 3 renders one row per
+    derivation field (numeric + schedule), using `default_checked`
+    for the initial checkbox state and `proposed_value` /
+    `proposed_segments` for the right-hand "From Nightscout"
+    column.
+
+    Shape stable: the derivation includes ALL derivable fields even
+    when NS has nothing to propose (with `proposed_value=None` /
+    `proposed_segments=None`), so the wizard's row layout is
+    deterministic across users + connections.
+    """
+
+    has_profile: bool
+    # True when the Nightscout profile is in mmol/L but our canonical
+    # settings are mg/dL (or vice versa). The wizard surfaces this
+    # so the user understands values were unit-converted before the
+    # diff table renders. Always False when units match.
+    units_converted: bool = False
+    # True when the snapshot's `source_units` did NOT match any
+    # known mg/dL or mmol/L variant. The wizard MUST surface this
+    # before applying any glucose-domain proposal -- silently
+    # defaulting an unknown unit string to mg/dL could write wrong
+    # targets / ISFs to canonical settings.
+    units_unknown: bool = False
+    target_low: OnboardingNumericFieldDerivation
+    target_high: OnboardingNumericFieldDerivation
+    dia_hours: OnboardingNumericFieldDerivation
+    carb_ratio_schedule: OnboardingScheduleFieldDerivation
+    isf_schedule: OnboardingScheduleFieldDerivation
+    basal_schedule: OnboardingScheduleFieldDerivation
+
+
 class NightscoutDiscoveryReport(BaseModel):
     """Story 43.7a AC1: the evaluate endpoint's response shape.
 

--- a/apps/api/src/services/integrations/nightscout/onboarding_derive.py
+++ b/apps/api/src/services/integrations/nightscout/onboarding_derive.py
@@ -1,0 +1,541 @@
+"""Story 43.7b -- pure-function derivation: NS profile -> wizard proposals.
+
+Given a `NightscoutProfileSnapshot` row and the user's current
+canonical settings, produce a typed `OnboardingDerivation` describing
+what the smart-onboarding wizard should propose for each setting.
+
+This module is intentionally pure: no DB writes, no I/O, no network.
+The orchestrator (43.7c apply endpoint) reads the snapshot + current
+settings, calls this module, then writes confirmed proposals to the
+canonical tables. Keeping the derive logic side-effect-free keeps
+table-driven tests simple and lets future code (mobile, brief
+generation, audit logs) reuse the same logic without spinning up an
+ORM session.
+
+Entry point: `derive_onboarding_proposals(snapshot, *, current_*)`.
+
+**AC4 default_checked semantics:** the wizard's initial checkbox
+state per row is True iff the user's CURRENT canonical value matches
+the platform default -- i.e. they have not customized this setting.
+That gates the "auto-import" UX: a fresh-signup user gets every
+checkbox auto-checked (one click finalizes); a long-time user with
+custom basal patterns gets ALL checkboxes UNCHECKED so the wizard
+can't silently overwrite their dialed-in config.
+
+**AC11 / sparse-profile handling:** when the snapshot is None or
+has no parseable schedules, the per-field derivations carry
+`proposed_value=None` / `proposed_segments=None`. `has_profile`
+is False. The wizard's settings-import step renders a "no profile
+data -- we'll just sync data" banner and hides the diff table.
+
+**Unit conversion:** Nightscout profiles can be in `mg/dl` OR
+`mmol`. Our canonical settings are mg/dL across the board. When NS
+is mmol, glucose-domain values (target_low, target_high, ISF) are
+multiplied by `MMOL_TO_MGDL` and rounded to one decimal. Basal
+rates (U/hr) and carb ratios (g/U) are unit-agnostic. DIA (hours)
+is unit-agnostic. The derivation surfaces `units_converted=True`
+so the wizard can show "values converted from mmol to mg/dL" copy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from src.models.insulin_config import InsulinConfig
+from src.models.nightscout_profile_snapshot import NightscoutProfileSnapshot
+from src.models.pump_profile import PumpProfile
+from src.models.target_glucose_range import TargetGlucoseRange
+from src.schemas.nightscout import (
+    OnboardingDerivation,
+    OnboardingNumericFieldDerivation,
+    OnboardingScheduleFieldDerivation,
+    OnboardingScheduleSegment,
+)
+
+# 1 mmol/L = 18.0182 mg/dL (per the standard glucose mass-to-molarity
+# conversion). Reference: ADA / IFCC consensus, 18.0156 to 4 decimals,
+# 18.0182 used here for one-trip precision after rounding to 1 decimal
+# at the wire boundary. Rounding washes out any sub-decimal divergence
+# (e.g. 4.4 mmol -> 79.28 vs 79.27 both round to 79.3).
+MMOL_TO_MGDL: float = 18.0182
+
+# Allowed glucose unit strings on a Nightscout profile. Anything OUTSIDE
+# this set is flagged on the derivation as `units_unknown=True` -- the
+# wizard MUST surface that to the user, since silently treating a
+# weird unit as mg/dL would write wrong glucose targets / ISFs to the
+# canonical settings. See `_classify_units` below for the logic.
+_KNOWN_MGDL_UNITS = frozenset({"mg/dl", "mgdl", "mg-dl"})
+_KNOWN_MMOL_UNITS = frozenset({"mmol", "mmol/l", "mmol/litre", "mmoll"})
+
+# Platform defaults (must mirror the SQLAlchemy column defaults on the
+# canonical models). If a user's stored value matches the default, the
+# wizard treats them as "not customized" and pre-checks the import row
+# (AC4). Drift between this constant and the model default would silently
+# break the AC; the test suite asserts the coupling.
+DEFAULT_TARGET_LOW_MGDL: float = 70.0
+DEFAULT_TARGET_HIGH_MGDL: float = 180.0
+DEFAULT_DIA_HOURS: float = 4.0
+
+
+def derive_onboarding_proposals(
+    snapshot: NightscoutProfileSnapshot | None,
+    *,
+    current_target_range: TargetGlucoseRange | None,
+    current_insulin_config: InsulinConfig | None,
+    current_pump_profile: PumpProfile | None,
+) -> OnboardingDerivation:
+    """Map a Nightscout profile snapshot to wizard step-3 proposals.
+
+    Pure function -- no DB writes, no I/O. The caller fetches the
+    current canonical settings (one-row-per-user shape for target
+    range and insulin config; the active row for pump profile) and
+    threads them through.
+
+    The derivation always carries every derivable field, so the
+    wizard's row layout is deterministic. Fields where NS has
+    nothing to propose carry `proposed_value=None` /
+    `proposed_segments=None`; the wizard hides those rows.
+    """
+    if snapshot is None:
+        return _empty_derivation(
+            current_target_range=current_target_range,
+            current_insulin_config=current_insulin_config,
+            current_pump_profile=current_pump_profile,
+        )
+
+    # Strict unit classification (CR fix H1): explicitly distinguish
+    # mg/dL, mmol/L, and unknown. An unrecognized unit string flips
+    # `units_unknown=True` on the derivation; the wizard MUST refuse
+    # to auto-import glucose-domain values until the user confirms.
+    is_mmol, is_mgdl = _classify_units(snapshot.source_units)
+    units_unknown = not is_mmol and not is_mgdl
+
+    # ---- target_low / target_high (single-value fields) -----------------
+    target_low = _derive_target_field(
+        field="target_low",
+        snapshot_segments=snapshot.target_low_segments,
+        current_value=(
+            current_target_range.low_target if current_target_range else None
+        ),
+        platform_default=DEFAULT_TARGET_LOW_MGDL,
+        is_mmol=is_mmol,
+        aggregator=min,
+    )
+    target_high = _derive_target_field(
+        field="target_high",
+        snapshot_segments=snapshot.target_high_segments,
+        current_value=(
+            current_target_range.high_target if current_target_range else None
+        ),
+        platform_default=DEFAULT_TARGET_HIGH_MGDL,
+        is_mmol=is_mmol,
+        aggregator=max,
+    )
+
+    # ---- dia_hours (single value) --------------------------------------
+    proposed_dia = snapshot.source_dia_hours
+    current_dia = current_insulin_config.dia_hours if current_insulin_config else None
+    dia_hours = OnboardingNumericFieldDerivation(
+        field="dia_hours",
+        current_value=current_dia,
+        proposed_value=proposed_dia,
+        # Pre-check iff the user is at platform default OR the
+        # proposal happens to match what they already have (the
+        # latter is a no-op if applied -- safe to import; CR M1).
+        default_checked=proposed_dia is not None
+        and (
+            _is_default(current_dia, DEFAULT_DIA_HOURS)
+            or _values_match(current_dia, proposed_dia)
+        ),
+    )
+
+    # ---- schedules ------------------------------------------------------
+    # `current_pump_profile` carries a list of merged segments
+    # (basal_rate / carb_ratio / correction_factor / target_bg per
+    # time slot). We split it back out per-axis so the wizard can
+    # show "Currently 1.0 U/hr basal" alongside "From NS 0.65 U/hr".
+    # No pump_profile row at all = treat the schedule as default
+    # (checked-by-default) since the user has no custom config.
+    has_custom_pump_profile = current_pump_profile is not None and bool(
+        current_pump_profile.segments
+    )
+    current_basal = _extract_axis_from_pump_profile(current_pump_profile, "basal_rate")
+    current_isf = _extract_axis_from_pump_profile(
+        current_pump_profile, "correction_factor"
+    )
+    current_icr = _extract_axis_from_pump_profile(current_pump_profile, "carb_ratio")
+
+    basal_schedule = OnboardingScheduleFieldDerivation(
+        field="basal_schedule",
+        current_segments=current_basal,
+        proposed_segments=_segments_to_canonical(snapshot.basal_segments),
+        default_checked=(
+            not has_custom_pump_profile
+            and snapshot.basal_segments is not None
+            and len(snapshot.basal_segments) > 0
+        ),
+    )
+    carb_ratio_schedule = OnboardingScheduleFieldDerivation(
+        field="carb_ratio_schedule",
+        current_segments=current_icr,
+        proposed_segments=_segments_to_canonical(snapshot.carb_ratio_segments),
+        default_checked=(
+            not has_custom_pump_profile
+            and snapshot.carb_ratio_segments is not None
+            and len(snapshot.carb_ratio_segments) > 0
+        ),
+    )
+    isf_schedule = OnboardingScheduleFieldDerivation(
+        field="isf_schedule",
+        current_segments=current_isf,
+        proposed_segments=_segments_to_canonical(
+            snapshot.sensitivity_segments,
+            value_transform=(_mmol_to_mgdl_per_unit if is_mmol else None),
+        ),
+        default_checked=(
+            not has_custom_pump_profile
+            and snapshot.sensitivity_segments is not None
+            and len(snapshot.sensitivity_segments) > 0
+        ),
+    )
+
+    return OnboardingDerivation(
+        has_profile=True,
+        units_converted=is_mmol,
+        units_unknown=units_unknown,
+        target_low=target_low,
+        target_high=target_high,
+        dia_hours=dia_hours,
+        carb_ratio_schedule=carb_ratio_schedule,
+        isf_schedule=isf_schedule,
+        basal_schedule=basal_schedule,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _empty_derivation(
+    *,
+    current_target_range: TargetGlucoseRange | None,
+    current_insulin_config: InsulinConfig | None,
+    current_pump_profile: PumpProfile | None,
+) -> OnboardingDerivation:
+    """Build a no-snapshot derivation: every field carries the user's
+    current value but `proposed_value=None`. AC11 path (Tandem-only-
+    via-tconnectsync etc) -- wizard skips the import step entirely.
+    """
+    current_basal = _extract_axis_from_pump_profile(current_pump_profile, "basal_rate")
+    current_isf = _extract_axis_from_pump_profile(
+        current_pump_profile, "correction_factor"
+    )
+    current_icr = _extract_axis_from_pump_profile(current_pump_profile, "carb_ratio")
+    return OnboardingDerivation(
+        has_profile=False,
+        units_converted=False,
+        units_unknown=False,
+        target_low=OnboardingNumericFieldDerivation(
+            field="target_low",
+            current_value=(
+                current_target_range.low_target if current_target_range else None
+            ),
+            proposed_value=None,
+            default_checked=False,
+        ),
+        target_high=OnboardingNumericFieldDerivation(
+            field="target_high",
+            current_value=(
+                current_target_range.high_target if current_target_range else None
+            ),
+            proposed_value=None,
+            default_checked=False,
+        ),
+        dia_hours=OnboardingNumericFieldDerivation(
+            field="dia_hours",
+            current_value=(
+                current_insulin_config.dia_hours if current_insulin_config else None
+            ),
+            proposed_value=None,
+            default_checked=False,
+        ),
+        carb_ratio_schedule=OnboardingScheduleFieldDerivation(
+            field="carb_ratio_schedule",
+            current_segments=current_icr,
+            proposed_segments=None,
+            default_checked=False,
+        ),
+        isf_schedule=OnboardingScheduleFieldDerivation(
+            field="isf_schedule",
+            current_segments=current_isf,
+            proposed_segments=None,
+            default_checked=False,
+        ),
+        basal_schedule=OnboardingScheduleFieldDerivation(
+            field="basal_schedule",
+            current_segments=current_basal,
+            proposed_segments=None,
+            default_checked=False,
+        ),
+    )
+
+
+def _derive_target_field(
+    *,
+    field: str,
+    snapshot_segments: list[dict] | None,
+    current_value: float | None,
+    platform_default: float,
+    is_mmol: bool,
+    aggregator: Callable[[list[float]], float],
+) -> OnboardingNumericFieldDerivation:
+    """Single-value target derivation.
+
+    For time-varying targets (the segmented case), we collapse to
+    one number using `aggregator` (`min` for low, `max` for high).
+    The wizard renders one row per target, so the worst-case bound
+    across the schedule is the safest summary -- matches the
+    discovery report's profile_summary semantics.
+    """
+    proposed = _aggregate_segment_value(snapshot_segments, aggregator)
+    if proposed is not None and is_mmol:
+        proposed = round(proposed * MMOL_TO_MGDL, 1)
+    return OnboardingNumericFieldDerivation(
+        field=field,
+        current_value=current_value,
+        proposed_value=proposed,
+        # AC4 + CR M1: pre-check iff user is at platform default
+        # OR the import would be a no-op (current matches proposal).
+        default_checked=proposed is not None
+        and (
+            _is_default(current_value, platform_default)
+            or _values_match(current_value, proposed)
+        ),
+    )
+
+
+def _aggregate_segment_value(
+    segments: list[dict] | None,
+    aggregator: Callable[[list[float]], float],
+) -> float | None:
+    """Apply `aggregator` (min/max) over the `value` field of each
+    segment, dropping non-numeric. None when no usable values."""
+    if not segments:
+        return None
+    values: list[float] = []
+    for entry in segments:
+        if not isinstance(entry, dict):
+            continue
+        value = entry.get("value")
+        try:
+            values.append(float(value))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+    return aggregator(values) if values else None
+
+
+def _segments_to_canonical(
+    raw: list[dict] | None,
+    *,
+    value_transform: Callable[[float], float] | None = None,
+) -> list[OnboardingScheduleSegment] | None:
+    """NS `[{time, value, timeAsSeconds?}, ...]` -> our canonical
+    `[{start_minutes, value}, ...]`.
+
+    - `time` is parsed from "HH:MM" when present; falls back to
+      `timeAsSeconds // 60`. Segments missing both are dropped.
+    - Sorted by `start_minutes` (NS doesn't guarantee order). Sort
+      is stable; equal-start_minutes segments would keep insertion
+      order, but NS profiles never emit duplicate keys in practice.
+    - `value_transform`, when provided, runs over each segment's
+      `value` -- used for mmol->mg/dL on the ISF schedule.
+    - Returns None when the input is empty/None or no segment
+      survives parsing -- the wizard's "schedule absent" branch
+      fires cleanly.
+
+    **Midnight-wrap (CR H2):** if the first segment isn't at
+    `start_minutes=0` (e.g. a basal pattern starting at `06:00`),
+    THIS function does NOT prepend a wrap segment. The 43.7c
+    apply orchestrator owns full-24h coverage on the canonical
+    `pump_profiles.segments` write -- it's responsible for
+    detecting the gap and either (a) prepending the last segment
+    to cover `00:00 -> first_start` (matches Loop / AAPS
+    convention) or (b) raising a "schedule has unconvered hours"
+    error to surface in the wizard. Keeping the responsibility
+    at the apply step lets the derive module stay pure.
+    """
+    if not raw:
+        return None
+    parsed: list[OnboardingScheduleSegment] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        start_minutes = _segment_start_minutes(entry)
+        if start_minutes is None:
+            continue
+        value = entry.get("value")
+        try:
+            float_value = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if value_transform is not None:
+            float_value = value_transform(float_value)
+        parsed.append(
+            OnboardingScheduleSegment(
+                start_minutes=start_minutes,
+                value=float_value,
+            )
+        )
+    if not parsed:
+        return None
+    parsed.sort(key=lambda seg: seg.start_minutes)
+    return parsed
+
+
+def _segment_start_minutes(entry: dict) -> int | None:
+    """Resolve a segment's start-of-day minute count.
+
+    Prefers the explicit `time` "HH:MM" string (NS canonical); falls
+    back to `timeAsSeconds` for profiles that omit `time` (some Loop
+    versions do this on derived schedules). Returns None when both
+    are absent / unparseable -- caller drops the segment.
+    """
+    time_str = entry.get("time")
+    if isinstance(time_str, str):
+        parts = time_str.split(":")
+        if len(parts) >= 2:
+            try:
+                hours = int(parts[0])
+                minutes = int(parts[1])
+            except ValueError:
+                pass
+            else:
+                if 0 <= hours < 24 and 0 <= minutes < 60:
+                    return hours * 60 + minutes
+    seconds = entry.get("timeAsSeconds")
+    if isinstance(seconds, int | float):
+        try:
+            mins = int(seconds) // 60
+        except (TypeError, ValueError):
+            return None
+        if 0 <= mins < 24 * 60:
+            return mins
+    return None
+
+
+def _extract_axis_from_pump_profile(
+    profile: PumpProfile | None, axis: str
+) -> list[OnboardingScheduleSegment] | None:
+    """Pull a single axis (basal_rate / carb_ratio / correction_factor)
+    out of the merged `pump_profiles.segments` list.
+
+    Our canonical pump_profile stores ONE list of merged segments
+    where each entry carries `start_minutes` + per-axis values
+    (`basal_rate`, `carb_ratio`, `correction_factor`, `target_bg`).
+    For the wizard's diff table we want each axis as its own
+    schedule. Drops segments where the axis value is missing/null.
+    Returns None when no profile or no segments carry the axis.
+    """
+    if profile is None or not profile.segments:
+        return None
+    out: list[OnboardingScheduleSegment] = []
+    for seg in profile.segments:
+        if not isinstance(seg, dict):
+            continue
+        # CR M3: JSONB round-trips can produce floats where ints were
+        # written; coerce numerics rather than dropping the segment.
+        # Booleans are int subclasses in Python -- explicitly reject
+        # them so a stray `True` doesn't masquerade as start_minutes=1.
+        raw_start = seg.get("start_minutes")
+        if isinstance(raw_start, bool) or not isinstance(raw_start, int | float):
+            continue
+        try:
+            start_minutes = int(raw_start)
+        except (TypeError, ValueError):
+            continue
+        if not (0 <= start_minutes < 24 * 60):
+            continue
+        value = seg.get(axis)
+        if value is None:
+            continue
+        try:
+            float_value = float(value)
+        except (TypeError, ValueError):
+            continue
+        out.append(
+            OnboardingScheduleSegment(
+                start_minutes=start_minutes,
+                value=float_value,
+            )
+        )
+    if not out:
+        return None
+    out.sort(key=lambda s: s.start_minutes)
+    return out
+
+
+def _is_default(value: float | None, platform_default: float) -> bool:
+    """AC4: True iff the stored value matches the platform default
+    within float tolerance.
+
+    `value=None` (no canonical row at all) is treated as "default" --
+    a fresh-signup user has no row, so checking-by-default is the
+    right UX (nothing to overwrite). CR M4 note: this conflates "no
+    row" with "user explicitly at default"; if the platform later
+    treats absent rows as "explicitly opted out," update Story 43.7c
+    apply orchestrator + this comparison together so AC4 stays
+    correct.
+
+    Tolerance is generous (1e-3) because canonical defaults are
+    integer-ish (70.0, 180.0, 4.0) and stored as floats; round-trip
+    drift is well below 1e-3.
+    """
+    if value is None:
+        return True
+    return abs(value - platform_default) < 1e-3
+
+
+def _values_match(a: float | None, b: float | None) -> bool:
+    """True iff two values are close enough that importing one over
+    the other would be a no-op. CR M1: the wizard pre-checks when
+    proposal == current so a user who happens to have dialed in the
+    EXACT same setting NS proposes doesn't see a misleading
+    unchecked row.
+
+    Both None counts as a match (no-op import). One-sided None
+    counts as a mismatch (we have something to import or remove).
+    """
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    return abs(a - b) < 1e-3
+
+
+def _classify_units(raw: str | None) -> tuple[bool, bool]:
+    """Classify a Nightscout `source_units` string.
+
+    Returns `(is_mmol, is_mgdl)`. Both False -> unknown unit; the
+    caller flips `units_unknown=True` on the derivation so the
+    wizard refuses to auto-import glucose-domain values until the
+    user confirms (CR H1).
+
+    Accepted variants:
+      - mg/dL: "mg/dl", "mgdl", "mg-dl" (case-insensitive)
+      - mmol/L: "mmol", "mmol/l", "mmol/litre", "mmoll"
+    """
+    if not isinstance(raw, str):
+        return False, False
+    normalized = raw.lower().strip()
+    if normalized in _KNOWN_MGDL_UNITS:
+        return False, True
+    if normalized in _KNOWN_MMOL_UNITS:
+        return True, False
+    return False, False
+
+
+def _mmol_to_mgdl_per_unit(value: float) -> float:
+    """ISF (mmol/L per U) -> mg/dL per U. Multiplies by MMOL_TO_MGDL,
+    rounds to 1 decimal."""
+    return round(value * MMOL_TO_MGDL, 1)

--- a/apps/api/src/services/integrations/nightscout/onboarding_derive.py
+++ b/apps/api/src/services/integrations/nightscout/onboarding_derive.py
@@ -133,8 +133,16 @@ def derive_onboarding_proposals(
     )
 
     # ---- dia_hours (single value) --------------------------------------
-    proposed_dia = snapshot.source_dia_hours
-    current_dia = current_insulin_config.dia_hours if current_insulin_config else None
+    # Sanitize before model construction: the schema's `gt=0` guard on
+    # current_value/proposed_value would RAISE ValidationError on a
+    # zero / negative input rather than fail-safing -- which would 500
+    # the whole evaluate path on a single malformed NS profile. Coerce
+    # non-positive values to None so the wizard sees "no proposal" and
+    # the user retains their existing setting.
+    proposed_dia = _coerce_positive(snapshot.source_dia_hours)
+    current_dia = _coerce_positive(
+        current_insulin_config.dia_hours if current_insulin_config else None
+    )
     dia_hours = OnboardingNumericFieldDerivation(
         field="dia_hours",
         current_value=current_dia,
@@ -301,12 +309,19 @@ def _derive_target_field(
     proposed = _aggregate_segment_value(snapshot_segments, aggregator)
     if proposed is not None and is_mmol:
         proposed = round(proposed * MMOL_TO_MGDL, 1)
+    # Sanitize before model construction: the schema's gt=0 guard
+    # would RAISE ValidationError on non-positive values rather than
+    # fail-safing. Coerce to None so the wizard sees "no proposal"
+    # cleanly. Also defensively coerce current_value -- a corrupted
+    # canonical row with a stored 0 would otherwise crash here too.
+    proposed = _coerce_positive(proposed)
+    current_value = _coerce_positive(current_value)
     return OnboardingNumericFieldDerivation(
         field=field,
         current_value=current_value,
         proposed_value=proposed,
-        # AC4 + CR M1: pre-check iff user is at platform default
-        # OR the import would be a no-op (current matches proposal).
+        # Pre-check iff user is at platform default OR the import
+        # would be a no-op (current matches proposal).
         default_checked=proposed is not None
         and (
             _is_default(current_value, platform_default)
@@ -381,6 +396,14 @@ def _segments_to_canonical(
             continue
         if value_transform is not None:
             float_value = value_transform(float_value)
+        # Drop non-positive segments rather than crashing the whole
+        # derive call on the schema's gt=0 guard. NS profiles in the
+        # wild sometimes carry 0-valued basal segments (suspend
+        # patterns encoded as 0, malformed Loop overrides, AAPS edge
+        # cases). The wizard sees the surviving segments only --
+        # safer than 500ing the endpoint.
+        if float_value <= 0:
+            continue
         parsed.append(
             OnboardingScheduleSegment(
                 start_minutes=start_minutes,
@@ -463,6 +486,12 @@ def _extract_axis_from_pump_profile(
             float_value = float(value)
         except (TypeError, ValueError):
             continue
+        # Drop non-positive entries -- a corrupted JSONB row with a
+        # stored 0 basal_rate / carb_ratio / correction_factor would
+        # otherwise crash on the schema's gt=0 guard. Same treatment
+        # as `_segments_to_canonical` for symmetry.
+        if float_value <= 0:
+            continue
         out.append(
             OnboardingScheduleSegment(
                 start_minutes=start_minutes,
@@ -494,6 +523,29 @@ def _is_default(value: float | None, platform_default: float) -> bool:
     if value is None:
         return True
     return abs(value - platform_default) < 1e-3
+
+
+def _coerce_positive(value: float | None) -> float | None:
+    """Boundary sanitizer for the `Field(gt=0)` schema constraints.
+
+    Returns the input unchanged when it's already a positive float,
+    None when it's None, and None when it's <= 0 (instead of letting
+    the model construction raise ValidationError).
+
+    NS profiles in the wild occasionally carry 0 / negative values
+    (malformed uploads, suspend-encoded-as-zero, edge cases in older
+    Loop / AAPS versions). The medical-safety guard at the schema
+    layer is correct -- we don't WANT to write zeros to canonical
+    settings -- but we also don't want to 500 the whole evaluate
+    path on a single bad field. Coercing to None at the boundary
+    means the wizard sees "no proposal for this field" cleanly and
+    the user keeps their existing setting. CR feedback on PR #595.
+    """
+    if value is None:
+        return None
+    if value <= 0:
+        return None
+    return value
 
 
 def _values_match(a: float | None, b: float | None) -> bool:

--- a/apps/api/tests/test_nightscout_onboarding_derive.py
+++ b/apps/api/tests/test_nightscout_onboarding_derive.py
@@ -1,0 +1,802 @@
+"""Story 43.7b -- tests for the pure-function derive module.
+
+Pure unit tests over `derive_onboarding_proposals()` -- no DB, no
+HTTP, no fixtures. Each test stands up a transient
+`NightscoutProfileSnapshot` + transient canonical-settings rows and
+asserts the resulting `OnboardingDerivation`. Table-driven coverage
+across Loop / AAPS / Trio / mmol / sparse / no-profile shapes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from src.models.insulin_config import InsulinConfig
+from src.models.nightscout_profile_snapshot import NightscoutProfileSnapshot
+from src.models.pump_profile import PumpProfile
+from src.models.target_glucose_range import TargetGlucoseRange
+from src.services.integrations.nightscout.onboarding_derive import (
+    DEFAULT_DIA_HOURS,
+    DEFAULT_TARGET_HIGH_MGDL,
+    DEFAULT_TARGET_LOW_MGDL,
+    MMOL_TO_MGDL,
+    derive_onboarding_proposals,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+# Sentinel so test fixtures can distinguish "use default schedule"
+# from "explicit empty list" (the latter is a meaningful test input;
+# `or default` would conflate them since `[] or X == X`).
+_DEFAULT_SENTINEL: Any = object()
+
+
+def _mk_snapshot(
+    *,
+    units: str = "mg/dl",
+    dia_hours: float | None = 5.0,
+    timezone: str = "UTC",
+    basal_segments: Any = _DEFAULT_SENTINEL,
+    carb_ratio_segments: Any = _DEFAULT_SENTINEL,
+    sensitivity_segments: Any = _DEFAULT_SENTINEL,
+    target_low_segments: Any = _DEFAULT_SENTINEL,
+    target_high_segments: Any = _DEFAULT_SENTINEL,
+) -> NightscoutProfileSnapshot:
+    """Build a transient snapshot row (not persisted).
+
+    Pass an explicit `[]` for any segment field to test the empty-
+    schedule branch; pass `None` to test the missing-schedule
+    branch; omit the kwarg to use a sensible default fixture.
+    """
+    return NightscoutProfileSnapshot(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        nightscout_connection_id=uuid.uuid4(),
+        fetched_at=datetime.now(UTC),
+        source_default_profile_name="Default",
+        source_units=units,
+        source_timezone=timezone,
+        source_dia_hours=dia_hours,
+        basal_segments=(
+            [{"time": "00:00", "value": 0.65}]
+            if basal_segments is _DEFAULT_SENTINEL
+            else basal_segments
+        ),
+        carb_ratio_segments=(
+            [{"time": "00:00", "value": 12.0}]
+            if carb_ratio_segments is _DEFAULT_SENTINEL
+            else carb_ratio_segments
+        ),
+        sensitivity_segments=(
+            [{"time": "00:00", "value": 50.0}]
+            if sensitivity_segments is _DEFAULT_SENTINEL
+            else sensitivity_segments
+        ),
+        target_low_segments=(
+            [{"time": "00:00", "value": 90.0}]
+            if target_low_segments is _DEFAULT_SENTINEL
+            else target_low_segments
+        ),
+        target_high_segments=(
+            [{"time": "00:00", "value": 120.0}]
+            if target_high_segments is _DEFAULT_SENTINEL
+            else target_high_segments
+        ),
+        profile_json_full={},
+    )
+
+
+def _mk_target_range(
+    *,
+    low: float = DEFAULT_TARGET_LOW_MGDL,
+    high: float = DEFAULT_TARGET_HIGH_MGDL,
+) -> TargetGlucoseRange:
+    """Default low=70, high=180 ('user not customized'). Override
+    to simulate a user with custom target."""
+    return TargetGlucoseRange(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        urgent_low=55.0,
+        low_target=low,
+        high_target=high,
+        urgent_high=250.0,
+    )
+
+
+def _mk_insulin_config(
+    *,
+    dia_hours: float = DEFAULT_DIA_HOURS,
+) -> InsulinConfig:
+    return InsulinConfig(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        insulin_type="humalog",
+        dia_hours=dia_hours,
+        onset_minutes=15.0,
+    )
+
+
+def _mk_pump_profile(
+    *,
+    segments: list[dict] | None = None,
+) -> PumpProfile:
+    """When `segments=None`, returns a profile with NO segments
+    (treated as 'no custom config'). Pass an explicit list to
+    simulate a user with customized pump settings."""
+    return PumpProfile(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        profile_name="Tandem-imported",
+        is_active=True,
+        segments=segments or [],
+        insulin_duration_min=300,
+        carb_entry_enabled=True,
+        synced_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loop happy path
+# ---------------------------------------------------------------------------
+
+
+class TestLoopHappyPath:
+    """Loop profile, mg/dL, default canonical settings -> all
+    proposals checked-by-default per AC4."""
+
+    def test_basic_loop_profile_pre_checks_everything(self):
+        snapshot = _mk_snapshot()  # mg/dl defaults
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),  # platform default
+            current_insulin_config=_mk_insulin_config(),  # platform default
+            current_pump_profile=None,  # no custom pump
+        )
+
+        assert result.has_profile is True
+        assert result.units_converted is False
+
+        # Numeric fields all checked-by-default (user is at platform default).
+        assert result.target_low.proposed_value == 90.0
+        assert result.target_low.current_value == DEFAULT_TARGET_LOW_MGDL
+        assert result.target_low.default_checked is True
+
+        assert result.target_high.proposed_value == 120.0
+        assert result.target_high.current_value == DEFAULT_TARGET_HIGH_MGDL
+        assert result.target_high.default_checked is True
+
+        assert result.dia_hours.proposed_value == 5.0
+        assert result.dia_hours.current_value == DEFAULT_DIA_HOURS
+        assert result.dia_hours.default_checked is True
+
+        # Schedules: no pump_profile -> default-checked.
+        assert result.basal_schedule.proposed_segments is not None
+        assert result.basal_schedule.proposed_segments[0].start_minutes == 0
+        assert result.basal_schedule.proposed_segments[0].value == 0.65
+        assert result.basal_schedule.default_checked is True
+        assert result.basal_schedule.current_segments is None  # no pump profile
+
+        assert result.carb_ratio_schedule.proposed_segments[0].value == 12.0
+        assert result.carb_ratio_schedule.default_checked is True
+
+        assert result.isf_schedule.proposed_segments[0].value == 50.0
+        assert result.isf_schedule.default_checked is True
+
+
+# ---------------------------------------------------------------------------
+# AC4 default_checked: customized user -> all UNchecked
+# ---------------------------------------------------------------------------
+
+
+class TestAC4DefaultChecked:
+    """AC4: 'defaults to checked if the user has no current value
+    (or platform default), unchecked if the user already has a
+    non-default value'. The latter is the most important guard --
+    a long-time user with custom settings must NOT have their
+    config silently overwritten."""
+
+    def test_customized_target_unchecks_target_rows(self):
+        snapshot = _mk_snapshot()
+        # User has dialed in a tighter target.
+        custom_range = _mk_target_range(low=80.0, high=140.0)
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=custom_range,
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        # Targets: customized -> UNchecked.
+        assert result.target_low.default_checked is False
+        assert result.target_high.default_checked is False
+        # Other fields untouched by target customization.
+        assert result.dia_hours.default_checked is True
+
+    def test_customized_dia_unchecks_dia_row(self):
+        snapshot = _mk_snapshot(dia_hours=6.0)
+        # User has DIA at 5h (not the 4h default).
+        custom_insulin = _mk_insulin_config(dia_hours=5.0)
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=custom_insulin,
+            current_pump_profile=None,
+        )
+
+        assert result.dia_hours.proposed_value == 6.0
+        assert result.dia_hours.current_value == 5.0
+        assert result.dia_hours.default_checked is False
+        assert result.target_low.default_checked is True
+
+    def test_existing_pump_profile_unchecks_all_schedules(self):
+        snapshot = _mk_snapshot()
+        # User has Tandem-synced pump segments already.
+        custom_pump = _mk_pump_profile(
+            segments=[
+                {
+                    "time": "00:00",
+                    "start_minutes": 0,
+                    "basal_rate": 1.0,
+                    "carb_ratio": 10.0,
+                    "correction_factor": 60.0,
+                    "target_bg": 110,
+                },
+            ]
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=custom_pump,
+        )
+
+        # All three schedules: customized -> UNchecked.
+        assert result.basal_schedule.default_checked is False
+        assert result.carb_ratio_schedule.default_checked is False
+        assert result.isf_schedule.default_checked is False
+        # Numeric fields still default-checked (independent axes).
+        assert result.target_low.default_checked is True
+        assert result.dia_hours.default_checked is True
+        # current_segments populated from the pump profile.
+        assert result.basal_schedule.current_segments is not None
+        assert result.basal_schedule.current_segments[0].value == 1.0
+        assert result.carb_ratio_schedule.current_segments[0].value == 10.0
+        assert result.isf_schedule.current_segments[0].value == 60.0
+
+
+# ---------------------------------------------------------------------------
+# Unit conversion (mmol -> mg/dL)
+# ---------------------------------------------------------------------------
+
+
+class TestUnitConversion:
+    def test_mmol_target_converts_to_mgdl(self):
+        snapshot = _mk_snapshot(
+            units="mmol",
+            target_low_segments=[{"time": "00:00", "value": 4.4}],
+            target_high_segments=[{"time": "00:00", "value": 7.8}],
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        assert result.units_converted is True
+        # 4.4 * 18.0182 = 79.28 -> rounds to 79.3
+        assert result.target_low.proposed_value == round(4.4 * MMOL_TO_MGDL, 1)
+        assert result.target_high.proposed_value == round(7.8 * MMOL_TO_MGDL, 1)
+
+    def test_mmol_isf_converts_to_mgdl_per_unit(self):
+        """ISF in mmol/L per U converts to mg/dL per U at segment level."""
+        snapshot = _mk_snapshot(
+            units="mmol",
+            sensitivity_segments=[{"time": "00:00", "value": 2.5}],
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        assert result.units_converted is True
+        # 2.5 mmol/L per U * 18.0182 = 45.0455 -> rounds to 45.0
+        assert result.isf_schedule.proposed_segments[0].value == round(
+            2.5 * MMOL_TO_MGDL, 1
+        )
+
+    def test_mmol_basal_and_carb_ratio_not_converted(self):
+        """Rate (U/hr) and carb ratio (g/U) are unit-agnostic."""
+        snapshot = _mk_snapshot(
+            units="mmol",
+            basal_segments=[{"time": "00:00", "value": 0.7}],
+            carb_ratio_segments=[{"time": "00:00", "value": 11.0}],
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        # Pass-through.
+        assert result.basal_schedule.proposed_segments[0].value == 0.7
+        assert result.carb_ratio_schedule.proposed_segments[0].value == 11.0
+
+    def test_mgdl_no_conversion(self):
+        snapshot = _mk_snapshot(units="mg/dl")
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.units_converted is False
+        assert result.units_unknown is False
+        assert result.target_low.proposed_value == 90.0
+
+    def test_long_form_mmol_l_recognized(self):
+        """CR H1: 'mmol/L' (long form, mixed case) must be recognized,
+        not silently fall through as mg/dL."""
+        snapshot = _mk_snapshot(
+            units="mmol/L",
+            target_low_segments=[{"time": "00:00", "value": 4.4}],
+            target_high_segments=[{"time": "00:00", "value": 7.8}],
+        )
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.units_converted is True
+        assert result.units_unknown is False
+        # 4.4 * 18.0182 = 79.28 -> 79.3
+        assert result.target_low.proposed_value == round(4.4 * MMOL_TO_MGDL, 1)
+
+    def test_unknown_units_flagged(self):
+        """CR H1: an unknown unit string must NOT silently default to
+        mg/dL. The wizard should refuse to auto-import glucose-domain
+        values."""
+        snapshot = _mk_snapshot(units="some-future-unit-string")
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.units_converted is False
+        assert result.units_unknown is True
+
+    def test_units_none_flagged(self):
+        """A profile with `source_units=None` is also unknown."""
+        snapshot = _mk_snapshot(units=None)
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.units_unknown is True
+
+
+class TestIdenticalValuePreCheck:
+    """CR M1: when the user's current value is non-default but
+    happens to match the proposed value, importing is a no-op
+    and the wizard should pre-check the row."""
+
+    def test_dia_match_pre_checks_even_when_customized(self):
+        snapshot = _mk_snapshot(dia_hours=5.0)
+        # User's customized DIA happens to match what NS proposes.
+        custom_insulin = _mk_insulin_config(dia_hours=5.0)
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=custom_insulin,
+            current_pump_profile=None,
+        )
+        # Customized BUT identical to proposal -> still pre-checked
+        # (importing is a no-op).
+        assert result.dia_hours.default_checked is True
+
+    def test_target_match_pre_checks_even_when_customized(self):
+        snapshot = _mk_snapshot(
+            target_low_segments=[{"time": "00:00", "value": 80.0}],
+            target_high_segments=[{"time": "00:00", "value": 140.0}],
+        )
+        custom_range = _mk_target_range(low=80.0, high=140.0)
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=custom_range,
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.target_low.default_checked is True
+        assert result.target_high.default_checked is True
+
+
+class TestPumpProfileFloatCoerce:
+    """CR M3: JSONB round-trips can produce floats where ints were
+    written. Coerce numerics rather than dropping the segment."""
+
+    def test_float_start_minutes_coerced(self):
+        snapshot = _mk_snapshot()
+        # Plant float start_minutes (as a JSONB round-trip would).
+        custom_pump = _mk_pump_profile(
+            segments=[
+                {
+                    "time": "00:00",
+                    "start_minutes": 0.0,  # float
+                    "basal_rate": 1.2,
+                    "carb_ratio": 10.0,
+                    "correction_factor": 60.0,
+                },
+            ]
+        )
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=custom_pump,
+        )
+        # Coerced -- segment survived.
+        assert result.basal_schedule.current_segments is not None
+        assert result.basal_schedule.current_segments[0].start_minutes == 0
+        assert result.basal_schedule.current_segments[0].value == 1.2
+
+    def test_bool_start_minutes_rejected(self):
+        """Python's `bool` is an int subclass; reject explicitly so a
+        stray `True` doesn't become start_minutes=1."""
+        snapshot = _mk_snapshot()
+        custom_pump = _mk_pump_profile(
+            segments=[
+                {
+                    "start_minutes": True,  # bool, not int
+                    "basal_rate": 1.2,
+                },
+            ]
+        )
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=custom_pump,
+        )
+        # The segment was dropped -> no current_segments.
+        assert result.basal_schedule.current_segments is None
+
+    def test_out_of_range_start_minutes_rejected(self):
+        snapshot = _mk_snapshot()
+        custom_pump = _mk_pump_profile(
+            segments=[
+                {"start_minutes": 0, "basal_rate": 1.0},
+                {"start_minutes": 1500, "basal_rate": 1.5},  # > 24h
+                {"start_minutes": -60, "basal_rate": 0.5},  # negative
+            ]
+        )
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=custom_pump,
+        )
+        segs = result.basal_schedule.current_segments
+        assert segs is not None
+        # Only the in-range segment survived.
+        assert len(segs) == 1
+        assert segs[0].start_minutes == 0
+
+
+# ---------------------------------------------------------------------------
+# Time-segment parsing
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentParsing:
+    def test_hh_mm_parsing(self):
+        snapshot = _mk_snapshot(
+            basal_segments=[
+                {"time": "00:00", "value": 0.5},
+                {"time": "06:00", "value": 0.7},
+                {"time": "22:30", "value": 0.6},
+            ]
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        segs = result.basal_schedule.proposed_segments
+        assert segs is not None
+        assert [s.start_minutes for s in segs] == [0, 360, 1350]
+        assert [s.value for s in segs] == [0.5, 0.7, 0.6]
+
+    def test_time_as_seconds_fallback(self):
+        """When `time` is missing/invalid, fall back to timeAsSeconds."""
+        snapshot = _mk_snapshot(
+            basal_segments=[
+                {"timeAsSeconds": 0, "value": 0.5},
+                {"timeAsSeconds": 28800, "value": 0.7},  # 8h
+            ]
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        segs = result.basal_schedule.proposed_segments
+        assert segs is not None
+        assert [s.start_minutes for s in segs] == [0, 480]
+
+    def test_segments_sorted_by_start_minutes(self):
+        """NS doesn't guarantee order; we sort."""
+        snapshot = _mk_snapshot(
+            basal_segments=[
+                {"time": "12:00", "value": 1.2},
+                {"time": "00:00", "value": 0.5},
+                {"time": "06:00", "value": 0.7},
+            ]
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        segs = result.basal_schedule.proposed_segments
+        assert [s.start_minutes for s in segs] == [0, 360, 720]
+        assert [s.value for s in segs] == [0.5, 0.7, 1.2]
+
+    def test_segments_with_invalid_entries_dropped(self):
+        snapshot = _mk_snapshot(
+            basal_segments=[
+                {"time": "00:00", "value": 0.5},
+                {"time": "garbage", "value": 0.7},  # bad time
+                {"time": "06:00", "value": "not a number"},  # bad value
+                "not a dict",  # bad shape
+                {"time": "12:00", "value": 1.2},
+            ]
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        segs = result.basal_schedule.proposed_segments
+        # Only the two valid segments survive.
+        assert len(segs) == 2
+        assert [s.start_minutes for s in segs] == [0, 720]
+
+
+# ---------------------------------------------------------------------------
+# Time-varying targets -> min/max aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentedTargets:
+    """Time-varying targets collapse to one number using min(low) /
+    max(high) -- the safest summary the wizard can render in one row."""
+
+    def test_segmented_target_low_uses_min(self):
+        snapshot = _mk_snapshot(
+            target_low_segments=[
+                {"time": "00:00", "value": 90.0},
+                {"time": "08:00", "value": 80.0},  # lower
+                {"time": "22:00", "value": 100.0},
+            ]
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        assert result.target_low.proposed_value == 80.0
+
+    def test_segmented_target_high_uses_max(self):
+        snapshot = _mk_snapshot(
+            target_high_segments=[
+                {"time": "00:00", "value": 130.0},
+                {"time": "08:00", "value": 150.0},  # higher
+                {"time": "22:00", "value": 110.0},
+            ]
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        assert result.target_high.proposed_value == 150.0
+
+
+# ---------------------------------------------------------------------------
+# AC11 / sparse profile: no snapshot OR empty schedules
+# ---------------------------------------------------------------------------
+
+
+class TestAC11Sparse:
+    def test_no_snapshot_returns_empty_derivation(self):
+        """Tandem-via-tconnectsync path: pump posts treatments
+        but never authors a profile -> snapshot is None ->
+        wizard skips the settings-import step."""
+        result = derive_onboarding_proposals(
+            None,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        assert result.has_profile is False
+        # All fields present but with no proposed values.
+        assert result.target_low.proposed_value is None
+        assert result.target_high.proposed_value is None
+        assert result.dia_hours.proposed_value is None
+        assert result.basal_schedule.proposed_segments is None
+        assert result.carb_ratio_schedule.proposed_segments is None
+        assert result.isf_schedule.proposed_segments is None
+        # No proposals -> nothing to import -> all unchecked.
+        assert result.target_low.default_checked is False
+        assert result.dia_hours.default_checked is False
+        assert result.basal_schedule.default_checked is False
+
+    def test_no_snapshot_preserves_current_values(self):
+        """Even on a no-snapshot path, the wizard's diff table
+        should still show the user's current settings (so they
+        understand what they have)."""
+        custom_range = _mk_target_range(low=85.0, high=140.0)
+        custom_insulin = _mk_insulin_config(dia_hours=5.5)
+
+        result = derive_onboarding_proposals(
+            None,
+            current_target_range=custom_range,
+            current_insulin_config=custom_insulin,
+            current_pump_profile=None,
+        )
+
+        assert result.target_low.current_value == 85.0
+        assert result.target_high.current_value == 140.0
+        assert result.dia_hours.current_value == 5.5
+
+    def test_snapshot_with_empty_schedules(self):
+        """Snapshot exists but every schedule list is empty
+        (degenerate but legal NS shape). Numeric fields with
+        single values still propose; schedules don't."""
+        snapshot = _mk_snapshot(
+            dia_hours=4.5,
+            basal_segments=[],
+            carb_ratio_segments=[],
+            sensitivity_segments=[],
+            target_low_segments=[],
+            target_high_segments=[],
+        )
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        assert result.has_profile is True
+        # No targets to aggregate -> proposed=None.
+        assert result.target_low.proposed_value is None
+        assert result.target_high.proposed_value is None
+        # No schedules -> proposed_segments None, default unchecked
+        # (no proposal to apply).
+        assert result.basal_schedule.proposed_segments is None
+        assert result.basal_schedule.default_checked is False
+        # DIA still derives from the single source_dia_hours field.
+        assert result.dia_hours.proposed_value == 4.5
+
+    def test_dia_missing_not_checked(self):
+        """`source_dia_hours=None` -> proposed=None -> not checked
+        even if user is at the default."""
+        snapshot = _mk_snapshot(dia_hours=None)
+
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+
+        assert result.dia_hours.proposed_value is None
+        assert result.dia_hours.default_checked is False
+
+
+# ---------------------------------------------------------------------------
+# No canonical-settings rows yet (fresh signup)
+# ---------------------------------------------------------------------------
+
+
+class TestFreshSignup:
+    def test_all_canonical_none_treats_user_as_default(self):
+        """Brand-new user with no target_glucose_range,
+        insulin_config, or pump_profile rows yet -- all checked
+        because there's nothing to overwrite."""
+        snapshot = _mk_snapshot()
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=None,
+            current_insulin_config=None,
+            current_pump_profile=None,
+        )
+
+        assert result.target_low.current_value is None
+        assert result.target_high.current_value is None
+        assert result.dia_hours.current_value is None
+        # All checked because "no row" counts as default per AC4.
+        assert result.target_low.default_checked is True
+        assert result.target_high.default_checked is True
+        assert result.dia_hours.default_checked is True
+        assert result.basal_schedule.default_checked is True
+        assert result.carb_ratio_schedule.default_checked is True
+        assert result.isf_schedule.default_checked is True
+
+
+# ---------------------------------------------------------------------------
+# Coupling: defaults must mirror the SQLAlchemy column defaults
+# ---------------------------------------------------------------------------
+
+
+def _scalar_default(column) -> float:
+    """Pull the scalar value out of a SQLAlchemy column's default,
+    failing loudly with a clear message if the default is a
+    callable / server_default / sequence. CR L4: previous
+    `.default.arg` access produced confusing AttributeErrors when
+    the default form changed.
+    """
+    default = column.default
+    assert default is not None, (
+        f"column {column.name} has no default; AC4 coupling test needs one"
+    )
+    assert default.is_scalar, (
+        f"column {column.name} default is not scalar "
+        f"(got {type(default).__name__}); update the test helper to "
+        "handle the new default form before assuming `.arg` is the value"
+    )
+    return float(default.arg)
+
+
+def test_default_constants_match_canonical_model_defaults():
+    """If a future migration changes a model default, this test
+    fires so the AC4 constant stays coupled."""
+    assert (
+        _scalar_default(TargetGlucoseRange.__table__.c.low_target)
+        == DEFAULT_TARGET_LOW_MGDL
+    )
+    assert (
+        _scalar_default(TargetGlucoseRange.__table__.c.high_target)
+        == DEFAULT_TARGET_HIGH_MGDL
+    )
+    assert _scalar_default(InsulinConfig.__table__.c.dia_hours) == DEFAULT_DIA_HOURS

--- a/apps/api/tests/test_nightscout_onboarding_derive.py
+++ b/apps/api/tests/test_nightscout_onboarding_derive.py
@@ -769,6 +769,147 @@ class TestFreshSignup:
 # ---------------------------------------------------------------------------
 
 
+class TestNonPositiveInputCoercion:
+    """Regression tests for the four sites where a non-positive
+    input (NS-supplied 0/negative dia, target, basal/ICR/ISF
+    segment, or a corrupted canonical row) previously raised
+    Pydantic ValidationError on the schema's gt=0 guard. Each
+    site now coerces to None / drops the segment, so a single
+    bad field doesn't 500 the whole derive call.
+    """
+
+    def test_zero_dia_coerced_to_none_no_crash(self):
+        """NS profile with `source_dia_hours=0` (malformed upload)
+        must not 500 the call -- proposed_dia becomes None."""
+        snapshot = _mk_snapshot(dia_hours=0.0)
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.dia_hours.proposed_value is None
+        assert result.dia_hours.default_checked is False
+
+    def test_negative_dia_coerced_to_none_no_crash(self):
+        snapshot = _mk_snapshot(dia_hours=-1.5)
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.dia_hours.proposed_value is None
+
+    def test_zero_target_low_coerced_to_none_no_crash(self):
+        """An NS target_low of 0 (impossible but seen on malformed
+        uploads) must not crash -- target_low.proposed_value=None.
+        """
+        snapshot = _mk_snapshot(target_low_segments=[{"time": "00:00", "value": 0.0}])
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.target_low.proposed_value is None
+
+    def test_negative_target_high_coerced_to_none_no_crash(self):
+        snapshot = _mk_snapshot(target_high_segments=[{"time": "00:00", "value": -5.0}])
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.target_high.proposed_value is None
+
+    def test_zero_basal_segment_dropped_no_crash(self):
+        """NS profile with a 0-valued basal segment (suspend-encoded-
+        as-zero pattern, malformed upload). The 0 segment is
+        dropped; surviving segments still flow through.
+        """
+        snapshot = _mk_snapshot(
+            basal_segments=[
+                {"time": "00:00", "value": 0.5},
+                {"time": "06:00", "value": 0.0},  # bad -- dropped
+                {"time": "12:00", "value": 0.7},
+            ]
+        )
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        segs = result.basal_schedule.proposed_segments
+        assert segs is not None
+        # Only the two positive segments survived.
+        assert [s.start_minutes for s in segs] == [0, 720]
+        assert [s.value for s in segs] == [0.5, 0.7]
+
+    def test_all_basal_segments_zero_returns_none_schedule(self):
+        """If every segment is non-positive, the schedule disappears
+        entirely (proposed_segments=None) -- wizard skips the row."""
+        snapshot = _mk_snapshot(
+            basal_segments=[
+                {"time": "00:00", "value": 0.0},
+                {"time": "12:00", "value": -0.5},
+            ]
+        )
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        assert result.basal_schedule.proposed_segments is None
+
+    def test_pump_profile_zero_basal_rate_segment_dropped(self):
+        """A corrupted canonical pump_profile row with a 0
+        basal_rate must not crash on read -- the segment is
+        dropped from current_segments."""
+        snapshot = _mk_snapshot()
+        custom_pump = _mk_pump_profile(
+            segments=[
+                {"start_minutes": 0, "basal_rate": 1.0},
+                {"start_minutes": 360, "basal_rate": 0.0},  # bad
+                {"start_minutes": 720, "basal_rate": 1.5},
+            ]
+        )
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=_mk_target_range(),
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=custom_pump,
+        )
+        segs = result.basal_schedule.current_segments
+        assert segs is not None
+        assert [s.start_minutes for s in segs] == [0, 720]
+
+    def test_corrupted_current_target_zero_coerced_to_none(self):
+        """Defensively: if a canonical TargetGlucoseRange row got
+        corrupted with a stored 0 (would never happen via normal
+        writes, but defense-in-depth), the derive must not crash.
+        """
+        snapshot = _mk_snapshot()
+        # Build a corrupted-state range row and bypass the
+        # SQLAlchemy default by setting low_target=0 directly. (In
+        # production this would never happen; this is paranoia.)
+        bad_range = _mk_target_range(low=0.0, high=0.0)
+        result = derive_onboarding_proposals(
+            snapshot,
+            current_target_range=bad_range,
+            current_insulin_config=_mk_insulin_config(),
+            current_pump_profile=None,
+        )
+        # current_value coerced to None; proposal still flows.
+        assert result.target_low.current_value is None
+        assert result.target_low.proposed_value == 90.0
+        assert result.target_high.current_value is None
+        assert result.target_high.proposed_value == 120.0
+
+
 def _scalar_default(column) -> float:
     """Pull the scalar value out of a SQLAlchemy column's default,
     failing loudly with a clear message if the default is a


### PR DESCRIPTION
## Summary

**smart onboarding**. Adds the pure-function module the apply endpoint will use to populate the wizard's step-3 review table.

\`derive_onboarding_proposals(snapshot, *, current_target_range, current_insulin_config, current_pump_profile)\` -> \`OnboardingDerivation\`. No DB writes, no I/O, no network -- so 43.7c can wrap it in a single transaction without contention concerns.

## What it does

For each canonical setting the wizard exposes:
- \`target_low\` / \`target_high\` (single values; min/max aggregation across time-varying NS targets)
- \`dia_hours\`
- \`carb_ratio_schedule\` / \`isf_schedule\` / \`basal_schedule\` (full segment lists)

Returns a typed \`OnboardingNumericFieldDerivation\` / \`OnboardingScheduleFieldDerivation\` per field with:
- \`current_value\` / \`current_segments\` -- what the user has now
- \`proposed_value\` / \`proposed_segments\` -- what NS suggests (None when the snapshot doesn't carry it)
- \`default_checked\` -- AC4 logic: True iff user's current value matches platform default OR proposal matches current (no-op import)

## Edge cases handled

| Case | Behavior |
|---|---|
| Snapshot is None (Tandem-only-via-tconnectsync, no profile) | \`has_profile=False\`; all proposals None; wizard skips settings step (AC11) |
| User customized (e.g. low_target=80) | \`default_checked=False\` so the wizard can't silently overwrite (AC8) |
| User customized but happens to match NS proposal | \`default_checked=True\` (no-op import is safe) |
| Time-varying targets | \`target_low\` reports min, \`target_high\` reports max -- safest single-row summary |
| mmol/L profile | Glucose-domain values converted to mg/dL (* 18.0182, round to 1 decimal); basal/carb-ratio pass through |
| Unknown unit string | \`units_unknown=True\` flag -- wizard MUST refuse to auto-import |
| First segment not at 00:00 | Documented: 43.7c apply step owns the midnight-wrap fix-up |
| JSONB round-trip floats in \`pump_profile.segments[].start_minutes\` | Coerced to int (with bool subclass guard + bounds check) |

## Reviews

- **Adversarial**: H1 (silent unknown-units default) fixed via \`_classify_units\` + \`units_unknown\` flag. H2 (midnight-wrap) documented as 43.7c responsibility. M1-M4 (identical-value pre-check, untyped Callables, JSONB float coerce, None-row coupling) all addressed.
- **CodeRabbit CLI**: 2 Critical (medical-safety constraints on numeric fields + schedule values) + 1 Minor (explicit \`units_unknown=False\` on empty path) all addressed. \`OnboardingScheduleSegment.value: Field(gt=0)\` and \`OnboardingNumericFieldDerivation.current_value/proposed_value: Field(default=None, gt=0)\` reject negative / zero values at schema validation, before they can reach a canonical write.
- **Security**: PASS, no findings. Pure module -- no I/O, no SSRF surface, no secret disclosure, no debug logging. Type-coerce is bool-safe.

## Test plan

- [x] 28 unit tests, table-driven (Loop happy path, AC4 default_checked, mmol conversion, segment parsing, sparse-profile, fresh-signup, identical-value pre-check, pump_profile float coerce, bool rejection, out-of-range rejection, default-constant coupling)
- [x] Wider regression: 48 NS tests pass (20 evaluate + 28 derive), no regressions
- [x] Lint + format clean (ruff)

## Acceptance criteria covered

- [x] **AC4** -- default_checked logic: pre-checked iff user is at platform default OR proposal matches current
- [x] **AC8** -- no silent overwrite: customized user with non-matching proposal stays UNCHECKED
- [x] **AC11** -- sparse/no-profile graceful degrade: \`has_profile=False\`; wizard skips settings step

ACs covered by later sub-stories (43.7c apply endpoint + frontend wizard, 43.7d re-import, 43.7e tests + docs): AC1 (evaluate report -- already shipped in 43.7a), AC2 (wizard preview), AC3 (sync-window selector), AC5 (apply transaction), AC6 (real-time sync progress), AC7 (post-finalize redirect), AC10 (re-import entry point), AC12 (Playwright e2e).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smart onboarding capability for Nightscout profile integration, automatically converting glucose units and pre-populating settings based on existing profiles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/595)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->