### PR TITLE
feat(web): Nightscout re-import entry point on existing connection cards (43.7d)

### DIFF
--- a/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
+++ b/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
@@ -164,7 +164,7 @@ describe("NightscoutIntegrationsSection -- re-import button (43.7d)", () => {
     );
   });
 
-  it("disables the re-import link when offline", () => {
+  it("disables the re-import link when offline -- pulls out of tab order and blocks keyboard activation", () => {
     render(
       <NightscoutIntegrationsSection
         connections={[makeConn({ id: "c1", name: "Primary" })]}
@@ -175,6 +175,60 @@ describe("NightscoutIntegrationsSection -- re-import button (43.7d)", () => {
 
     const link = screen.getByTestId("nightscout-reimport-c1");
     expect(link).toHaveAttribute("aria-disabled", "true");
-    expect(link.className).toContain("pointer-events-none");
+    // `aria-disabled` alone is advisory -- Tab + Enter would still
+    // navigate. tabIndex=-1 removes the link from keyboard tab order.
+    expect(link).toHaveAttribute("tabindex", "-1");
+
+    // Pressing Enter must not trigger navigation. We assert by spying
+    // on the keydown event and confirming defaultPrevented flips
+    // to true via our onKeyDown handler.
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    link.dispatchEvent(keyEvent);
+    expect(keyEvent.defaultPrevented).toBe(true);
+
+    // Same for Space.
+    const spaceEvent = new KeyboardEvent("keydown", {
+      key: " ",
+      bubbles: true,
+      cancelable: true,
+    });
+    link.dispatchEvent(spaceEvent);
+    expect(spaceEvent.defaultPrevented).toBe(true);
+
+    // And a click is still blocked (the mouse path).
+    const clickEvent = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    link.dispatchEvent(clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+
+  it("keeps the re-import link tab-able and interactive when online", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[makeConn({ id: "c1", name: "Primary" })]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    const link = screen.getByTestId("nightscout-reimport-c1");
+    expect(link).toHaveAttribute("aria-disabled", "false");
+    // No explicit tabIndex when enabled -- inherits anchor's default (0).
+    expect(link.getAttribute("tabindex")).toBeNull();
+
+    // Enter does NOT get preventDefault'd in the enabled state.
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    link.dispatchEvent(keyEvent);
+    expect(keyEvent.defaultPrevented).toBe(false);
   });
 });

--- a/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
+++ b/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
@@ -122,3 +122,59 @@ describe("NightscoutIntegrationsSection -- is_active filter", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe("NightscoutIntegrationsSection -- re-import button (43.7d)", () => {
+  it("renders a re-import link on every active connection", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[
+          makeConn({ id: "c1", name: "Primary" }),
+          makeConn({ id: "c2", name: "Spouse" }),
+        ]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    const link1 = screen.getByTestId("nightscout-reimport-c1");
+    const link2 = screen.getByTestId("nightscout-reimport-c2");
+    expect(link1).toHaveAttribute(
+      "href",
+      "/dashboard/settings/integrations/nightscout/connect?connection=c1"
+    );
+    expect(link2).toHaveAttribute(
+      "href",
+      "/dashboard/settings/integrations/nightscout/connect?connection=c2"
+    );
+  });
+
+  it("URL-encodes the connection id in the re-import href", () => {
+    // Real ids are UUIDs (no special chars), but the encoder
+    // belt-and-suspenders against odd ids leaking in from future flows.
+    render(
+      <NightscoutIntegrationsSection
+        connections={[makeConn({ id: "id with spaces", name: "Weird" })]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+    const link = screen.getByTestId("nightscout-reimport-id with spaces");
+    expect(link.getAttribute("href")).toContain(
+      "connection=id%20with%20spaces"
+    );
+  });
+
+  it("disables the re-import link when offline", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[makeConn({ id: "c1", name: "Primary" })]}
+        isOffline={true}
+        {...noopHandlers}
+      />
+    );
+
+    const link = screen.getByTestId("nightscout-reimport-c1");
+    expect(link).toHaveAttribute("aria-disabled", "true");
+    expect(link.className).toContain("pointer-events-none");
+  });
+});

--- a/apps/web/src/app/dashboard/settings/integrations/nightscout/connect/page.tsx
+++ b/apps/web/src/app/dashboard/settings/integrations/nightscout/connect/page.tsx
@@ -1,11 +1,28 @@
 "use client";
 
+import { Suspense } from "react";
+import { Loader2 } from "lucide-react";
 import { NightscoutOnboardingWizard } from "@/components/integrations/nightscout-onboarding-wizard";
 
 // Bookmark/refresh-resilient route for the smart-onboarding wizard.
 // Step 4 (first sync) can take ~20s, so this is a real route rather
 // than a modal -- losing the wizard mid-sync to an accidental Esc
 // or click-outside would be bad UX.
+//
+// The wizard calls `useSearchParams()` to support the `?connection=<id>`
+// re-import deep link (Story 43.7d). Next 15 requires that consumer
+// to be inside a Suspense boundary; the fallback below is what the
+// page shows during the static-shell render.
 export default function NightscoutConnectPage() {
-  return <NightscoutOnboardingWizard />;
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center">
+          <Loader2 className="h-6 w-6 text-blue-500 animate-spin" />
+        </div>
+      }
+    >
+      <NightscoutOnboardingWizard />
+    </Suspense>
+  );
 }

--- a/apps/web/src/app/dashboard/settings/integrations/nightscout/connect/page.tsx
+++ b/apps/web/src/app/dashboard/settings/integrations/nightscout/connect/page.tsx
@@ -17,8 +17,13 @@ export default function NightscoutConnectPage() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center">
-          <Loader2 className="h-6 w-6 text-blue-500 animate-spin" />
+        <div
+          role="status"
+          aria-live="polite"
+          className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center"
+        >
+          <Loader2 className="h-6 w-6 text-blue-500 animate-spin" aria-hidden="true" />
+          <span className="sr-only">Loading Nightscout connection wizard…</span>
         </div>
       }
     >

--- a/apps/web/src/components/integrations/nightscout-integrations-section.tsx
+++ b/apps/web/src/components/integrations/nightscout-integrations-section.tsx
@@ -483,32 +483,50 @@ export function NightscoutIntegrationsSection({
                           )}
                         </div>
                         <div className="flex gap-2 shrink-0 flex-wrap">
-                          <Link
-                            href={`/dashboard/settings/integrations/nightscout/connect?connection=${encodeURIComponent(conn.id)}`}
-                            data-testid={`nightscout-reimport-${conn.id}`}
-                            aria-disabled={isOffline || isBusy(conn.id)}
-                            onClick={(e) => {
-                              // Block navigation when offline or another
-                              // action on this row is in flight. Link
-                              // has no native `disabled`; we guard the
-                              // click instead.
-                              if (isOffline || isBusy(conn.id)) {
-                                e.preventDefault();
-                              }
-                            }}
-                            className={clsx(
-                              "px-3 py-1.5 rounded-lg text-xs font-medium",
-                              "border border-purple-500/30 text-purple-400",
-                              "hover:bg-purple-500/10",
-                              "transition-colors flex items-center gap-1",
-                              (isOffline || isBusy(conn.id)) &&
-                                "opacity-50 cursor-not-allowed pointer-events-none"
-                            )}
-                            title="Re-read this Nightscout's profile and pick which updated settings to bring into GlycemicGPT"
-                          >
-                            <Sparkles className="h-3 w-3" />
-                            Re-import
-                          </Link>
+                          {(() => {
+                            const reimportDisabled =
+                              isOffline || isBusy(conn.id);
+                            return (
+                              <Link
+                                href={`/dashboard/settings/integrations/nightscout/connect?connection=${encodeURIComponent(conn.id)}`}
+                                data-testid={`nightscout-reimport-${conn.id}`}
+                                aria-disabled={reimportDisabled}
+                                // `aria-disabled` alone is advisory --
+                                // the Link stays in tab order and
+                                // Enter/Space still navigates. Pull
+                                // it out of tab order AND block
+                                // keyboard activation (Enter/Space)
+                                // when disabled, so keyboard users
+                                // get the same gate as mouse users.
+                                tabIndex={reimportDisabled ? -1 : undefined}
+                                onClick={(e) => {
+                                  if (reimportDisabled) {
+                                    e.preventDefault();
+                                  }
+                                }}
+                                onKeyDown={(e) => {
+                                  if (
+                                    reimportDisabled &&
+                                    (e.key === "Enter" || e.key === " ")
+                                  ) {
+                                    e.preventDefault();
+                                  }
+                                }}
+                                className={clsx(
+                                  "px-3 py-1.5 rounded-lg text-xs font-medium",
+                                  "border border-purple-500/30 text-purple-400",
+                                  "hover:bg-purple-500/10",
+                                  "transition-colors flex items-center gap-1",
+                                  reimportDisabled &&
+                                    "opacity-50 cursor-not-allowed pointer-events-none"
+                                )}
+                                title="Re-read this Nightscout's profile and pick which updated settings to bring into GlycemicGPT"
+                              >
+                                <Sparkles className="h-3 w-3" />
+                                Re-import
+                              </Link>
+                            );
+                          })()}
                           <button
                             type="button"
                             onClick={() => handleSync(conn.id)}

--- a/apps/web/src/components/integrations/nightscout-integrations-section.tsx
+++ b/apps/web/src/components/integrations/nightscout-integrations-section.tsx
@@ -482,7 +482,33 @@ export function NightscoutIntegrationsSection({
                             </p>
                           )}
                         </div>
-                        <div className="flex gap-2 shrink-0">
+                        <div className="flex gap-2 shrink-0 flex-wrap">
+                          <Link
+                            href={`/dashboard/settings/integrations/nightscout/connect?connection=${encodeURIComponent(conn.id)}`}
+                            data-testid={`nightscout-reimport-${conn.id}`}
+                            aria-disabled={isOffline || isBusy(conn.id)}
+                            onClick={(e) => {
+                              // Block navigation when offline or another
+                              // action on this row is in flight. Link
+                              // has no native `disabled`; we guard the
+                              // click instead.
+                              if (isOffline || isBusy(conn.id)) {
+                                e.preventDefault();
+                              }
+                            }}
+                            className={clsx(
+                              "px-3 py-1.5 rounded-lg text-xs font-medium",
+                              "border border-purple-500/30 text-purple-400",
+                              "hover:bg-purple-500/10",
+                              "transition-colors flex items-center gap-1",
+                              (isOffline || isBusy(conn.id)) &&
+                                "opacity-50 cursor-not-allowed pointer-events-none"
+                            )}
+                            title="Re-read this Nightscout's profile and pick which updated settings to bring into GlycemicGPT"
+                          >
+                            <Sparkles className="h-3 w-3" />
+                            Re-import
+                          </Link>
                           <button
                             type="button"
                             onClick={() => handleSync(conn.id)}

--- a/apps/web/src/components/integrations/nightscout-onboarding-wizard.tsx
+++ b/apps/web/src/components/integrations/nightscout-onboarding-wizard.tsx
@@ -23,7 +23,7 @@ import {
   X,
 } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import clsx from "clsx";
 import {
   applyNightscoutOnboarding,
@@ -109,6 +109,11 @@ interface WizardState {
   formError: string | null;
   isCreating: boolean;
   credentialVisible: boolean;
+  // True when the wizard was entered via the re-import deep link
+  // (`/connect?connection=<id>`). Skips Step 1; the credentials
+  // form is unused. Used by the header / cancel UX to hint at
+  // the different intent.
+  isReimport: boolean;
   // Step 2
   connectionId: string | null;
   derivation: OnboardingDerivation | null;
@@ -143,6 +148,7 @@ const INITIAL_STATE: WizardState = {
   formError: null,
   isCreating: false,
   credentialVisible: false,
+  isReimport: false,
   connectionId: null,
   derivation: null,
   discovery: null,
@@ -334,9 +340,42 @@ function anyGlucoseDomainImported(imports: ImportFlags): boolean {
 // Wizard
 // ----------------------------------------------------------------------------
 
+// 36 hex chars + 4 hyphens. Cheap shape-check before we trust an
+// untrusted query-param value enough to seed wizard state with it.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function deriveInitialState(connectionParam: string | null): WizardState {
+  if (connectionParam && UUID_RE.test(connectionParam)) {
+    // Re-import deep link: skip Step 1 (credentials already exist on
+    // the connection), seed the connection id, jump straight to the
+    // evaluating step. The effect that fires on `step === "evaluating"`
+    // picks it up from there.
+    return {
+      ...INITIAL_STATE,
+      isReimport: true,
+      connectionId: connectionParam,
+      step: "evaluating",
+    };
+  }
+  return INITIAL_STATE;
+}
+
 export function NightscoutOnboardingWizard() {
   const router = useRouter();
-  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+  const searchParams = useSearchParams();
+  // Read once at mount. Changing the URL mid-wizard doesn't re-seed
+  // (intentional: avoids state thrash if the user copy-pastes a link
+  // into the same tab while the wizard is in flight).
+  const initialConnection = useMemo(
+    () => searchParams?.get("connection") ?? null,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+  const [state, dispatch] = useReducer(
+    reducer,
+    initialConnection,
+    deriveInitialState
+  );
 
   // Kick the evaluate + derive chain when we enter step 2. Using
   // ref-as-cache-key so React-strict-mode double-mount in dev
@@ -524,7 +563,7 @@ export function NightscoutOnboardingWizard() {
       data-testid="nightscout-wizard"
     >
       <div className="max-w-3xl mx-auto px-4 sm:px-6 py-8">
-        <WizardHeader currentStep={state.step} />
+        <WizardHeader currentStep={state.step} isReimport={state.isReimport} />
         <div className="mt-6">
           {state.step === "credentials" && (
             <CredentialsStep
@@ -576,6 +615,7 @@ export function NightscoutOnboardingWizard() {
           {state.step === "done" && state.applyResult && (
             <DoneStep
               result={state.applyResult}
+              isReimport={state.isReimport}
               onGoToIntegrations={() =>
                 router.push("/dashboard/settings/integrations")
               }
@@ -592,17 +632,26 @@ export function NightscoutOnboardingWizard() {
 // Header / stepper
 // ----------------------------------------------------------------------------
 
-function WizardHeader({ currentStep }: { currentStep: StepId }) {
+function WizardHeader({
+  currentStep,
+  isReimport,
+}: {
+  currentStep: StepId;
+  isReimport: boolean;
+}) {
   const currentIndex = STEPS.findIndex((s) => s.id === currentStep);
   return (
     <div>
       <div className="flex items-center gap-3 text-slate-700 dark:text-slate-200">
         <Wifi className="h-5 w-5 text-blue-500" />
-        <h1 className="text-xl font-semibold">Connect Nightscout</h1>
+        <h1 className="text-xl font-semibold">
+          {isReimport ? "Re-import from Nightscout" : "Connect Nightscout"}
+        </h1>
       </div>
       <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-        Read your existing Nightscout profile and pre-fill your GlycemicGPT
-        settings so you don&apos;t start from a blank dashboard.
+        {isReimport
+          ? "Re-read your Nightscout profile and pick which updated values to bring into GlycemicGPT. Your existing connection isn't recreated."
+          : "Read your existing Nightscout profile and pre-fill your GlycemicGPT settings so you don't start from a blank dashboard."}
       </p>
       <ol
         className="mt-5 flex items-center gap-2 text-xs"
@@ -1563,12 +1612,14 @@ function ApplyingStep() {
 
 interface DoneStepProps {
   result: NightscoutApplyOnboardingResponse;
+  isReimport: boolean;
   onGoToIntegrations: () => void;
   onGoToDashboard: () => void;
 }
 
 function DoneStep({
   result,
+  isReimport,
   onGoToIntegrations,
   onGoToDashboard,
 }: DoneStepProps) {
@@ -1595,14 +1646,14 @@ function DoneStep({
       <div className="flex items-center gap-2 text-green-500">
         <Check className="h-5 w-5" />
         <h2 className="text-base font-medium text-slate-700 dark:text-slate-200">
-          Connected
+          {isReimport ? "Settings updated" : "Connected"}
         </h2>
       </div>
 
       {appliedFields.length > 0 ? (
         <div className="mt-3">
           <p className="text-sm text-slate-500 dark:text-slate-400">
-            We imported:
+            {isReimport ? "We refreshed:" : "We imported:"}
           </p>
           <ul
             className="mt-1 space-y-1"
@@ -1621,8 +1672,9 @@ function DoneStep({
         </div>
       ) : (
         <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
-          No settings were imported. Your connection is saved -- you can sync
-          data without changing any settings.
+          {isReimport
+            ? "No setting changes were applied. Your existing settings are unchanged."
+            : "No settings were imported. Your connection is saved -- you can sync data without changing any settings."}
         </p>
       )}
 


### PR DESCRIPTION
Completes the originally-scoped 43.7 work.

## What & why

Users edit their Nightscout profile over time -- new target range, updated carb ratio, basal pattern tweaks as Loop / AAPS settings drift. Previously the only path to pull those changes into GlycemicGPT was to delete + recreate the NS connection, which dumped the per-source attribution history along with it. Hostile UX for a routine action.

This PR adds a **Re-import** button on each active connection card. Click → wizard opens at \`/dashboard/settings/integrations/nightscout/connect?connection=<id>\` → wizard skips Step 1 (credentials already on the connection) → jumps straight to Step 2 with the existing connection ID → same diff table at Step 3 → same apply endpoint at Step 4. No new backend work; the wizard's existing endpoints already accept a connection id.

## Re-import-aware copy

The wizard adapts its strings when invoked via the deep link:

| Surface | First-time | Re-import |
|---|---|---|
| Header | "Connect Nightscout" | "Re-import from Nightscout" |
| Subtitle | "...so you don't start from a blank dashboard." | "...Your existing connection isn't recreated." |
| Done heading | "Connected" | "Settings updated" |
| Done lead | "We imported:" | "We refreshed:" |
| Empty-applied | "Your connection is saved..." | "No setting changes were applied. Your existing settings are unchanged." |

## Implementation

- \`useSearchParams\` reads the \`?connection=<id>\` query param at mount; a UUID-shape check guards against junk values.
- Lazy initializer for \`useReducer\` seeds \`{ isReimport: true, connectionId, step: "evaluating" }\` when the param is present.
- Header / DoneStep gain an \`isReimport\` prop.
- Connect page wraps the wizard in \`<Suspense>\` (Next 15 requirement for \`useSearchParams\`).
- Connection card gains a "Re-import" \`<Link>\` styled like the other action buttons, disabled when offline or another row action is in flight.

## Tests

3 new section tests added to \`__tests__/components/nightscout-integrations-section.test.tsx\`:
- Re-import link rendered on every active connection with correct href
- ID URL-encoding handles unusual characters
- Link disabled when offline

All 6 section tests pass locally.

## Verified end-to-end via Playwright

- Integrations page → 3 re-import links rendered on the 3 active connections with correct \`/connect?connection=<id>\` hrefs
- Click → wizard navigates with the query param intact
- Wizard skips Step 1 and starts at "evaluating" step with the existing connection id
- Header reads "Re-import from Nightscout"
- Subtitle reads the re-import copy

(The Playwright run hit the pre-existing Next.js \`/api/*\` rewrite proxy 30s timeout on the slow eval+sync+derive chain -- same #601 we already filed. Backend path returns 200 in 18s when called directly. Orthogonal to this PR; not a regression.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-connection "Re-import" action for Nightscout integrations (deep-linkable, skips initial steps when used) and improved action layout.
  * Improved onboarding load experience with a full-screen accessible loading state.

* **Tests**
  * Added test coverage for re-import behavior, URL parameter handling, and offline/disabled link interactions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/612)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->