### PR TITLE
fix(ci): single-shot release-body extraction (no historical bleed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -484,13 +484,36 @@ jobs:
           TAG: ${{ steps.version-info.outputs.tag_name }}
           VERSION: ${{ steps.version-info.outputs.version }}
         run: |
-          # Extract the latest dated section from CHANGELOG.md
-          # (populated by changelog-pr.yml with @username contributor credits)
-          BODY=$(sed -n '/^## [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/,/^\(## [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\|<!-- changelog-cutoff:\)/{
-            /^## [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/!{
-              /^\(## [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\|<!-- changelog-cutoff:\)/!p
+          # Extract ONLY the latest dated section from CHANGELOG.md.
+          #
+          # CHANGELOG layout per `changelog-pr.yml`:
+          #
+          #   ## YYYY-MM-DD          <- latest release heading
+          #   ...latest entries...
+          #   <!-- changelog-cutoff:YYYY-MM-DDTHH:MM:SSZ -->
+          #
+          #   ## YYYY-MM-DD          <- previous release heading
+          #   ...previous entries...
+          #   <!-- changelog-cutoff:... -->
+          #
+          # The previous implementation used a `sed -n /START/,/END/` address
+          # range. sed range matching is **recurring** -- once the closing
+          # address matches, sed keeps scanning and re-opens a new range on
+          # the next `## YYYY-MM-DD` heading. The net result was that every
+          # release's body included entries going back to the beginning of
+          # the changelog. Awk with an `exit` after the first range close
+          # gives single-shot extraction.
+          BODY=$(awk '
+            /^## [0-9]{4}-[0-9]{2}-[0-9]{2}/ {
+              if (in_section) exit
+              in_section = 1
+              next
             }
-          }' CHANGELOG.md)
+            /^<!-- changelog-cutoff:/ {
+              if (in_section) exit
+            }
+            in_section { print }
+          ' CHANGELOG.md)
 
           if [ -n "$BODY" ]; then
             {


### PR DESCRIPTION
## Bug

GitHub Release bodies created by \`release.yml\` -> \`update-release-body\` include the **entire CHANGELOG history**, not just the current release's entries.

For example, the v0.6.0 release body (just published) contained entries from v0.5.0, v0.4.x, v0.3.x, and v0.2.0 -- including breaking-changes labels (\"💥 Breaking Changes\") from a past release re-tagged into the current one. Not just visually annoying -- legitimately misleading to anyone reading the release page for change scope.

## Root cause

The workflow uses a \`sed -n /START/,/END/\` address-range form. **sed range matching is recurring**: once the closing pattern matches, sed keeps scanning. On the next \`## YYYY-MM-DD\` heading sed reopens a new range. Net effect: every dated section in CHANGELOG.md gets printed.

## Fix

Replace the recurring sed range with awk that \`exit\`s on first close.

## Verified locally

Against the actual CHANGELOG.md on main:

| Extractor | Lines emitted | Status |
|---|---|---|
| Old sed range | 217 | ❌ includes v0.5.0 / v0.4.x / v0.3.x / v0.2.0 sections |
| New awk | 86 | ✅ exactly v0.6.0's section (the one between \`## 2026-05-11\` and its cutoff marker) |

## Test plan

- [x] Lint: awk script is portable POSIX-ish (no GNU extensions)
- [x] Tested against current \`CHANGELOG.md\` on main -- 86 lines vs 217 lines
- [ ] Verify on next release that the body shows only the current release's entries
- [ ] Retroactively patch the v0.6.0 release body (follow-up after merge; tracked separately)

## Follow-up

Historical releases (v0.5.0 and earlier) all have the same bloated body. Optional cleanup: re-extract and \`gh release edit --notes-file\` each one. Low value for going-forward UX, but worth a pass if release notes get linked from public-facing docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release notes generation to include only the latest changelog entry, preventing older entries from being inadvertently included in release bodies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/605)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->