### PR TITLE
fix(web): hide soft-deleted Nightscout connections from the list

### DIFF
--- a/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
+++ b/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for NightscoutIntegrationsSection.
+ *
+ * Specifically validates that soft-deleted (`is_active=false`) connections
+ * are hidden from the list. The backend's DELETE endpoint deactivates
+ * rather than hard-deleting to preserve attribution on historical
+ * pump_events (`source = "nightscout:<id>"`), but the list endpoint
+ * still returns those rows -- the UI is responsible for filtering.
+ *
+ * Regression coverage for: users reported clicking Delete appeared to do
+ * nothing because the soft-deleted row immediately re-appeared on refetch.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { NightscoutIntegrationsSection } from "../../src/components/integrations/nightscout-integrations-section";
+import type { NightscoutConnectionResponse } from "../../src/lib/api";
+
+// framer-motion shows up via CollapsibleSection -- mock to avoid jsdom
+// animation noise.
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode;
+      [key: string]: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+function makeConn(
+  overrides: Partial<NightscoutConnectionResponse>
+): NightscoutConnectionResponse {
+  return {
+    id: "00000000-0000-0000-0000-000000000000",
+    name: "Test connection",
+    base_url: "https://example.org",
+    auth_type: "auto",
+    api_version: "v1",
+    is_active: true,
+    has_credential: true,
+    sync_interval_minutes: 5,
+    initial_sync_window_days: 7,
+    last_sync_status: "ok",
+    last_synced_at: "2026-05-11T00:00:00Z",
+    last_sync_error: null,
+    detected_uploaders_json: null,
+    last_evaluated_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const noopHandlers = {
+  onCreate: jest.fn(),
+  onDelete: jest.fn(),
+  onTest: jest.fn(),
+  onSync: jest.fn(),
+  onUpdate: jest.fn(),
+};
+
+describe("NightscoutIntegrationsSection -- is_active filter", () => {
+  it("renders only active connections in the list", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[
+          makeConn({ id: "active-1", name: "Active One" }),
+          makeConn({ id: "inactive-1", name: "Soft Deleted", is_active: false }),
+          makeConn({ id: "active-2", name: "Active Two" }),
+        ]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    // Active rows are present.
+    expect(screen.getByText("Active One")).toBeInTheDocument();
+    expect(screen.getByText("Active Two")).toBeInTheDocument();
+
+    // Soft-deleted row is gone (this is the regression -- previously it
+    // rendered alongside the active ones).
+    expect(screen.queryByText("Soft Deleted")).not.toBeInTheDocument();
+  });
+
+  it("reports the count of active connections only", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[
+          makeConn({ id: "a", name: "Alpha" }),
+          makeConn({ id: "b", name: "Beta", is_active: false }),
+          makeConn({ id: "c", name: "Gamma", is_active: false }),
+        ]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    // "1 connection" (singular) -- because only Alpha is active.
+    expect(screen.getByText(/1 connection/)).toBeInTheDocument();
+    expect(screen.queryByText(/3 connection/)).not.toBeInTheDocument();
+  });
+
+  it("hides the connections list entirely when all connections are inactive", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[
+          makeConn({ id: "a", name: "Alpha", is_active: false }),
+          makeConn({ id: "b", name: "Beta", is_active: false }),
+        ]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    expect(
+      screen.queryByTestId("nightscout-connections-list")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/integrations/nightscout-integrations-section.tsx
+++ b/apps/web/src/components/integrations/nightscout-integrations-section.tsx
@@ -107,6 +107,14 @@ export function NightscoutIntegrationsSection({
   onSync,
   onUpdate,
 }: NightscoutIntegrationsSectionProps) {
+  // The backend DELETE is a soft-delete that flips `is_active = false`
+  // (preserves `source = "nightscout:<id>"` attribution on historical
+  // pump_events). The list endpoint intentionally returns inactive
+  // rows so the UI can group them. Until a dedicated "deactivated
+  // history" affordance ships, we hide them entirely -- otherwise
+  // clicking Delete appears to fail because the soft-deleted row
+  // immediately re-appears on refetch.
+  const activeConnections = connections.filter((c) => c.is_active);
   const [name, setName] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [credential, setCredential] = useState("");
@@ -352,8 +360,8 @@ export function NightscoutIntegrationsSection({
           variant="subsection"
           badge={
             <span className="ml-2 text-xs font-medium text-slate-500">
-              {connections.length} connection
-              {connections.length === 1 ? "" : "s"}
+              {activeConnections.length} connection
+              {activeConnections.length === 1 ? "" : "s"}
             </span>
           }
         >
@@ -367,14 +375,14 @@ export function NightscoutIntegrationsSection({
               uploader).
             </p>
 
-            {connections.length > 0 && (
+            {activeConnections.length > 0 && (
               <ul
                 role="list"
                 aria-label="Nightscout connections"
                 className="space-y-3"
                 data-testid="nightscout-connections-list"
               >
-                {connections.map((conn) => {
+                {activeConnections.map((conn) => {
                   const result = perConnectionResult[conn.id];
                   const showConfirm = confirmDeleteId === conn.id;
                   return (


### PR DESCRIPTION
## Bug report

Users reported that clicking **Delete** on a Nightscout connection appeared to do nothing -- the row stayed in the list. This wasn't specific to one connection; it affects every soft-deleted connection.

## Root cause

The backend's \`DELETE /api/integrations/nightscout/{id}\` is a **soft delete** by design (Story 43.1):

> Hard-delete is intentionally avoided -- ingested rows carry \`source = \"nightscout:<connection_id>\"\` attribution that we want to keep readable in the dashboard even after a user removes the connection.

So DELETE flips \`is_active = false\`, the row stays in the DB, and \`GET /api/integrations/nightscout\` keeps returning it. The backend comment is explicit:

> \"Includes inactive connections so users can see their full history; UI is responsible for grouping active vs deactivated.\"

The wizard PR shipped the integration section without that grouping. Result: every soft-deleted row stayed visible.

## Fix

\`NightscoutIntegrationsSection\` now derives \`activeConnections = connections.filter((c) => c.is_active)\` and uses that for both the count badge and the rendered list.

## Tests

3 jest tests in a new \`__tests__/components/nightscout-integrations-section.test.tsx\`:

- Filter drops inactive rows
- \"N connections\" count reflects active-only
- List disappears entirely when nothing is active

## Manual verification

Playwright against the live dev stack:

| Behavior | Before | After |
|---|---|---|
| Page load with 6 connections (3 inactive in DB) | All 6 visible | 3 active visible, 3 inactive hidden |
| Live click Delete -> Confirm | Row stayed visible until page reload | Row gone in ~400ms |
| \"N connections\" badge | Counted all rows | Counts active only |

## Follow-up (not in this PR)

A future \"Deactivated connections (N)\" collapsed section would give users visibility into soft-deleted rows + a restore path. Tracked separately. For now the safest behavior matches user expectation: Delete = gone from the UI.

Note: re-adding a connection with the same name still works -- there's no uniqueness constraint on \`(user_id, name)\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nightscout integrations section now displays only active connections, filtering out inactive or soft-deleted ones from the user interface.
  * Connection count badge now reflects only active connection count with proper singular/plural text handling.

* **Tests**
  * Added comprehensive test coverage for Nightscout integrations section to validate filtering behavior and proper display of active connections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/610)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->