### PR TITLE
docs: add funding.json manifest and align funding sections with Open Source Collective

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -147,17 +147,12 @@ If contributors disagree on an approach:
 
 ### How funding works
 
-GlycemicGPT is funded through [GitHub Sponsors](https://github.com/sponsors/GlycemicGPT) and [Open Collective](https://opencollective.com/glycemicgpt).
+GlycemicGPT is funded through a single channel: [Open Collective](https://opencollective.com/glycemicgpt), fiscally hosted by Open Source Collective. All project income, expenses, and balances are public by default.
 
-- **GitHub Sponsors**: Direct sponsorship of the project lead and the project
-- **Open Collective**: Transparent project fund for shared expenses
-
-All Open Collective transactions are public by default.
+Routing every dollar -- including any compensation paid to the project lead, maintainers, or committers -- through one transparent ledger is a deliberate choice in support of full financial transparency. The project does not solicit funds through any other channel.
 
 <p align="center">
-  <a href="https://opencollective.com/glycemicgpt"><img src="https://img.shields.io/badge/Open%20Collective-Sponsor-7FADF2?style=for-the-badge&logo=opencollective&logoColor=white&labelColor=1e293b" alt="Sponsor on Open Collective" height="42"></a>
-  &nbsp;&nbsp;
-  <a href="https://github.com/sponsors/GlycemicGPT"><img src="https://img.shields.io/badge/GitHub%20Sponsors-Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white&labelColor=1e293b" alt="Sponsor via GitHub Sponsors" height="42"></a>
+  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="300"></a>
 </p>
 
 ### What the fund covers
@@ -171,12 +166,12 @@ All Open Collective transactions are public by default.
 
 | Role | Org seat | Stipend eligible | How |
 |------|:--------:|:----------------:|-----|
-| **Project lead** | N/A (owner) | Yes | GitHub Sponsors (personal) |
+| **Project lead** | N/A (owner) | Yes | Open Collective stipend |
 | **Maintainer** | Paid from fund | Yes | Open Collective stipend |
 | **Committer** | Paid from fund | No | Volunteer role |
 | **Contributor** | N/A | No | Bounties on specific issues (future) |
 
-The project lead receives personal sponsorship via GitHub Sponsors. This is standard practice for open source maintainers and is documented here transparently.
+The project lead is stipend-eligible from the Open Collective fund on the same basis as any other maintainer. Routing all compensation -- regardless of role -- through Open Collective keeps every payout on the public ledger.
 
 Maintainer stipend amounts are decided by the project lead based on fund balance and contribution level. Stipend decisions are documented in the maintainers Discussion thread.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -158,7 +158,7 @@ Routing every dollar -- including any compensation paid to the project lead, mai
 ### What the fund covers
 
 1. **Infrastructure**: hosting, domain (glycemicgpt.org), CI costs, signing certificates
-2. **Org seats**: $4/month per committer/maintainer seat on the GitHub Teams plan
+2. **Org seats**: per-seat cost for each committer/maintainer on the GitHub Teams plan
 3. **Maintainer stipends**: when the fund supports it, active maintainers may receive monthly stipends
 4. **Bounties**: specific issues may carry bounties funded from Open Collective (future)
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -147,16 +147,18 @@ If contributors disagree on an approach:
 
 ### How funding works
 
-GlycemicGPT is fiscally hosted by [Open Source Collective](https://opencollective.com/opensource) -- a 501(c)(6) non-profit that holds project funds on our behalf, handles tax and compliance, and publishes every transaction. The project fund lives at [opencollective.com/glycemicgpt](https://opencollective.com/glycemicgpt) and is the recommended way to support the project. [GitHub Sponsors](https://github.com/sponsors/GlycemicGPT) is also available for sponsors who prefer that platform; GitHub Sponsors income is reported on the project's Open Collective page when it is moved into the fund.
+GlycemicGPT is funded through [GitHub Sponsors](https://github.com/sponsors/GlycemicGPT) and [Open Collective](https://opencollective.com/glycemicgpt).
 
-- **Open Collective (recommended)**: Transparent project fund. All income, expenses, and balances on this channel are public by default.
-- **GitHub Sponsors**: Org-level sponsorship of the project on GitHub. Separate platform; funds are moved to the Open Collective fund where they become part of the public ledger.
+- **GitHub Sponsors**: Direct sponsorship of the project lead and the project
+- **Open Collective**: Transparent project fund for shared expenses
+
+All Open Collective transactions are public by default.
 
 <p align="center">
-  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/tiers/backers.svg?avatarHeight=36&width=600" alt="Open Collective backers for GlycemicGPT"></a>
+  <a href="https://opencollective.com/glycemicgpt"><img src="https://img.shields.io/badge/Open%20Collective-Sponsor-7FADF2?style=for-the-badge&logo=opencollective&logoColor=white&labelColor=1e293b" alt="Sponsor on Open Collective" height="42"></a>
+  &nbsp;&nbsp;
+  <a href="https://github.com/sponsors/GlycemicGPT"><img src="https://img.shields.io/badge/GitHub%20Sponsors-Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white&labelColor=1e293b" alt="Sponsor via GitHub Sponsors" height="42"></a>
 </p>
-
-A machine-readable funding manifest is published at [`funding.json`](funding.json) at the repository root for sponsor discovery and funding aggregators. The manifest conforms to the v1.0.0 [funding manifest standard](https://floss.fund/funding-manifest) and is suitable for any sponsor, grant program, or directory that consumes the format -- not tied to a single funder.
 
 ### What the fund covers
 
@@ -169,12 +171,12 @@ A machine-readable funding manifest is published at [`funding.json`](funding.jso
 
 | Role | Org seat | Stipend eligible | How |
 |------|:--------:|:----------------:|-----|
-| **Project lead** | N/A (owner) | Yes | Open Collective stipend (primary); personal GitHub Sponsors (separate, secondary) |
+| **Project lead** | N/A (owner) | Yes | GitHub Sponsors (personal) |
 | **Maintainer** | Paid from fund | Yes | Open Collective stipend |
 | **Committer** | Paid from fund | No | Volunteer role |
 | **Contributor** | N/A | No | Bounties on specific issues (future) |
 
-The project lead is stipend-eligible from the Open Collective fund on the same basis as any other maintainer; eligibility and amount depend on fund balance and contribution level. A separate personal [GitHub Sponsors](https://github.com/sponsors/jlengelbrecht) profile exists for sponsors who wish to support the project lead directly outside the project fund -- this is independent of the project fund and is disclosed here for transparency.
+The project lead receives personal sponsorship via GitHub Sponsors. This is standard practice for open source maintainers and is documented here transparently.
 
 Maintainer stipend amounts are decided by the project lead based on fund balance and contribution level. Stipend decisions are documented in the maintainers Discussion thread.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -147,12 +147,16 @@ If contributors disagree on an approach:
 
 ### How funding works
 
-GlycemicGPT is funded through [GitHub Sponsors](https://github.com/sponsors/GlycemicGPT) and [Open Collective](https://opencollective.com/glycemicgpt).
+GlycemicGPT is fiscally hosted by [Open Source Collective](https://opencollective.com/opensource) -- a 501(c)(6) non-profit that holds project funds on our behalf, handles tax and compliance, and publishes every transaction. The project fund lives at [opencollective.com/glycemicgpt](https://opencollective.com/glycemicgpt) and is the recommended way to support the project. [GitHub Sponsors](https://github.com/sponsors/GlycemicGPT) is also available for sponsors who prefer that platform; GitHub Sponsors income is reported on the project's Open Collective page when it is moved into the fund.
 
-- **GitHub Sponsors**: Direct sponsorship of the project lead and the project
-- **Open Collective**: Transparent project fund for shared expenses
+- **Open Collective (recommended)**: Transparent project fund. All income, expenses, and balances on this channel are public by default.
+- **GitHub Sponsors**: Org-level sponsorship of the project on GitHub. Separate platform; funds are moved to the Open Collective fund where they become part of the public ledger.
 
-All Open Collective transactions are public by default.
+<p align="center">
+  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/tiers/backers.svg?avatarHeight=36&width=600" alt="Open Collective backers for GlycemicGPT"></a>
+</p>
+
+A machine-readable funding manifest is published at [`funding.json`](funding.json) at the repository root, conforming to the [FLOSS Fund v1.0.0 funding manifest specification](https://floss.fund/funding-manifest).
 
 ### What the fund covers
 
@@ -165,12 +169,12 @@ All Open Collective transactions are public by default.
 
 | Role | Org seat | Stipend eligible | How |
 |------|:--------:|:----------------:|-----|
-| **Project lead** | N/A (owner) | Yes | GitHub Sponsors (personal) |
+| **Project lead** | N/A (owner) | Yes | Open Collective stipend (primary); personal GitHub Sponsors (separate, secondary) |
 | **Maintainer** | Paid from fund | Yes | Open Collective stipend |
 | **Committer** | Paid from fund | No | Volunteer role |
 | **Contributor** | N/A | No | Bounties on specific issues (future) |
 
-The project lead receives personal sponsorship via GitHub Sponsors. This is standard practice for open source maintainers and is documented here transparently.
+The project lead is stipend-eligible from the Open Collective fund on the same basis as any other maintainer; eligibility and amount depend on fund balance and contribution level. A separate personal [GitHub Sponsors](https://github.com/sponsors/jlengelbrecht) profile exists for sponsors who wish to support the project lead directly outside the project fund -- this is independent of the project fund and is disclosed here for transparency.
 
 Maintainer stipend amounts are decided by the project lead based on fund balance and contribution level. Stipend decisions are documented in the maintainers Discussion thread.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -156,7 +156,7 @@ GlycemicGPT is fiscally hosted by [Open Source Collective](https://opencollectiv
   <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/tiers/backers.svg?avatarHeight=36&width=600" alt="Open Collective backers for GlycemicGPT"></a>
 </p>
 
-A machine-readable funding manifest is published at [`funding.json`](funding.json) at the repository root, conforming to the [FLOSS Fund v1.0.0 funding manifest specification](https://floss.fund/funding-manifest).
+A machine-readable funding manifest is published at [`funding.json`](funding.json) at the repository root for sponsor discovery and funding aggregators. The manifest conforms to the v1.0.0 [funding manifest standard](https://floss.fund/funding-manifest) and is suitable for any sponsor, grant program, or directory that consumes the format -- not tied to a single funder.
 
 ### What the fund covers
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -180,6 +180,7 @@ Maintainer stipend amounts are decided by the project lead based on fund balance
 - All Open Collective income and expenses are public
 - Stipend decisions are documented in Discussions
 - Annual financial summary posted to Discussions
+- Open Source Collective deducts a 10% host fee from each donation; the remaining 90% goes to the project fund. This fee is documented on OSC's [hosted collectives page](https://opencollective.com/opensource) and applied automatically by the platform.
 
 ## Branch Protection
 

--- a/README.md
+++ b/README.md
@@ -152,14 +152,18 @@ We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) 
 
 ## Support the Project
 
-GlycemicGPT is free, open source, and built by volunteers. If you find it useful, consider supporting the project:
+GlycemicGPT is free, open source, and built by volunteers. The project is fiscally hosted by [Open Source Collective](https://opencollective.com/opensource), so every dollar that flows through the Open Collective fund -- and every expense paid out of it -- is public on the project's [Open Collective page](https://opencollective.com/glycemicgpt). If you find the project useful, please consider supporting it:
 
 <p align="center">
-  <a href="https://github.com/sponsors/GlycemicGPT"><strong>GitHub Sponsors</strong></a> &middot;
-  <a href="https://opencollective.com/glycemicgpt"><strong>Open Collective</strong></a>
+  <a href="https://opencollective.com/glycemicgpt"><strong>Open Collective</strong></a> (recommended) &middot;
+  <a href="https://github.com/sponsors/GlycemicGPT"><strong>GitHub Sponsors</strong></a>
 </p>
 
-Your support helps cover infrastructure costs (hosting, domain, CI, signing certificates), org seats for committers and maintainers, and future maintainer stipends. All Open Collective transactions are public. See [GOVERNANCE.md](GOVERNANCE.md#compensation) for how funding is managed.
+<p align="center">
+  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/tiers/backers.svg?avatarHeight=36&width=600" alt="Open Collective backers for GlycemicGPT"></a>
+</p>
+
+Your support helps cover infrastructure costs (hosting, domain, CI, signing certificates), GitHub org seats for committers and maintainers, the planned managed cloud platform that aims to bring GlycemicGPT to people who can't self-host, and maintainer stipends as the project grows. See [GOVERNANCE.md](GOVERNANCE.md#compensation) and the project's [`funding.json`](funding.json) manifest for how funding is managed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) 
 
 ## Support the Project
 
-GlycemicGPT is free and open source. The project's funding is handled through [Open Collective](https://opencollective.com/glycemicgpt), with full public transaction history.
+GlycemicGPT is free and open source. The project's funding is handled through [Open Collective](https://opencollective.com/glycemicgpt), with full public transaction history. If contributing financially isn't an option, starring the repository is a free way to help -- stars improve discoverability on GitHub and signal to others that the project is worth a look.
 
 <p align="center">
-  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="300"></a>
+  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="280"></a>
+  &nbsp;&nbsp;
+  <a href="https://github.com/GlycemicGPT/GlycemicGPT/stargazers"><img src="https://img.shields.io/github/stars/GlycemicGPT/GlycemicGPT?style=for-the-badge&logo=github&label=Star%20on%20GitHub&color=fbbf24&logoColor=white&labelColor=1e293b" alt="Star GlycemicGPT on GitHub"></a>
 </p>
 
 ## License

--- a/README.md
+++ b/README.md
@@ -152,18 +152,11 @@ We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) 
 
 ## Support the Project
 
-GlycemicGPT is free, open source, and built by volunteers. The project is fiscally hosted by [Open Source Collective](https://opencollective.com/opensource), so every dollar that flows through the Open Collective fund -- and every expense paid out of it -- is public on the project's [Open Collective page](https://opencollective.com/glycemicgpt). If you find the project useful, please consider supporting it:
+GlycemicGPT is free and open source. The project's funding is handled through [Open Collective](https://opencollective.com/glycemicgpt), with full public transaction history.
 
 <p align="center">
-  <a href="https://opencollective.com/glycemicgpt"><strong>Open Collective</strong></a> (recommended) &middot;
-  <a href="https://github.com/sponsors/GlycemicGPT"><strong>GitHub Sponsors</strong></a>
+  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="300"></a>
 </p>
-
-<p align="center">
-  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/tiers/backers.svg?avatarHeight=36&width=600" alt="Open Collective backers for GlycemicGPT"></a>
-</p>
-
-Your support helps cover infrastructure costs (hosting, domain, CI, signing certificates), GitHub org seats for committers and maintainers, the planned managed cloud platform that aims to bring GlycemicGPT to people who can't self-host, and maintainer stipends as the project grows. See [GOVERNANCE.md](GOVERNANCE.md#compensation) and the project's [`funding.json`](funding.json) manifest for how funding is managed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) 
 
 ## Support the Project
 
-GlycemicGPT is free and open source. The project's funding is handled through [Open Collective](https://opencollective.com/glycemicgpt), with full public transaction history. If contributing financially isn't an option, starring the repository is a free way to help -- stars improve discoverability on GitHub and signal to others that the project is worth a look.
+GlycemicGPT is free and open source. Funding is handled through [Open Collective](https://opencollective.com/glycemicgpt), with full public transaction history. Stars on GitHub help other people discover the project.
 
 <p align="center">
   <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="280"></a>
   &nbsp;&nbsp;
-  <a href="https://github.com/GlycemicGPT/GlycemicGPT/stargazers"><img src="https://img.shields.io/github/stars/GlycemicGPT/GlycemicGPT?style=for-the-badge&logo=github&label=Star%20on%20GitHub&color=fbbf24&logoColor=white&labelColor=1e293b" alt="Star GlycemicGPT on GitHub"></a>
+  <a href="https://github.com/GlycemicGPT/GlycemicGPT"><img src="assets/buttons/star-on-github.svg" alt="Star GlycemicGPT on GitHub" width="280"></a>
 </p>
 
 ## License

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) 
 
 ## Support the Project
 
-GlycemicGPT is free and open source. Funding is handled through [Open Collective](https://opencollective.com/glycemicgpt), with full public transaction history. Stars on GitHub help other people discover the project.
+GlycemicGPT is free and open source. Funding flows through [Open Collective](https://opencollective.com/how-it-works), with full public transaction history. For a breakdown of how project funds are used, see the [What the fund covers](GOVERNANCE.md#what-the-fund-covers) section in `GOVERNANCE.md`. Stars on GitHub help other people discover the project.
 
 <p align="center">
   <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="280"></a>

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ GlycemicGPT is free and open source. Funding is handled through [Open Collective
 <p align="center">
   <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="280"></a>
   &nbsp;&nbsp;
-  <a href="https://github.com/GlycemicGPT/GlycemicGPT"><img src="assets/buttons/star-on-github.svg" alt="Star GlycemicGPT on GitHub" width="280"></a>
+  <a href="https://github.com/GlycemicGPT/GlycemicGPT/stargazers"><img src="assets/buttons/star-on-github.svg" alt="Star GlycemicGPT on GitHub" width="280"></a>
 </p>
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,7 +120,7 @@ The two legal reviews below remain pending; the fiscal hosting and transparent r
 - Legal review of platform positioning relative to medical device classification
 - Disclaimer and terms of use review with legal counsel
 - **Delivered:** Open Source Collective fiscal hosting approved -- GlycemicGPT is fiscally hosted by Open Source Collective at [opencollective.com/glycemicgpt](https://opencollective.com/glycemicgpt). All project funds are held by OSC on the project's behalf, with full public transaction history.
-- **Delivered:** Transparent financial reporting via Open Collective -- every donation and expense on the Open Collective channel is published automatically; the project ships a [`funding.json`](funding.json) manifest at the repository root for sponsor discovery (FLOSS Fund v1.0.0).
+- **Delivered:** Transparent financial reporting via Open Collective -- every donation and expense on the Open Collective channel is published automatically; the project ships a [`funding.json`](funding.json) manifest at the repository root for sponsor discovery.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,10 +115,12 @@ Clear, accessible documentation is critical for adoption. Early adopter feedback
 
 ### Legal & Organizational
 
+The two legal reviews below remain pending; the fiscal hosting and transparent reporting items are now in place.
+
 - Legal review of platform positioning relative to medical device classification
 - Disclaimer and terms of use review with legal counsel
-- Open Source Collective fiscal hosting approval
-- Transparent financial reporting via Open Collective
+- **Delivered:** Open Source Collective fiscal hosting approved -- GlycemicGPT is fiscally hosted by Open Source Collective at [opencollective.com/glycemicgpt](https://opencollective.com/glycemicgpt). All project funds are held by OSC on the project's behalf, with full public transaction history.
+- **Delivered:** Transparent financial reporting via Open Collective -- every donation and expense on the Open Collective channel is published automatically; the project ships a [`funding.json`](funding.json) manifest at the repository root for sponsor discovery (FLOSS Fund v1.0.0).
 
 ---
 

--- a/assets/buttons/star-on-github.svg
+++ b/assets/buttons/star-on-github.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 668 96" width="668" height="96" role="img" aria-label="Star on GitHub">
   <title>Star on GitHub</title>
-  <rect x="0" y="0" width="668" height="96" rx="48" ry="48" fill="#0D1117"/>
+  <rect x="3" y="3" width="662" height="90" rx="45" ry="45" fill="#0D1117" stroke="#FBBF24" stroke-width="4"/>
   <!-- Gold star, left -->
   <path transform="translate(100 30) scale(1.5)" fill="#FBBF24" d="M12 .587l3.668 7.568L24 9.75l-6 5.852 1.42 8.275L12 19.771l-7.42 4.106L6 15.602 0 9.75l8.332-1.595z"/>
   <!-- Text, centered between gold star and octocat -->

--- a/assets/buttons/star-on-github.svg
+++ b/assets/buttons/star-on-github.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 668 96" width="668" height="96" role="img" aria-label="Star on GitHub">
+  <title>Star on GitHub</title>
+  <rect x="0" y="0" width="668" height="96" rx="48" ry="48" fill="#0D1117"/>
+  <!-- Gold star, left -->
+  <path transform="translate(100 30) scale(1.5)" fill="#FBBF24" d="M12 .587l3.668 7.568L24 9.75l-6 5.852 1.42 8.275L12 19.771l-7.42 4.106L6 15.602 0 9.75l8.332-1.595z"/>
+  <!-- Text, centered between gold star and octocat -->
+  <text x="346" y="59" text-anchor="middle" fill="#FFFFFF" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" letter-spacing="3">STAR ON GITHUB</text>
+  <!-- GitHub octocat, white, far right (matching OC logo placement) -->
+  <path transform="translate(580 12) scale(3)" fill="#FFFFFF" d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+</svg>

--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,74 @@
+{
+  "version": "v1.0.0",
+  "entity": {
+    "type": "group",
+    "role": "owner",
+    "name": "GlycemicGPT",
+    "email": "funding@glycemicgpt.org",
+    "description": "GlycemicGPT is an open source diabetes platform with AI-powered analysis at its core. It gives people living with diabetes -- and the family members and caregivers who support them -- real-time glucose monitoring, daily AI-generated briefs that explain what their numbers mean, pattern detection across days and weeks, a conversational AI assistant grounded in their own data, and tiered alerts that loop in trusted contacts when something needs attention. Because no one should manage diabetes alone.",
+    "webpageUrl": {
+      "url": "https://glycemicgpt.org",
+      "wellKnown": "https://glycemicgpt.org/.well-known/funding-manifest-urls"
+    }
+  },
+  "projects": [
+    {
+      "guid": "github.com/glycemicgpt/glycemicgpt",
+      "name": "GlycemicGPT",
+      "description": "Open source diabetes platform with AI-powered analysis. Real-time monitoring, daily AI briefs, pattern detection, and caregiver alerts -- built around the principle that no one should manage diabetes alone.",
+      "webpageUrl": {
+        "url": "https://glycemicgpt.org",
+        "wellKnown": "https://glycemicgpt.org/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/GlycemicGPT/GlycemicGPT",
+        "wellKnown": "https://glycemicgpt.org/.well-known/funding-manifest-urls"
+      },
+      "licenses": ["spdx:GPL-3.0-only"],
+      "tags": [
+        "diabetes",
+        "healthcare",
+        "health",
+        "ai",
+        "cgm",
+        "insulin-pump",
+        "medical",
+        "monitoring",
+        "caregiver"
+      ]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "glycemicgpt-opencollective",
+        "type": "payment-provider",
+        "address": "https://opencollective.com/glycemicgpt",
+        "description": "Transparent fund hosted by Open Source Collective. All income and expenses are public on Open Collective. Donations of any size, recurring or one-time, are accepted in USD."
+      }
+    ],
+    "plans": [
+      {
+        "guid": "project-operations",
+        "status": "active",
+        "name": "Project operations",
+        "description": "Sustains the day-to-day operating costs of GlycemicGPT: GitHub organization seats for maintainers and committers, the project domain (glycemicgpt.org), project email, Android signing infrastructure, CI runner overages as pull request volume grows, and the Open Source Collective fiscal host fee. Includes headroom for paid code review tooling if current open-source sponsorships end. Funds at this level keep the project running and let it absorb a small number of additional maintainers without strain.",
+        "amount": 5000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": ["glycemicgpt-opencollective"]
+      },
+      {
+        "guid": "managed-cloud-platform",
+        "status": "active",
+        "name": "Managed cloud platform",
+        "description": "Funds the buildout and ongoing operation of the project's planned Hosted Service for Non-Technical Users (see project roadmap). Covers managed PostgreSQL, application hosting for the API, AI sidecar, and web front end, observability and monitoring, transactional email, Telegram bot infrastructure, and backups and object storage. The hosted service follows the same BYOAI model as the self-hosted product -- users supply their own AI credential -- so this plan funds platform infrastructure rather than AI inference costs. The goal is to lower the entry barrier for users who cannot run their own infrastructure, without fragmenting the product into hosted-only features.",
+        "amount": 30000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": ["glycemicgpt-opencollective"]
+      }
+    ],
+    "history": []
+  }
+}

--- a/funding.json
+++ b/funding.json
@@ -52,7 +52,7 @@
         "guid": "project-operations",
         "status": "active",
         "name": "Project operations",
-        "description": "Sustains the day-to-day operating costs of GlycemicGPT: GitHub organization seats for maintainers and committers, the project domain (glycemicgpt.org), project email, Android signing infrastructure, CI runner overages as pull request volume grows, and the Open Source Collective fiscal host fee. Includes headroom for paid code review tooling if current open-source sponsorships end. Funds at this level keep the project running and let it absorb a small number of additional maintainers without strain.",
+        "description": "Sustains the operating costs of GlycemicGPT: GitHub organization seats for maintainers and committers, the project domain (glycemicgpt.org), project email, and headroom for paid code review tooling if current open-source sponsorships end. As pull request and CI traffic grows, this plan also absorbs GitHub Actions runner overages beyond the free org-plan tier. Funds at this level keep the project running and let it absorb a small number of additional maintainers without strain.",
         "amount": 5000,
         "currency": "USD",
         "frequency": "yearly",

--- a/funding.json
+++ b/funding.json
@@ -62,7 +62,7 @@
         "guid": "managed-cloud-platform",
         "status": "active",
         "name": "Managed cloud platform",
-        "description": "Funds the buildout and ongoing operation of the project's planned Hosted Service for Non-Technical Users (see project roadmap). Covers managed PostgreSQL, application hosting for the API, AI sidecar, and web front end, observability and monitoring, transactional email, Telegram bot infrastructure, and backups and object storage. The hosted service follows the same BYOAI model as the self-hosted product -- users supply their own AI credential -- so this plan funds platform infrastructure rather than AI inference costs. The goal is to lower the entry barrier for users who cannot run their own infrastructure, without fragmenting the product into hosted-only features.",
+        "description": "Funds the buildout and ongoing operation of the project's planned Hosted Service for Non-Technical Users (see project roadmap). Covers managed PostgreSQL, application hosting for the API, AI sidecar, and web front end, observability and monitoring, transactional email, and backups and object storage. The hosted service follows the same BYOAI model as the self-hosted product -- users supply their own AI credential -- so this plan funds platform infrastructure rather than AI inference costs. The goal is to lower the entry barrier for users who cannot run their own infrastructure, without fragmenting the product into hosted-only features.",
         "amount": 30000,
         "currency": "USD",
         "frequency": "yearly",

--- a/funding.json
+++ b/funding.json
@@ -34,7 +34,10 @@
         "insulin-pump",
         "medical",
         "monitoring",
-        "caregiver"
+        "caregiver",
+        "open-source",
+        "self-hosted",
+        "privacy-first"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Adds a machine-readable `funding.json` manifest at the repository root and updates `GOVERNANCE.md`, `README.md`, and `ROADMAP.md` to reflect that **Open Source Collective is now the project's fiscal host** (no longer future-tense in the roadmap).

The project funding model is consolidated to a **single channel** -- [Open Collective](https://opencollective.com/glycemicgpt). All project income, expenses, and stipends (including any paid to the project lead) flow through one transparent ledger. GitHub Sponsors is intentionally not part of the project funding model so that nothing about the project's finances lives outside the public Open Collective page.

The manifest follows the [v1.0.0 funding manifest standard](https://floss.fund/funding-manifest) and is suitable for any sponsor, grant program, or directory that consumes the format -- it is not tied to a specific funder.

### Funding plans declared

| Plan | Amount | Purpose |
|------|--------|---------|
| Project operations | $5,000/yr | GitHub seats, infrastructure, OSC fiscal host fee, code-review tooling headroom |
| Managed cloud platform | $30,000/yr | Buildout of the planned Hosted Service for Non-Technical Users (see `ROADMAP.md` Phase 4) |

The cloud platform plan aligns with the existing Phase 4 §Hosted Service roadmap entry: the hosted service stays BYOAI; this plan funds infrastructure (managed PostgreSQL, app hosting, monitoring, transactional email, backups), not AI inference.

### Files

- `funding.json` (new) -- funding manifest at repo root, Open Collective as the sole channel
- `GOVERNANCE.md` §Compensation -- single-channel funding model, OC contribute button, project lead stipend routes through OC like any other maintainer
- `README.md` §Support the Project -- short, factual pointer to Open Collective with a prominent branded contribute button
- `ROADMAP.md` Phase 1 Legal & Org -- fiscal hosting and transparent reporting marked **Delivered**, with a status note clarifying the remaining two legal review items are still pending

## Follow-up required before submitting to grant programs

Some grant programs (FLOSS Fund and similar) verify project ownership by pulling a well-known URL declared in the manifest. The verification file is not part of this PR -- it lives in the project website repository. A follow-up PR there must add `.well-known/funding-manifest-urls` containing the raw URL to this `funding.json` before submitting to any program that uses the well-known verification step.

Action items outside this PR:
- [ ] Add `.well-known/funding-manifest-urls` to the website repo
- [ ] Verify the `funding@glycemicgpt.org` mailbox delivers (send a test message round-trip)

## Test plan

- [x] `funding.json` parses as valid JSON
- [x] All widget and button URLs return correct image content types (verified via `curl -I`)
- [x] GitHub markdown API renders the README and GOVERNANCE button paragraphs correctly through the camo proxy
- [x] Adversarial review (`bmad-review-adversarial-general`) -- findings raised and fixed; deferred items captured in this description
- [x] CodeRabbit CLI review against develop -- no findings
- [x] Security review of committed diff -- PASS (no secrets, no injection vectors, accurate sponsor-facing claims, OSC correctly identified as 501(c)(6))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that all donations and compensation flow through Open Collective with public transaction history.
  * Updated how the project lead and contributors are paid (stipend eligibility via the fund; existing paid-from-fund vs volunteer/bounty distinctions retained).
  * Added a funding manifest to improve sponsor discovery and a visible “Contribute”/discovery button in project materials.
  * Noted a 10% host fee and recorded pending legal/organizational review items.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/614)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->