### PR TITLE
docs: add Integrations page covering Nightscout + reflect live integration

### DIFF
--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -90,7 +90,7 @@ Brief glossary of the projects you might encounter in T1 communities. See [Relat
 
 ### Nightscout
 
-The open-source web dashboard that has been the backbone of self-hosted CGM monitoring since around 2014. Runs on Heroku / Render / Atlas + Vercel; has follower-token authentication; broad CGM and pump bridging via plugins; rich JSON API. Phase 2 of GlycemicGPT will support pulling from Nightscout as a data source. [nightscout.github.io](https://nightscout.github.io/)
+The open-source web dashboard that has been the backbone of self-hosted CGM monitoring since around 2014. Runs on Heroku / Render / Atlas + Vercel; has follower-token authentication; broad CGM and pump bridging via plugins; rich JSON API. GlycemicGPT can read CGM entries, treatments, devicestatus, and your profile straight from your Nightscout site -- see [Integrations → Nightscout](../daily-use/integrations.md#nightscout). [nightscout.github.io](https://nightscout.github.io/)
 
 ### Loop
 

--- a/docs/concepts/relationship-to-other-tools.md
+++ b/docs/concepts/relationship-to-other-tools.md
@@ -13,7 +13,7 @@ The breakdown by tool is below.
 
 | Tool | What it does | Relationship to GlycemicGPT |
 |---|---|---|
-| [Nightscout](https://nightscout.github.io/) | Web dashboard, alerts, follower auth, broad CGM/pump bridging | Closest peer in the OSS world. Phase 2 will let GlycemicGPT pull from your Nightscout instead of polling Dexcom independently. |
+| [Nightscout](https://nightscout.github.io/) | Web dashboard, alerts, follower auth, broad CGM/pump bridging | Closest peer in the OSS world. GlycemicGPT can read CGM entries, treatments, devicestatus, and your profile straight from your Nightscout site. See [Integrations → Nightscout](../daily-use/integrations.md#nightscout). |
 | [Loop](https://loopkit.github.io/loopdocs/) | iOS closed-loop insulin delivery | Different category. GlycemicGPT is monitoring/analysis only; Loop closes the loop. We recommend you use both. |
 | [AndroidAPS / AAPS](https://androidaps.readthedocs.io/) | Android closed-loop with broad pump support | Same: different category. We recommend you use both. |
 | [Trio](https://triodocs.org/) / [iAPS](https://iaps-app.org/) | Loop forks for iOS | Same as Loop. We recommend you use both. |
@@ -52,8 +52,9 @@ Both deliver the standard diabetes-platform table stakes (real-time glucose, ale
 
 **If you already run Nightscout today:**
 
-- **Phase 1 (today):** GlycemicGPT and Nightscout work side-by-side without interference. They both pull from Dexcom's cloud independently using your Dexcom account credentials. There's no integration between them yet -- this means two tools polling Dexcom on your behalf, which is wasteful but not broken.
-- **Phase 2 (planned):** GlycemicGPT will be able to use your Nightscout instance as a data source. You'd configure GlycemicGPT to read CGM entries and pump data from your Nightscout's `/api/v1/entries.json` and `/api/v1/treatments.json` endpoints, eliminating the duplicate Dexcom polling. See [ROADMAP.md](https://github.com/GlycemicGPT/GlycemicGPT/blob/main/ROADMAP.md).
+GlycemicGPT can use your Nightscout instance as a data source. You configure a Nightscout connection (URL + API_SECRET or bearer token) in **Settings → Integrations**, and GlycemicGPT reads CGM entries, treatments (boluses, carbs, basal changes), devicestatus (loop / pump status), and your profile from your Nightscout's `/api/v1/*.json` endpoints. A guided 5-step **smart onboarding wizard** also pre-fills your GlycemicGPT settings (target range, ISF, carb ratio, basal schedule, DIA) from your existing Nightscout profile -- so a Nightscout user lands on a populated dashboard instead of a blank one. Full setup is documented under [Integrations → Nightscout](../daily-use/integrations.md#nightscout).
+
+If you'd rather GlycemicGPT keep polling Dexcom directly and use Nightscout only as a backstop, you can wire up both -- they coexist without conflict. The platform de-duplicates on import, so running both adds redundancy without doubling stored data.
 
 If you're a Nightscout admin curious about what GlycemicGPT adds on top of what you already run, the answer is: AI chat, AI-written briefs, AGP visualization on the home dashboard, and finer-grained caregiver permissions. The data model overlaps; the analytical surface above the data is where they differ.
 
@@ -68,7 +69,7 @@ GlycemicGPT is a different category of tool. It does not, will not, and cannot d
 **If you're already a Looper / AAPS user:**
 
 - GlycemicGPT does not replace any of what your closed-loop system does. There is no overlap at the dosing layer.
-- GlycemicGPT can read the CGM data your loop is acting on (today via Dexcom directly; later via Nightscout if you have one). Then the analysis layer and the AI chat answer questions about *what your loop did* -- "what happened during this overnight series of microboluses?", "did the loop catch the post-meal rise on time?", "is there a weekly pattern in correction frequency?".
+- GlycemicGPT can read the CGM data your loop is acting on -- either via Dexcom directly, or via your loop's Nightscout uploader (see [Integrations → Nightscout](../daily-use/integrations.md#nightscout)). Once the data flows in, the analysis layer and the AI chat answer questions about *what your loop did* -- "what happened during this overnight series of microboluses?", "did the loop catch the post-meal rise on time?", "is there a weekly pattern in correction frequency?".
 - The benefit is retrospective analysis and pattern interrogation. It does not affect or interact with your loop's runtime decisions.
 
 We recommend Loopers run both: closed-loop for runtime delivery, GlycemicGPT for the analysis and AI layer over the data your loop generates.
@@ -92,7 +93,7 @@ If you currently rely on Tidepool for endo appointments, **keep using Tidepool**
 **Relationship to GlycemicGPT:**
 
 - xDrip+ is a far more mature CGM-side tool for non-Dexcom sensors than anything GlycemicGPT does today. If you use a Libre or an older Dexcom, **xDrip+ is your CGM companion, not the GlycemicGPT mobile app.**
-- xDrip+ uploads to Nightscout. Once GlycemicGPT can read from Nightscout (Phase 2), the data flow is: sensor → xDrip+ → Nightscout → GlycemicGPT. That's the canonical path for non-Dexcom CGMs once Phase 2 lands.
+- xDrip+ uploads to Nightscout. The canonical path for non-Dexcom CGMs (Libre 2 / 3 / 3+, Eversense, etc.) is: sensor → xDrip+ → Nightscout → GlycemicGPT. See [Integrations → Nightscout](../daily-use/integrations.md#nightscout) for the setup.
 - The two coexist without conflict today. They're solving different problems at different layers.
 
 ## Sugarmate
@@ -116,7 +117,7 @@ If Sugarmate works for you and self-hosting isn't appealing, Sugarmate is the lo
 
 ## "Should I switch?"
 
-- **You already have Nightscout?** Keep it. Run GlycemicGPT alongside it today; Phase 2 will give you a real integration. The AI chat, AI briefs, and AGP-on-the-home-dashboard are the additions on top of what Nightscout gives you.
+- **You already have Nightscout?** Keep it. Connect it to GlycemicGPT via [Integrations → Nightscout](../daily-use/integrations.md#nightscout) and a guided wizard reads your existing profile to pre-fill GlycemicGPT's settings. The AI chat, AI briefs, and AGP-on-the-home-dashboard are the additions on top of what Nightscout already gives you.
 - **You're a Looper?** Keep Looping. GlycemicGPT is the analysis and AI layer on top, not a replacement for any part of your closed-loop stack. We recommend running both.
 - **You use Tidepool for endo appointments?** Keep using Tidepool until GlycemicGPT supports a Tidepool-equivalent export. Tidepool will likely remain in your stack indefinitely as the clinician-facing report format.
 - **You have nothing today and are evaluating from scratch?** GlycemicGPT can be your full stack on its own (CGM → dashboard → AI). The existing tools have years of polish; you'd be choosing AI-first novelty over years of community shake-down. That's a fair trade for some users; not for others.

--- a/docs/daily-use/_meta.json
+++ b/docs/daily-use/_meta.json
@@ -2,6 +2,7 @@
   "title": "Daily Use",
   "pages": [
     "dashboard",
+    "integrations",
     "connecting-dexcom",
     "connecting-tandem-cloud",
     "ai-chat",

--- a/docs/daily-use/connecting-dexcom.md
+++ b/docs/daily-use/connecting-dexcom.md
@@ -5,7 +5,7 @@ description: Hook GlycemicGPT up to your Dexcom account so glucose flows into th
 
 GlycemicGPT pulls Dexcom data from Dexcom's cloud using your normal Dexcom account credentials. You don't need to do anything on your phone for this; the platform checks Dexcom for new data directly on a schedule.
 
-> **If you're already running Nightscout:** today, GlycemicGPT pulls from Dexcom Share independently of Nightscout. If you also have Nightscout pulling from Dexcom Share, both will hit Dexcom's servers with your credentials -- not broken, but wasteful. The Phase 2 roadmap item for [Nightscout-as-data-source](../concepts/relationship-to-other-tools.md#nightscout) will let GlycemicGPT read from your Nightscout's `/entries.json` instead, eliminating the duplicate. Watch [ROADMAP.md](https://github.com/GlycemicGPT/GlycemicGPT/blob/main/ROADMAP.md) for timing.
+> **If you're already running Nightscout:** you can connect your Nightscout instance directly instead of (or alongside) Dexcom -- GlycemicGPT will read CGM entries, treatments, and your profile from your Nightscout site. See [Integrations → Nightscout](./integrations.md#nightscout) for the guided setup. If you connect both Dexcom and Nightscout, the platform will pull from both; pick one if you want to avoid the duplicate Dexcom-cloud poll.
 
 > **Before you start, you need:**
 >
@@ -77,7 +77,7 @@ If Dexcom's developer API becomes practical for hobbyist projects (rate limits r
 
 Any Dexcom CGM that uploads to Dexcom's cloud through the standard Dexcom mobile app should work -- this includes Dexcom G7 and Dexcom G6, since both stream to the same Dexcom cloud the platform reads from. The platform's daily testing is on G7, so G7 is the most validated model; G6 is expected to work but has had less direct testing.
 
-If you have a non-Dexcom CGM (Freestyle Libre, Medtronic Guardian, etc.) it won't work today. Support for additional CGMs and integrations with platforms like Nightscout (which can bridge other CGMs) is on the roadmap -- see [ROADMAP.md](https://github.com/GlycemicGPT/GlycemicGPT/blob/main/ROADMAP.md) §Phase 2.
+If you have a non-Dexcom CGM (Freestyle Libre, Medtronic Guardian, Eversense, etc.) the direct Dexcom integration won't work, but the [Nightscout integration](./integrations.md#nightscout) does -- upload to a Nightscout site from your CGM's bridge (xDrip+ for Libre, LibreLinkUp-Uploader, etc.) and connect that Nightscout to GlycemicGPT. Anything that flows into Nightscout flows in here.
 
 ## Still stuck?
 

--- a/docs/daily-use/data-export.md
+++ b/docs/daily-use/data-export.md
@@ -64,7 +64,7 @@ It does **not** contain anything stored anywhere else (your pump's full memory, 
 If you're coming from another tool and expecting an export here, the honest answer:
 
 - **Tidepool JSON** -- not supported today. Roadmap.
-- **Nightscout-format `entries.json` / `treatments.json`** -- not supported today. Roadmap (closely tied to the Phase 2 Nightscout-as-data-source work).
+- **Nightscout-format `entries.json` / `treatments.json` (export)** -- not supported today. Roadmap. Note: reading **from** Nightscout into GlycemicGPT is fully supported -- see [Integrations → Nightscout](./integrations.md#nightscout) -- the gap is on the export side, not the import side.
 - **AGP (Ambulatory Glucose Profile) PDF** -- not supported today. Roadmap.
 - **OpenAPS profile JSON** -- not currently planned. If this matters to you, file an issue.
 - **FHIR / HL7** -- not currently planned. Same.
@@ -73,7 +73,7 @@ Each of these is a real format with a real audience. They are not in today's rel
 
 ## Importing data into GlycemicGPT
 
-The reverse is also limited today. There is no in-dashboard "import from Nightscout" or "import from Tidepool" button. The Phase 2 Nightscout integration will be a *live* read connection (GlycemicGPT pulls continuously from your Nightscout) rather than a one-time import.
+The reverse story is asymmetric. **Live import from Nightscout works today** -- the platform pulls CGM entries, treatments, devicestatus, and your profile continuously from your Nightscout instance once connected. See [Integrations → Nightscout](./integrations.md#nightscout). There's no one-time "import a historical dump from Tidepool" button; live read connections are the supported pattern.
 
 If you have historical CGM data in another tool and want it in GlycemicGPT today, you can:
 

--- a/docs/daily-use/integrations.md
+++ b/docs/daily-use/integrations.md
@@ -1,0 +1,170 @@
+---
+title: Integrations
+description: Connect GlycemicGPT to Dexcom, Tandem, Nightscout, and the other data sources / notification channels that make up your diabetes setup.
+---
+
+GlycemicGPT is designed to sit alongside the tools you already use -- your CGM's app, your pump's cloud, and (if you have one) your Nightscout instance. Integrations are how the platform gets your data and how it talks back out to you.
+
+This page is the index. Each integration with a longer setup flow has its own page; the short ones are documented in full here.
+
+> **One-line mental model.** Integrations either **pull data in** (CGM cloud, pump cloud, Nightscout) or **push notifications out** (Telegram, email, web push). Set them up once in **Settings → Integrations**; everything else is automatic.
+
+## What's available
+
+| Integration | Direction | Use it if you... | Setup |
+|---|---|---|---|
+| [Dexcom](./connecting-dexcom.md) | Pull (CGM) | Have a Dexcom G6 / G7 / ONE+ and want real-time glucose | Dexcom email + password |
+| [Tandem Cloud](./connecting-tandem-cloud.md) | Pull (pump, both ways) | Have a t:slim X2 or Mobi and want pump history + IoB | Tandem email + password |
+| [Nightscout](#nightscout) | Pull (CGM + pump + treatments) | Already run a Nightscout site -- often with a CGM we don't speak directly to (Libre, Eversense, etc.) | Nightscout URL + API_SECRET |
+| [Telegram bot](#telegram-bot) | Push (notifications + chat) | Want alerts and a portable AI chat in Telegram | Bot token from `@BotFather` |
+| [AI provider](#ai-providers-byoai) | Push (analysis) | Want AI briefs and AI chat over your own data | Subscription, your own API key, or a self-hosted model |
+
+Everything lives at **Settings → Integrations** on the dashboard.
+
+---
+
+## Nightscout
+
+If you already self-host (or use a hosted) [Nightscout](https://nightscout.github.io/), GlycemicGPT can read your CGM entries, pump treatments, devicestatus, and profile straight from your Nightscout site. This is the easiest path for CGMs we don't speak to directly (Libre, Eversense, Medtronic), and for closed-loop users on Loop / AAPS / Trio whose loop already uploads to Nightscout.
+
+> **Why connect Nightscout?** Anything that flows into Nightscout -- glucose entries, boluses, basal changes, loop status, profile settings -- flows into GlycemicGPT through this connection. It's the universal onramp for the diabetes-OSS ecosystem.
+
+### Before you start, you need
+
+- A working Nightscout site you can sign in to. The URL looks like `https://your-name.up.railway.app` or `https://your-name.onrender.com`.
+- Your Nightscout **API_SECRET** (the long string from your Nightscout config, used for authenticated reads), **or** a bearer token issued by your deployment.
+- GlycemicGPT running and you signed in to your dashboard.
+
+### Smart onboarding (recommended)
+
+GlycemicGPT ships a guided 5-step wizard that connects to your Nightscout, reads your existing profile, and pre-fills your GlycemicGPT settings (target range, ISF, carb ratio, basal schedule, DIA) so you don't start from a blank dashboard.
+
+#### How to start the wizard
+
+1. Go to **Settings → Integrations** on the dashboard.
+2. Open the **Third-Party Integrations → Nightscout** section.
+3. Click **Start smart onboarding**.
+
+#### What each step does
+
+**Step 1 -- Credentials.** Type a friendly name (e.g. "Home Loop"), your Nightscout URL, and your API_SECRET / bearer token. GlycemicGPT tests the connection before reading anything. If the test fails, fix the URL or credential and try again -- nothing else has been saved yet.
+
+**Step 2 -- Reading your Nightscout.** The wizard:
+
+1. Probes your Nightscout to estimate how much data you have (entries count, treatment count, which uploaders are detected, server version).
+2. Pulls your first sync so the connection is populated.
+3. Reads your default profile (the one your Nightscout is configured to use).
+
+This usually takes a few seconds. On a Nightscout with months of treatments it can take up to half a minute -- the wizard will tell you it's still working.
+
+**Step 3 -- Review what we found.** A diff table shows, for each setting:
+
+- What GlycemicGPT has now (your current value).
+- What your Nightscout profile suggests (the proposed value).
+- A **Use this?** checkbox.
+
+The settings covered:
+
+- **Target low** / **Target high** -- your glucose target range, in mg/dL.
+- **DIA (Duration of Insulin Action)** in hours.
+- **Basal schedule** -- the time-of-day basal rate table from your profile.
+- **Carb ratio schedule** -- carbs-per-unit, time-of-day.
+- **ISF (Insulin Sensitivity Factor) schedule** -- mg/dL per unit, time-of-day.
+
+For each numeric row you can type a different value in the **override** box to use instead of the proposed value. Empty box = use the proposed value. The wizard validates that overrides are positive numbers -- if you typo a negative or zero, Apply stays disabled until you fix it.
+
+Schedule rows have a **Preview** button that expands a table showing every segment from your Nightscout profile so you can see exactly what would land.
+
+Below the table, **Import history for** picks how far back to pull entries on the first sync: 1 day, 7 days, 30 days, 90 days, or all available.
+
+> **Insulin type is not auto-imported.** GlycemicGPT needs to know what insulin you're on (Humalog, Novolog, Fiasp, Lyumjev, etc.) to compute IoB curves correctly. The wizard intentionally doesn't guess -- pick yours under **Settings → Insulin** once after the wizard finishes.
+
+> **mmol/L users.** If your Nightscout reports `units: mmol`, the wizard automatically converts target ranges and ISF to mg/dL before they land in GlycemicGPT and surfaces a banner so you can see the conversion happened. GlycemicGPT stores glucose values in mg/dL internally regardless of how you view them.
+
+> **What if your Nightscout reports unrecognized units?** A warning banner appears and the wizard refuses to import glucose-domain settings (target range, ISF) until you tick a confirmation box stating your values are actually in mg/dL. If they're actually mmol/L and you tick the box, your targets and ISF will be 18x off -- so read carefully.
+
+**Step 4 -- Importing.** GlycemicGPT writes the settings you chose and kicks the first sync. This step can take up to 20 seconds on a busy Nightscout.
+
+**Step 5 -- Done.** A summary lists which settings landed and how many records the first sync imported. From here you can jump to the dashboard to see your data, or back to **Settings → Integrations** to add a second Nightscout connection (e.g. for a child or partner you also follow).
+
+### Expert mode (manual setup)
+
+The original credential-only form is preserved under **Settings → Integrations → Nightscout → Expert mode (manual setup)**. It connects without the profile read or the diff table -- useful if you're scripting setup, only want to import data without changing settings, or you've already imported once and just want a second connection.
+
+### What you can do after connecting
+
+- **Sync now** -- force a fetch immediately instead of waiting for the scheduled tick.
+- **Sync every** -- a quick selector for how often GlycemicGPT polls your Nightscout (1m / 5m / 15m / 30m / 60m). Default 5m balances freshness against your Nightscout's resource budget.
+- **Test** -- verifies the URL / credential still authenticates without doing a full sync.
+- **Delete** -- removes the connection. Data already imported into GlycemicGPT stays in your local store; only future syncs stop.
+
+You can have **more than one** Nightscout connection -- common pattern for caregivers who follow multiple people, each with their own Nightscout.
+
+### What flows in
+
+| Nightscout collection | What lands in GlycemicGPT |
+|---|---|
+| `entries` | CGM readings on your glucose chart, AGP, Time in Range |
+| `treatments` (boluses, carbs) | Bolus markers on the chart, IoB calculation, carb history |
+| `treatments` (basal changes) | Basal schedule history |
+| `devicestatus` | Loop / AAPS / Trio status, pump battery / reservoir if reported |
+| `profile` | Target range, ISF, carb ratio, basal, DIA (during the wizard) |
+
+### Troubleshooting
+
+- **"Could not resolve host."** Your Nightscout URL is unreachable from where GlycemicGPT runs. Double-check the URL is the one you sign in at, including `https://`, and that the instance is up.
+- **"401 / 403."** API_SECRET or token is wrong, or your Nightscout has scope-restricted authentication. Try regenerating a token from your Nightscout admin page.
+- **The chart still has gaps after a sync.** A known limitation -- if your Nightscout's uploader had a disconnect and backfilled into Nightscout after our sync cursor advanced, we may not pick those records up. Workaround: delete and re-create the connection with a wider initial sync window, or contact support. Tracked in [GitHub issue #598](https://github.com/GlycemicGPT/GlycemicGPT/issues/598).
+- **No profile detected.** Some Nightscout sites have profile auto-discovery turned off. You can still use the connection for data import; you'll need to set glucose / insulin settings manually under **Settings**.
+
+---
+
+## Telegram bot
+
+The Telegram integration is GlycemicGPT's portable extension. Once it's set up you can:
+
+- Receive alerts on Telegram (warning / critical glucose, predictive low, escalation).
+- Get your daily brief pushed to a Telegram chat.
+- Ask the same AI chat questions you'd ask on the dashboard, from anywhere.
+- Caregivers can be granted read-only access via the same bot without giving them dashboard credentials.
+
+### Setup
+
+1. On Telegram, message [@BotFather](https://t.me/BotFather) and run `/newbot`. Pick a name and username for **your** bot.
+2. BotFather sends you a **bot token** that looks like `123456789:AAH...`. Copy it.
+3. In GlycemicGPT, go to **Settings → Integrations → Telegram** and paste the token. Save.
+4. Open Telegram and send `/start` to your new bot. The bot links your Telegram account to your GlycemicGPT user.
+
+That's it. You can now send commands like `/brief`, `/glucose`, `/iob`, or just ask the bot a question.
+
+> **Privacy.** Your bot token belongs to **your** Telegram account, not GlycemicGPT's. The platform stores it encrypted and uses it to send messages on your behalf. If you ever rotate the token in BotFather, paste the new one back in.
+
+---
+
+## AI providers (BYOAI)
+
+GlycemicGPT's AI features -- daily / weekly briefs and AI chat -- need an AI provider. You bring your own. The platform supports:
+
+- **Anthropic** (Claude) -- API key from [console.anthropic.com](https://console.anthropic.com).
+- **OpenAI** (GPT-4, GPT-4o) -- API key from [platform.openai.com](https://platform.openai.com).
+- **Google** (Gemini) -- API key from [aistudio.google.com](https://aistudio.google.com).
+- **Subscription** -- a GlycemicGPT-hosted subscription tier (no API key, billed through the platform).
+- **Self-hosted / BYOAI** -- any OpenAI-compatible endpoint (Ollama, llama.cpp, vLLM, your own runtime) by URL. Useful if you want everything to stay on your network.
+
+Configure under **Settings → AI**. You can switch providers without losing your chat history -- AI chat responses are stored locally regardless of who generated them.
+
+> **Switching providers.** Different providers produce different writing styles in briefs and different answer quality in chat. Try a few; the platform doesn't lock you in.
+
+---
+
+## Adding more
+
+The integration list grows. The current roadmap targets are LibreLinkUp (Freestyle Libre cloud), Tidepool (cloud upload and clinical reports), and broader pump bridges. Watch [ROADMAP.md](https://github.com/GlycemicGPT/GlycemicGPT/blob/main/ROADMAP.md) for what's coming and approximate timing.
+
+If your CGM, pump, or cloud platform isn't on the list yet, the workaround that already works **today** is to upload to a Nightscout instance (often via [xDrip+](https://github.com/NightscoutFoundation/xDrip), [LibreLinkUp-Uploader](https://github.com/timoschlueter/nightscout-librelink-up), or your loop's built-in uploader) and then connect that Nightscout here. Anything that flows into Nightscout flows into GlycemicGPT.
+
+## Still stuck?
+
+- Watch the relevant section of the [Troubleshooting guide](../troubleshooting/index.md).
+- Ask on [Discord](https://discord.gg/QbyhCQKDBs) -- include the integration name, what step you're on, and any error message you see.
+- File an issue at [github.com/GlycemicGPT/GlycemicGPT/issues](https://github.com/GlycemicGPT/GlycemicGPT/issues/new/choose). Include your platform version and how you deployed (Docker / k8s / self-built).

--- a/docs/daily-use/integrations.md
+++ b/docs/daily-use/integrations.md
@@ -1,23 +1,21 @@
 ---
 title: Integrations
-description: Connect GlycemicGPT to Dexcom, Tandem, Nightscout, and the other data sources / notification channels that make up your diabetes setup.
+description: Connect GlycemicGPT to Dexcom, Tandem, Nightscout, and other data sources that flow your diabetes data into the platform.
 ---
 
-GlycemicGPT is designed to sit alongside the tools you already use -- your CGM's app, your pump's cloud, and (if you have one) your Nightscout instance. Integrations are how the platform gets your data and how it talks back out to you.
+GlycemicGPT is designed to sit alongside the tools you already use -- your CGM's app, your pump's cloud, and (if you have one) your Nightscout instance. Integrations are how the platform gets your data in.
 
 This page is the index. Each integration with a longer setup flow has its own page; the short ones are documented in full here.
 
-> **One-line mental model.** Integrations either **pull data in** (CGM cloud, pump cloud, Nightscout) or **push notifications out** (Telegram, email, web push). Set them up once in **Settings → Integrations**; everything else is automatic.
+> **One-line mental model.** An integration is a connection that pulls your diabetes data into GlycemicGPT -- from your CGM cloud, your pump cloud, or your Nightscout site. Set it up once in **Settings → Integrations**; the platform polls on a schedule from there.
 
 ## What's available
 
-| Integration | Direction | Use it if you... | Setup |
+| Integration | What it brings in | Use it if you... | Setup |
 |---|---|---|---|
-| [Dexcom](./connecting-dexcom.md) | Pull (CGM) | Have a Dexcom G6 / G7 / ONE+ and want real-time glucose | Dexcom email + password |
-| [Tandem Cloud](./connecting-tandem-cloud.md) | Pull (pump, both ways) | Have a t:slim X2 or Mobi and want pump history + IoB | Tandem email + password |
-| [Nightscout](#nightscout) | Pull (CGM + pump + treatments) | Already run a Nightscout site -- often with a CGM we don't speak directly to (Libre, Eversense, etc.) | Nightscout URL + API_SECRET |
-| [Telegram bot](#telegram-bot) | Push (notifications + chat) | Want alerts and a portable AI chat in Telegram | Bot token from `@BotFather` |
-| [AI provider](#ai-providers-byoai) | Push (analysis) | Want AI briefs and AI chat over your own data | Subscription, your own API key, or a self-hosted model |
+| [Dexcom](./connecting-dexcom.md) | Real-time glucose | Have a Dexcom G6 / G7 / ONE+ | Dexcom email + password |
+| [Tandem Cloud](./connecting-tandem-cloud.md) | Pump history, boluses, basal, IoB | Have a t:slim X2 or Mobi | Tandem email + password |
+| [Nightscout](#nightscout) | CGM entries, treatments, devicestatus, profile | Already run a Nightscout site -- often with a CGM we don't speak directly to (Libre, Eversense, Medtronic, etc.) | Nightscout URL + API_SECRET |
 
 Everything lives at **Settings → Integrations** on the dashboard.
 
@@ -116,44 +114,6 @@ You can have **more than one** Nightscout connection -- common pattern for careg
 - **"401 / 403."** API_SECRET or token is wrong, or your Nightscout has scope-restricted authentication. Try regenerating a token from your Nightscout admin page.
 - **The chart still has gaps after a sync.** A known limitation -- if your Nightscout's uploader had a disconnect and backfilled into Nightscout after our sync cursor advanced, we may not pick those records up. Workaround: delete and re-create the connection with a wider initial sync window, or contact support. Tracked in [GitHub issue #598](https://github.com/GlycemicGPT/GlycemicGPT/issues/598).
 - **No profile detected.** Some Nightscout sites have profile auto-discovery turned off. You can still use the connection for data import; you'll need to set glucose / insulin settings manually under **Settings**.
-
----
-
-## Telegram bot
-
-The Telegram integration is GlycemicGPT's portable extension. Once it's set up you can:
-
-- Receive alerts on Telegram (warning / critical glucose, predictive low, escalation).
-- Get your daily brief pushed to a Telegram chat.
-- Ask the same AI chat questions you'd ask on the dashboard, from anywhere.
-- Caregivers can be granted read-only access via the same bot without giving them dashboard credentials.
-
-### Setup
-
-1. On Telegram, message [@BotFather](https://t.me/BotFather) and run `/newbot`. Pick a name and username for **your** bot.
-2. BotFather sends you a **bot token** that looks like `123456789:AAH...`. Copy it.
-3. In GlycemicGPT, go to **Settings → Integrations → Telegram** and paste the token. Save.
-4. Open Telegram and send `/start` to your new bot. The bot links your Telegram account to your GlycemicGPT user.
-
-That's it. You can now send commands like `/brief`, `/glucose`, `/iob`, or just ask the bot a question.
-
-> **Privacy.** Your bot token belongs to **your** Telegram account, not GlycemicGPT's. The platform stores it encrypted and uses it to send messages on your behalf. If you ever rotate the token in BotFather, paste the new one back in.
-
----
-
-## AI providers (BYOAI)
-
-GlycemicGPT's AI features -- daily / weekly briefs and AI chat -- need an AI provider. You bring your own. The platform supports:
-
-- **Anthropic** (Claude) -- API key from [console.anthropic.com](https://console.anthropic.com).
-- **OpenAI** (GPT-4, GPT-4o) -- API key from [platform.openai.com](https://platform.openai.com).
-- **Google** (Gemini) -- API key from [aistudio.google.com](https://aistudio.google.com).
-- **Subscription** -- a GlycemicGPT-hosted subscription tier (no API key, billed through the platform).
-- **Self-hosted / BYOAI** -- any OpenAI-compatible endpoint (Ollama, llama.cpp, vLLM, your own runtime) by URL. Useful if you want everything to stay on your network.
-
-Configure under **Settings → AI**. You can switch providers without losing your chat history -- AI chat responses are stored locally regardless of who generated them.
-
-> **Switching providers.** Different providers produce different writing styles in briefs and different answer quality in chat. Try a few; the platform doesn't lock you in.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,9 +72,9 @@ The honest matrix. "Verified" means daily-tested on real hardware; "expected to 
 | Dexcom G7 | **Verified** | Cloud-API path, polled from Dexcom every 5-10 min. Project lead's daily-driver CGM. |
 | Dexcom G6 | **Expected to work** | Same cloud-API path as G7 (pydexcom supports both); not continuously tested by the project. |
 | Dexcom Stelo | **Not yet** | Planned once the underlying library adds Stelo support. |
-| Freestyle Libre 2 / 3 / 3+ | **Not supported today** | Roadmap. Recommended path until then: xDrip+ → Nightscout, then Phase 2 Nightscout integration. |
-| Eversense | **Not supported today** | Roadmap. |
-| Medtronic Guardian | **Not supported today** | Tied to Medtronic pump support; see roadmap. |
+| Freestyle Libre 2 / 3 / 3+ | **Via Nightscout** | Upload via LibreLinkUp-Uploader or xDrip+, then connect [Nightscout](./daily-use/integrations.md#nightscout). |
+| Eversense | **Via Nightscout** | Upload to Nightscout via the official Eversense bridge / xDrip+, then connect [Nightscout](./daily-use/integrations.md#nightscout). |
+| Medtronic Guardian | **Via Nightscout** | Upload via [MM Connect](https://github.com/cjo20/Medtronic-Carelink-Uploader-Heroku) or similar, then connect [Nightscout](./daily-use/integrations.md#nightscout). Direct Medtronic support is roadmap. |
 
 ### Insulin pumps
 
@@ -89,7 +89,7 @@ The honest matrix. "Verified" means daily-tested on real hardware; "expected to 
 
 For Tandem users: the Bluetooth and cloud paths complement each other -- Bluetooth gives live data, cloud fills in history. Most people end up using both. See [Connecting Your Tandem Pump](./daily-use/connecting-tandem-cloud.md).
 
-If your device isn't here today, the path forward is usually [Nightscout integration (Phase 2)](./concepts/relationship-to-other-tools.md#nightscout) -- once that lands, anything that flows into Nightscout flows into GlycemicGPT. See [ROADMAP.md](https://github.com/GlycemicGPT/GlycemicGPT/blob/main/ROADMAP.md) for the full picture.
+If your device isn't here today, the path forward is usually the [Nightscout integration](./daily-use/integrations.md#nightscout) -- anything that flows into Nightscout (via xDrip+, LibreLinkUp, Medtronic-Carelink-Uploader, your loop, etc.) flows into GlycemicGPT once the connection is set up. See [ROADMAP.md](https://github.com/GlycemicGPT/GlycemicGPT/blob/main/ROADMAP.md) for the full picture of direct integrations.
 
 ## What's distinctive
 


### PR DESCRIPTION
## Summary

- New page **\`docs/daily-use/integrations.md\`** -- the umbrella user-facing integrations page. Covers Dexcom, Tandem Cloud, Nightscout (full setup walkthrough including the smart-onboarding wizard), Telegram, and BYOAI provider configuration. Linked from the Daily Use nav.
- Updated existing docs that still described Nightscout as a Phase 2 roadmap item: \`docs/index.md\`, \`docs/daily-use/connecting-dexcom.md\`, \`docs/concepts/relationship-to-other-tools.md\`, \`docs/concepts/glossary.md\`, \`docs/daily-use/data-export.md\`.
- Tone matches the existing per-device docs: aimed at normal users, not engineers; explains the \"why\" before the \"how\"; talks about the Settings UI by name; links out to deeper docs where they exist.

## What stays accurate

- Tidepool integration is still described as roadmap.
- Direct support for Libre, Eversense, and Medtronic Guardian remains roadmap -- but the docs now point users at the Nightscout-bridged path as the supported workaround today.
- AGP / Tidepool / Nightscout-format **exports** are still roadmap. Only the **import** side via Nightscout is now live.

## Test plan

- [x] \`integrations.md\` renders in the docs site (Nextra) without broken anchor links.
- [x] \`_meta.json\` ordering puts Integrations between Dashboard and Connecting Dexcom.
- [ ] Visual review of the docs site once Vercel preview deploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive integrations page with setup guides for Nightscout, Dexcom, Telegram, and AI providers.
  * Updated device compatibility matrix to include non-Dexcom CGM support (Freestyle Libre, Eversense, Medtronic Guardian) via Nightscout.
  * Enhanced Nightscout integration documentation with configuration, wizard setup, and troubleshooting.
  * Clarified data flow and positioning relative to other diabetes management tools.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/599)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->