### PR TITLE
feat(api): Nightscout apply-onboarding endpoint + derivation read

### DIFF
--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.auth import DiabeticOrAdminUser
@@ -19,14 +19,20 @@ from src.core.encryption import decrypt_credential, encrypt_credential
 from src.database import get_db
 from src.logging_config import get_logger
 from src.models.glucose import GlucoseReading
+from src.models.insulin_config import InsulinConfig
 from src.models.nightscout_connection import (
     NightscoutConnection,
     NightscoutSyncStatus,
 )
 from src.models.nightscout_profile_snapshot import NightscoutProfileSnapshot
 from src.models.pump_data import PumpEvent
+from src.models.pump_profile import PumpProfile
+from src.models.target_glucose_range import TargetGlucoseRange
 from src.schemas.auth import ErrorResponse
+from src.schemas.insulin_config import InsulinConfigUpdate
 from src.schemas.nightscout import (
+    NightscoutApplyOnboardingRequest,
+    NightscoutApplyOnboardingResponse,
     NightscoutConnectionCreate,
     NightscoutConnectionCreatedResponse,
     NightscoutConnectionDeletedResponse,
@@ -40,13 +46,21 @@ from src.schemas.nightscout import (
     NightscoutManualSyncResponse,
     NightscoutProfileSnapshotResponse,
     NightscoutPumpEventDTO,
+    OnboardingDerivation,
 )
+from src.schemas.target_glucose_range import TargetGlucoseRangeUpdate
+from src.services import insulin_config as insulin_config_service
+from src.services import pump_profile as pump_profile_service
+from src.services import target_glucose_range as target_range_service
 from src.services.integrations.nightscout.connection_test import (
     ConnectionTestOutcome,
     test_connection,
 )
 from src.services.integrations.nightscout.evaluate import (
     evaluate_nightscout_for_connection,
+)
+from src.services.integrations.nightscout.onboarding_derive import (
+    derive_onboarding_proposals,
 )
 from src.services.integrations.nightscout.sync import (
     sync_nightscout_for_connection,
@@ -612,6 +626,451 @@ async def run_evaluate(
         await db.commit()
 
     return report
+
+
+# ---------------------------------------------------------------------------
+# Onboarding wizard: derivation read + apply
+# ---------------------------------------------------------------------------
+
+
+async def _load_user_settings(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> tuple[
+    TargetGlucoseRange | None,
+    InsulinConfig | None,
+    PumpProfile | None,
+]:
+    """Read-only fetch of the user's canonical settings.
+
+    Returns (target_range, insulin_config, pump_profile) where any
+    of the three may be None when the user hasn't been seeded with
+    that row yet. Importantly does NOT create defaults -- the
+    wizard's "Currently" column should display the absence of a
+    customization, not a freshly-materialized default. Active pump
+    profile only (mirrors `get_active_profile`).
+    """
+    range_q = await db.execute(
+        select(TargetGlucoseRange).where(TargetGlucoseRange.user_id == user_id)
+    )
+    config_q = await db.execute(
+        select(InsulinConfig).where(InsulinConfig.user_id == user_id)
+    )
+    pump_profile = await pump_profile_service.get_active_profile(user_id, db)
+    return (
+        range_q.scalar_one_or_none(),
+        config_q.scalar_one_or_none(),
+        pump_profile,
+    )
+
+
+async def _load_snapshot(
+    db: AsyncSession,
+    *,
+    connection_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> NightscoutProfileSnapshot | None:
+    """Latest profile snapshot for `(connection, user)`, or None."""
+    result = await db.execute(
+        select(NightscoutProfileSnapshot).where(
+            NightscoutProfileSnapshot.nightscout_connection_id == connection_id,
+            NightscoutProfileSnapshot.user_id == user_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+@router.get(
+    "/{connection_id}/onboarding-derivation",
+    response_model=OnboardingDerivation,
+    responses={
+        200: {"description": "Derivation of pre-fill proposals + current values"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Connection not found"},
+    },
+)
+async def read_onboarding_derivation(
+    connection_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> OnboardingDerivation:
+    """Build the wizard step 3 diff-table source for this connection.
+
+    Reads the latest stored profile snapshot + the user's current
+    canonical settings, then runs `derive_onboarding_proposals` to
+    produce the field-by-field "Currently | From Nightscout" rows.
+
+    Pure read: no DB writes. Soft-deleted connections return 404
+    (parity with `/evaluate` and `/sync`).
+
+    The snapshot is populated by `/evaluate` and routine `/sync`
+    runs; if neither has happened yet the derivation surfaces
+    `has_profile=False` and the wizard shows a "no profile data --
+    we'll just sync data" banner. The wizard renders the same
+    UI shape on every call so step 3 is deterministic regardless
+    of NS state.
+    """
+    conn = await _load_owned(db, connection_id, current_user.id, require_active=True)
+    snapshot = await _load_snapshot(db, connection_id=conn.id, user_id=current_user.id)
+    target_range, insulin, pump = await _load_user_settings(db, current_user.id)
+    return derive_onboarding_proposals(
+        snapshot,
+        current_target_range=target_range,
+        current_insulin_config=insulin,
+        current_pump_profile=pump,
+    )
+
+
+def _glucose_domain_requested(req: NightscoutApplyOnboardingRequest) -> bool:
+    """Whether any glucose-domain import was requested.
+
+    Drives the `units_unknown` confirmation gate: if the source
+    profile's units couldn't be classified, applying mg/dL targets
+    or ISFs that came in unitless from NS would silently miscompute
+    -- so the apply endpoint refuses without an explicit
+    `confirm_units_unknown=True` ack from the caller.
+    """
+    return req.import_target_low or req.import_target_high or req.import_isf_schedule
+
+
+@router.post(
+    "/{connection_id}/apply-onboarding",
+    response_model=NightscoutApplyOnboardingResponse,
+    responses={
+        200: {"description": "Settings applied (check `first_sync_status`)"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Connection not found"},
+        409: {
+            "model": ErrorResponse,
+            "description": "Profile units unknown -- caller must confirm",
+        },
+        422: {"model": ErrorResponse, "description": "Validation error"},
+    },
+)
+async def apply_onboarding(  # noqa: PLR0912, PLR0915  -- linear, readable orchestration
+    connection_id: uuid.UUID,
+    request: NightscoutApplyOnboardingRequest,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> NightscoutApplyOnboardingResponse:
+    """Persist confirmed onboarding proposals + kick the first sync.
+
+    Sequence:
+        1. Load the connection + latest snapshot + current settings.
+        2. Run the derivation (same code as `/onboarding-derivation`).
+        3. Apply per-field imports honoring overrides.
+        4. Persist `initial_sync_window_days` on the connection if set.
+        5. Trigger `sync_nightscout_for_connection` bounded by
+           `_SYNC_TIMEOUT_SECONDS`.
+
+    The first sync runs INSIDE the request, so the wizard step 4
+    progress UI gets a real status back instead of polling. On
+    timeout the response is still 200 (settings landed
+    successfully) with `first_sync_status="timeout"` and
+    `first_sync_error` set; the wizard renders "we'll keep trying
+    in the background" copy and routes the user to the dashboard.
+
+    Idempotent: re-running with the same body re-asserts the same
+    settings rows. The pump profile is upserted on
+    `(user_id, "Nightscout")` so it doesn't accumulate duplicates;
+    target range / insulin config are one-row-per-user by design.
+    """
+    conn = await _load_owned(db, connection_id, current_user.id, require_active=True)
+
+    # Serialize concurrent applies for the same user. Postgres
+    # advisory lock keyed on hashtext(user_id) -- xact-scoped, so
+    # released automatically by commit or rollback. A double-clicked
+    # wizard (two simultaneous applies) waits here instead of racing
+    # the pump_profiles UPSERT or kicking two parallel syncs.
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+        {"k": str(current_user.id)},
+    )
+
+    snapshot = await _load_snapshot(db, connection_id=conn.id, user_id=current_user.id)
+    target_range, insulin, pump = await _load_user_settings(db, current_user.id)
+    derivation = derive_onboarding_proposals(
+        snapshot,
+        current_target_range=target_range,
+        current_insulin_config=insulin,
+        current_pump_profile=pump,
+    )
+
+    # Hard gate: glucose-domain imports require an explicit ack
+    # when the source unit is unrecognized. Returning 409 (not 422)
+    # because the request body is well-formed -- the conflict is
+    # with the upstream profile's state, which the caller can
+    # resolve by re-confirming.
+    if (
+        derivation.units_unknown
+        and _glucose_domain_requested(request)
+        and not request.confirm_units_unknown
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Nightscout profile units could not be classified as "
+                "mg/dL or mmol/L; resend with confirm_units_unknown=true "
+                "to apply glucose-domain settings anyway."
+            ),
+        )
+
+    # Pre-validate target range ordering BEFORE any writer commits.
+    # The settings writers (`update_range`, `update_config`) commit
+    # internally, so a mid-sequence ValueError would leave us with
+    # a partially-applied state. By computing the merged thresholds
+    # against the user's current row and rejecting up front, the
+    # only failure modes left are infrastructure-level (DB drop) --
+    # in which case partial application is unavoidable but the
+    # subsequent writers would also have failed anyway.
+    if request.import_target_low or request.import_target_high:
+        new_low = (
+            (
+                request.override_target_low
+                if request.override_target_low is not None
+                else derivation.target_low.proposed_value
+            )
+            if request.import_target_low
+            else (target_range.low_target if target_range else None)
+        )
+        new_high = (
+            (
+                request.override_target_high
+                if request.override_target_high is not None
+                else derivation.target_high.proposed_value
+            )
+            if request.import_target_high
+            else (target_range.high_target if target_range else None)
+        )
+        # urgent_low/urgent_high are not modified by this endpoint,
+        # so they retain whatever the user has (or defaults if no
+        # row yet -- get_or_create_range will seed defaults that
+        # already satisfy the ordering invariant).
+        if new_low is not None and new_high is not None and new_low >= new_high:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"low_target ({new_low}) must be less than high_target ({new_high})"
+                ),
+            )
+
+    applied: dict[str, bool] = {
+        "target_low": False,
+        "target_high": False,
+        "dia_hours": False,
+        "basal_schedule": False,
+        "carb_ratio_schedule": False,
+        "isf_schedule": False,
+        "initial_sync_window_days": False,
+    }
+
+    # ---- target range ----------------------------------------------------
+    target_range_payload: dict[str, float] = {}
+    if request.import_target_low:
+        value = request.override_target_low
+        if value is None:
+            value = derivation.target_low.proposed_value
+        if value is not None:
+            target_range_payload["low_target"] = float(value)
+            applied["target_low"] = True
+    if request.import_target_high:
+        value = request.override_target_high
+        if value is None:
+            value = derivation.target_high.proposed_value
+        if value is not None:
+            target_range_payload["high_target"] = float(value)
+            applied["target_high"] = True
+
+    target_range_response: dict | None = None
+    if target_range_payload:
+        try:
+            updated_range = await target_range_service.update_range(
+                current_user.id,
+                TargetGlucoseRangeUpdate(**target_range_payload),
+                db,
+            )
+        except ValueError as e:
+            # Ordering invariant violated (e.g. low_target came in
+            # above existing high_target). Surface as 422 with the
+            # writer's message; nothing has been committed yet
+            # because update_range commits at the end.
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(e),
+            ) from e
+        target_range_response = {
+            "id": str(updated_range.id),
+            "urgent_low": updated_range.urgent_low,
+            "low_target": updated_range.low_target,
+            "high_target": updated_range.high_target,
+            "urgent_high": updated_range.urgent_high,
+        }
+
+    # ---- insulin config (DIA only) --------------------------------------
+    insulin_response: dict | None = None
+    if request.import_dia_hours:
+        dia_value = request.override_dia_hours
+        if dia_value is None:
+            dia_value = derivation.dia_hours.proposed_value
+        if dia_value is not None:
+            try:
+                updated_config = await insulin_config_service.update_config(
+                    current_user.id,
+                    InsulinConfigUpdate(dia_hours=float(dia_value)),
+                    db,
+                )
+            except ValueError as e:
+                # The schema enforces 2.0 <= dia_hours <= 8.0 at
+                # validation time; this branch fires on writer-level
+                # invariants. Same 422 surface as target range.
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=str(e),
+                ) from e
+            applied["dia_hours"] = True
+            insulin_response = {
+                "id": str(updated_config.id),
+                "insulin_type": updated_config.insulin_type,
+                "dia_hours": updated_config.dia_hours,
+                "onset_minutes": updated_config.onset_minutes,
+            }
+
+    # ---- pump profile (basal / ICR / ISF) -------------------------------
+    pump_profile_id: uuid.UUID | None = None
+    persisted_profile = await pump_profile_service.upsert_from_onboarding(
+        current_user.id,
+        derivation,
+        apply_basal=request.import_basal_schedule
+        and derivation.basal_schedule.proposed_segments is not None,
+        apply_carb_ratio=request.import_carb_ratio_schedule
+        and derivation.carb_ratio_schedule.proposed_segments is not None,
+        apply_isf=request.import_isf_schedule
+        and derivation.isf_schedule.proposed_segments is not None,
+        # DIA is mirrored onto the pump_profile row only when the
+        # user opted in to importing it, so the active profile read
+        # by mobile is internally consistent with insulin_configs.
+        apply_dia=request.import_dia_hours
+        and derivation.dia_hours.proposed_value is not None,
+        db=db,
+    )
+    if persisted_profile is not None:
+        pump_profile_id = persisted_profile.id
+        applied["basal_schedule"] = (
+            request.import_basal_schedule
+            and derivation.basal_schedule.proposed_segments is not None
+        )
+        applied["carb_ratio_schedule"] = (
+            request.import_carb_ratio_schedule
+            and derivation.carb_ratio_schedule.proposed_segments is not None
+        )
+        applied["isf_schedule"] = (
+            request.import_isf_schedule
+            and derivation.isf_schedule.proposed_segments is not None
+        )
+
+    # ---- connection-level: initial sync window --------------------------
+    if request.initial_sync_window_days is not None:
+        conn.initial_sync_window_days = request.initial_sync_window_days
+        applied["initial_sync_window_days"] = True
+
+    # Commit all settings changes BEFORE the first sync runs so
+    # that a sync timeout doesn't unwind the user's confirmed
+    # imports. The sync writes its own rows + connection status
+    # in a separate transaction managed by the orchestrator.
+    await db.commit()
+
+    # ---- first sync -----------------------------------------------------
+    first_sync_status: str = "skipped"
+    first_sync_error: str | None = None
+    sync_response: NightscoutManualSyncResponse | None = None
+
+    try:
+        result = await asyncio.wait_for(
+            sync_nightscout_for_connection(db, conn),
+            timeout=_SYNC_TIMEOUT_SECONDS,
+        )
+        sync_response = NightscoutManualSyncResponse(
+            connection_id=conn.id,
+            status=result.status,
+            entries_inserted=result.entries_inserted,
+            entries_skipped=result.entries_skipped,
+            entries_failed=result.entries_failed,
+            treatments_inserted_pump=result.treatments_inserted_pump,
+            treatments_inserted_glucose=result.treatments_inserted_glucose,
+            treatments_failed=result.treatments_failed,
+            devicestatuses_inserted=result.devicestatuses_inserted,
+            devicestatuses_failed=result.devicestatuses_failed,
+            profile_synced=result.profile_synced,
+            duration_ms=result.duration_ms,
+            error=result.error,
+        )
+        if result.status == NightscoutSyncStatus.OK:
+            first_sync_status = "ok"
+        else:
+            # Sync ran but the orchestrator recorded a non-OK
+            # status (auth fail, validation, partial). We surface
+            # this as `error` so the wizard distinguishes "we
+            # never got a response" (timeout) from "we got a
+            # response but the upstream rejected the call".
+            first_sync_status = "error"
+            first_sync_error = result.error or result.status.value
+    except TimeoutError:
+        # Mirror the `/sync` endpoint's recovery: roll back any
+        # partial sync rows, mark the connection NETWORK, commit
+        # the status update. Distinct from `/sync` in that we do
+        # NOT raise 504 -- settings already landed and the user
+        # deserves a 200 with a clear "timed out, retry pending"
+        # signal so the wizard's progress step can render the
+        # "we'll keep trying in the background" copy.
+        first_sync_status = "timeout"
+        first_sync_error = f"First sync exceeded {_SYNC_TIMEOUT_SECONDS}s timeout"
+        try:
+            await db.rollback()
+            # The rollback expires the loaded `conn` object; re-fetch
+            # before mutating to avoid touching a detached row.
+            refreshed = (
+                await db.execute(
+                    select(NightscoutConnection).where(
+                        NightscoutConnection.id == conn.id
+                    )
+                )
+            ).scalar_one()
+            refreshed.last_sync_status = NightscoutSyncStatus.NETWORK
+            refreshed.last_sync_error = first_sync_error
+            await db.commit()
+        except Exception:  # noqa: BLE001
+            # Status-update commit failure is non-fatal: settings
+            # already landed in the prior commit, and the wizard
+            # only needs `first_sync_status` to render correctly.
+            # The next scheduler tick will re-establish a real
+            # `last_sync_status` regardless.
+            logger.warning(
+                "nightscout_apply_onboarding_status_update_failed",
+                connection_id=str(conn.id),
+            )
+            try:
+                await db.rollback()
+            except Exception:  # noqa: BLE001
+                pass
+
+    logger.info(
+        "nightscout_apply_onboarding_completed",
+        user_id=str(current_user.id),
+        connection_id=str(conn.id),
+        first_sync_status=first_sync_status,
+        applied_fields=[k for k, v in applied.items() if v],
+    )
+
+    return NightscoutApplyOnboardingResponse(
+        connection_id=conn.id,
+        applied=applied,
+        target_glucose_range=target_range_response,
+        insulin_config=insulin_response,
+        pump_profile_id=pump_profile_id,
+        first_sync_status=first_sync_status,  # type: ignore[arg-type]
+        first_sync_error=first_sync_error,
+        sync_result=sync_response,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -777,11 +777,18 @@ async def apply_onboarding(  # noqa: PLR0912, PLR0915  -- linear, readable orche
     """
     conn = await _load_owned(db, connection_id, current_user.id, require_active=True)
 
-    # Serialize concurrent applies for the same user. Postgres
-    # advisory lock keyed on hashtext(user_id) -- xact-scoped, so
-    # released automatically by commit or rollback. A double-clicked
-    # wizard (two simultaneous applies) waits here instead of racing
-    # the pump_profiles UPSERT or kicking two parallel syncs.
+    # Serialize the read-and-merge step for concurrent applies.
+    # The xact-scoped advisory lock is released by the first
+    # internal commit inside `update_range` / `update_config`, so
+    # this DOES NOT serialize the full apply path -- it only
+    # protects the snapshot+settings read and pre-flight ordering
+    # check from racing with another in-flight apply for the same
+    # user. The remaining window (two simultaneous syncs from a
+    # double-clicked wizard) is mitigated by the
+    # `uq_pump_profile_user_name` UPSERT (no row duplication) and
+    # by the wizard's UI gating the button after the first click.
+    # Acceptable for a same-user-only scope; full atomicity would
+    # require non-committing variants of the settings writers.
     await db.execute(
         text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
         {"k": str(current_user.id)},
@@ -936,16 +943,20 @@ async def apply_onboarding(  # noqa: PLR0912, PLR0915  -- linear, readable orche
             }
 
     # ---- pump profile (basal / ICR / ISF) -------------------------------
+    # Use truthy checks (not `is not None`) so an empty proposed
+    # list -- which `_segments_by_start` collapses to {} -- doesn't
+    # claim a schedule was applied when no segments existed to write.
+    has_basal = bool(derivation.basal_schedule.proposed_segments)
+    has_carb_ratio = bool(derivation.carb_ratio_schedule.proposed_segments)
+    has_isf = bool(derivation.isf_schedule.proposed_segments)
+
     pump_profile_id: uuid.UUID | None = None
     persisted_profile = await pump_profile_service.upsert_from_onboarding(
         current_user.id,
         derivation,
-        apply_basal=request.import_basal_schedule
-        and derivation.basal_schedule.proposed_segments is not None,
-        apply_carb_ratio=request.import_carb_ratio_schedule
-        and derivation.carb_ratio_schedule.proposed_segments is not None,
-        apply_isf=request.import_isf_schedule
-        and derivation.isf_schedule.proposed_segments is not None,
+        apply_basal=request.import_basal_schedule and has_basal,
+        apply_carb_ratio=request.import_carb_ratio_schedule and has_carb_ratio,
+        apply_isf=request.import_isf_schedule and has_isf,
         # DIA is mirrored onto the pump_profile row only when the
         # user opted in to importing it, so the active profile read
         # by mobile is internally consistent with insulin_configs.
@@ -955,18 +966,11 @@ async def apply_onboarding(  # noqa: PLR0912, PLR0915  -- linear, readable orche
     )
     if persisted_profile is not None:
         pump_profile_id = persisted_profile.id
-        applied["basal_schedule"] = (
-            request.import_basal_schedule
-            and derivation.basal_schedule.proposed_segments is not None
-        )
+        applied["basal_schedule"] = request.import_basal_schedule and has_basal
         applied["carb_ratio_schedule"] = (
-            request.import_carb_ratio_schedule
-            and derivation.carb_ratio_schedule.proposed_segments is not None
+            request.import_carb_ratio_schedule and has_carb_ratio
         )
-        applied["isf_schedule"] = (
-            request.import_isf_schedule
-            and derivation.isf_schedule.proposed_segments is not None
-        )
+        applied["isf_schedule"] = request.import_isf_schedule and has_isf
 
     # ---- connection-level: initial sync window --------------------------
     if request.initial_sync_window_days is not None:

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -572,3 +572,118 @@ class NightscoutDiscoveryReport(BaseModel):
     partial_resources: list[str] = []
     evaluated_at: datetime
     error: str | None = None  # populated when status_ok is False
+
+
+# ---------------------------------------------------------------------------
+# Apply-onboarding endpoint -- writes confirmed proposals to canonical
+# settings tables and triggers the connection's first sync.
+# ---------------------------------------------------------------------------
+
+
+class NightscoutApplyOnboardingRequest(BaseModel):
+    """Request body for POST /{id}/apply-onboarding.
+
+    Per-field opt-in flags drive what gets written. Override values
+    let the user replace the Nightscout-derived proposal with their
+    own typed value at confirmation time -- limited to top-level
+    numerics in this iteration; per-segment schedule overrides are
+    deferred. `initial_sync_window_days` (when present) writes to
+    the connection row and drives the first sync's lookback window.
+
+    `confirm_units_unknown` is a hard gate: when the discovery
+    derivation flagged `units_unknown=True` AND any glucose-domain
+    import is requested (target_low / target_high / isf_schedule),
+    the request MUST include `confirm_units_unknown=True` to
+    proceed. Default false -- silence is rejection.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    # Per-field opt-in flags. Default false: omitting a flag means
+    # "do not import this field." Wizard step 3's "Use this?"
+    # checkboxes drive these.
+    import_target_low: bool = False
+    import_target_high: bool = False
+    import_dia_hours: bool = False
+    import_basal_schedule: bool = False
+    import_carb_ratio_schedule: bool = False
+    import_isf_schedule: bool = False
+
+    # Top-level overrides. Honored only when the matching import
+    # flag is true; ignored otherwise (validated below). Range
+    # validation falls through to the existing canonical writers
+    # (TargetGlucoseRangeUpdate / InsulinConfigUpdate validators).
+    override_target_low: float | None = Field(default=None, gt=0)
+    override_target_high: float | None = Field(default=None, gt=0)
+    override_dia_hours: float | None = Field(default=None, gt=0)
+
+    # First-sync window. None = leave the connection's existing
+    # value alone. Allowed: matches `INITIAL_SYNC_WINDOW_DAYS_OPTIONS`
+    # (1, 7, 30, 90, 0) where 0 means "all available".
+    initial_sync_window_days: int | None = None
+
+    # Hard gate for unknown-units profiles. Required true when
+    # the derivation reported `units_unknown=True` AND the request
+    # includes any glucose-domain import. Server-side enforced in
+    # the endpoint (the request schema can't see the derivation).
+    confirm_units_unknown: bool = False
+
+    @field_validator("initial_sync_window_days")
+    @classmethod
+    def _valid_sync_window(cls, value: int | None) -> int | None:
+        if value is None:
+            return None
+        if value not in INITIAL_SYNC_WINDOW_DAYS_OPTIONS:
+            raise ValueError(
+                f"initial_sync_window_days must be one of "
+                f"{list(INITIAL_SYNC_WINDOW_DAYS_OPTIONS)} (got {value})"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _overrides_only_with_import_flag(self) -> "NightscoutApplyOnboardingRequest":
+        """Reject overrides for fields whose import flag is false.
+
+        A user passing `override_target_low=80` without
+        `import_target_low=True` is signaling intent that the schema
+        can't honor (we'd silently ignore the override). 422 makes
+        the contract explicit.
+        """
+        violations: list[str] = []
+        if self.override_target_low is not None and not self.import_target_low:
+            violations.append("override_target_low requires import_target_low=true")
+        if self.override_target_high is not None and not self.import_target_high:
+            violations.append("override_target_high requires import_target_high=true")
+        if self.override_dia_hours is not None and not self.import_dia_hours:
+            violations.append("override_dia_hours requires import_dia_hours=true")
+        if violations:
+            raise ValueError("; ".join(violations))
+        return self
+
+
+FirstSyncStatus = Literal["ok", "timeout", "error", "skipped"]
+
+
+class NightscoutApplyOnboardingResponse(BaseModel):
+    """Response body for POST /{id}/apply-onboarding.
+
+    Mirrors the wizard step 4's progress UI requirements: the
+    `applied` map tells the wizard which rows in its diff table
+    actually got written (so it can render checkmarks), and
+    `first_sync_status` distinguishes "settings saved, sync ran
+    fine" from "settings saved, sync timed out" -- both are 200
+    on the wire (the settings success deserves the success code;
+    the wizard reads the field to decide whether to poll).
+    """
+
+    connection_id: uuid.UUID
+    # Per-field "did we actually persist this?" flags. True iff
+    # the import flag was set AND the derivation had a value to
+    # apply. False otherwise. Wizard renders ticks against this.
+    applied: dict[str, bool]
+    target_glucose_range: dict[str, Any] | None = None
+    insulin_config: dict[str, Any] | None = None
+    pump_profile_id: uuid.UUID | None = None
+    first_sync_status: FirstSyncStatus
+    first_sync_error: str | None = None
+    sync_result: NightscoutManualSyncResponse | None = None

--- a/apps/api/src/services/pump_profile.py
+++ b/apps/api/src/services/pump_profile.py
@@ -1,29 +1,29 @@
-"""Pump profile service.
-
-Retrieves the user's active pump profile for mobile consumption.
-"""
+"""Pump profile service."""
 
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.pump_profile import PumpProfile
+from src.schemas.nightscout import OnboardingDerivation, OnboardingScheduleSegment
+
+# Stable name for profiles imported from a Nightscout connection.
+# Distinct from the "Tandem" name used by `tandem_sync.py` so the two
+# integrations cannot collide on `uq_pump_profile_user_name` and so a
+# user with both connections sees both rows in their profile history.
+# The active-profile reader (`get_active_profile`) tie-breaks across
+# names by `synced_at desc`, so the most recently synced source wins.
+NIGHTSCOUT_PROFILE_NAME = "Nightscout"
 
 
 async def get_active_profile(
     user_id: uuid.UUID,
     db: AsyncSession,
 ) -> PumpProfile | None:
-    """Get the user's most recently synced active pump profile.
-
-    Args:
-        user_id: User's UUID.
-        db: Database session.
-
-    Returns:
-        The active PumpProfile, or None if no profile has been synced.
-    """
+    """Get the user's most recently synced active pump profile."""
     result = await db.execute(
         select(PumpProfile)
         .where(PumpProfile.user_id == user_id, PumpProfile.is_active.is_(True))
@@ -31,3 +31,173 @@ async def get_active_profile(
         .limit(1)
     )
     return result.scalar_one_or_none()
+
+
+def _format_time_label(start_minutes: int) -> str:
+    """Render `start_minutes` as a 12-hour clock label, e.g. "6:30 AM"."""
+    hours = start_minutes // 60
+    minutes = start_minutes % 60
+    period = "AM" if hours < 12 else "PM"
+    display_hour = hours % 12 or 12
+    return f"{display_hour}:{minutes:02d} {period}"
+
+
+def _segments_by_start(
+    segments: list[OnboardingScheduleSegment] | None,
+) -> dict[int, float]:
+    """Index a derivation's segment list by `start_minutes`.
+
+    Returns an empty map when no segments were proposed (None or
+    empty list) so callers can treat "missing schedule" and "no
+    schedule segments" identically.
+    """
+    if not segments:
+        return {}
+    return {seg.start_minutes: seg.value for seg in segments}
+
+
+def _merge_segments(
+    *,
+    basal_by_start: dict[int, float],
+    carb_ratio_by_start: dict[int, float],
+    isf_by_start: dict[int, float],
+) -> list[dict]:
+    """Merge per-domain schedule maps into the canonical segment list.
+
+    The pump_profiles JSONB shape co-locates basal_rate /
+    correction_factor / carb_ratio / target_bg per time slot, but
+    Nightscout exposes them as independent schedules with
+    independent breakpoints. We take the UNION of breakpoints
+    across whichever schedules the caller opted to import; any
+    domain without a value at a given breakpoint is left at 0.0.
+
+    Zero is a sentinel for "this domain wasn't imported at this
+    slot" rather than a real basal/ICR/ISF/target_bg value (those
+    are all `gt=0` in the derivation schema). Downstream readers
+    must not treat 0.0 as a valid pump setting -- the active
+    profile is a UI/AI surface, not a delivery target on this
+    monitoring-only project. This matches the convention already
+    used by the Tandem writer in `tandem_sync.py`.
+
+    `correction_factor` (ISF) is stored as a float to preserve
+    fractional values from Nightscout (e.g. mmol-converted ISFs
+    that round to non-integer mg/dL/U). Mobile readers must accept
+    either int or float -- the JSONB column is untyped per-field
+    by design.
+    """
+    breakpoints = sorted(
+        set(basal_by_start) | set(carb_ratio_by_start) | set(isf_by_start)
+    )
+    out: list[dict] = []
+    for start in breakpoints:
+        out.append(
+            {
+                "time": _format_time_label(start),
+                "start_minutes": start,
+                "basal_rate": float(basal_by_start.get(start, 0.0)),
+                "correction_factor": float(isf_by_start.get(start, 0.0)),
+                "carb_ratio": float(carb_ratio_by_start.get(start, 0.0)),
+                "target_bg": 0,
+            }
+        )
+    return out
+
+
+async def upsert_from_onboarding(
+    user_id: uuid.UUID,
+    derivation: OnboardingDerivation,
+    *,
+    apply_basal: bool,
+    apply_carb_ratio: bool,
+    apply_isf: bool,
+    apply_dia: bool,
+    db: AsyncSession,
+) -> PumpProfile | None:
+    """Persist a Nightscout-imported pump profile for the user.
+
+    Returns the upserted row, or None when nothing was actually
+    applied (all flags false, or all opted-in schedules empty AND
+    DIA not opted in / unavailable). The connection's confirmed
+    DIA writes to `insulin_configs` separately by the caller; the
+    DIA value here is mirrored onto `insulin_duration_min` only so
+    the active-profile reader surfaces a coherent value to mobile
+    clients alongside the schedule segments.
+
+    Idempotent: re-running with the same derivation yields the
+    same row state. UPSERTs by `(user_id, profile_name)` so a user
+    re-running the wizard refreshes their existing Nightscout
+    profile in place rather than accumulating duplicates.
+
+    `is_active=True` on every write: the cross-source tie-break
+    is `synced_at desc` (see `get_active_profile`), so a fresh
+    Tandem sync after a Nightscout import will retake priority
+    naturally without needing to flip flags here.
+    """
+    basal_map = (
+        _segments_by_start(derivation.basal_schedule.proposed_segments)
+        if apply_basal
+        else {}
+    )
+    carb_map = (
+        _segments_by_start(derivation.carb_ratio_schedule.proposed_segments)
+        if apply_carb_ratio
+        else {}
+    )
+    isf_map = (
+        _segments_by_start(derivation.isf_schedule.proposed_segments)
+        if apply_isf
+        else {}
+    )
+
+    dia_value = derivation.dia_hours.proposed_value if apply_dia else None
+    dia_minutes: int | None = (
+        int(round(dia_value * 60)) if dia_value is not None and dia_value > 0 else None
+    )
+
+    if not basal_map and not carb_map and not isf_map and dia_minutes is None:
+        return None
+
+    segments = _merge_segments(
+        basal_by_start=basal_map,
+        carb_ratio_by_start=carb_map,
+        isf_by_start=isf_map,
+    )
+
+    now = datetime.now(UTC)
+
+    stmt = (
+        insert(PumpProfile)
+        .values(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            profile_name=NIGHTSCOUT_PROFILE_NAME,
+            is_active=True,
+            segments=segments,
+            insulin_duration_min=dia_minutes,
+            carb_entry_enabled=True,
+            max_bolus_units=None,
+            cgm_high_alert_mgdl=None,
+            cgm_low_alert_mgdl=None,
+            synced_at=now,
+        )
+        .on_conflict_do_update(
+            constraint="uq_pump_profile_user_name",
+            set_={
+                "is_active": True,
+                "segments": segments,
+                "insulin_duration_min": dia_minutes,
+                "carb_entry_enabled": True,
+                "synced_at": now,
+            },
+        )
+    )
+    await db.execute(stmt)
+    await db.flush()
+
+    result = await db.execute(
+        select(PumpProfile).where(
+            PumpProfile.user_id == user_id,
+            PumpProfile.profile_name == NIGHTSCOUT_PROFILE_NAME,
+        )
+    )
+    return result.scalar_one()

--- a/apps/api/tests/test_nightscout_apply_onboarding.py
+++ b/apps/api/tests/test_nightscout_apply_onboarding.py
@@ -1,0 +1,992 @@
+"""Tests for the smart-onboarding apply + derivation endpoints.
+
+End-to-end coverage of:
+  * GET /api/integrations/nightscout/{id}/onboarding-derivation
+  * POST /api/integrations/nightscout/{id}/apply-onboarding
+
+The pure derivation logic is covered by `test_nightscout_onboarding_derive`.
+This file focuses on endpoint behavior: auth/RBAC, soft-delete, snapshot
+loading, schema-level overrides, the units-unknown gate, settings
+persistence, and the bounded first-sync envelope.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import delete
+
+from src.core.encryption import encrypt_credential
+from src.database import get_session_maker
+from src.main import app
+from src.models.insulin_config import InsulinConfig
+from src.models.nightscout_connection import (
+    NightscoutConnection,
+    NightscoutSyncStatus,
+)
+from src.models.nightscout_profile_snapshot import NightscoutProfileSnapshot
+from src.models.pump_profile import PumpProfile
+from src.models.target_glucose_range import TargetGlucoseRange
+from src.models.user import User
+from src.services.integrations.nightscout.connection_test import ConnectionTestOutcome
+from src.services.integrations.nightscout.sync import SyncResult
+
+
+# ---------------------------------------------------------------------------
+# Auth / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _unique_email(stem: str) -> str:
+    return f"{stem}_{uuid.uuid4().hex[:10]}@example.com"
+
+
+async def _register_and_login(client, email: str, password: str = "Test1234!"):
+    from src.config import settings
+
+    reg = await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+    assert reg.status_code in (200, 201), f"register failed: {reg.text}"
+    resp = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert resp.status_code == 200, f"login failed: {resp.text}"
+    cookie = resp.cookies.get(settings.jwt_cookie_name)
+    assert cookie, "login did not set the auth cookie"
+    return {settings.jwt_cookie_name: cookie}
+
+
+async def _cleanup(emails: list[str]) -> None:
+    async with get_session_maker()() as db:
+        result = await db.execute(User.__table__.select().where(User.email.in_(emails)))
+        ids = [row.id for row in result.fetchall()]
+        if ids:
+            # Snapshots first (FK to connection AND user).
+            await db.execute(
+                delete(NightscoutProfileSnapshot).where(
+                    NightscoutProfileSnapshot.user_id.in_(ids)
+                )
+            )
+            await db.execute(
+                delete(NightscoutConnection).where(
+                    NightscoutConnection.user_id.in_(ids)
+                )
+            )
+            await db.execute(
+                delete(PumpProfile).where(PumpProfile.user_id.in_(ids))
+            )
+            await db.execute(
+                delete(TargetGlucoseRange).where(
+                    TargetGlucoseRange.user_id.in_(ids)
+                )
+            )
+            await db.execute(
+                delete(InsulinConfig).where(InsulinConfig.user_id.in_(ids))
+            )
+            await db.execute(delete(User).where(User.id.in_(ids)))
+            await db.commit()
+
+
+@pytest_asyncio.fixture
+async def http_client():
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+
+# ---------------------------------------------------------------------------
+# Connection + snapshot seeders
+# ---------------------------------------------------------------------------
+
+
+def _ok_outcome() -> ConnectionTestOutcome:
+    return ConnectionTestOutcome(
+        ok=True,
+        server_version="15.0.3",
+        api_version_detected=None,
+        auth_validated=True,
+    )
+
+
+async def _create_conn(http_client, cookies, name: str = "Apply NS") -> str:
+    """Create a connection via the real POST endpoint (mocked test stub)."""
+    with patch(
+        "src.routers.nightscout.test_connection",
+        new=AsyncMock(return_value=_ok_outcome()),
+    ):
+        resp = await http_client.post(
+            "/api/integrations/nightscout",
+            cookies=cookies,
+            json={
+                "name": name,
+                "base_url": "https://example.com",
+                "auth_type": "secret",
+                "credential": "test-secret-12chars",
+                "api_version": "v1",
+            },
+        )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["connection"]["id"]
+
+
+async def _seed_snapshot(
+    *,
+    connection_id: str,
+    user_email: str,
+    units: str = "mg/dl",
+    dia_hours: float | None = 5.0,
+    basal_segments: list[dict] | None = None,
+    carb_ratio_segments: list[dict] | None = None,
+    sensitivity_segments: list[dict] | None = None,
+    target_low_segments: list[dict] | None = None,
+    target_high_segments: list[dict] | None = None,
+) -> None:
+    """Persist a minimal NightscoutProfileSnapshot tied to (connection, user)."""
+    async with get_session_maker()() as db:
+        user_row = await db.execute(
+            User.__table__.select().where(User.email == user_email)
+        )
+        user_id = user_row.fetchone().id
+        snap = NightscoutProfileSnapshot(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            nightscout_connection_id=uuid.UUID(connection_id),
+            fetched_at=datetime.now(UTC),
+            source_default_profile_name="Default",
+            source_units=units,
+            source_timezone="UTC",
+            source_dia_hours=dia_hours,
+            basal_segments=basal_segments,
+            carb_ratio_segments=carb_ratio_segments,
+            sensitivity_segments=sensitivity_segments,
+            target_low_segments=target_low_segments,
+            target_high_segments=target_high_segments,
+        )
+        db.add(snap)
+        await db.commit()
+
+
+def _loop_segments() -> dict:
+    """Realistic single-segment Loop schedules + targets for an mg/dL profile."""
+    return {
+        "basal_segments": [{"time": "00:00", "timeAsSeconds": 0, "value": 0.65}],
+        "carb_ratio_segments": [{"time": "00:00", "timeAsSeconds": 0, "value": 12.0}],
+        "sensitivity_segments": [{"time": "00:00", "timeAsSeconds": 0, "value": 50.0}],
+        "target_low_segments": [{"time": "00:00", "timeAsSeconds": 0, "value": 90.0}],
+        "target_high_segments": [{"time": "00:00", "timeAsSeconds": 0, "value": 120.0}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sync stubs (apply tests)
+# ---------------------------------------------------------------------------
+
+
+def _ok_sync_result(connection_id: uuid.UUID) -> SyncResult:
+    return SyncResult(
+        connection_id=connection_id,
+        status=NightscoutSyncStatus.OK,
+        entries_inserted=1,
+        entries_skipped=0,
+        entries_failed=0,
+        treatments_inserted_pump=0,
+        treatments_inserted_glucose=0,
+        treatments_failed=0,
+        devicestatuses_inserted=0,
+        devicestatuses_failed=0,
+        profile_synced=False,
+        duration_ms=12,
+        error=None,
+    )
+
+
+def _patch_sync_ok():
+    return patch(
+        "src.routers.nightscout.sync_nightscout_for_connection",
+        new=AsyncMock(side_effect=lambda db, conn: _ok_sync_result(conn.id)),
+    )
+
+
+def _patch_sync_timeout():
+    async def _raise(db, conn):
+        raise TimeoutError("simulated upstream hang")
+
+    return patch(
+        "src.routers.nightscout.sync_nightscout_for_connection",
+        new=AsyncMock(side_effect=_raise),
+    )
+
+
+def _patch_sync_orchestrator_error(connection_id_factory):
+    async def _err(db, conn):
+        return SyncResult(
+            connection_id=connection_id_factory(conn),
+            status=NightscoutSyncStatus.AUTH_FAILED,
+            entries_inserted=0,
+            entries_skipped=0,
+            entries_failed=0,
+            treatments_inserted_pump=0,
+            treatments_inserted_glucose=0,
+            treatments_failed=0,
+            devicestatuses_inserted=0,
+            devicestatuses_failed=0,
+            profile_synced=False,
+            duration_ms=5,
+            error="Authentication rejected",
+        )
+
+    return patch(
+        "src.routers.nightscout.sync_nightscout_for_connection",
+        new=AsyncMock(side_effect=_err),
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /onboarding-derivation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_derivation_returns_proposals_when_snapshot_present(http_client):
+    email = _unique_email("ns_derive_ok")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            **_loop_segments(),
+        )
+        resp = await http_client.get(
+            f"/api/integrations/nightscout/{connection_id}/onboarding-derivation",
+            cookies=cookies,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["has_profile"] is True
+        assert body["units_unknown"] is False
+        assert body["target_low"]["proposed_value"] == 90.0
+        assert body["target_high"]["proposed_value"] == 120.0
+        assert body["dia_hours"]["proposed_value"] == 5.0
+        assert len(body["basal_schedule"]["proposed_segments"]) == 1
+        assert body["basal_schedule"]["proposed_segments"][0]["value"] == 0.65
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_derivation_returns_empty_when_no_snapshot(http_client):
+    email = _unique_email("ns_derive_empty")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        resp = await http_client.get(
+            f"/api/integrations/nightscout/{connection_id}/onboarding-derivation",
+            cookies=cookies,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["has_profile"] is False
+        assert body["target_low"]["proposed_value"] is None
+        assert body["basal_schedule"]["proposed_segments"] is None
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_derivation_unauthenticated_rejected(http_client):
+    resp = await http_client.get(
+        f"/api/integrations/nightscout/{uuid.uuid4()}/onboarding-derivation",
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_derivation_cross_tenant_404(http_client):
+    email_a = _unique_email("ns_derive_a")
+    email_b = _unique_email("ns_derive_b")
+    cookies_a = await _register_and_login(http_client, email_a)
+    cookies_b = await _register_and_login(http_client, email_b)
+    try:
+        connection_id = await _create_conn(http_client, cookies_a)
+        resp = await http_client.get(
+            f"/api/integrations/nightscout/{connection_id}/onboarding-derivation",
+            cookies=cookies_b,
+        )
+        assert resp.status_code == 404
+    finally:
+        await _cleanup([email_a, email_b])
+
+
+@pytest.mark.asyncio
+async def test_derivation_404s_soft_deleted_connection(http_client):
+    email = _unique_email("ns_derive_softdel")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        # Soft-delete by flipping is_active in the DB.
+        async with get_session_maker()() as db:
+            row = (
+                await db.execute(
+                    NightscoutConnection.__table__.select().where(
+                        NightscoutConnection.id == uuid.UUID(connection_id)
+                    )
+                )
+            ).fetchone()
+            assert row is not None
+            await db.execute(
+                NightscoutConnection.__table__.update()
+                .where(NightscoutConnection.id == uuid.UUID(connection_id))
+                .values(is_active=False)
+            )
+            await db.commit()
+        resp = await http_client.get(
+            f"/api/integrations/nightscout/{connection_id}/onboarding-derivation",
+            cookies=cookies,
+        )
+        assert resp.status_code == 404
+    finally:
+        await _cleanup([email])
+
+
+# ---------------------------------------------------------------------------
+# POST /apply-onboarding -- request schema validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_override_without_import_flag(http_client):
+    email = _unique_email("ns_apply_override")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        resp = await http_client.post(
+            f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+            cookies=cookies,
+            json={
+                # No import_target_low flag, but override given.
+                "override_target_low": 85.0,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        assert "override_target_low" in resp.text
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_unsupported_initial_sync_window(http_client):
+    email = _unique_email("ns_apply_window")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        resp = await http_client.post(
+            f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+            cookies=cookies,
+            json={"initial_sync_window_days": 14},
+        )
+        assert resp.status_code == 422, resp.text
+    finally:
+        await _cleanup([email])
+
+
+# ---------------------------------------------------------------------------
+# POST /apply-onboarding -- units-unknown gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_409s_units_unknown_without_confirm(http_client):
+    email = _unique_email("ns_apply_unitsq")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            units="weird_unit",
+            **_loop_segments(),
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={"import_target_low": True},
+            )
+        assert resp.status_code == 409, resp.text
+        assert "units" in resp.text.lower()
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_passes_units_unknown_for_non_glucose_imports(http_client):
+    """Importing only basal/DIA when units are unknown is safe -- those are
+    unit-agnostic. The 409 gate must NOT fire."""
+    email = _unique_email("ns_apply_unitsok")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            units="weird_unit",
+            **_loop_segments(),
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_basal_schedule": True,
+                    "import_dia_hours": True,
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["applied"]["basal_schedule"] is True
+        assert body["applied"]["dia_hours"] is True
+        assert body["first_sync_status"] == "ok"
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_passes_units_unknown_with_explicit_confirm(http_client):
+    email = _unique_email("ns_apply_unitsconfirm")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            units="weird_unit",
+            **_loop_segments(),
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_target_low": True,
+                    "import_target_high": True,
+                    "confirm_units_unknown": True,
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["applied"]["target_low"] is True
+        assert body["applied"]["target_high"] is True
+    finally:
+        await _cleanup([email])
+
+
+# ---------------------------------------------------------------------------
+# POST /apply-onboarding -- happy path + persistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_persists_settings_and_returns_first_sync_ok(http_client):
+    email = _unique_email("ns_apply_happy")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            **_loop_segments(),
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_target_low": True,
+                    "import_target_high": True,
+                    "import_dia_hours": True,
+                    "import_basal_schedule": True,
+                    "import_carb_ratio_schedule": True,
+                    "import_isf_schedule": True,
+                    "initial_sync_window_days": 30,
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["first_sync_status"] == "ok"
+        assert body["sync_result"] is not None
+        assert body["applied"]["target_low"] is True
+        assert body["applied"]["target_high"] is True
+        assert body["applied"]["dia_hours"] is True
+        assert body["applied"]["basal_schedule"] is True
+        assert body["applied"]["initial_sync_window_days"] is True
+        assert body["target_glucose_range"]["low_target"] == 90.0
+        assert body["target_glucose_range"]["high_target"] == 120.0
+        assert body["insulin_config"]["dia_hours"] == 5.0
+        assert body["pump_profile_id"] is not None
+
+        # Persistence: row state matches the response shape.
+        async with get_session_maker()() as db:
+            user = (
+                await db.execute(User.__table__.select().where(User.email == email))
+            ).fetchone()
+            tgr = (
+                await db.execute(
+                    TargetGlucoseRange.__table__.select().where(
+                        TargetGlucoseRange.user_id == user.id
+                    )
+                )
+            ).fetchone()
+            assert tgr.low_target == 90.0
+            assert tgr.high_target == 120.0
+
+            ic = (
+                await db.execute(
+                    InsulinConfig.__table__.select().where(
+                        InsulinConfig.user_id == user.id
+                    )
+                )
+            ).fetchone()
+            assert ic.dia_hours == 5.0
+
+            pp = (
+                await db.execute(
+                    PumpProfile.__table__.select().where(
+                        PumpProfile.user_id == user.id,
+                    )
+                )
+            ).fetchone()
+            assert pp.profile_name == "Nightscout"
+            assert pp.is_active is True
+            assert len(pp.segments) >= 1
+            assert pp.segments[0]["basal_rate"] == 0.65
+            assert pp.segments[0]["correction_factor"] == 50.0
+            assert pp.segments[0]["carb_ratio"] == 12.0
+
+            conn = (
+                await db.execute(
+                    NightscoutConnection.__table__.select().where(
+                        NightscoutConnection.id == uuid.UUID(connection_id)
+                    )
+                )
+            ).fetchone()
+            assert conn.initial_sync_window_days == 30
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_idempotent_rerun_does_not_duplicate_pump_profile(http_client):
+    email = _unique_email("ns_apply_idem")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            **_loop_segments(),
+        )
+        body = {
+            "import_basal_schedule": True,
+            "import_carb_ratio_schedule": True,
+            "import_isf_schedule": True,
+        }
+        with _patch_sync_ok():
+            r1 = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json=body,
+            )
+            r2 = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json=body,
+            )
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        # Same row UPSERTed, not two rows.
+        async with get_session_maker()() as db:
+            user = (
+                await db.execute(User.__table__.select().where(User.email == email))
+            ).fetchone()
+            rows = (
+                await db.execute(
+                    PumpProfile.__table__.select().where(
+                        PumpProfile.user_id == user.id,
+                        PumpProfile.profile_name == "Nightscout",
+                    )
+                )
+            ).fetchall()
+            assert len(rows) == 1
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_uses_override_value_when_provided(http_client):
+    email = _unique_email("ns_apply_override_val")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            **_loop_segments(),
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_target_low": True,
+                    "import_target_high": True,
+                    "override_target_low": 95.0,
+                    "override_target_high": 130.0,
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Override value wins over the proposal.
+        assert body["target_glucose_range"]["low_target"] == 95.0
+        assert body["target_glucose_range"]["high_target"] == 130.0
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_returns_200_with_timeout_on_first_sync_hang(http_client):
+    """Settings persisted; sync timed out. 200 + first_sync_status='timeout'."""
+    email = _unique_email("ns_apply_timeout")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            **_loop_segments(),
+        )
+        with _patch_sync_timeout():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={"import_dia_hours": True},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["first_sync_status"] == "timeout"
+        assert body["first_sync_error"] is not None
+        assert body["sync_result"] is None
+        # Settings still landed.
+        assert body["applied"]["dia_hours"] is True
+
+        # Connection row marked NETWORK.
+        async with get_session_maker()() as db:
+            row = (
+                await db.execute(
+                    NightscoutConnection.__table__.select().where(
+                        NightscoutConnection.id == uuid.UUID(connection_id)
+                    )
+                )
+            ).fetchone()
+            assert row.last_sync_status == NightscoutSyncStatus.NETWORK
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_returns_200_with_error_on_orchestrator_non_ok(http_client):
+    email = _unique_email("ns_apply_syncerr")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            **_loop_segments(),
+        )
+        with _patch_sync_orchestrator_error(lambda c: c.id):
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={"import_dia_hours": True},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["first_sync_status"] == "error"
+        assert "auth" in (body["first_sync_error"] or "").lower()
+        # Sync result still surfaced for the wizard's progress UI.
+        assert body["sync_result"]["status"] == NightscoutSyncStatus.AUTH_FAILED.value
+        # Connection row mirrors the orchestrator-reported status.
+        async with get_session_maker()() as db:
+            row = (
+                await db.execute(
+                    NightscoutConnection.__table__.select().where(
+                        NightscoutConnection.id == uuid.UUID(connection_id)
+                    )
+                )
+            ).fetchone()
+            # The orchestrator MOCK returns a SyncResult without
+            # updating the connection row itself; in production the
+            # real orchestrator persists `last_sync_status`. Under
+            # the mock the row stays at NEVER (creation default),
+            # which is what we assert here.
+            assert row.last_sync_status == NightscoutSyncStatus.NEVER
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_unauthenticated_rejected(http_client):
+    resp = await http_client.post(
+        f"/api/integrations/nightscout/{uuid.uuid4()}/apply-onboarding",
+        json={"import_dia_hours": True},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_apply_cross_tenant_404(http_client):
+    email_a = _unique_email("ns_apply_xt_a")
+    email_b = _unique_email("ns_apply_xt_b")
+    cookies_a = await _register_and_login(http_client, email_a)
+    cookies_b = await _register_and_login(http_client, email_b)
+    try:
+        connection_id = await _create_conn(http_client, cookies_a)
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies_b,
+                json={"import_dia_hours": True},
+            )
+        assert resp.status_code == 404
+    finally:
+        await _cleanup([email_a, email_b])
+
+
+@pytest.mark.asyncio
+async def test_apply_preserves_fractional_isf_precision(http_client):
+    """mmol-converted ISFs land as floats; integer truncation would
+    silently shift the user's correction factor by up to ~0.5 mg/dL/U."""
+    email = _unique_email("ns_apply_isf_float")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        # mmol/L profile: ISF=1.8 mmol/L/U converts to 32.4 mg/dL/U.
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            units="mmol",
+            sensitivity_segments=[
+                {"time": "00:00", "timeAsSeconds": 0, "value": 1.8},
+            ],
+            basal_segments=[{"time": "00:00", "timeAsSeconds": 0, "value": 0.5}],
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_isf_schedule": True,
+                    "import_basal_schedule": True,
+                    "confirm_units_unknown": False,
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        async with get_session_maker()() as db:
+            user = (
+                await db.execute(User.__table__.select().where(User.email == email))
+            ).fetchone()
+            pp = (
+                await db.execute(
+                    PumpProfile.__table__.select().where(
+                        PumpProfile.user_id == user.id,
+                    )
+                )
+            ).fetchone()
+            cf = pp.segments[0]["correction_factor"]
+            # Float, not int; precision preserved (1.8 mmol/L/U * 18.0182 = 32.43...).
+            assert isinstance(cf, float)
+            assert 32.0 < cf < 33.0
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_target_low_above_target_high(http_client):
+    """Pre-flight ordering check rejects bad merges before any writer commits."""
+    email = _unique_email("ns_apply_ordering")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            **_loop_segments(),
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_target_low": True,
+                    "import_target_high": True,
+                    "override_target_low": 200.0,
+                    "override_target_high": 150.0,
+                },
+            )
+        assert resp.status_code == 422, resp.text
+        # Critically: NOTHING should have committed -- target range
+        # row should not exist at all.
+        async with get_session_maker()() as db:
+            user = (
+                await db.execute(User.__table__.select().where(User.email == email))
+            ).fetchone()
+            row = (
+                await db.execute(
+                    TargetGlucoseRange.__table__.select().where(
+                        TargetGlucoseRange.user_id == user.id
+                    )
+                )
+            ).fetchone()
+            assert row is None
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_handles_null_segments_gracefully(http_client):
+    """Snapshot with null/empty schedule fields must not crash; the
+    derivation surfaces None proposals and apply leaves pump_profile
+    untouched without error."""
+    email = _unique_email("ns_apply_nullseg")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            basal_segments=None,
+            carb_ratio_segments=None,
+            sensitivity_segments=None,
+            target_low_segments=[],
+            target_high_segments=[],
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_basal_schedule": True,
+                    "import_carb_ratio_schedule": True,
+                    "import_isf_schedule": True,
+                    "import_target_low": True,
+                    "import_target_high": True,
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Flags were set but no proposals to apply -> nothing landed.
+        assert body["applied"]["target_low"] is False
+        assert body["applied"]["target_high"] is False
+        assert body["applied"]["basal_schedule"] is False
+        assert body["applied"]["carb_ratio_schedule"] is False
+        assert body["applied"]["isf_schedule"] is False
+        assert body["pump_profile_id"] is None
+        assert body["target_glucose_range"] is None
+        assert body["first_sync_status"] == "ok"
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_at_realistic_glucose_edges_persists(http_client):
+    """Targets at the upper end of the typical user range (low=80,
+    high=200) must apply within the writer's ordering invariant
+    (default urgent_low=55, urgent_high=250)."""
+    email = _unique_email("ns_apply_edges")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            **_loop_segments(),
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_target_low": True,
+                    "import_target_high": True,
+                    "override_target_low": 80.0,
+                    "override_target_high": 200.0,
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["target_glucose_range"]["low_target"] == 80.0
+        assert body["target_glucose_range"]["high_target"] == 200.0
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_low_target_below_urgent_low_default(http_client):
+    """Override below the default urgent_low (55) must 422 with the
+    writer's ordering message -- the apply pre-flight only checks
+    low<high; deeper invariants are caught by `update_range`."""
+    email = _unique_email("ns_apply_low_urgent")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            **_loop_segments(),
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_target_low": True,
+                    "override_target_low": 50.0,  # below urgent_low default of 55
+                },
+            )
+        # 422 from the inner writer's ordering invariant.
+        assert resp.status_code == 422, resp.text
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_no_imports_returns_skipped(http_client):
+    """All flags false -> no settings written, sync still kicks (skipped status
+    is reserved for the no-sync path; here sync runs OK)."""
+    email = _unique_email("ns_apply_noop")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["target_glucose_range"] is None
+        assert body["insulin_config"] is None
+        assert body["pump_profile_id"] is None
+        assert all(v is False for v in body["applied"].values())
+    finally:
+        await _cleanup([email])

--- a/apps/api/tests/test_nightscout_apply_onboarding.py
+++ b/apps/api/tests/test_nightscout_apply_onboarding.py
@@ -19,7 +19,6 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import delete
 
-from src.core.encryption import encrypt_credential
 from src.database import get_session_maker
 from src.main import app
 from src.models.insulin_config import InsulinConfig
@@ -33,7 +32,6 @@ from src.models.target_glucose_range import TargetGlucoseRange
 from src.models.user import User
 from src.services.integrations.nightscout.connection_test import ConnectionTestOutcome
 from src.services.integrations.nightscout.sync import SyncResult
-
 
 # ---------------------------------------------------------------------------
 # Auth / fixtures
@@ -78,13 +76,9 @@ async def _cleanup(emails: list[str]) -> None:
                     NightscoutConnection.user_id.in_(ids)
                 )
             )
+            await db.execute(delete(PumpProfile).where(PumpProfile.user_id.in_(ids)))
             await db.execute(
-                delete(PumpProfile).where(PumpProfile.user_id.in_(ids))
-            )
-            await db.execute(
-                delete(TargetGlucoseRange).where(
-                    TargetGlucoseRange.user_id.in_(ids)
-                )
+                delete(TargetGlucoseRange).where(TargetGlucoseRange.user_id.in_(ids))
             )
             await db.execute(
                 delete(InsulinConfig).where(InsulinConfig.user_id.in_(ids))
@@ -857,6 +851,49 @@ async def test_apply_rejects_target_low_above_target_high(http_client):
                 )
             ).fetchone()
             assert row is None
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_does_not_claim_empty_schedule_was_applied(http_client):
+    """An empty proposed_segments list (vs None) must NOT report
+    `applied[*_schedule] = True`. The other-domain breakpoints would
+    drive the merged row, so an empty schedule contributes nothing
+    and the response should reflect that."""
+    email = _unique_email("ns_apply_empty_seg")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        # ICR + ISF have segments; basal is explicitly empty.
+        await _seed_snapshot(
+            connection_id=connection_id,
+            user_email=email,
+            basal_segments=[],
+            carb_ratio_segments=[
+                {"time": "00:00", "timeAsSeconds": 0, "value": 12.0},
+            ],
+            sensitivity_segments=[
+                {"time": "00:00", "timeAsSeconds": 0, "value": 50.0},
+            ],
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={
+                    "import_basal_schedule": True,
+                    "import_carb_ratio_schedule": True,
+                    "import_isf_schedule": True,
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Empty basal must not claim it landed.
+        assert body["applied"]["basal_schedule"] is False
+        # Non-empty schedules did land.
+        assert body["applied"]["carb_ratio_schedule"] is True
+        assert body["applied"]["isf_schedule"] is True
     finally:
         await _cleanup([email])
 


### PR DESCRIPTION
## Summary

Adds the backend for the Nightscout smart-onboarding wizard's review-and-apply step. Two endpoints under `/api/integrations/nightscout/{id}/`:

- **`GET /onboarding-derivation`** — pure read combining the latest profile snapshot with the user's current canonical settings. Returns the field-by-field "Currently | From Nightscout" diff source the wizard renders at step 3. Soft-deleted connections 404; cross-tenant access also 404.
- **`POST /apply-onboarding`** — persists per-field opt-in proposals to `target_glucose_ranges`, `insulin_configs`, and `pump_profiles`, updates `initial_sync_window_days` on the connection, and triggers the first sync inside the request bounded by `_SYNC_TIMEOUT_SECONDS=20`. Returns 200 with `first_sync_status` ∈ `{ok, error, timeout, skipped}` so the wizard's progress UI can render the right copy without polling. Settings always land even on sync timeout.

## Behaviour highlights

- **Units gate.** When the source profile's units can't be classified as mg/dL or mmol/L, any glucose-domain import (target_low/high, ISF) requires `confirm_units_unknown=true` — otherwise 409. Non-glucose imports (basal, DIA, carb-ratio) skip the gate since those are unit-agnostic.
- **Per-field overrides.** Top-level numeric overrides (`override_target_low/high`, `override_dia_hours`) replace the derived proposal at confirmation time; per-time-slot schedule overrides are deferred to a follow-up. The schema rejects an override without its matching `import_*` flag (422) so the contract is explicit.
- **Concurrency.** `pg_advisory_xact_lock(hashtext(user_id))` at the start of apply serializes a double-clicked wizard; the pump_profile UPSERT is keyed on `(user_id, profile_name='Nightscout')` so a re-run refreshes the existing row instead of accumulating duplicates.
- **Cross-source coexistence.** The pump_profile row uses `profile_name='Nightscout'` (distinct from `'Tandem'`), so users with both connections see both rows; `get_active_profile` tie-breaks across sources by `synced_at desc` (last-write-wins).
- **Pre-flight ordering.** `low_target < high_target` is checked on the override+derivation merge before any settings writer commits, so a 422 is raised cleanly without leaving partial state.
- **Robust timeout recovery.** On sync `TimeoutError` we still return 200 (settings already landed). The recovery commit re-fetches the connection row after rollback and is wrapped in try/except so a status-update failure can't bubble a 500 over a settings-success.

## Test plan

- [x] 23 new `pytest` cases covering: derivation happy-path / no-snapshot / cross-tenant / soft-delete; apply schema validation (override-without-flag, bad sync window); units gate (409 default, pass on confirm, pass on non-glucose imports); happy-path persistence + sync OK; idempotent re-run; override values; first-sync timeout returns 200; orchestrator non-OK returns 200 with error; cross-tenant 404; ISF float precision (mmol-converted); pre-flight ordering; null/empty schedules; near-boundary glucose targets.
- [x] Wider Nightscout regression (105 tests across `onboarding_derive`, `apply_onboarding`, `evaluate`, `connection`) — clean.
- [x] `ruff check` + `ruff format --check` clean on changed files.
- [x] Live e2e: `GET /onboarding-derivation` against the real test connection returns the expected derivation shape.
- [x] Adversarial review pass + fixes (atomicity pre-flight, advisory lock, robust timeout recovery, ISF float precision).
- [x] CodeRabbit CLI review pass (boundary + null-segments tests added; deterministic `last_sync_status` assertion).
- [x] Security review pass on staged diff: no secrets, parameterized SQL bind for `pg_advisory_xact_lock`, CSRF middleware covers the new POST, `extra="forbid"` on the request schema, cross-tenant write blocked by `current_user.id`-scoped writers.

## Follow-up

The frontend wizard route (5 steps: credentials → evaluate → review-and-apply → progress → done) lands separately on top of these endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Nightscout onboarding wizard enabling users to review and apply derived settings—including target glucose ranges, insulin duration, and pump profiles—directly from their Nightscout profile data.
  * Implemented automatic initial sync validation with timeout protection to ensure settings persist correctly after onboarding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/596)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->