### PR TITLE
feat(api): forecast_snapshots + forecast_evaluations schema (43.12 PR 1)

### DIFF
--- a/apps/api/migrations/versions/055_forecast_snapshots.py
+++ b/apps/api/migrations/versions/055_forecast_snapshots.py
@@ -188,6 +188,14 @@ def upgrade() -> None:
         # Minutes past `start_at`. e.g. step_minutes=5 means rows
         # at offsets 0, 5, 10, 15, ... up to horizon_minutes.
         sa.Column("offset_minutes", sa.Integer(), nullable=False),
+        # A negative offset would mean a forecast point *before* the
+        # forecast was issued -- nonsense, and would corrupt MAE /
+        # coverage rollups. Pin at the DB boundary so a buggy scoring
+        # job can't quietly land bad data.
+        sa.CheckConstraint(
+            "offset_minutes >= 0",
+            name="ck_forecast_eval_offset_nonnegative",
+        ),
         sa.Column("predicted_mgdl", sa.Float(), nullable=False),
         # NULL when no CGM reading landed within the tolerance window
         # (e.g., user's CGM dropped out during the forecast horizon).

--- a/apps/api/migrations/versions/055_forecast_snapshots.py
+++ b/apps/api/migrations/versions/055_forecast_snapshots.py
@@ -1,0 +1,227 @@
+"""Forecast snapshots + evaluation pairs (Story 43.12 PR 1).
+
+Adds the storage layer for closed-loop forecast data. PR #572's
+translator captures each Nightscout devicestatus payload verbatim
+into `device_status_snapshots.{loop_subtree_json, openaps_subtree_json}`
+and nothing currently reads from those JSON columns -- the forecast
+arrays sit unused.
+
+This migration introduces a normalized table the translator writes
+to on each devicestatus fetch when a forecast is present. Chart
+overlay, AI context, and a future calibration / training-signal
+pipeline all read from the same shape.
+
+See `_bmad-output/planning-artifacts/story-43.12-forecast-overlay-design.md`
+for the full design discussion (why a separate table vs JSON-extract
+on read; why JSONB curves vs typed columns; why per-user picker
+instead of per-connection toggle).
+
+`forecast_evaluations` lands empty here. The scoring job that
+populates it is deferred to a follow-up. Schema cost is essentially
+zero (empty table) but having it in place now means when the future
+GlycemicGPT prediction engine team starts work, they have a labelled
+dataset waiting -- not a year of un-captured forecasts to lament.
+
+Revision ID: 055_forecast_snapshots
+Revises: 054_ns_entry_object_id_cursor
+Create Date: 2026-05-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "055_forecast_snapshots"
+down_revision = "054_ns_entry_object_id_cursor"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "forecast_snapshots",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # Nullable so non-NS sources can attach rows by source_engine
+        # alone (future direct-integration paths, our own engine).
+        sa.Column(
+            "nightscout_connection_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("nightscout_connections.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        # 'loop' | 'aaps' | 'trio' | 'oref0' | 'iaps' | 'glycemicgpt'.
+        # Free-form text rather than an enum to absorb the iAPS / Trio
+        # variant landscape without schema changes; the read endpoint
+        # validates the set it knows about.
+        sa.Column("source_engine", sa.Text(), nullable=False),
+        # Bounded set. Adding a new engine is a one-line migration; the
+        # cost of catching translator typos (`"AAPS"` vs `"aaps"`) at
+        # the DB boundary is worth it.
+        sa.CheckConstraint(
+            "source_engine IN ('loop','aaps','trio','oref0','iaps','glycemicgpt')",
+            name="ck_forecast_source_engine_known",
+        ),
+        # Denormalized from device_status_snapshots.source_uploader so
+        # the forecast row is self-sufficient for chart rendering
+        # without a join.
+        sa.Column("source_uploader", sa.Text(), nullable=True),
+        # When the engine *issued* the forecast (its internal clock).
+        # For Loop this is `loop_subtree_json.timestamp`; for AAPS it's
+        # the `suggested.deliverAt`; for our engine it'll be wall clock
+        # at compute time. NOT when we ingested it (see `received_at`).
+        sa.Column(
+            "issued_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        # t=0 on the chart for this forecast. For most sources ==
+        # issued_at; for Loop it's `predicted.startDate` which can lag
+        # the devicestatus timestamp by a cycle. The chart anchors the
+        # dotted line at start_at, not issued_at.
+        sa.Column(
+            "start_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column("step_minutes", sa.Integer(), nullable=False),
+        sa.Column("horizon_minutes", sa.Integer(), nullable=False),
+        sa.CheckConstraint(
+            "step_minutes > 0 AND horizon_minutes > 0",
+            name="ck_forecast_step_horizon_positive",
+        ),
+        # JSONB shape:
+        #   {
+        #     "IOB":  [120, 122, 125, ...],
+        #     "COB":  [120, 124, 130, ...],   // optional
+        #     "UAM":  [...],                  // optional
+        #     "ZT":   [...]                   // optional
+        #   }
+        # Loop (single curve): {"main": [...]}.
+        sa.Column(
+            "curves_mgdl_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        # Which key in `curves_mgdl_json` the source's UI defaults to
+        # drawing. Loop -> "main"; AAPS/Trio/oref0 -> "IOB" when
+        # present, else first available. Computed at translate time so
+        # the chart doesn't have to re-derive on every render.
+        sa.Column(
+            "default_curve_name",
+            sa.Text(),
+            nullable=False,
+        ),
+        # The chart will KeyError on render if these drift. Pin the
+        # invariant at the DB boundary so a buggy translator can't land
+        # a row the read path can't display.
+        sa.CheckConstraint(
+            "curves_mgdl_json ? default_curve_name",
+            name="ck_forecast_default_curve_in_curves",
+        ),
+        # Idempotency key. For NS-imported rows this is the
+        # devicestatus `_id` (same value used on
+        # `device_status_snapshots.ns_id`). For engine outputs it's a
+        # UUID we mint. Lets re-translating the same devicestatus
+        # upsert in place rather than duplicating.
+        sa.Column("dedupe_key", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "char_length(dedupe_key) BETWEEN 1 AND 128",
+            name="ck_forecast_dedupe_key_length",
+        ),
+        sa.Column(
+            "received_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.UniqueConstraint(
+            "source_engine",
+            "dedupe_key",
+            name="uq_forecast_snapshots_source_dedupe",
+        ),
+    )
+    op.create_index(
+        "ix_forecast_user_issued",
+        "forecast_snapshots",
+        ["user_id", sa.text("issued_at DESC")],
+    )
+    # Lets us answer "what does this user's chart need right now"
+    # cheaply per-source. Same indexing strategy as our other
+    # source-attributed time-series.
+    op.create_index(
+        "ix_forecast_user_source_issued",
+        "forecast_snapshots",
+        ["user_id", "source_engine", sa.text("issued_at DESC")],
+    )
+
+    # ------------------------------------------------------------------
+    # `forecast_evaluations` lands empty. The scoring job that pairs
+    # each forecast point against the actual CGM reading at the
+    # matching horizon time is deferred to a follow-up. See design
+    # doc Section 5.2 for the eventual job semantics.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "forecast_evaluations",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "forecast_snapshot_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("forecast_snapshots.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # Minutes past `start_at`. e.g. step_minutes=5 means rows
+        # at offsets 0, 5, 10, 15, ... up to horizon_minutes.
+        sa.Column("offset_minutes", sa.Integer(), nullable=False),
+        sa.Column("predicted_mgdl", sa.Float(), nullable=False),
+        # NULL when no CGM reading landed within the tolerance window
+        # (e.g., user's CGM dropped out during the forecast horizon).
+        # Don't drop the row -- a NULL is data ("we couldn't score
+        # this point") and feeds into MAE-with-coverage metrics.
+        sa.Column("actual_mgdl", sa.Float(), nullable=True),
+        # Signed delta in seconds between the matched reading's actual
+        # timestamp and the target offset. 0 = exact; negative = reading
+        # arrived *before* the target offset; positive = after. The
+        # scoring job clamps to a tolerance window (deferred PR sets the
+        # bound) so this column is bounded in practice.
+        sa.Column("actual_offset_seconds", sa.Integer(), nullable=True),
+        sa.Column(
+            "computed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.UniqueConstraint(
+            "forecast_snapshot_id",
+            "offset_minutes",
+            name="uq_forecast_eval_snapshot_offset",
+        ),
+    )
+    op.create_index(
+        "ix_forecast_eval_snapshot",
+        "forecast_evaluations",
+        ["forecast_snapshot_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_forecast_eval_snapshot", table_name="forecast_evaluations")
+    op.drop_table("forecast_evaluations")
+    op.drop_index("ix_forecast_user_source_issued", table_name="forecast_snapshots")
+    op.drop_index("ix_forecast_user_issued", table_name="forecast_snapshots")
+    op.drop_table("forecast_snapshots")

--- a/apps/api/src/models/forecast_snapshot.py
+++ b/apps/api/src/models/forecast_snapshot.py
@@ -241,6 +241,13 @@ class ForecastEvaluation(Base):
             "offset_minutes",
             name="uq_forecast_eval_snapshot_offset",
         ),
+        # Mirror of migration CHECK. Negative offsets would mean a
+        # forecast point before issuance -- nonsense, and would corrupt
+        # MAE / coverage rollups.
+        CheckConstraint(
+            "offset_minutes >= 0",
+            name="ck_forecast_eval_offset_nonnegative",
+        ),
         Index("ix_forecast_eval_snapshot", "forecast_snapshot_id"),
     )
 

--- a/apps/api/src/models/forecast_snapshot.py
+++ b/apps/api/src/models/forecast_snapshot.py
@@ -1,0 +1,300 @@
+"""Forecast snapshot models (Story 43.12 PR 1).
+
+`ForecastSnapshot` is a normalized per-cycle row capturing a single
+closed-loop's BG forecast. The translator writes one row per
+Nightscout devicestatus payload that carries forecast data (Loop's
+`predicted.values[]`, AAPS / Trio / oref0's `predBGs.{IOB,COB,UAM,ZT}`).
+
+This is a separate table from `device_status_snapshots` (which holds
+verbatim JSONB subtrees) by design:
+
+- Multiple consumers need a clean shape: chart overlay, AI context
+  builder, future calibration / training-signal pipeline.
+- Future GlycemicGPT prediction engine outputs aren't NS payloads --
+  having a neutral table lets us land engine-emitted rows alongside
+  NS-imported ones without lying about the source.
+- Write-time normalization moves per-uploader shape parsing out of
+  every read path.
+
+`ForecastEvaluation` lands as schema-only in this PR. The pairing-
+to-actual-CGM-reading job that populates it is deferred to a
+follow-up; see design doc Section 5.2.
+
+Design doc:
+    `_bmad-output/planning-artifacts/story-43.12-forecast-overlay-design.md`
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+
+
+class ForecastSnapshot(Base):
+    """A single point-in-time closed-loop BG forecast."""
+
+    __tablename__ = "forecast_snapshots"
+
+    __table_args__ = (
+        # Idempotency: same Nightscout devicestatus `_id` -> same
+        # forecast row across sync cycles. The translator UPSERTs on
+        # this key. Engine-emitted rows mint a fresh UUID dedupe key.
+        UniqueConstraint(
+            "source_engine",
+            "dedupe_key",
+            name="uq_forecast_snapshots_source_dedupe",
+        ),
+        # Mirror of migration CHECKs. Keeping them on the ORM means
+        # autogenerate diffs stay quiet and the invariants are visible
+        # next to the columns they constrain.
+        CheckConstraint(
+            "source_engine IN ('loop','aaps','trio','oref0','iaps','glycemicgpt')",
+            name="ck_forecast_source_engine_known",
+        ),
+        CheckConstraint(
+            "step_minutes > 0 AND horizon_minutes > 0",
+            name="ck_forecast_step_horizon_positive",
+        ),
+        CheckConstraint(
+            "curves_mgdl_json ? default_curve_name",
+            name="ck_forecast_default_curve_in_curves",
+        ),
+        CheckConstraint(
+            "char_length(dedupe_key) BETWEEN 1 AND 128",
+            name="ck_forecast_dedupe_key_length",
+        ),
+        # "Latest forecast for this user, any source." Indexes the
+        # default dashboard read path. DESC matches migration so
+        # autogenerate stays quiet.
+        Index(
+            "ix_forecast_user_issued",
+            "user_id",
+            text("issued_at DESC"),
+        ),
+        # "Latest forecast for this user from THIS source." Indexes
+        # the picker-aware read path ("user picked Loop; give me their
+        # latest Loop forecast").
+        Index(
+            "ix_forecast_user_source_issued",
+            "user_id",
+            "source_engine",
+            text("issued_at DESC"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Nullable so non-NS sources can attach without a connection FK.
+    # Future direct-integration paths and the GlycemicGPT engine
+    # use source_engine alone for attribution; nightscout_connection_id
+    # is NULL for those rows.
+    nightscout_connection_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("nightscout_connections.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+
+    # 'loop' | 'aaps' | 'trio' | 'oref0' | 'iaps' | 'glycemicgpt'.
+    # Stored as Text (not a Postgres ENUM type) so adding a new
+    # engine is a one-line CHECK update -- not a CREATE TYPE /
+    # ALTER TYPE dance. The CHECK constraint
+    # `ck_forecast_source_engine_known` bounds the allowed set as
+    # defense-in-depth so translator typos (`"AAPS"` vs `"aaps"`)
+    # fail at the DB boundary instead of silently minting phantom
+    # engines. Adding a new uploader is intentionally a migration
+    # event so the read endpoint, AI context builder, and any
+    # eventual scoring job stay in sync with what the DB accepts.
+    source_engine: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Denormalized from `device_status_snapshots.source_uploader` so
+    # chart rendering doesn't need a join. Same values + nullability
+    # semantics as the source column.
+    source_uploader: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # When the engine *issued* the forecast (its internal clock).
+    # NOT when we ingested it. For Loop: `loop_subtree_json.timestamp`.
+    # For AAPS / Trio / oref0: `suggested.deliverAt`. Future engine:
+    # compute wall clock at emit time.
+    issued_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # t=0 on the chart for this forecast. For most sources this equals
+    # `issued_at`. Loop occasionally posts `predicted.startDate` lagging
+    # the devicestatus timestamp by a cycle when its sync cadence and
+    # NS upload cadence diverge -- the chart anchors the dotted line at
+    # `start_at`, not `issued_at`, so the first forecast point lines up
+    # with the actual reading underneath it.
+    start_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    step_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
+    horizon_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # JSONB shape:
+    #   {
+    #     "IOB":  [120, 122, 125, ...],
+    #     "COB":  [120, 124, 130, ...],  -- optional
+    #     "UAM":  [...],                  -- optional
+    #     "ZT":   [...]                   -- optional
+    #   }
+    # Loop (single curve): {"main": [...]}.
+    #
+    # Single-curve and multi-curve sources both fit this shape.
+    # `default_curve_name` picks which key the chart draws by default.
+    curves_mgdl_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+    )
+
+    # Which curve to draw on the chart by default for this source.
+    # Loop -> "main". AAPS / Trio / oref0 / iAPS -> "IOB" when present
+    # (the source's own UI default), else the first available curve.
+    # Computed at translate time so chart render doesn't re-derive.
+    default_curve_name: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # NS devicestatus `_id` for NS-imported rows; UUID for engine
+    # rows. UNIQUE with `source_engine` keeps Loop's `_id` and AAPS's
+    # `_id` from accidentally colliding even though both look like
+    # 24-hex strings.
+    dedupe_key: Mapped[str] = mapped_column(Text, nullable=False)
+
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    # ---- Relationships ---------------------------------------------------
+
+    user = relationship("User")
+    connection = relationship("NightscoutConnection")
+    evaluations: Mapped[list[ForecastEvaluation]] = relationship(
+        "ForecastEvaluation",
+        back_populates="forecast_snapshot",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ForecastSnapshot(user_id={self.user_id}, "
+            f"source={self.source_engine!r}, "
+            f"issued_at={self.issued_at}, "
+            f"horizon_minutes={self.horizon_minutes})>"
+        )
+
+
+class ForecastEvaluation(Base):
+    """One pairing of `(forecast_point, actual_CGM_reading)`.
+
+    Populated by a scoring job (deferred, not in this PR) that runs
+    just past each forecast's horizon time and looks up the actual
+    CGM reading at each forecast offset. The result feeds:
+
+    - Per-user / per-source accuracy reports ("your Loop's 30-min
+      MAE is 12 mg/dL over the last week").
+    - Calibration features for the future GlycemicGPT prediction
+      engine ("Loop is consistently over-predicting at night for
+      this user; weight its forecast lower in the nighttime model").
+
+    Schema-only in this PR. The job lands later.
+    """
+
+    __tablename__ = "forecast_evaluations"
+
+    __table_args__ = (
+        # One evaluation row per (forecast, offset). Re-running the
+        # scoring job is idempotent: it UPSERTs by this key.
+        UniqueConstraint(
+            "forecast_snapshot_id",
+            "offset_minutes",
+            name="uq_forecast_eval_snapshot_offset",
+        ),
+        Index("ix_forecast_eval_snapshot", "forecast_snapshot_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    forecast_snapshot_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("forecast_snapshots.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Minutes past `forecast_snapshots.start_at`. Typically 5-min
+    # multiples up to `horizon_minutes`. Same offset values regardless
+    # of source.
+    offset_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    predicted_mgdl: Mapped[float] = mapped_column(Float, nullable=False)
+
+    # NULL when no CGM reading landed within the tolerance window for
+    # this offset (sensor warm-up, transmitter dropout, etc.). NULL is
+    # data -- aggregations should report it as "coverage gap" rather
+    # than skipping the row, otherwise we under-count missed forecasts.
+    actual_mgdl: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Signed delta in seconds between the matched reading's actual
+    # timestamp and the target offset. 0 = exact; negative = reading
+    # arrived *before* the target offset; positive = after. Useful for
+    # "is this user's CGM cadence reliable enough to score accurately?"
+    # debugging. The scoring job (deferred) clamps absolute value to a
+    # tolerance window.
+    actual_offset_seconds: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    forecast_snapshot: Mapped[ForecastSnapshot] = relationship(
+        "ForecastSnapshot",
+        back_populates="evaluations",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ForecastEvaluation(forecast_snapshot_id={self.forecast_snapshot_id}, "
+            f"offset_minutes={self.offset_minutes}, "
+            f"predicted={self.predicted_mgdl}, "
+            f"actual={self.actual_mgdl})>"
+        )

--- a/apps/api/tests/test_aggregate_stats.py
+++ b/apps/api/tests/test_aggregate_stats.py
@@ -1376,8 +1376,11 @@ class TestSourceFilteringAndDedup:
             async for db in get_db():
                 now = datetime.now(UTC)
                 uid = uuid.UUID(user_id)
-                cutoff = _boundary_cutoff(days=1)
-                ts = cutoff + timedelta(hours=1)
+                # `cutoff + 1h` lands in the future when CI runs in the
+                # first hour after UTC midnight, and the query filters
+                # `event_timestamp <= :now`. Use `_stable_test_ts` which
+                # already clamps to `[cutoff+1s, now]`.
+                ts = _stable_test_ts(days=1)
                 db.add(
                     PumpEvent(
                         user_id=uid,
@@ -1491,12 +1494,20 @@ class TestSourceFilteringAndDedup:
             async for db in get_db():
                 now = datetime.now(UTC)
                 uid = uuid.UUID(user_id)
-                ts = _stable_test_ts(days=1)
+                # Both timestamps must land inside the boundary-aligned
+                # window. `_stable_test_ts` can return `cutoff + 1s`
+                # when CI runs near UTC midnight, so subtracting 5s
+                # from it lands *before* the cutoff and the row gets
+                # filtered out -- making the test deterministically
+                # fail in that hour. Bracket around a center inside
+                # the window instead.
+                ts_center = _stable_test_ts(days=1) + timedelta(seconds=30)
+                ts_center = min(ts_center, now - timedelta(seconds=1))
                 db.add(
                     PumpEvent(
                         user_id=uid,
                         event_type=PumpEventType.BOLUS,
-                        event_timestamp=ts,
+                        event_timestamp=ts_center,
                         units=4.0,
                         is_automated=False,
                         received_at=now,
@@ -1507,7 +1518,7 @@ class TestSourceFilteringAndDedup:
                     PumpEvent(
                         user_id=uid,
                         event_type=PumpEventType.BOLUS,
-                        event_timestamp=ts - timedelta(seconds=5),
+                        event_timestamp=ts_center - timedelta(seconds=5),
                         units=4.0,
                         is_automated=False,
                         received_at=now,

--- a/apps/api/tests/test_forecast_snapshot_model.py
+++ b/apps/api/tests/test_forecast_snapshot_model.py
@@ -158,8 +158,14 @@ def _aaps_curves_iob_only() -> tuple[dict, str]:
 
 
 class TestForecastSnapshotInsert:
+    """Round-trip insertion tests for the wire-format families captured
+    by the design doc: Loop single-curve, AAPS / Trio / oref0 multi-curve,
+    and the future engine-emitted path (no NS connection FK)."""
+
     @pytest.mark.asyncio
     async def test_loop_single_curve_round_trip(self, fc_ctx):
+        """Loop's single-curve payload round-trips intact, including
+        the server-defaulted `received_at`."""
         session, user_id, conn = fc_ctx
         issued = datetime.now(UTC)
         curves, default_curve = _loop_curve()
@@ -194,6 +200,8 @@ class TestForecastSnapshotInsert:
 
     @pytest.mark.asyncio
     async def test_aaps_multi_curve_round_trip(self, fc_ctx):
+        """AAPS's multi-curve payload (IOB/COB/UAM/ZT) round-trips with
+        all four keys preserved and IOB as the source's default."""
         session, user_id, conn = fc_ctx
         issued = datetime.now(UTC)
         curves, default_curve = _aaps_curves()
@@ -298,6 +306,10 @@ class TestForecastSnapshotInsert:
 
 
 class TestForecastSnapshotUniqueness:
+    """Pins `(source_engine, dedupe_key)` UPSERT semantics:
+    same key + same engine rejects (idempotency); same key + different
+    engines allowed (cross-source non-collision)."""
+
     @pytest.mark.asyncio
     async def test_same_source_engine_and_dedupe_key_rejects(self, fc_ctx):
         """Same NS devicestatus _id arriving twice (different sync
@@ -386,6 +398,10 @@ class TestForecastSnapshotUniqueness:
 
 
 class TestForecastEvaluation:
+    """Pins the schema contract for the deferred scoring job: partial
+    rows (NULL actual), idempotent UPSERT by (snapshot_id, offset), and
+    snapshot-delete cascade."""
+
     @pytest.mark.asyncio
     async def test_evaluation_partial_row(self, fc_ctx):
         """The future scoring job writes one evaluation row per
@@ -539,6 +555,9 @@ class TestForecastEvaluation:
 
 
 class TestForecastQueryByLatest:
+    """Verifies the read path's index ordering for
+    `(user_id, source_engine, issued_at DESC)`."""
+
     @pytest.mark.asyncio
     async def test_latest_per_source_via_issued_at_index(self, fc_ctx):
         """Read endpoint will hit `ix_forecast_user_source_issued` to
@@ -622,6 +641,7 @@ class TestForecastDbInvariants:
 
     @pytest.mark.asyncio
     async def test_zero_step_minutes_rejected(self, fc_ctx):
+        """`step_minutes=0` would divide by zero on chart render."""
         session, user_id, _conn = fc_ctx
         kwargs = await self._base_snap_kwargs(user_id)
         kwargs["step_minutes"] = 0
@@ -632,6 +652,7 @@ class TestForecastDbInvariants:
 
     @pytest.mark.asyncio
     async def test_negative_horizon_minutes_rejected(self, fc_ctx):
+        """A negative horizon is physically meaningless."""
         session, user_id, _conn = fc_ctx
         kwargs = await self._base_snap_kwargs(user_id)
         kwargs["horizon_minutes"] = -5
@@ -655,6 +676,7 @@ class TestForecastDbInvariants:
 
     @pytest.mark.asyncio
     async def test_empty_dedupe_key_rejected(self, fc_ctx):
+        """Empty dedupe key would defeat UPSERT idempotency."""
         session, user_id, _conn = fc_ctx
         kwargs = await self._base_snap_kwargs(user_id)
         kwargs["dedupe_key"] = ""
@@ -665,6 +687,7 @@ class TestForecastDbInvariants:
 
     @pytest.mark.asyncio
     async def test_oversized_dedupe_key_rejected(self, fc_ctx):
+        """Bounds against a malformed translator writing huge strings."""
         session, user_id, _conn = fc_ctx
         kwargs = await self._base_snap_kwargs(user_id)
         kwargs["dedupe_key"] = "x" * 200  # over 128
@@ -682,6 +705,30 @@ class TestForecastDbInvariants:
             ForecastEvaluation(
                 forecast_snapshot_id=uuid.uuid4(),  # no such snapshot
                 offset_minutes=5,
+                predicted_mgdl=120.0,
+                actual_mgdl=120.0,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_evaluation_negative_offset_rejected(self, fc_ctx):
+        """A negative `offset_minutes` would mean a forecast point
+        before the forecast was issued -- nonsense, and would corrupt
+        MAE / coverage rollups. The DB must reject it."""
+        session, user_id, conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["nightscout_connection_id"] = conn.id
+        snap = ForecastSnapshot(**kwargs)
+        session.add(snap)
+        await session.flush()
+
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=snap.id,
+                offset_minutes=-5,  # invalid
                 predicted_mgdl=120.0,
                 actual_mgdl=120.0,
             )

--- a/apps/api/tests/test_forecast_snapshot_model.py
+++ b/apps/api/tests/test_forecast_snapshot_model.py
@@ -1,0 +1,722 @@
+"""Model + schema tests for `forecast_snapshots` and `forecast_evaluations`.
+
+Story 43.12 PR 1. The translator that writes to these tables lands in
+PR 2 of the story; the read endpoint in PR 3. This file pins:
+
+- Insert / round-trip of a representative ForecastSnapshot row for
+  each of the wire-format families captured by the design doc
+  (Loop single-curve, AAPS / Trio / oref0 multi-curve).
+- The `(source_engine, dedupe_key)` uniqueness constraint -- the
+  translator's UPSERT correctness rides on this.
+- `forecast_evaluations` schema accepts the partial-row shape the
+  future scoring job will write (actual_mgdl NULL when no CGM
+  reading lands in the tolerance window).
+- ON DELETE CASCADE wiring: dropping the parent snapshot drops its
+  evaluations; dropping the user drops everything.
+
+Design doc:
+    `_bmad-output/planning-artifacts/story-43.12-forecast-overlay-design.md`
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.encryption import encrypt_credential
+from src.database import get_session_maker
+from src.models.forecast_snapshot import ForecastEvaluation, ForecastSnapshot
+from src.models.nightscout_connection import (
+    NightscoutAuthType,
+    NightscoutConnection,
+)
+from src.models.user import User
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def fc_ctx() -> AsyncGenerator[
+    tuple[AsyncSession, uuid.UUID, NightscoutConnection], None
+]:
+    """Per-test session + user + connection.
+
+    Same shape as test_nightscout_sync.py's `sync_ctx` -- own
+    session_maker so cross-loop teardown doesn't crash. Returns the
+    session, the user's id, and a connection row so tests can attach
+    forecast snapshots either to the connection (NS-imported path)
+    or unattached (future engine path).
+    """
+    session_maker = get_session_maker()
+    session = session_maker()
+    # Pre-yield TRUNCATE: bulletproof against rows leaked by a malformed
+    # prior test (NULL user_id, partially-rolled-back commit, etc.).
+    # Teardown delete is best-effort; this is belt-and-braces.
+    await session.execute(
+        text("TRUNCATE forecast_evaluations, forecast_snapshots CASCADE")
+    )
+    await session.commit()
+    email = f"forecast_{uuid.uuid4().hex[:10]}@example.com"
+    user = User(email=email, hashed_password="not-a-real-hash")
+    session.add(user)
+    await session.flush()
+    user_id = user.id
+
+    conn = NightscoutConnection(
+        user_id=user_id,
+        name="test-forecast",
+        base_url="https://example.com",
+        auth_type=NightscoutAuthType.SECRET,
+        encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+        initial_sync_window_days=7,
+    )
+    session.add(conn)
+    await session.flush()
+    await session.commit()
+
+    try:
+        yield session, user_id, conn
+    finally:
+        try:
+            await session.rollback()
+            # Explicit deletion in dependency order rather than relying
+            # on FK cascade. Cascade is correct in healthy state, but
+            # if a test left the session in an error state the cascade
+            # didn't reliably fire here -- rows leaked into the next
+            # test run, which then saw multiple-results errors on
+            # source_engine queries that don't filter by user_id.
+            # Defensive explicit deletes match the pattern in
+            # test_nightscout_sync.py's sync_ctx fixture.
+            await session.execute(
+                delete(ForecastEvaluation).where(
+                    ForecastEvaluation.forecast_snapshot_id.in_(
+                        select(ForecastSnapshot.id).where(
+                            ForecastSnapshot.user_id == user_id
+                        )
+                    )
+                )
+            )
+            await session.execute(
+                delete(ForecastSnapshot).where(
+                    ForecastSnapshot.user_id == user_id
+                )
+            )
+            await session.execute(delete(User).where(User.id == user_id))
+            await session.commit()
+        except RuntimeError:
+            pass
+        finally:
+            try:
+                await session.close()
+            except RuntimeError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Sample payload builders (per source family)
+# ---------------------------------------------------------------------------
+
+
+def _loop_curve() -> tuple[dict, str]:
+    """Loop's single-curve shape. {default_curve_name} == "main"."""
+    return ({"main": [120, 122, 125, 128, 130, 131, 130, 128, 125]}, "main")
+
+
+def _aaps_curves() -> tuple[dict, str]:
+    """AAPS / Trio / oref0 multi-curve shape. Default to "IOB" curve
+    because that's the source's own default; the picker lets a power
+    user switch later (deferred)."""
+    return (
+        {
+            "IOB": [120, 124, 130, 135, 138],
+            "COB": [120, 130, 145, 160, 170],
+            "UAM": [120, 125, 131, 138, 142],
+            "ZT": [120, 125, 130, 132, 132],
+        },
+        "IOB",
+    )
+
+
+def _aaps_curves_iob_only() -> tuple[dict, str]:
+    """AAPS sometimes posts only IOB (no carbs active, no UAM
+    detected, no zero-temp scenario). Translator must tolerate."""
+    return ({"IOB": [120, 122, 125, 128]}, "IOB")
+
+
+# ---------------------------------------------------------------------------
+# Insert + round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestForecastSnapshotInsert:
+    @pytest.mark.asyncio
+    async def test_loop_single_curve_round_trip(self, fc_ctx):
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"loop-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.commit()
+
+        result = await session.execute(
+            select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+        )
+        row = result.scalar_one()
+        assert row.source_engine == "loop"
+        assert row.default_curve_name == "main"
+        assert row.curves_mgdl_json == {
+            "main": [120, 122, 125, 128, 130, 131, 130, 128, 125]
+        }
+        # received_at is server-defaulted -- assert it landed
+        assert row.received_at is not None
+
+    @pytest.mark.asyncio
+    async def test_aaps_multi_curve_round_trip(self, fc_ctx):
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _aaps_curves()
+
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="aaps",
+            source_uploader="aaps",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=20,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"aaps-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.commit()
+
+        result = await session.execute(
+            select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+        )
+        row = result.scalar_one()
+        assert set(row.curves_mgdl_json.keys()) == {"IOB", "COB", "UAM", "ZT"}
+        assert row.default_curve_name == "IOB"
+
+    @pytest.mark.asyncio
+    async def test_aaps_partial_curves_round_trip(self, fc_ctx):
+        """Partial-curve payload: only IOB present. Required: must
+        store without breaking on missing COB/UAM/ZT and surface
+        IOB as the default."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _aaps_curves_iob_only()
+
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="aaps",
+            source_uploader="aaps",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=15,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"aaps-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.commit()
+
+        result = await session.execute(
+            select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+        )
+        row = result.scalar_one()
+        assert row.curves_mgdl_json == {"IOB": [120, 122, 125, 128]}
+
+    @pytest.mark.asyncio
+    async def test_engine_source_without_connection(self, fc_ctx):
+        """Future-engine path: source_engine = "glycemicgpt", no NS
+        connection FK. The column is nullable for exactly this case;
+        regression-guard so a future migration doesn't accidentally
+        constrain it."""
+        session, user_id, _conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=None,  # <-- key part
+            source_engine="glycemicgpt",
+            source_uploader=None,
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"gg-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.commit()
+
+        # Scope to this test's user -- cross-test leakage (e.g., a
+        # prior failing test that didn't clean up) would otherwise
+        # produce multiple rows and break scalar_one().
+        result = await session.execute(
+            select(ForecastSnapshot).where(
+                ForecastSnapshot.user_id == user_id,
+                ForecastSnapshot.source_engine == "glycemicgpt",
+            )
+        )
+        row = result.scalar_one()
+        assert row.nightscout_connection_id is None
+        assert row.source_engine == "glycemicgpt"
+
+
+# ---------------------------------------------------------------------------
+# Uniqueness + idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestForecastSnapshotUniqueness:
+    @pytest.mark.asyncio
+    async def test_same_source_engine_and_dedupe_key_rejects(self, fc_ctx):
+        """Same NS devicestatus _id arriving twice (different sync
+        cycles, same upstream row) must NOT create two ForecastSnapshot
+        rows. Translator's UPSERT correctness depends on this."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        ns_id = "abc123def456abc123def456"  # 24-char mongo objectid shape
+
+        snap1 = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=ns_id,
+        )
+        session.add(snap1)
+        await session.commit()
+
+        snap2 = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=ns_id,  # same key
+        )
+        session.add(snap2)
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_same_dedupe_key_different_source_engine_allowed(self, fc_ctx):
+        """Different engines might both pick `_id = abc123...` by
+        coincidence (NS Mongo ObjectIds are 24-hex, the GlycemicGPT
+        engine mints UUIDs but the test pins the cross-source
+        non-collision contract independent of length). Translator
+        UPSERTs by `(source_engine, dedupe_key)`, not dedupe_key
+        alone."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        same_key = "abc123def456abc123def456"
+
+        for engine in ("loop", "aaps"):
+            snap = ForecastSnapshot(
+                user_id=user_id,
+                nightscout_connection_id=conn.id,
+                source_engine=engine,
+                source_uploader=engine,
+                issued_at=issued,
+                start_at=issued,
+                step_minutes=5,
+                horizon_minutes=40,
+                curves_mgdl_json=curves,
+                default_curve_name=default_curve,
+                dedupe_key=same_key,
+            )
+            session.add(snap)
+            await session.commit()
+
+        result = await session.execute(
+            select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+        )
+        rows = result.scalars().all()
+        assert len(rows) == 2
+        assert {r.source_engine for r in rows} == {"loop", "aaps"}
+
+
+# ---------------------------------------------------------------------------
+# ForecastEvaluation
+# ---------------------------------------------------------------------------
+
+
+class TestForecastEvaluation:
+    @pytest.mark.asyncio
+    async def test_evaluation_partial_row(self, fc_ctx):
+        """The future scoring job writes one evaluation row per
+        forecast offset. `actual_mgdl` is NULL when no CGM reading
+        landed within tolerance -- the schema must accept that."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"loop-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.flush()
+
+        # Scored point: actual reading landed exactly.
+        eval_scored = ForecastEvaluation(
+            forecast_snapshot_id=snap.id,
+            offset_minutes=5,
+            predicted_mgdl=122.0,
+            actual_mgdl=120.0,
+            actual_offset_seconds=0,
+        )
+        # Unscored point: CGM dropout, no reading in window.
+        eval_unscored = ForecastEvaluation(
+            forecast_snapshot_id=snap.id,
+            offset_minutes=10,
+            predicted_mgdl=125.0,
+            actual_mgdl=None,
+            actual_offset_seconds=None,
+        )
+        session.add_all([eval_scored, eval_unscored])
+        await session.commit()
+
+        result = await session.execute(
+            select(ForecastEvaluation)
+            .where(ForecastEvaluation.forecast_snapshot_id == snap.id)
+            .order_by(ForecastEvaluation.offset_minutes)
+        )
+        rows = result.scalars().all()
+        assert len(rows) == 2
+        assert rows[0].actual_mgdl == 120.0
+        assert rows[0].actual_offset_seconds == 0
+        assert rows[1].actual_mgdl is None
+        assert rows[1].actual_offset_seconds is None
+
+    @pytest.mark.asyncio
+    async def test_evaluation_same_offset_rejected(self, fc_ctx):
+        """Re-running the scoring job on the same snapshot must not
+        produce duplicate offset rows. UPSERT relies on the
+        `(forecast_snapshot_id, offset_minutes)` unique constraint."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"loop-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.flush()
+
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=snap.id,
+                offset_minutes=5,
+                predicted_mgdl=122.0,
+                actual_mgdl=120.0,
+            )
+        )
+        await session.commit()
+
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=snap.id,
+                offset_minutes=5,  # duplicate
+                predicted_mgdl=122.0,
+                actual_mgdl=121.0,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_evaluation_cascades_on_snapshot_delete(self, fc_ctx):
+        """Drop the parent snapshot; the eval rows go with it."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"loop-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.flush()
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=snap.id,
+                offset_minutes=5,
+                predicted_mgdl=122.0,
+                actual_mgdl=120.0,
+            )
+        )
+        await session.commit()
+        snap_id = snap.id
+
+        await session.execute(
+            delete(ForecastSnapshot).where(ForecastSnapshot.id == snap_id)
+        )
+        await session.commit()
+
+        # The evaluation row is gone too.
+        result = await session.execute(
+            select(ForecastEvaluation).where(
+                ForecastEvaluation.forecast_snapshot_id == snap_id
+            )
+        )
+        assert result.scalars().first() is None
+
+
+# ---------------------------------------------------------------------------
+# Time-series query path (latest forecast per source for a user)
+# ---------------------------------------------------------------------------
+
+
+class TestForecastQueryByLatest:
+    @pytest.mark.asyncio
+    async def test_latest_per_source_via_issued_at_index(self, fc_ctx):
+        """Read endpoint will hit `ix_forecast_user_source_issued` to
+        answer 'give me this user's latest Loop forecast'. Verify the
+        ordering does what the index claims."""
+        session, user_id, conn = fc_ctx
+        base = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+
+        # Three Loop forecasts, 5 min apart.
+        for i in range(3):
+            session.add(
+                ForecastSnapshot(
+                    user_id=user_id,
+                    nightscout_connection_id=conn.id,
+                    source_engine="loop",
+                    source_uploader="loop",
+                    issued_at=base - timedelta(minutes=(2 - i) * 5),
+                    start_at=base - timedelta(minutes=(2 - i) * 5),
+                    step_minutes=5,
+                    horizon_minutes=40,
+                    curves_mgdl_json=curves,
+                    default_curve_name=default_curve,
+                    dedupe_key=f"loop-{i}-{uuid.uuid4().hex}",
+                )
+            )
+        await session.commit()
+
+        # "Latest Loop forecast for this user" query.
+        latest = (
+            await session.execute(
+                select(ForecastSnapshot)
+                .where(
+                    ForecastSnapshot.user_id == user_id,
+                    ForecastSnapshot.source_engine == "loop",
+                )
+                .order_by(ForecastSnapshot.issued_at.desc())
+                .limit(1)
+            )
+        ).scalar_one()
+        assert latest.issued_at == base  # the most-recent one
+
+
+# ---------------------------------------------------------------------------
+# DB-level invariants (CHECK constraints from migration 055)
+# ---------------------------------------------------------------------------
+
+
+class TestForecastDbInvariants:
+    """Pins the CHECK constraints the migration declares. Each test
+    proves the DB rejects a malformed row that a buggy PR 2 translator
+    might otherwise land.
+    """
+
+    async def _base_snap_kwargs(self, user_id: uuid.UUID) -> dict:
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        return {
+            "user_id": user_id,
+            "nightscout_connection_id": None,
+            "source_engine": "loop",
+            "source_uploader": "loop",
+            "issued_at": issued,
+            "start_at": issued,
+            "step_minutes": 5,
+            "horizon_minutes": 40,
+            "curves_mgdl_json": curves,
+            "default_curve_name": default_curve,
+            "dedupe_key": f"loop-{uuid.uuid4().hex}",
+        }
+
+    @pytest.mark.asyncio
+    async def test_unknown_source_engine_rejected(self, fc_ctx):
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["source_engine"] = "AAPS"  # casing typo, NOT in allowed set
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_zero_step_minutes_rejected(self, fc_ctx):
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["step_minutes"] = 0
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_negative_horizon_minutes_rejected(self, fc_ctx):
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["horizon_minutes"] = -5
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_default_curve_missing_from_curves_rejected(self, fc_ctx):
+        """default_curve_name = "IOB" but curves only has "main".
+        Read endpoint would KeyError. DB must reject."""
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["curves_mgdl_json"] = {"main": [120, 122]}
+        kwargs["default_curve_name"] = "IOB"  # not in curves
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_empty_dedupe_key_rejected(self, fc_ctx):
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["dedupe_key"] = ""
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_oversized_dedupe_key_rejected(self, fc_ctx):
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["dedupe_key"] = "x" * 200  # over 128
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_evaluation_fk_rejects_bogus_snapshot(self, fc_ctx):
+        """Inserting an eval row pointing at a non-existent snapshot
+        must fail at the FK boundary, not later."""
+        session, _user_id, _conn = fc_ctx
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=uuid.uuid4(),  # no such snapshot
+                offset_minutes=5,
+                predicted_mgdl=120.0,
+                actual_mgdl=120.0,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_non_utc_timezone_round_trip(self, fc_ctx):
+        """PR 2 translator may receive timestamps in non-UTC offsets
+        (NS payloads carry whatever the uploader's clock reports).
+        DB stores TIMESTAMPTZ; round-trip must preserve the absolute
+        instant regardless of the wire-format tz."""
+        session, user_id, _conn = fc_ctx
+        # 14:30 in UTC+05:30 == 09:00 UTC
+        ist = timezone(timedelta(hours=5, minutes=30))
+        issued_local = datetime(2026, 5, 12, 14, 30, 0, tzinfo=ist)
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["issued_at"] = issued_local
+        kwargs["start_at"] = issued_local
+        session.add(ForecastSnapshot(**kwargs))
+        await session.commit()
+
+        row = (
+            await session.execute(
+                select(ForecastSnapshot).where(
+                    ForecastSnapshot.user_id == user_id
+                )
+            )
+        ).scalar_one()
+        # Postgres TIMESTAMPTZ normalizes to UTC on storage.
+        assert row.issued_at.tzinfo is not None
+        assert row.issued_at == issued_local  # same absolute instant
+        # Confirm the absolute-instant equivalence explicitly.
+        assert row.issued_at.astimezone(UTC) == datetime(
+            2026, 5, 12, 9, 0, 0, tzinfo=UTC
+        )

--- a/apps/api/tests/test_forecast_snapshot_model.py
+++ b/apps/api/tests/test_forecast_snapshot_model.py
@@ -106,9 +106,7 @@ async def fc_ctx() -> AsyncGenerator[
                 )
             )
             await session.execute(
-                delete(ForecastSnapshot).where(
-                    ForecastSnapshot.user_id == user_id
-                )
+                delete(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
             )
             await session.execute(delete(User).where(User.id == user_id))
             await session.commit()
@@ -755,9 +753,7 @@ class TestForecastDbInvariants:
 
         row = (
             await session.execute(
-                select(ForecastSnapshot).where(
-                    ForecastSnapshot.user_id == user_id
-                )
+                select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
             )
         ).scalar_one()
         # Postgres TIMESTAMPTZ normalizes to UTC on storage.


### PR DESCRIPTION
## Summary

First PR in a six-PR series adding closed-loop forecast overlay support (Loop, AAPS, Trio, oref0, iAPS). Schema-only: introduces `forecast_snapshots` and `forecast_evaluations` tables with FKs, CHECK constraints, and the indexes the dashboard read path will hit.

PR #572 already captures the raw `loop`/`openaps` subtrees on `device_status_snapshots` but nothing reads them. This PR lands the consumable shape that PR 2 (translator), PR 3 (read endpoint), the chart overlay, the AI context builder, and a future scoring / training-signal pipeline all share.

## Schema highlights

- **`forecast_snapshots`** — per-cycle row, source-attributed via `source_engine`. `(source_engine, dedupe_key)` is UNIQUE so the translator can UPSERT by NS devicestatus `_id`.
- **`curves_mgdl_json`** JSONB stores Loop's single curve (`{"main": [...]}`) and AAPS / Trio / oref0's multi-curve (`{"IOB","COB","UAM","ZT"}`) in one shape. `default_curve_name` records the source's own UI default.
- **`forecast_evaluations`** lands empty. The scoring job that pairs each forecast point against the actual CGM reading is deferred to a follow-up. Zero schema cost; future prediction-engine work inherits a labelled dataset.

## Defense-in-depth (DB CHECK constraints)

- `source_engine IN ('loop','aaps','trio','oref0','iaps','glycemicgpt')` — catches translator typos at the boundary.
- `step_minutes > 0 AND horizon_minutes > 0`.
- `curves_mgdl_json ? default_curve_name` — read endpoint would `KeyError` if these drift.
- `char_length(dedupe_key) BETWEEN 1 AND 128`.

ON DELETE CASCADE on `user_id` and `forecast_snapshot_id`; `nightscout_connection_id` nullable for future direct-integration and engine-emitted rows.

## Tests

18 pytest cases:

- Round-trip for Loop / AAPS multi-curve / AAPS partial-curves / engine-emitted-without-connection
- `(source_engine, dedupe_key)` uniqueness; cross-source non-collision
- `forecast_evaluations` partial-row insert (NULL `actual_mgdl`), same-offset rejection, snapshot-delete cascade
- "Latest forecast per source" ordering against `ix_forecast_user_source_issued`
- Every CHECK rejects malformed rows; bogus-FK insert rejected
- TIMESTAMPTZ round-trip preserves the absolute instant across non-UTC tz inputs

Fixture pre-yield TRUNCATEs both tables — belt-and-braces against leaked rows from a malformed prior test.

## Test plan

- [x] `alembic upgrade head` then `alembic downgrade` cleanly
- [x] `pytest tests/test_forecast_snapshot_model.py` — 18 passed
- [x] Full NS suite + forecast tests — 234 passed, 13 skipped
- [x] Full backend pytest — 1932 passed, 14 skipped, 1 pre-existing flake (`test_tick_budget_exceeded_cancels_in_flight_syncs`, confirmed identical failure on develop baseline)
- [x] `ruff check` clean on all three files
- [x] API `/health` returns 200 after schema applied
- [x] Web dashboard renders cleanly (Playwright snapshot — glucose hero, AGP, insulin summary, time-in-range, data sources)
- [x] Adversarial review (HIGH/MEDIUM/LOW findings all addressed; remaining LOWs deferred with rationale)
- [x] CodeRabbit CLI review — clean after addressing the one finding on PR code (`source_engine` comment/CHECK consistency)
- [x] Security review — clean (no secrets, FK cascade chain sound, JSONB safe-deserialized, all LOWs are correctly deferred to PR 2's translator)

## What's next

- PR 2 — Translator extension writes `forecast_snapshots` from Loop / AAPS / Trio / oref0 devicestatus payloads (idempotent UPSERT on `(source_engine, dedupe_key)`)
- PR 3 — `GET /api/v1/dashboard/forecast` read endpoint
- PR 4 — Frontend per-user picker + dotted-line overlay on the glucose trend chart (3H / 6H windows only)
- PR 5 — AI chat context extension
- PR 6 — Hero card surfaces (independent of PRs 2-5)

Design doc: `_bmad-output/planning-artifacts/story-43.12-forecast-overlay-design.md` (local).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save normalized closed‑loop glucose forecast snapshots from multiple engines (single- and multi‑curve formats), with idempotent deduplication and retrieval of the latest per user and per source.
  * Store per‑horizon forecast evaluations to compare predicted vs actual CGM readings, allowing partial/nullable actuals.

* **Tests**
  * Added integration tests covering insertion, uniqueness/idempotency, constraints, cascade deletes, query-by-latest, and timezone round‑trips.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/613)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->