### PR TITLE
fix(nightscout): swap entries cursor to NS Mongo `_id` (closes #598)

### DIFF
--- a/apps/api/migrations/versions/054_ns_entry_object_id_cursor.py
+++ b/apps/api/migrations/versions/054_ns_entry_object_id_cursor.py
@@ -1,0 +1,50 @@
+"""Add `last_entry_object_id` to nightscout_connections.
+
+Switches the entries cursor from `dateString` (recorded time) to NS's
+MongoDB `_id` (insertion time, monotonically increasing). The old
+cursor missed entries that uploaders backfilled into NS *after* our
+last sync but with `dateString` values from *before* our last sync
+window. The Dexcom Share -> Nightscout bridge is the most common
+example: a brief disconnect causes the bridge to upload missed
+readings later with their original timestamps, which our cursor had
+already advanced past.
+
+Mongo `_id` is monotonic by insertion time regardless of `dateString`,
+so a backfilled entry inserted at T+5min always gets a larger `_id`
+than entries inserted at T. Querying `find[_id][$gt]=<lastSeen>` is
+immune to late uploads with old timestamps.
+
+NULL on existing rows means "no `_id` cursor yet" -- the sync code
+falls back to the legacy `last_synced_at` (dateString-based) cursor
+for the next sync, then locks in the new ObjectId cursor afterward.
+No backfill migration is required; the transition is a single sync
+cycle per connection.
+
+Treatments and devicestatus already use server-side `created_at` and
+are immune to this class of bug. They are intentionally unchanged.
+
+Closes issue #598.
+
+Revision ID: 054_ns_entry_object_id_cursor
+Revises: 053_ai_max_response_tokens
+Create Date: 2026-05-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "054_ns_entry_object_id_cursor"
+down_revision = "053_ai_max_response_tokens"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "nightscout_connections",
+        sa.Column("last_entry_object_id", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("nightscout_connections", "last_entry_object_id")

--- a/apps/api/src/models/nightscout_connection.py
+++ b/apps/api/src/models/nightscout_connection.py
@@ -187,6 +187,19 @@ class NightscoutConnection(Base, TimestampMixin):
         DateTime(timezone=True),
         nullable=True,
     )
+    # Entries cursor by NS Mongo `_id` (insertion-time-monotonic).
+    # Set after each successful entries fetch to the max `_id` from
+    # the returned batch. NULL means "no ObjectId cursor yet" -- the
+    # sync code falls back to the legacy `last_synced_at` (dateString)
+    # cursor for that one sync, then locks in the ObjectId cursor
+    # afterward. The ObjectId cursor is immune to uploaders that
+    # backfill entries with old `dateString` values (issue #598).
+    # Treatments / devicestatus use `created_at` (already server-time)
+    # and don't need this fallback.
+    last_entry_object_id: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+    )
     last_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Discovery metadata (set by Story 43.7 evaluate endpoint).

--- a/apps/api/src/services/integrations/nightscout/client.py
+++ b/apps/api/src/services/integrations/nightscout/client.py
@@ -692,10 +692,12 @@ class NightscoutClient:
         cursor to `max(_id)` from the returned batch.
         """
         if not _is_valid_object_id(since_object_id):
-            # Bad cursor value -- log + skip the filter rather than
-            # 400-ing or empty-returning. Caller will get a full
-            # window which is wrong but at least keeps sync moving;
-            # cursor recovery happens on the next successful fetch.
+            # Bad cursor value -- fail loud at the client boundary so a
+            # corrupted cursor in the DB can't silently send junk to
+            # NS (which would either 400 or return the full window).
+            # The sync layer catches and the next cycle re-attempts;
+            # a persistent bad value will need manual cursor clearing
+            # on the connection row.
             raise ValueError(
                 "since_object_id must be a 24-character hex ObjectId; "
                 f"got {since_object_id!r}"
@@ -726,9 +728,10 @@ _PARSE_FAILED = object()  # sentinel distinct from None / [] / {}
 
 
 def _is_valid_object_id(value: str) -> bool:
-    """24-character lowercase hex string -- the canonical Mongo
-    ObjectId shape NS persists in `_id`. Reject anything else loudly
-    rather than passing junk into the `find[_id][$gt]` filter."""
+    """24-character hex string (case-insensitive) matching the
+    canonical Mongo ObjectId shape NS persists in `_id`. Reject
+    anything else loudly rather than passing junk into the
+    `find[_id][$gt]` filter."""
     if not isinstance(value, str) or len(value) != 24:
         return False
     try:

--- a/apps/api/src/services/integrations/nightscout/client.py
+++ b/apps/api/src/services/integrations/nightscout/client.py
@@ -555,20 +555,37 @@ class NightscoutClient:
         self,
         *,
         since: datetime | None = None,
+        since_object_id: str | None = None,
         count: int = DEFAULT_PAGE_SIZE,
     ) -> list[dict[str, Any]]:
         """Fetch CGM entries newest-first.
 
+        Prefers the `_id`-based cursor when `since_object_id` is set.
+        Mongo `_id` is monotonic by insertion time, so this catches
+        entries that uploaders backfilled into NS with old
+        `dateString` values (issue #598 -- Dexcom Share -> NS bridge
+        is the most common offender). Falls back to `since`
+        (dateString filter) when no ObjectId cursor is available
+        (first-ever sync, or for instances where `_id` isn't returned).
+
         Args:
-            since: only return entries with dateString >= this UTC
-                timestamp. **Must be timezone-aware** (raises ValueError
-                on naive datetimes -- silently treating naive as UTC
-                corrupted wall-clock data on dev machines outside UTC).
-                None = no lower bound (subject to Nightscout's
-                own retention).
+            since: dateString-based fallback cursor. **Must be
+                timezone-aware** (raises ValueError on naive
+                datetimes -- silently treating naive as UTC corrupted
+                wall-clock data on dev machines outside UTC).
+                Ignored when `since_object_id` is provided.
+            since_object_id: NS Mongo `_id` lower bound. Preferred
+                cursor (see issue #598). The 24-char hex ObjectId
+                from a prior fetch's max-id.
             count: page size. Server caps at ~50000 silently.
         """
         self._require_v1_for_fetch("entries")
+        if since_object_id is not None:
+            return await self._fetch_v1_collection_by_id(
+                "/api/v1/entries.json",
+                since_object_id=since_object_id,
+                count=count,
+            )
         return await self._fetch_v1_collection(
             "/api/v1/entries.json",
             since=since,
@@ -658,6 +675,47 @@ class NightscoutClient:
         body = _parse_json_or_none(resp)
         return body if isinstance(body, list) else []
 
+    async def _fetch_v1_collection_by_id(
+        self,
+        path: str,
+        *,
+        since_object_id: str,
+        count: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch a v1 collection with an ObjectId-based lower bound.
+
+        Used for entries to avoid the dateString-cursor backfill miss
+        (issue #598). The 24-char hex ObjectId encodes insertion time
+        in its first 4 bytes; querying `find[_id][$gt]=<lastSeen>`
+        returns everything inserted *after* that ObjectId regardless
+        of `dateString`. Caller is responsible for advancing the
+        cursor to `max(_id)` from the returned batch.
+        """
+        if not _is_valid_object_id(since_object_id):
+            # Bad cursor value -- log + skip the filter rather than
+            # 400-ing or empty-returning. Caller will get a full
+            # window which is wrong but at least keeps sync moving;
+            # cursor recovery happens on the next successful fetch.
+            raise ValueError(
+                "since_object_id must be a 24-character hex ObjectId; "
+                f"got {since_object_id!r}"
+            )
+        params: dict[str, Any] = {
+            "count": count,
+            "find[_id][$gt]": since_object_id,
+        }
+        resp = await self._request(
+            "GET", path, params=params, headers=self._v1_headers()
+        )
+        self._raise_for_auth_or_404(resp, what=path)
+        if resp.status_code != 200:
+            raise NightscoutServerError(
+                f"{path} returned status {resp.status_code}",
+                status_code=resp.status_code,
+            )
+        body = _parse_json_or_none(resp)
+        return body if isinstance(body, list) else []
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -665,6 +723,19 @@ class NightscoutClient:
 
 
 _PARSE_FAILED = object()  # sentinel distinct from None / [] / {}
+
+
+def _is_valid_object_id(value: str) -> bool:
+    """24-character lowercase hex string -- the canonical Mongo
+    ObjectId shape NS persists in `_id`. Reject anything else loudly
+    rather than passing junk into the `find[_id][$gt]` filter."""
+    if not isinstance(value, str) or len(value) != 24:
+        return False
+    try:
+        int(value, 16)
+        return True
+    except ValueError:
+        return False
 
 
 def _parse_json_or_none(resp: httpx.Response) -> Any:

--- a/apps/api/src/services/integrations/nightscout/sync.py
+++ b/apps/api/src/services/integrations/nightscout/sync.py
@@ -9,15 +9,23 @@ Drives the four translator entry points against a single
   which calls this once per due connection on each tick.
 
 `since` semantics:
-- First sync (no `last_synced_at`): default backfill window from
+- First sync (no cursor yet): default backfill window from
   `initial_sync_window_days` (0 = unbounded for entries/treatments;
   always capped at 30 days for devicestatus to bound blast radius).
-- Subsequent syncs: `last_synced_at` (timezone-aware UTC).
+- Subsequent syncs (entries): `last_entry_object_id` -- NS's Mongo
+  `_id` from the last response. Mongo ObjectId is monotonic by
+  insertion time, so this catches entries that uploaders backfilled
+  into NS with `dateString` values from before our last sync
+  (Dexcom Share -> NS bridge is the most common offender; issue #598).
+- Subsequent syncs (treatments / devicestatus): `last_synced_at` --
+  these endpoints already query by NS server-side `created_at`, which
+  is monotonic by insertion time, so they're immune to the late-upload
+  class of bug that hit entries.
 
-`last_synced_at` advancement: only on full success (all four
-translate calls returned without raising). On any partial failure the
-status / error are recorded but the cursor stays put so the next run
-re-fetches the same window. Documented + tested in `test_sync.py`.
+Cursor advancement: only on full success (all four translate calls
+returned without raising). On any partial failure the status / error
+are recorded but the cursor stays put so the next run re-fetches the
+same window. Documented + tested in `test_sync.py`.
 
 Exception mapping:
 - NightscoutAuthError              -> AUTH_FAILED
@@ -208,6 +216,15 @@ async def _do_sync(session: AsyncSession, conn: NightscoutConnection) -> SyncRes
     error_msg: str | None = None
     status = NightscoutSyncStatus.OK
 
+    # Entries use NS's Mongo `_id` cursor when available -- immune to
+    # uploaders backfilling entries with old `dateString` timestamps
+    # (issue #598; Dexcom Share -> NS bridge is the most common
+    # offender). First sync after the 054 migration has no ObjectId
+    # cursor yet, so we fall back to the legacy `last_synced_at`
+    # cursor for that one cycle and lock in the new cursor after.
+    last_entry_object_id = conn.last_entry_object_id
+    new_entry_object_id: str | None = None
+
     try:
         async with await NightscoutClient.create(
             base_url=conn.base_url,
@@ -216,8 +233,19 @@ async def _do_sync(session: AsyncSession, conn: NightscoutConnection) -> SyncRes
             api_version=conn.api_version,
         ) as client:
             entries = await client.fetch_entries(
-                since=_resolve_since(last_synced, window_days, now)
+                since=_resolve_since(last_synced, window_days, now),
+                since_object_id=last_entry_object_id,
             )
+            # Advance the cursor to the largest `_id` in the response.
+            # NS returns entries newest-first, so the head row is the
+            # max by insertion time. Missing `_id` (rare; some legacy
+            # NS plugins strip it) leaves the cursor at its prior
+            # value -- worst case is we re-fetch on next sync, dedupe
+            # handles it.
+            if entries:
+                head_id = entries[0].get("_id")
+                if isinstance(head_id, str) and len(head_id) == 24:
+                    new_entry_object_id = head_id
             treatments = await client.fetch_treatments(
                 since=_resolve_since(last_synced, window_days, now)
             )
@@ -282,11 +310,17 @@ async def _do_sync(session: AsyncSession, conn: NightscoutConnection) -> SyncRes
             user_id=user_id_str,
         )
 
-    # Persist status + (only on success) advance the cursor.
+    # Persist status + (only on success) advance the cursors.
     conn.last_sync_status = status
     conn.last_sync_error = error_msg
     if status == NightscoutSyncStatus.OK:
         conn.last_synced_at = now
+        # Only advance the ObjectId cursor when we actually saw a new
+        # row. NULL preserves "no cursor yet" semantics on the very
+        # first sync if the upstream had zero entries -- next cycle
+        # will retry from the time-window fallback.
+        if new_entry_object_id is not None:
+            conn.last_entry_object_id = new_entry_object_id
     await session.commit()
 
     duration_ms = int((time.monotonic() - started) * 1000)

--- a/apps/api/tests/test_nightscout_client.py
+++ b/apps/api/tests/test_nightscout_client.py
@@ -424,6 +424,66 @@ class TestFetchEntries:
             await c.fetch_entries(since=naive)
 
 
+class TestFetchEntriesByObjectId:
+    """Issue #598: entries cursor swaps to NS Mongo `_id` to avoid
+    missing entries that uploaders backfilled into NS with old
+    `dateString` values (Dexcom Share -> NS bridge being the canonical
+    offender)."""
+
+    @pytest.mark.asyncio
+    async def test_uses_find_id_gt_when_object_id_provided(self):
+        c = _make_client()
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_entries(since_object_id="6a001f288e31759edc8c0d25")
+        params = mock_request.call_args.kwargs["params"]
+        assert params["find[_id][$gt]"] == "6a001f288e31759edc8c0d25"
+        # dateString filter is NOT sent when ObjectId cursor is in play
+        # -- it would over-constrain and silently drop late-uploaded
+        # entries from a window that's now in the past.
+        assert "find[dateString][$gte]" not in params
+
+    @pytest.mark.asyncio
+    async def test_object_id_takes_precedence_over_since(self):
+        """When both cursors are passed, ObjectId wins. Sync wires
+        both during the first cycle after migration 054; we must NOT
+        AND them together (would re-introduce the backfill miss)."""
+        c = _make_client()
+        since = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_entries(
+                since=since,
+                since_object_id="6a001f288e31759edc8c0d25",
+            )
+        params = mock_request.call_args.kwargs["params"]
+        assert "find[_id][$gt]" in params
+        assert "find[dateString][$gte]" not in params
+
+    @pytest.mark.asyncio
+    async def test_invalid_object_id_raises_value_error(self):
+        """Bad cursor value should fail loud at the client boundary
+        rather than send junk to NS. Sync code catches and retries
+        the next cycle with the time-window fallback."""
+        c = _make_client()
+        with pytest.raises(ValueError, match="24-character hex ObjectId"):
+            await c.fetch_entries(since_object_id="not-an-object-id")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_datestring_when_no_object_id(self):
+        """First sync after migration 054 has no ObjectId cursor yet.
+        Client falls back to the legacy dateString filter so we still
+        get a bounded window."""
+        c = _make_client()
+        since = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_entries(since=since)
+        params = mock_request.call_args.kwargs["params"]
+        assert params["find[dateString][$gte]"] == "2026-05-01T12:00:00Z"
+        assert "find[_id][$gt]" not in params
+
+
 # ---------------------------------------------------------------------------
 # fetch_profile
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_nightscout_sync.py
+++ b/apps/api/tests/test_nightscout_sync.py
@@ -282,3 +282,123 @@ class TestSyncOutcome:
             .all()
         )
         assert len(rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# Entries ObjectId cursor (issue #598)
+# ---------------------------------------------------------------------------
+
+
+class TestEntriesObjectIdCursor:
+    """Issue #598: entries cursor switched from `dateString` (recorded
+    time, vulnerable to backfill) to NS Mongo `_id` (insertion time,
+    monotonic). These tests pin the sync flow's wiring so a future
+    refactor can't silently regress us back to the old behavior."""
+
+    _VALID_OBJECT_ID = "6a001f288e31759edc8c0d25"
+    _NEW_OBJECT_ID = "6a001f338e31759edc8c0d74"  # larger than the first
+
+    @pytest.mark.asyncio
+    async def test_first_sync_passes_no_object_id(self, sync_ctx):
+        """No cursor yet -> sync passes since_object_id=None, client
+        falls back to the dateString-window filter."""
+        session, conn = sync_ctx
+        assert conn.last_entry_object_id is None
+
+        client_mock = _mk_client_mock(
+            entries=[
+                {
+                    "_id": self._VALID_OBJECT_ID,
+                    "type": "sgv",
+                    "sgv": 120,
+                    "dateString": "2026-05-10T12:00:00.000Z",
+                    "device": "xdrip",
+                }
+            ],
+        )
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            await sync_nightscout_for_connection(session, conn)
+
+        # The first sync calls with since_object_id=None (the column
+        # was NULL going in).
+        kwargs = client_mock.fetch_entries.call_args.kwargs
+        assert kwargs.get("since_object_id") is None
+        # After the sync the cursor is locked in for future cycles.
+        await session.refresh(conn)
+        assert conn.last_entry_object_id == self._VALID_OBJECT_ID
+
+    @pytest.mark.asyncio
+    async def test_subsequent_sync_uses_object_id_cursor(self, sync_ctx):
+        """Second sync passes the stored ObjectId, bypassing the
+        backfill-vulnerable dateString filter."""
+        session, conn = sync_ctx
+        conn.last_entry_object_id = self._VALID_OBJECT_ID
+        await session.commit()
+
+        client_mock = _mk_client_mock(
+            entries=[
+                {
+                    "_id": self._NEW_OBJECT_ID,
+                    "type": "sgv",
+                    "sgv": 130,
+                    "dateString": "2026-05-10T12:05:00.000Z",
+                    "device": "xdrip",
+                }
+            ],
+        )
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            await sync_nightscout_for_connection(session, conn)
+
+        kwargs = client_mock.fetch_entries.call_args.kwargs
+        assert kwargs.get("since_object_id") == self._VALID_OBJECT_ID
+        await session.refresh(conn)
+        assert conn.last_entry_object_id == self._NEW_OBJECT_ID
+
+    @pytest.mark.asyncio
+    async def test_cursor_stays_put_on_failure(self, sync_ctx):
+        """Same guarantee as `last_synced_at`: failed sync does NOT
+        advance the cursor. Next attempt re-fetches from the same
+        starting point so we don't lose entries to a transient blip."""
+        session, conn = sync_ctx
+        conn.last_entry_object_id = self._VALID_OBJECT_ID
+        await session.commit()
+
+        client_mock = _mk_client_mock(
+            fetch_exception=NightscoutNetworkError("connection reset")
+        )
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            result = await sync_nightscout_for_connection(session, conn)
+
+        assert result.status == NightscoutSyncStatus.NETWORK
+        await session.refresh(conn)
+        assert conn.last_entry_object_id == self._VALID_OBJECT_ID
+
+    @pytest.mark.asyncio
+    async def test_empty_response_keeps_existing_cursor(self, sync_ctx):
+        """When NS returns zero entries (no new data this cycle), the
+        cursor must not get clobbered to NULL -- next cycle would
+        re-fetch a wide window and burn bandwidth. Existing cursor
+        stays in place."""
+        session, conn = sync_ctx
+        conn.last_entry_object_id = self._VALID_OBJECT_ID
+        await session.commit()
+
+        client_mock = _mk_client_mock(entries=[])
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            result = await sync_nightscout_for_connection(session, conn)
+
+        assert result.status == NightscoutSyncStatus.OK
+        await session.refresh(conn)
+        assert conn.last_entry_object_id == self._VALID_OBJECT_ID


### PR DESCRIPTION
Closes #598.

## What the user saw

Discord report from a tester running Dexcom -> Nightscout (Dexcom Share bridge into NS, then GlycemicGPT pulling from NS). Chart on GlycemicGPT showed irregular gaps in the CGM stream even though NS itself had the data.

## Root cause

Our entries cursor queried NS with \`find[dateString][\$gte]=<last_synced_at>\`. \`dateString\` is the **recorded time** of the reading. When the Dexcom Share bridge had a transient disconnect and later backfilled the missed readings, the backfilled entries went into NS with their ORIGINAL recorded timestamps -- which were already *behind* our cursor. We never refetched that window, so the backfilled entries silently disappeared from GlycemicGPT.

This is a class of bug: any uploader that backfills late (Dexcom Share, LibreLinkUp, anything with a queue-and-flush model) hits this.

## Fix

Switch the entries cursor to NS's Mongo \`_id\` (ObjectId). Mongo ObjectIds are **monotonic by insertion time**, regardless of the document's \`dateString\` field. Querying \`find[_id][\$gt]=<last_seen>\` returns everything NS *inserted* after our last cursor -- which includes late-uploaded entries with old timestamps.

- New column \`nightscout_connections.last_entry_object_id TEXT NULL\` (migration 054).
- \`NightscoutClient.fetch_entries(since_object_id=...)\` is the new path. Overrides the legacy time filter when set; rejects malformed cursors loud at the client boundary.
- \`sync._do_sync\` reads the stored cursor, passes it in, advances to \`max(_id)\` from the response on success.
- Cursor stays put on failure (same guarantee as \`last_synced_at\`).
- First sync after migration has NULL cursor -> falls back to the legacy dateString filter for one cycle, locks in the new cursor after.

Treatments / devicestatus already query by NS-side \`created_at\` (insertion time) and are immune; they're intentionally unchanged.

## Important note: this prevents NEW gaps

It does **NOT** retroactively recover entries that were already lost on the affected user's connection. Recovery requires a one-shot rescan (re-fetch the affected window with a wider lookback or with the new ObjectId cursor reset). That's intentionally not in this PR -- separate issue if anyone reports the gap is persisting after the fix lands.

Workaround for the affected user right now: bump their connection's \`initial_sync_window_days\` to 30 or 90 and trigger a manual Sync. Dedupe on \`(source, ns_id)\` makes the rescan idempotent for already-present entries.

## Test plan

- [x] 4 client tests pin the new client contract (ObjectId sent, beats since-time, invalid rejects, fallback to dateString).
- [x] 4 sync-flow tests pin the cursor lifecycle (first sync, subsequent, failure preserves, empty response preserves).
- [x] 60 / 60 NS sync + client tests passing (52 existing + 8 new).
- [x] Ruff lint + format clean.
- [x] Migration applies cleanly against current schema.

## Out of scope (filed / queued separately)

- One-shot rescan tool for users whose entries were already missed (separate issue, file if affected user reports gap persisting after this lands).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightscout entries synchronization now uses a cursor mechanism based on insertion order instead of timestamps, enabling more robust tracking across data backfills, session persistence, and historical data scenarios.

* **Tests**
  * Added comprehensive test suite covering the new entries cursor functionality, including cursor validation, precedence handling, fallback mechanisms, and edge cases in sync behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/611)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->