### PR TITLE
chore: promote develop to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -484,13 +484,36 @@ jobs:
           TAG: ${{ steps.version-info.outputs.tag_name }}
           VERSION: ${{ steps.version-info.outputs.version }}
         run: |
-          # Extract the latest dated section from CHANGELOG.md
-          # (populated by changelog-pr.yml with @username contributor credits)
-          BODY=$(sed -n '/^## [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/,/^\(## [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\|<!-- changelog-cutoff:\)/{
-            /^## [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/!{
-              /^\(## [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\|<!-- changelog-cutoff:\)/!p
+          # Extract ONLY the latest dated section from CHANGELOG.md.
+          #
+          # CHANGELOG layout per `changelog-pr.yml`:
+          #
+          #   ## YYYY-MM-DD          <- latest release heading
+          #   ...latest entries...
+          #   <!-- changelog-cutoff:YYYY-MM-DDTHH:MM:SSZ -->
+          #
+          #   ## YYYY-MM-DD          <- previous release heading
+          #   ...previous entries...
+          #   <!-- changelog-cutoff:... -->
+          #
+          # The previous implementation used a `sed -n /START/,/END/` address
+          # range. sed range matching is **recurring** -- once the closing
+          # address matches, sed keeps scanning and re-opens a new range on
+          # the next `## YYYY-MM-DD` heading. The net result was that every
+          # release's body included entries going back to the beginning of
+          # the changelog. Awk with an `exit` after the first range close
+          # gives single-shot extraction.
+          BODY=$(awk '
+            /^## [0-9]{4}-[0-9]{2}-[0-9]{2}/ {
+              if (in_section) exit
+              in_section = 1
+              next
             }
-          }' CHANGELOG.md)
+            /^<!-- changelog-cutoff:/ {
+              if (in_section) exit
+            }
+            in_section { print }
+          ' CHANGELOG.md)
 
           if [ -n "$BODY" ]; then
             {

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -147,17 +147,18 @@ If contributors disagree on an approach:
 
 ### How funding works
 
-GlycemicGPT is funded through [GitHub Sponsors](https://github.com/sponsors/GlycemicGPT) and [Open Collective](https://opencollective.com/glycemicgpt).
+GlycemicGPT is funded through a single channel: [Open Collective](https://opencollective.com/glycemicgpt), fiscally hosted by Open Source Collective. All project income, expenses, and balances are public by default.
 
-- **GitHub Sponsors**: Direct sponsorship of the project lead and the project
-- **Open Collective**: Transparent project fund for shared expenses
+Routing every dollar -- including any compensation paid to the project lead, maintainers, or committers -- through one transparent ledger is a deliberate choice in support of full financial transparency. The project does not solicit funds through any other channel.
 
-All Open Collective transactions are public by default.
+<p align="center">
+  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="300"></a>
+</p>
 
 ### What the fund covers
 
 1. **Infrastructure**: hosting, domain (glycemicgpt.org), CI costs, signing certificates
-2. **Org seats**: $4/month per committer/maintainer seat on the GitHub Teams plan
+2. **Org seats**: per-seat cost for each committer/maintainer on the GitHub Teams plan
 3. **Maintainer stipends**: when the fund supports it, active maintainers may receive monthly stipends
 4. **Bounties**: specific issues may carry bounties funded from Open Collective (future)
 
@@ -165,12 +166,12 @@ All Open Collective transactions are public by default.
 
 | Role | Org seat | Stipend eligible | How |
 |------|:--------:|:----------------:|-----|
-| **Project lead** | N/A (owner) | Yes | GitHub Sponsors (personal) |
+| **Project lead** | N/A (owner) | Yes | Open Collective stipend |
 | **Maintainer** | Paid from fund | Yes | Open Collective stipend |
 | **Committer** | Paid from fund | No | Volunteer role |
 | **Contributor** | N/A | No | Bounties on specific issues (future) |
 
-The project lead receives personal sponsorship via GitHub Sponsors. This is standard practice for open source maintainers and is documented here transparently.
+The project lead is stipend-eligible from the Open Collective fund on the same basis as any other maintainer. Routing all compensation -- regardless of role -- through Open Collective keeps every payout on the public ledger.
 
 Maintainer stipend amounts are decided by the project lead based on fund balance and contribution level. Stipend decisions are documented in the maintainers Discussion thread.
 
@@ -179,6 +180,7 @@ Maintainer stipend amounts are decided by the project lead based on fund balance
 - All Open Collective income and expenses are public
 - Stipend decisions are documented in Discussions
 - Annual financial summary posted to Discussions
+- Open Source Collective deducts a 10% host fee from each donation; the remaining 90% goes to the project fund. This fee is documented on OSC's [hosted collectives page](https://opencollective.com/opensource) and applied automatically by the platform.
 
 ## Branch Protection
 

--- a/README.md
+++ b/README.md
@@ -152,14 +152,13 @@ We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) 
 
 ## Support the Project
 
-GlycemicGPT is free, open source, and built by volunteers. If you find it useful, consider supporting the project:
+GlycemicGPT is free and open source. Funding flows through [Open Collective](https://opencollective.com/how-it-works), with full public transaction history. For a breakdown of how project funds are used, see the [What the fund covers](GOVERNANCE.md#what-the-fund-covers) section in `GOVERNANCE.md`. Stars on GitHub help other people discover the project.
 
 <p align="center">
-  <a href="https://github.com/sponsors/GlycemicGPT"><strong>GitHub Sponsors</strong></a> &middot;
-  <a href="https://opencollective.com/glycemicgpt"><strong>Open Collective</strong></a>
+  <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="280"></a>
+  &nbsp;&nbsp;
+  <a href="https://github.com/GlycemicGPT/GlycemicGPT/stargazers"><img src="assets/buttons/star-on-github.svg" alt="Star GlycemicGPT on GitHub" width="280"></a>
 </p>
-
-Your support helps cover infrastructure costs (hosting, domain, CI, signing certificates), org seats for committers and maintainers, and future maintainer stipends. All Open Collective transactions are public. See [GOVERNANCE.md](GOVERNANCE.md#compensation) for how funding is managed.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,10 +115,12 @@ Clear, accessible documentation is critical for adoption. Early adopter feedback
 
 ### Legal & Organizational
 
+The two legal reviews below remain pending; the fiscal hosting and transparent reporting items are now in place.
+
 - Legal review of platform positioning relative to medical device classification
 - Disclaimer and terms of use review with legal counsel
-- Open Source Collective fiscal hosting approval
-- Transparent financial reporting via Open Collective
+- **Delivered:** Open Source Collective fiscal hosting approved -- GlycemicGPT is fiscally hosted by Open Source Collective at [opencollective.com/glycemicgpt](https://opencollective.com/glycemicgpt). All project funds are held by OSC on the project's behalf, with full public transaction history.
+- **Delivered:** Transparent financial reporting via Open Collective -- every donation and expense on the Open Collective channel is published automatically; the project ships a [`funding.json`](funding.json) manifest at the repository root for sponsor discovery.
 
 ---
 

--- a/apps/api/migrations/versions/054_ns_entry_object_id_cursor.py
+++ b/apps/api/migrations/versions/054_ns_entry_object_id_cursor.py
@@ -1,0 +1,50 @@
+"""Add `last_entry_object_id` to nightscout_connections.
+
+Switches the entries cursor from `dateString` (recorded time) to NS's
+MongoDB `_id` (insertion time, monotonically increasing). The old
+cursor missed entries that uploaders backfilled into NS *after* our
+last sync but with `dateString` values from *before* our last sync
+window. The Dexcom Share -> Nightscout bridge is the most common
+example: a brief disconnect causes the bridge to upload missed
+readings later with their original timestamps, which our cursor had
+already advanced past.
+
+Mongo `_id` is monotonic by insertion time regardless of `dateString`,
+so a backfilled entry inserted at T+5min always gets a larger `_id`
+than entries inserted at T. Querying `find[_id][$gt]=<lastSeen>` is
+immune to late uploads with old timestamps.
+
+NULL on existing rows means "no `_id` cursor yet" -- the sync code
+falls back to the legacy `last_synced_at` (dateString-based) cursor
+for the next sync, then locks in the new ObjectId cursor afterward.
+No backfill migration is required; the transition is a single sync
+cycle per connection.
+
+Treatments and devicestatus already use server-side `created_at` and
+are immune to this class of bug. They are intentionally unchanged.
+
+Closes issue #598.
+
+Revision ID: 054_ns_entry_object_id_cursor
+Revises: 053_ai_max_response_tokens
+Create Date: 2026-05-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "054_ns_entry_object_id_cursor"
+down_revision = "053_ai_max_response_tokens"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "nightscout_connections",
+        sa.Column("last_entry_object_id", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("nightscout_connections", "last_entry_object_id")

--- a/apps/api/migrations/versions/055_forecast_snapshots.py
+++ b/apps/api/migrations/versions/055_forecast_snapshots.py
@@ -1,0 +1,235 @@
+"""Forecast snapshots + evaluation pairs (Story 43.12 PR 1).
+
+Adds the storage layer for closed-loop forecast data. PR #572's
+translator captures each Nightscout devicestatus payload verbatim
+into `device_status_snapshots.{loop_subtree_json, openaps_subtree_json}`
+and nothing currently reads from those JSON columns -- the forecast
+arrays sit unused.
+
+This migration introduces a normalized table the translator writes
+to on each devicestatus fetch when a forecast is present. Chart
+overlay, AI context, and a future calibration / training-signal
+pipeline all read from the same shape.
+
+See `_bmad-output/planning-artifacts/story-43.12-forecast-overlay-design.md`
+for the full design discussion (why a separate table vs JSON-extract
+on read; why JSONB curves vs typed columns; why per-user picker
+instead of per-connection toggle).
+
+`forecast_evaluations` lands empty here. The scoring job that
+populates it is deferred to a follow-up. Schema cost is essentially
+zero (empty table) but having it in place now means when the future
+GlycemicGPT prediction engine team starts work, they have a labelled
+dataset waiting -- not a year of un-captured forecasts to lament.
+
+Revision ID: 055_forecast_snapshots
+Revises: 054_ns_entry_object_id_cursor
+Create Date: 2026-05-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "055_forecast_snapshots"
+down_revision = "054_ns_entry_object_id_cursor"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "forecast_snapshots",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # Nullable so non-NS sources can attach rows by source_engine
+        # alone (future direct-integration paths, our own engine).
+        sa.Column(
+            "nightscout_connection_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("nightscout_connections.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        # 'loop' | 'aaps' | 'trio' | 'oref0' | 'iaps' | 'glycemicgpt'.
+        # Free-form text rather than an enum to absorb the iAPS / Trio
+        # variant landscape without schema changes; the read endpoint
+        # validates the set it knows about.
+        sa.Column("source_engine", sa.Text(), nullable=False),
+        # Bounded set. Adding a new engine is a one-line migration; the
+        # cost of catching translator typos (`"AAPS"` vs `"aaps"`) at
+        # the DB boundary is worth it.
+        sa.CheckConstraint(
+            "source_engine IN ('loop','aaps','trio','oref0','iaps','glycemicgpt')",
+            name="ck_forecast_source_engine_known",
+        ),
+        # Denormalized from device_status_snapshots.source_uploader so
+        # the forecast row is self-sufficient for chart rendering
+        # without a join.
+        sa.Column("source_uploader", sa.Text(), nullable=True),
+        # When the engine *issued* the forecast (its internal clock).
+        # For Loop this is `loop_subtree_json.timestamp`; for AAPS it's
+        # the `suggested.deliverAt`; for our engine it'll be wall clock
+        # at compute time. NOT when we ingested it (see `received_at`).
+        sa.Column(
+            "issued_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        # t=0 on the chart for this forecast. For most sources ==
+        # issued_at; for Loop it's `predicted.startDate` which can lag
+        # the devicestatus timestamp by a cycle. The chart anchors the
+        # dotted line at start_at, not issued_at.
+        sa.Column(
+            "start_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column("step_minutes", sa.Integer(), nullable=False),
+        sa.Column("horizon_minutes", sa.Integer(), nullable=False),
+        sa.CheckConstraint(
+            "step_minutes > 0 AND horizon_minutes > 0",
+            name="ck_forecast_step_horizon_positive",
+        ),
+        # JSONB shape:
+        #   {
+        #     "IOB":  [120, 122, 125, ...],
+        #     "COB":  [120, 124, 130, ...],   // optional
+        #     "UAM":  [...],                  // optional
+        #     "ZT":   [...]                   // optional
+        #   }
+        # Loop (single curve): {"main": [...]}.
+        sa.Column(
+            "curves_mgdl_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        # Which key in `curves_mgdl_json` the source's UI defaults to
+        # drawing. Loop -> "main"; AAPS/Trio/oref0 -> "IOB" when
+        # present, else first available. Computed at translate time so
+        # the chart doesn't have to re-derive on every render.
+        sa.Column(
+            "default_curve_name",
+            sa.Text(),
+            nullable=False,
+        ),
+        # The chart will KeyError on render if these drift. Pin the
+        # invariant at the DB boundary so a buggy translator can't land
+        # a row the read path can't display.
+        sa.CheckConstraint(
+            "curves_mgdl_json ? default_curve_name",
+            name="ck_forecast_default_curve_in_curves",
+        ),
+        # Idempotency key. For NS-imported rows this is the
+        # devicestatus `_id` (same value used on
+        # `device_status_snapshots.ns_id`). For engine outputs it's a
+        # UUID we mint. Lets re-translating the same devicestatus
+        # upsert in place rather than duplicating.
+        sa.Column("dedupe_key", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "char_length(dedupe_key) BETWEEN 1 AND 128",
+            name="ck_forecast_dedupe_key_length",
+        ),
+        sa.Column(
+            "received_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.UniqueConstraint(
+            "source_engine",
+            "dedupe_key",
+            name="uq_forecast_snapshots_source_dedupe",
+        ),
+    )
+    op.create_index(
+        "ix_forecast_user_issued",
+        "forecast_snapshots",
+        ["user_id", sa.text("issued_at DESC")],
+    )
+    # Lets us answer "what does this user's chart need right now"
+    # cheaply per-source. Same indexing strategy as our other
+    # source-attributed time-series.
+    op.create_index(
+        "ix_forecast_user_source_issued",
+        "forecast_snapshots",
+        ["user_id", "source_engine", sa.text("issued_at DESC")],
+    )
+
+    # ------------------------------------------------------------------
+    # `forecast_evaluations` lands empty. The scoring job that pairs
+    # each forecast point against the actual CGM reading at the
+    # matching horizon time is deferred to a follow-up. See design
+    # doc Section 5.2 for the eventual job semantics.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "forecast_evaluations",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "forecast_snapshot_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("forecast_snapshots.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # Minutes past `start_at`. e.g. step_minutes=5 means rows
+        # at offsets 0, 5, 10, 15, ... up to horizon_minutes.
+        sa.Column("offset_minutes", sa.Integer(), nullable=False),
+        # A negative offset would mean a forecast point *before* the
+        # forecast was issued -- nonsense, and would corrupt MAE /
+        # coverage rollups. Pin at the DB boundary so a buggy scoring
+        # job can't quietly land bad data.
+        sa.CheckConstraint(
+            "offset_minutes >= 0",
+            name="ck_forecast_eval_offset_nonnegative",
+        ),
+        sa.Column("predicted_mgdl", sa.Float(), nullable=False),
+        # NULL when no CGM reading landed within the tolerance window
+        # (e.g., user's CGM dropped out during the forecast horizon).
+        # Don't drop the row -- a NULL is data ("we couldn't score
+        # this point") and feeds into MAE-with-coverage metrics.
+        sa.Column("actual_mgdl", sa.Float(), nullable=True),
+        # Signed delta in seconds between the matched reading's actual
+        # timestamp and the target offset. 0 = exact; negative = reading
+        # arrived *before* the target offset; positive = after. The
+        # scoring job clamps to a tolerance window (deferred PR sets the
+        # bound) so this column is bounded in practice.
+        sa.Column("actual_offset_seconds", sa.Integer(), nullable=True),
+        sa.Column(
+            "computed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.UniqueConstraint(
+            "forecast_snapshot_id",
+            "offset_minutes",
+            name="uq_forecast_eval_snapshot_offset",
+        ),
+    )
+    op.create_index(
+        "ix_forecast_eval_snapshot",
+        "forecast_evaluations",
+        ["forecast_snapshot_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_forecast_eval_snapshot", table_name="forecast_evaluations")
+    op.drop_table("forecast_evaluations")
+    op.drop_index("ix_forecast_user_source_issued", table_name="forecast_snapshots")
+    op.drop_index("ix_forecast_user_issued", table_name="forecast_snapshots")
+    op.drop_table("forecast_snapshots")

--- a/apps/api/src/models/forecast_snapshot.py
+++ b/apps/api/src/models/forecast_snapshot.py
@@ -1,0 +1,307 @@
+"""Forecast snapshot models (Story 43.12 PR 1).
+
+`ForecastSnapshot` is a normalized per-cycle row capturing a single
+closed-loop's BG forecast. The translator writes one row per
+Nightscout devicestatus payload that carries forecast data (Loop's
+`predicted.values[]`, AAPS / Trio / oref0's `predBGs.{IOB,COB,UAM,ZT}`).
+
+This is a separate table from `device_status_snapshots` (which holds
+verbatim JSONB subtrees) by design:
+
+- Multiple consumers need a clean shape: chart overlay, AI context
+  builder, future calibration / training-signal pipeline.
+- Future GlycemicGPT prediction engine outputs aren't NS payloads --
+  having a neutral table lets us land engine-emitted rows alongside
+  NS-imported ones without lying about the source.
+- Write-time normalization moves per-uploader shape parsing out of
+  every read path.
+
+`ForecastEvaluation` lands as schema-only in this PR. The pairing-
+to-actual-CGM-reading job that populates it is deferred to a
+follow-up; see design doc Section 5.2.
+
+Design doc:
+    `_bmad-output/planning-artifacts/story-43.12-forecast-overlay-design.md`
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+
+
+class ForecastSnapshot(Base):
+    """A single point-in-time closed-loop BG forecast."""
+
+    __tablename__ = "forecast_snapshots"
+
+    __table_args__ = (
+        # Idempotency: same Nightscout devicestatus `_id` -> same
+        # forecast row across sync cycles. The translator UPSERTs on
+        # this key. Engine-emitted rows mint a fresh UUID dedupe key.
+        UniqueConstraint(
+            "source_engine",
+            "dedupe_key",
+            name="uq_forecast_snapshots_source_dedupe",
+        ),
+        # Mirror of migration CHECKs. Keeping them on the ORM means
+        # autogenerate diffs stay quiet and the invariants are visible
+        # next to the columns they constrain.
+        CheckConstraint(
+            "source_engine IN ('loop','aaps','trio','oref0','iaps','glycemicgpt')",
+            name="ck_forecast_source_engine_known",
+        ),
+        CheckConstraint(
+            "step_minutes > 0 AND horizon_minutes > 0",
+            name="ck_forecast_step_horizon_positive",
+        ),
+        CheckConstraint(
+            "curves_mgdl_json ? default_curve_name",
+            name="ck_forecast_default_curve_in_curves",
+        ),
+        CheckConstraint(
+            "char_length(dedupe_key) BETWEEN 1 AND 128",
+            name="ck_forecast_dedupe_key_length",
+        ),
+        # "Latest forecast for this user, any source." Indexes the
+        # default dashboard read path. DESC matches migration so
+        # autogenerate stays quiet.
+        Index(
+            "ix_forecast_user_issued",
+            "user_id",
+            text("issued_at DESC"),
+        ),
+        # "Latest forecast for this user from THIS source." Indexes
+        # the picker-aware read path ("user picked Loop; give me their
+        # latest Loop forecast").
+        Index(
+            "ix_forecast_user_source_issued",
+            "user_id",
+            "source_engine",
+            text("issued_at DESC"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Nullable so non-NS sources can attach without a connection FK.
+    # Future direct-integration paths and the GlycemicGPT engine
+    # use source_engine alone for attribution; nightscout_connection_id
+    # is NULL for those rows.
+    nightscout_connection_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("nightscout_connections.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+
+    # 'loop' | 'aaps' | 'trio' | 'oref0' | 'iaps' | 'glycemicgpt'.
+    # Stored as Text (not a Postgres ENUM type) so adding a new
+    # engine is a one-line CHECK update -- not a CREATE TYPE /
+    # ALTER TYPE dance. The CHECK constraint
+    # `ck_forecast_source_engine_known` bounds the allowed set as
+    # defense-in-depth so translator typos (`"AAPS"` vs `"aaps"`)
+    # fail at the DB boundary instead of silently minting phantom
+    # engines. Adding a new uploader is intentionally a migration
+    # event so the read endpoint, AI context builder, and any
+    # eventual scoring job stay in sync with what the DB accepts.
+    source_engine: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Denormalized from `device_status_snapshots.source_uploader` so
+    # chart rendering doesn't need a join. Same values + nullability
+    # semantics as the source column.
+    source_uploader: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # When the engine *issued* the forecast (its internal clock).
+    # NOT when we ingested it. For Loop: `loop_subtree_json.timestamp`.
+    # For AAPS / Trio / oref0: `suggested.deliverAt`. Future engine:
+    # compute wall clock at emit time.
+    issued_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # t=0 on the chart for this forecast. For most sources this equals
+    # `issued_at`. Loop occasionally posts `predicted.startDate` lagging
+    # the devicestatus timestamp by a cycle when its sync cadence and
+    # NS upload cadence diverge -- the chart anchors the dotted line at
+    # `start_at`, not `issued_at`, so the first forecast point lines up
+    # with the actual reading underneath it.
+    start_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    step_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
+    horizon_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # JSONB shape:
+    #   {
+    #     "IOB":  [120, 122, 125, ...],
+    #     "COB":  [120, 124, 130, ...],  -- optional
+    #     "UAM":  [...],                  -- optional
+    #     "ZT":   [...]                   -- optional
+    #   }
+    # Loop (single curve): {"main": [...]}.
+    #
+    # Single-curve and multi-curve sources both fit this shape.
+    # `default_curve_name` picks which key the chart draws by default.
+    curves_mgdl_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+    )
+
+    # Which curve to draw on the chart by default for this source.
+    # Loop -> "main". AAPS / Trio / oref0 / iAPS -> "IOB" when present
+    # (the source's own UI default), else the first available curve.
+    # Computed at translate time so chart render doesn't re-derive.
+    default_curve_name: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # NS devicestatus `_id` for NS-imported rows; UUID for engine
+    # rows. UNIQUE with `source_engine` keeps Loop's `_id` and AAPS's
+    # `_id` from accidentally colliding even though both look like
+    # 24-hex strings.
+    dedupe_key: Mapped[str] = mapped_column(Text, nullable=False)
+
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    # ---- Relationships ---------------------------------------------------
+
+    user = relationship("User")
+    connection = relationship("NightscoutConnection")
+    evaluations: Mapped[list[ForecastEvaluation]] = relationship(
+        "ForecastEvaluation",
+        back_populates="forecast_snapshot",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ForecastSnapshot(user_id={self.user_id}, "
+            f"source={self.source_engine!r}, "
+            f"issued_at={self.issued_at}, "
+            f"horizon_minutes={self.horizon_minutes})>"
+        )
+
+
+class ForecastEvaluation(Base):
+    """One pairing of `(forecast_point, actual_CGM_reading)`.
+
+    Populated by a scoring job (deferred, not in this PR) that runs
+    just past each forecast's horizon time and looks up the actual
+    CGM reading at each forecast offset. The result feeds:
+
+    - Per-user / per-source accuracy reports ("your Loop's 30-min
+      MAE is 12 mg/dL over the last week").
+    - Calibration features for the future GlycemicGPT prediction
+      engine ("Loop is consistently over-predicting at night for
+      this user; weight its forecast lower in the nighttime model").
+
+    Schema-only in this PR. The job lands later.
+    """
+
+    __tablename__ = "forecast_evaluations"
+
+    __table_args__ = (
+        # One evaluation row per (forecast, offset). Re-running the
+        # scoring job is idempotent: it UPSERTs by this key.
+        UniqueConstraint(
+            "forecast_snapshot_id",
+            "offset_minutes",
+            name="uq_forecast_eval_snapshot_offset",
+        ),
+        # Mirror of migration CHECK. Negative offsets would mean a
+        # forecast point before issuance -- nonsense, and would corrupt
+        # MAE / coverage rollups.
+        CheckConstraint(
+            "offset_minutes >= 0",
+            name="ck_forecast_eval_offset_nonnegative",
+        ),
+        Index("ix_forecast_eval_snapshot", "forecast_snapshot_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    forecast_snapshot_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("forecast_snapshots.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Minutes past `forecast_snapshots.start_at`. Typically 5-min
+    # multiples up to `horizon_minutes`. Same offset values regardless
+    # of source.
+    offset_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    predicted_mgdl: Mapped[float] = mapped_column(Float, nullable=False)
+
+    # NULL when no CGM reading landed within the tolerance window for
+    # this offset (sensor warm-up, transmitter dropout, etc.). NULL is
+    # data -- aggregations should report it as "coverage gap" rather
+    # than skipping the row, otherwise we under-count missed forecasts.
+    actual_mgdl: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Signed delta in seconds between the matched reading's actual
+    # timestamp and the target offset. 0 = exact; negative = reading
+    # arrived *before* the target offset; positive = after. Useful for
+    # "is this user's CGM cadence reliable enough to score accurately?"
+    # debugging. The scoring job (deferred) clamps absolute value to a
+    # tolerance window.
+    actual_offset_seconds: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    forecast_snapshot: Mapped[ForecastSnapshot] = relationship(
+        "ForecastSnapshot",
+        back_populates="evaluations",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ForecastEvaluation(forecast_snapshot_id={self.forecast_snapshot_id}, "
+            f"offset_minutes={self.offset_minutes}, "
+            f"predicted={self.predicted_mgdl}, "
+            f"actual={self.actual_mgdl})>"
+        )

--- a/apps/api/src/models/nightscout_connection.py
+++ b/apps/api/src/models/nightscout_connection.py
@@ -187,6 +187,19 @@ class NightscoutConnection(Base, TimestampMixin):
         DateTime(timezone=True),
         nullable=True,
     )
+    # Entries cursor by NS Mongo `_id` (insertion-time-monotonic).
+    # Set after each successful entries fetch to the max `_id` from
+    # the returned batch. NULL means "no ObjectId cursor yet" -- the
+    # sync code falls back to the legacy `last_synced_at` (dateString)
+    # cursor for that one sync, then locks in the ObjectId cursor
+    # afterward. The ObjectId cursor is immune to uploaders that
+    # backfill entries with old `dateString` values (issue #598).
+    # Treatments / devicestatus use `created_at` (already server-time)
+    # and don't need this fallback.
+    last_entry_object_id: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+    )
     last_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Discovery metadata (set by Story 43.7 evaluate endpoint).

--- a/apps/api/src/services/integrations/nightscout/client.py
+++ b/apps/api/src/services/integrations/nightscout/client.py
@@ -555,20 +555,37 @@ class NightscoutClient:
         self,
         *,
         since: datetime | None = None,
+        since_object_id: str | None = None,
         count: int = DEFAULT_PAGE_SIZE,
     ) -> list[dict[str, Any]]:
         """Fetch CGM entries newest-first.
 
+        Prefers the `_id`-based cursor when `since_object_id` is set.
+        Mongo `_id` is monotonic by insertion time, so this catches
+        entries that uploaders backfilled into NS with old
+        `dateString` values (issue #598 -- Dexcom Share -> NS bridge
+        is the most common offender). Falls back to `since`
+        (dateString filter) when no ObjectId cursor is available
+        (first-ever sync, or for instances where `_id` isn't returned).
+
         Args:
-            since: only return entries with dateString >= this UTC
-                timestamp. **Must be timezone-aware** (raises ValueError
-                on naive datetimes -- silently treating naive as UTC
-                corrupted wall-clock data on dev machines outside UTC).
-                None = no lower bound (subject to Nightscout's
-                own retention).
+            since: dateString-based fallback cursor. **Must be
+                timezone-aware** (raises ValueError on naive
+                datetimes -- silently treating naive as UTC corrupted
+                wall-clock data on dev machines outside UTC).
+                Ignored when `since_object_id` is provided.
+            since_object_id: NS Mongo `_id` lower bound. Preferred
+                cursor (see issue #598). The 24-char hex ObjectId
+                from a prior fetch's max-id.
             count: page size. Server caps at ~50000 silently.
         """
         self._require_v1_for_fetch("entries")
+        if since_object_id is not None:
+            return await self._fetch_v1_collection_by_id(
+                "/api/v1/entries.json",
+                since_object_id=since_object_id,
+                count=count,
+            )
         return await self._fetch_v1_collection(
             "/api/v1/entries.json",
             since=since,
@@ -658,6 +675,49 @@ class NightscoutClient:
         body = _parse_json_or_none(resp)
         return body if isinstance(body, list) else []
 
+    async def _fetch_v1_collection_by_id(
+        self,
+        path: str,
+        *,
+        since_object_id: str,
+        count: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch a v1 collection with an ObjectId-based lower bound.
+
+        Used for entries to avoid the dateString-cursor backfill miss
+        (issue #598). The 24-char hex ObjectId encodes insertion time
+        in its first 4 bytes; querying `find[_id][$gt]=<lastSeen>`
+        returns everything inserted *after* that ObjectId regardless
+        of `dateString`. Caller is responsible for advancing the
+        cursor to `max(_id)` from the returned batch.
+        """
+        if not _is_valid_object_id(since_object_id):
+            # Bad cursor value -- fail loud at the client boundary so a
+            # corrupted cursor in the DB can't silently send junk to
+            # NS (which would either 400 or return the full window).
+            # The sync layer catches and the next cycle re-attempts;
+            # a persistent bad value will need manual cursor clearing
+            # on the connection row.
+            raise ValueError(
+                "since_object_id must be a 24-character hex ObjectId; "
+                f"got {since_object_id!r}"
+            )
+        params: dict[str, Any] = {
+            "count": count,
+            "find[_id][$gt]": since_object_id,
+        }
+        resp = await self._request(
+            "GET", path, params=params, headers=self._v1_headers()
+        )
+        self._raise_for_auth_or_404(resp, what=path)
+        if resp.status_code != 200:
+            raise NightscoutServerError(
+                f"{path} returned status {resp.status_code}",
+                status_code=resp.status_code,
+            )
+        body = _parse_json_or_none(resp)
+        return body if isinstance(body, list) else []
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -665,6 +725,20 @@ class NightscoutClient:
 
 
 _PARSE_FAILED = object()  # sentinel distinct from None / [] / {}
+
+
+def _is_valid_object_id(value: str) -> bool:
+    """24-character hex string (case-insensitive) matching the
+    canonical Mongo ObjectId shape NS persists in `_id`. Reject
+    anything else loudly rather than passing junk into the
+    `find[_id][$gt]` filter."""
+    if not isinstance(value, str) or len(value) != 24:
+        return False
+    try:
+        int(value, 16)
+        return True
+    except ValueError:
+        return False
 
 
 def _parse_json_or_none(resp: httpx.Response) -> Any:

--- a/apps/api/src/services/integrations/nightscout/sync.py
+++ b/apps/api/src/services/integrations/nightscout/sync.py
@@ -9,15 +9,23 @@ Drives the four translator entry points against a single
   which calls this once per due connection on each tick.
 
 `since` semantics:
-- First sync (no `last_synced_at`): default backfill window from
+- First sync (no cursor yet): default backfill window from
   `initial_sync_window_days` (0 = unbounded for entries/treatments;
   always capped at 30 days for devicestatus to bound blast radius).
-- Subsequent syncs: `last_synced_at` (timezone-aware UTC).
+- Subsequent syncs (entries): `last_entry_object_id` -- NS's Mongo
+  `_id` from the last response. Mongo ObjectId is monotonic by
+  insertion time, so this catches entries that uploaders backfilled
+  into NS with `dateString` values from before our last sync
+  (Dexcom Share -> NS bridge is the most common offender; issue #598).
+- Subsequent syncs (treatments / devicestatus): `last_synced_at` --
+  these endpoints already query by NS server-side `created_at`, which
+  is monotonic by insertion time, so they're immune to the late-upload
+  class of bug that hit entries.
 
-`last_synced_at` advancement: only on full success (all four
-translate calls returned without raising). On any partial failure the
-status / error are recorded but the cursor stays put so the next run
-re-fetches the same window. Documented + tested in `test_sync.py`.
+Cursor advancement: only on full success (all four translate calls
+returned without raising). On any partial failure the status / error
+are recorded but the cursor stays put so the next run re-fetches the
+same window. Documented + tested in `test_sync.py`.
 
 Exception mapping:
 - NightscoutAuthError              -> AUTH_FAILED
@@ -208,6 +216,15 @@ async def _do_sync(session: AsyncSession, conn: NightscoutConnection) -> SyncRes
     error_msg: str | None = None
     status = NightscoutSyncStatus.OK
 
+    # Entries use NS's Mongo `_id` cursor when available -- immune to
+    # uploaders backfilling entries with old `dateString` timestamps
+    # (issue #598; Dexcom Share -> NS bridge is the most common
+    # offender). First sync after the 054 migration has no ObjectId
+    # cursor yet, so we fall back to the legacy `last_synced_at`
+    # cursor for that one cycle and lock in the new cursor after.
+    last_entry_object_id = conn.last_entry_object_id
+    new_entry_object_id: str | None = None
+
     try:
         async with await NightscoutClient.create(
             base_url=conn.base_url,
@@ -216,8 +233,19 @@ async def _do_sync(session: AsyncSession, conn: NightscoutConnection) -> SyncRes
             api_version=conn.api_version,
         ) as client:
             entries = await client.fetch_entries(
-                since=_resolve_since(last_synced, window_days, now)
+                since=_resolve_since(last_synced, window_days, now),
+                since_object_id=last_entry_object_id,
             )
+            # Advance the cursor to the largest `_id` in the response.
+            # NS returns entries newest-first, so the head row is the
+            # max by insertion time. Missing `_id` (rare; some legacy
+            # NS plugins strip it) leaves the cursor at its prior
+            # value -- worst case is we re-fetch on next sync, dedupe
+            # handles it.
+            if entries:
+                head_id = entries[0].get("_id")
+                if isinstance(head_id, str) and len(head_id) == 24:
+                    new_entry_object_id = head_id
             treatments = await client.fetch_treatments(
                 since=_resolve_since(last_synced, window_days, now)
             )
@@ -282,11 +310,17 @@ async def _do_sync(session: AsyncSession, conn: NightscoutConnection) -> SyncRes
             user_id=user_id_str,
         )
 
-    # Persist status + (only on success) advance the cursor.
+    # Persist status + (only on success) advance the cursors.
     conn.last_sync_status = status
     conn.last_sync_error = error_msg
     if status == NightscoutSyncStatus.OK:
         conn.last_synced_at = now
+        # Only advance the ObjectId cursor when we actually saw a new
+        # row. NULL preserves "no cursor yet" semantics on the very
+        # first sync if the upstream had zero entries -- next cycle
+        # will retry from the time-window fallback.
+        if new_entry_object_id is not None:
+            conn.last_entry_object_id = new_entry_object_id
     await session.commit()
 
     duration_ms = int((time.monotonic() - started) * 1000)

--- a/apps/api/tests/test_aggregate_stats.py
+++ b/apps/api/tests/test_aggregate_stats.py
@@ -1376,8 +1376,11 @@ class TestSourceFilteringAndDedup:
             async for db in get_db():
                 now = datetime.now(UTC)
                 uid = uuid.UUID(user_id)
-                cutoff = _boundary_cutoff(days=1)
-                ts = cutoff + timedelta(hours=1)
+                # `cutoff + 1h` lands in the future when CI runs in the
+                # first hour after UTC midnight, and the query filters
+                # `event_timestamp <= :now`. Use `_stable_test_ts` which
+                # already clamps to `[cutoff+1s, now]`.
+                ts = _stable_test_ts(days=1)
                 db.add(
                     PumpEvent(
                         user_id=uid,
@@ -1491,12 +1494,20 @@ class TestSourceFilteringAndDedup:
             async for db in get_db():
                 now = datetime.now(UTC)
                 uid = uuid.UUID(user_id)
-                ts = _stable_test_ts(days=1)
+                # Both timestamps must land inside the boundary-aligned
+                # window. `_stable_test_ts` can return `cutoff + 1s`
+                # when CI runs near UTC midnight, so subtracting 5s
+                # from it lands *before* the cutoff and the row gets
+                # filtered out -- making the test deterministically
+                # fail in that hour. Bracket around a center inside
+                # the window instead.
+                ts_center = _stable_test_ts(days=1) + timedelta(seconds=30)
+                ts_center = min(ts_center, now - timedelta(seconds=1))
                 db.add(
                     PumpEvent(
                         user_id=uid,
                         event_type=PumpEventType.BOLUS,
-                        event_timestamp=ts,
+                        event_timestamp=ts_center,
                         units=4.0,
                         is_automated=False,
                         received_at=now,
@@ -1507,7 +1518,7 @@ class TestSourceFilteringAndDedup:
                     PumpEvent(
                         user_id=uid,
                         event_type=PumpEventType.BOLUS,
-                        event_timestamp=ts - timedelta(seconds=5),
+                        event_timestamp=ts_center - timedelta(seconds=5),
                         units=4.0,
                         is_automated=False,
                         received_at=now,

--- a/apps/api/tests/test_forecast_snapshot_model.py
+++ b/apps/api/tests/test_forecast_snapshot_model.py
@@ -1,0 +1,765 @@
+"""Model + schema tests for `forecast_snapshots` and `forecast_evaluations`.
+
+Story 43.12 PR 1. The translator that writes to these tables lands in
+PR 2 of the story; the read endpoint in PR 3. This file pins:
+
+- Insert / round-trip of a representative ForecastSnapshot row for
+  each of the wire-format families captured by the design doc
+  (Loop single-curve, AAPS / Trio / oref0 multi-curve).
+- The `(source_engine, dedupe_key)` uniqueness constraint -- the
+  translator's UPSERT correctness rides on this.
+- `forecast_evaluations` schema accepts the partial-row shape the
+  future scoring job will write (actual_mgdl NULL when no CGM
+  reading lands in the tolerance window).
+- ON DELETE CASCADE wiring: dropping the parent snapshot drops its
+  evaluations; dropping the user drops everything.
+
+Design doc:
+    `_bmad-output/planning-artifacts/story-43.12-forecast-overlay-design.md`
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.encryption import encrypt_credential
+from src.database import get_session_maker
+from src.models.forecast_snapshot import ForecastEvaluation, ForecastSnapshot
+from src.models.nightscout_connection import (
+    NightscoutAuthType,
+    NightscoutConnection,
+)
+from src.models.user import User
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def fc_ctx() -> AsyncGenerator[
+    tuple[AsyncSession, uuid.UUID, NightscoutConnection], None
+]:
+    """Per-test session + user + connection.
+
+    Same shape as test_nightscout_sync.py's `sync_ctx` -- own
+    session_maker so cross-loop teardown doesn't crash. Returns the
+    session, the user's id, and a connection row so tests can attach
+    forecast snapshots either to the connection (NS-imported path)
+    or unattached (future engine path).
+    """
+    session_maker = get_session_maker()
+    session = session_maker()
+    # Pre-yield TRUNCATE: bulletproof against rows leaked by a malformed
+    # prior test (NULL user_id, partially-rolled-back commit, etc.).
+    # Teardown delete is best-effort; this is belt-and-braces.
+    await session.execute(
+        text("TRUNCATE forecast_evaluations, forecast_snapshots CASCADE")
+    )
+    await session.commit()
+    email = f"forecast_{uuid.uuid4().hex[:10]}@example.com"
+    user = User(email=email, hashed_password="not-a-real-hash")
+    session.add(user)
+    await session.flush()
+    user_id = user.id
+
+    conn = NightscoutConnection(
+        user_id=user_id,
+        name="test-forecast",
+        base_url="https://example.com",
+        auth_type=NightscoutAuthType.SECRET,
+        encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+        initial_sync_window_days=7,
+    )
+    session.add(conn)
+    await session.flush()
+    await session.commit()
+
+    try:
+        yield session, user_id, conn
+    finally:
+        try:
+            await session.rollback()
+            # Explicit deletion in dependency order rather than relying
+            # on FK cascade. Cascade is correct in healthy state, but
+            # if a test left the session in an error state the cascade
+            # didn't reliably fire here -- rows leaked into the next
+            # test run, which then saw multiple-results errors on
+            # source_engine queries that don't filter by user_id.
+            # Defensive explicit deletes match the pattern in
+            # test_nightscout_sync.py's sync_ctx fixture.
+            await session.execute(
+                delete(ForecastEvaluation).where(
+                    ForecastEvaluation.forecast_snapshot_id.in_(
+                        select(ForecastSnapshot.id).where(
+                            ForecastSnapshot.user_id == user_id
+                        )
+                    )
+                )
+            )
+            await session.execute(
+                delete(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+            )
+            await session.execute(delete(User).where(User.id == user_id))
+            await session.commit()
+        except RuntimeError:
+            pass
+        finally:
+            try:
+                await session.close()
+            except RuntimeError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Sample payload builders (per source family)
+# ---------------------------------------------------------------------------
+
+
+def _loop_curve() -> tuple[dict, str]:
+    """Loop's single-curve shape. {default_curve_name} == "main"."""
+    return ({"main": [120, 122, 125, 128, 130, 131, 130, 128, 125]}, "main")
+
+
+def _aaps_curves() -> tuple[dict, str]:
+    """AAPS / Trio / oref0 multi-curve shape. Default to "IOB" curve
+    because that's the source's own default; the picker lets a power
+    user switch later (deferred)."""
+    return (
+        {
+            "IOB": [120, 124, 130, 135, 138],
+            "COB": [120, 130, 145, 160, 170],
+            "UAM": [120, 125, 131, 138, 142],
+            "ZT": [120, 125, 130, 132, 132],
+        },
+        "IOB",
+    )
+
+
+def _aaps_curves_iob_only() -> tuple[dict, str]:
+    """AAPS sometimes posts only IOB (no carbs active, no UAM
+    detected, no zero-temp scenario). Translator must tolerate."""
+    return ({"IOB": [120, 122, 125, 128]}, "IOB")
+
+
+# ---------------------------------------------------------------------------
+# Insert + round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestForecastSnapshotInsert:
+    """Round-trip insertion tests for the wire-format families captured
+    by the design doc: Loop single-curve, AAPS / Trio / oref0 multi-curve,
+    and the future engine-emitted path (no NS connection FK)."""
+
+    @pytest.mark.asyncio
+    async def test_loop_single_curve_round_trip(self, fc_ctx):
+        """Loop's single-curve payload round-trips intact, including
+        the server-defaulted `received_at`."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"loop-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.commit()
+
+        result = await session.execute(
+            select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+        )
+        row = result.scalar_one()
+        assert row.source_engine == "loop"
+        assert row.default_curve_name == "main"
+        assert row.curves_mgdl_json == {
+            "main": [120, 122, 125, 128, 130, 131, 130, 128, 125]
+        }
+        # received_at is server-defaulted -- assert it landed
+        assert row.received_at is not None
+
+    @pytest.mark.asyncio
+    async def test_aaps_multi_curve_round_trip(self, fc_ctx):
+        """AAPS's multi-curve payload (IOB/COB/UAM/ZT) round-trips with
+        all four keys preserved and IOB as the source's default."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _aaps_curves()
+
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="aaps",
+            source_uploader="aaps",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=20,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"aaps-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.commit()
+
+        result = await session.execute(
+            select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+        )
+        row = result.scalar_one()
+        assert set(row.curves_mgdl_json.keys()) == {"IOB", "COB", "UAM", "ZT"}
+        assert row.default_curve_name == "IOB"
+
+    @pytest.mark.asyncio
+    async def test_aaps_partial_curves_round_trip(self, fc_ctx):
+        """Partial-curve payload: only IOB present. Required: must
+        store without breaking on missing COB/UAM/ZT and surface
+        IOB as the default."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _aaps_curves_iob_only()
+
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="aaps",
+            source_uploader="aaps",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=15,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"aaps-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.commit()
+
+        result = await session.execute(
+            select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+        )
+        row = result.scalar_one()
+        assert row.curves_mgdl_json == {"IOB": [120, 122, 125, 128]}
+
+    @pytest.mark.asyncio
+    async def test_engine_source_without_connection(self, fc_ctx):
+        """Future-engine path: source_engine = "glycemicgpt", no NS
+        connection FK. The column is nullable for exactly this case;
+        regression-guard so a future migration doesn't accidentally
+        constrain it."""
+        session, user_id, _conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=None,  # <-- key part
+            source_engine="glycemicgpt",
+            source_uploader=None,
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"gg-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.commit()
+
+        # Scope to this test's user -- cross-test leakage (e.g., a
+        # prior failing test that didn't clean up) would otherwise
+        # produce multiple rows and break scalar_one().
+        result = await session.execute(
+            select(ForecastSnapshot).where(
+                ForecastSnapshot.user_id == user_id,
+                ForecastSnapshot.source_engine == "glycemicgpt",
+            )
+        )
+        row = result.scalar_one()
+        assert row.nightscout_connection_id is None
+        assert row.source_engine == "glycemicgpt"
+
+
+# ---------------------------------------------------------------------------
+# Uniqueness + idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestForecastSnapshotUniqueness:
+    """Pins `(source_engine, dedupe_key)` UPSERT semantics:
+    same key + same engine rejects (idempotency); same key + different
+    engines allowed (cross-source non-collision)."""
+
+    @pytest.mark.asyncio
+    async def test_same_source_engine_and_dedupe_key_rejects(self, fc_ctx):
+        """Same NS devicestatus _id arriving twice (different sync
+        cycles, same upstream row) must NOT create two ForecastSnapshot
+        rows. Translator's UPSERT correctness depends on this."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        ns_id = "abc123def456abc123def456"  # 24-char mongo objectid shape
+
+        snap1 = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=ns_id,
+        )
+        session.add(snap1)
+        await session.commit()
+
+        snap2 = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=ns_id,  # same key
+        )
+        session.add(snap2)
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_same_dedupe_key_different_source_engine_allowed(self, fc_ctx):
+        """Different engines might both pick `_id = abc123...` by
+        coincidence (NS Mongo ObjectIds are 24-hex, the GlycemicGPT
+        engine mints UUIDs but the test pins the cross-source
+        non-collision contract independent of length). Translator
+        UPSERTs by `(source_engine, dedupe_key)`, not dedupe_key
+        alone."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        same_key = "abc123def456abc123def456"
+
+        for engine in ("loop", "aaps"):
+            snap = ForecastSnapshot(
+                user_id=user_id,
+                nightscout_connection_id=conn.id,
+                source_engine=engine,
+                source_uploader=engine,
+                issued_at=issued,
+                start_at=issued,
+                step_minutes=5,
+                horizon_minutes=40,
+                curves_mgdl_json=curves,
+                default_curve_name=default_curve,
+                dedupe_key=same_key,
+            )
+            session.add(snap)
+            await session.commit()
+
+        result = await session.execute(
+            select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+        )
+        rows = result.scalars().all()
+        assert len(rows) == 2
+        assert {r.source_engine for r in rows} == {"loop", "aaps"}
+
+
+# ---------------------------------------------------------------------------
+# ForecastEvaluation
+# ---------------------------------------------------------------------------
+
+
+class TestForecastEvaluation:
+    """Pins the schema contract for the deferred scoring job: partial
+    rows (NULL actual), idempotent UPSERT by (snapshot_id, offset), and
+    snapshot-delete cascade."""
+
+    @pytest.mark.asyncio
+    async def test_evaluation_partial_row(self, fc_ctx):
+        """The future scoring job writes one evaluation row per
+        forecast offset. `actual_mgdl` is NULL when no CGM reading
+        landed within tolerance -- the schema must accept that."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"loop-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.flush()
+
+        # Scored point: actual reading landed exactly.
+        eval_scored = ForecastEvaluation(
+            forecast_snapshot_id=snap.id,
+            offset_minutes=5,
+            predicted_mgdl=122.0,
+            actual_mgdl=120.0,
+            actual_offset_seconds=0,
+        )
+        # Unscored point: CGM dropout, no reading in window.
+        eval_unscored = ForecastEvaluation(
+            forecast_snapshot_id=snap.id,
+            offset_minutes=10,
+            predicted_mgdl=125.0,
+            actual_mgdl=None,
+            actual_offset_seconds=None,
+        )
+        session.add_all([eval_scored, eval_unscored])
+        await session.commit()
+
+        result = await session.execute(
+            select(ForecastEvaluation)
+            .where(ForecastEvaluation.forecast_snapshot_id == snap.id)
+            .order_by(ForecastEvaluation.offset_minutes)
+        )
+        rows = result.scalars().all()
+        assert len(rows) == 2
+        assert rows[0].actual_mgdl == 120.0
+        assert rows[0].actual_offset_seconds == 0
+        assert rows[1].actual_mgdl is None
+        assert rows[1].actual_offset_seconds is None
+
+    @pytest.mark.asyncio
+    async def test_evaluation_same_offset_rejected(self, fc_ctx):
+        """Re-running the scoring job on the same snapshot must not
+        produce duplicate offset rows. UPSERT relies on the
+        `(forecast_snapshot_id, offset_minutes)` unique constraint."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"loop-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.flush()
+
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=snap.id,
+                offset_minutes=5,
+                predicted_mgdl=122.0,
+                actual_mgdl=120.0,
+            )
+        )
+        await session.commit()
+
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=snap.id,
+                offset_minutes=5,  # duplicate
+                predicted_mgdl=122.0,
+                actual_mgdl=121.0,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_evaluation_cascades_on_snapshot_delete(self, fc_ctx):
+        """Drop the parent snapshot; the eval rows go with it."""
+        session, user_id, conn = fc_ctx
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        snap = ForecastSnapshot(
+            user_id=user_id,
+            nightscout_connection_id=conn.id,
+            source_engine="loop",
+            source_uploader="loop",
+            issued_at=issued,
+            start_at=issued,
+            step_minutes=5,
+            horizon_minutes=40,
+            curves_mgdl_json=curves,
+            default_curve_name=default_curve,
+            dedupe_key=f"loop-{uuid.uuid4().hex}",
+        )
+        session.add(snap)
+        await session.flush()
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=snap.id,
+                offset_minutes=5,
+                predicted_mgdl=122.0,
+                actual_mgdl=120.0,
+            )
+        )
+        await session.commit()
+        snap_id = snap.id
+
+        await session.execute(
+            delete(ForecastSnapshot).where(ForecastSnapshot.id == snap_id)
+        )
+        await session.commit()
+
+        # The evaluation row is gone too.
+        result = await session.execute(
+            select(ForecastEvaluation).where(
+                ForecastEvaluation.forecast_snapshot_id == snap_id
+            )
+        )
+        assert result.scalars().first() is None
+
+
+# ---------------------------------------------------------------------------
+# Time-series query path (latest forecast per source for a user)
+# ---------------------------------------------------------------------------
+
+
+class TestForecastQueryByLatest:
+    """Verifies the read path's index ordering for
+    `(user_id, source_engine, issued_at DESC)`."""
+
+    @pytest.mark.asyncio
+    async def test_latest_per_source_via_issued_at_index(self, fc_ctx):
+        """Read endpoint will hit `ix_forecast_user_source_issued` to
+        answer 'give me this user's latest Loop forecast'. Verify the
+        ordering does what the index claims."""
+        session, user_id, conn = fc_ctx
+        base = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+
+        # Three Loop forecasts, 5 min apart.
+        for i in range(3):
+            session.add(
+                ForecastSnapshot(
+                    user_id=user_id,
+                    nightscout_connection_id=conn.id,
+                    source_engine="loop",
+                    source_uploader="loop",
+                    issued_at=base - timedelta(minutes=(2 - i) * 5),
+                    start_at=base - timedelta(minutes=(2 - i) * 5),
+                    step_minutes=5,
+                    horizon_minutes=40,
+                    curves_mgdl_json=curves,
+                    default_curve_name=default_curve,
+                    dedupe_key=f"loop-{i}-{uuid.uuid4().hex}",
+                )
+            )
+        await session.commit()
+
+        # "Latest Loop forecast for this user" query.
+        latest = (
+            await session.execute(
+                select(ForecastSnapshot)
+                .where(
+                    ForecastSnapshot.user_id == user_id,
+                    ForecastSnapshot.source_engine == "loop",
+                )
+                .order_by(ForecastSnapshot.issued_at.desc())
+                .limit(1)
+            )
+        ).scalar_one()
+        assert latest.issued_at == base  # the most-recent one
+
+
+# ---------------------------------------------------------------------------
+# DB-level invariants (CHECK constraints from migration 055)
+# ---------------------------------------------------------------------------
+
+
+class TestForecastDbInvariants:
+    """Pins the CHECK constraints the migration declares. Each test
+    proves the DB rejects a malformed row that a buggy PR 2 translator
+    might otherwise land.
+    """
+
+    async def _base_snap_kwargs(self, user_id: uuid.UUID) -> dict:
+        issued = datetime.now(UTC)
+        curves, default_curve = _loop_curve()
+        return {
+            "user_id": user_id,
+            "nightscout_connection_id": None,
+            "source_engine": "loop",
+            "source_uploader": "loop",
+            "issued_at": issued,
+            "start_at": issued,
+            "step_minutes": 5,
+            "horizon_minutes": 40,
+            "curves_mgdl_json": curves,
+            "default_curve_name": default_curve,
+            "dedupe_key": f"loop-{uuid.uuid4().hex}",
+        }
+
+    @pytest.mark.asyncio
+    async def test_unknown_source_engine_rejected(self, fc_ctx):
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["source_engine"] = "AAPS"  # casing typo, NOT in allowed set
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_zero_step_minutes_rejected(self, fc_ctx):
+        """`step_minutes=0` would divide by zero on chart render."""
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["step_minutes"] = 0
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_negative_horizon_minutes_rejected(self, fc_ctx):
+        """A negative horizon is physically meaningless."""
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["horizon_minutes"] = -5
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_default_curve_missing_from_curves_rejected(self, fc_ctx):
+        """default_curve_name = "IOB" but curves only has "main".
+        Read endpoint would KeyError. DB must reject."""
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["curves_mgdl_json"] = {"main": [120, 122]}
+        kwargs["default_curve_name"] = "IOB"  # not in curves
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_empty_dedupe_key_rejected(self, fc_ctx):
+        """Empty dedupe key would defeat UPSERT idempotency."""
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["dedupe_key"] = ""
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_oversized_dedupe_key_rejected(self, fc_ctx):
+        """Bounds against a malformed translator writing huge strings."""
+        session, user_id, _conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["dedupe_key"] = "x" * 200  # over 128
+        session.add(ForecastSnapshot(**kwargs))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_evaluation_fk_rejects_bogus_snapshot(self, fc_ctx):
+        """Inserting an eval row pointing at a non-existent snapshot
+        must fail at the FK boundary, not later."""
+        session, _user_id, _conn = fc_ctx
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=uuid.uuid4(),  # no such snapshot
+                offset_minutes=5,
+                predicted_mgdl=120.0,
+                actual_mgdl=120.0,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_evaluation_negative_offset_rejected(self, fc_ctx):
+        """A negative `offset_minutes` would mean a forecast point
+        before the forecast was issued -- nonsense, and would corrupt
+        MAE / coverage rollups. The DB must reject it."""
+        session, user_id, conn = fc_ctx
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["nightscout_connection_id"] = conn.id
+        snap = ForecastSnapshot(**kwargs)
+        session.add(snap)
+        await session.flush()
+
+        session.add(
+            ForecastEvaluation(
+                forecast_snapshot_id=snap.id,
+                offset_minutes=-5,  # invalid
+                predicted_mgdl=120.0,
+                actual_mgdl=120.0,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_non_utc_timezone_round_trip(self, fc_ctx):
+        """PR 2 translator may receive timestamps in non-UTC offsets
+        (NS payloads carry whatever the uploader's clock reports).
+        DB stores TIMESTAMPTZ; round-trip must preserve the absolute
+        instant regardless of the wire-format tz."""
+        session, user_id, _conn = fc_ctx
+        # 14:30 in UTC+05:30 == 09:00 UTC
+        ist = timezone(timedelta(hours=5, minutes=30))
+        issued_local = datetime(2026, 5, 12, 14, 30, 0, tzinfo=ist)
+        kwargs = await self._base_snap_kwargs(user_id)
+        kwargs["issued_at"] = issued_local
+        kwargs["start_at"] = issued_local
+        session.add(ForecastSnapshot(**kwargs))
+        await session.commit()
+
+        row = (
+            await session.execute(
+                select(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+            )
+        ).scalar_one()
+        # Postgres TIMESTAMPTZ normalizes to UTC on storage.
+        assert row.issued_at.tzinfo is not None
+        assert row.issued_at == issued_local  # same absolute instant
+        # Confirm the absolute-instant equivalence explicitly.
+        assert row.issued_at.astimezone(UTC) == datetime(
+            2026, 5, 12, 9, 0, 0, tzinfo=UTC
+        )

--- a/apps/api/tests/test_nightscout_client.py
+++ b/apps/api/tests/test_nightscout_client.py
@@ -424,6 +424,66 @@ class TestFetchEntries:
             await c.fetch_entries(since=naive)
 
 
+class TestFetchEntriesByObjectId:
+    """Issue #598: entries cursor swaps to NS Mongo `_id` to avoid
+    missing entries that uploaders backfilled into NS with old
+    `dateString` values (Dexcom Share -> NS bridge being the canonical
+    offender)."""
+
+    @pytest.mark.asyncio
+    async def test_uses_find_id_gt_when_object_id_provided(self):
+        c = _make_client()
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_entries(since_object_id="6a001f288e31759edc8c0d25")
+        params = mock_request.call_args.kwargs["params"]
+        assert params["find[_id][$gt]"] == "6a001f288e31759edc8c0d25"
+        # dateString filter is NOT sent when ObjectId cursor is in play
+        # -- it would over-constrain and silently drop late-uploaded
+        # entries from a window that's now in the past.
+        assert "find[dateString][$gte]" not in params
+
+    @pytest.mark.asyncio
+    async def test_object_id_takes_precedence_over_since(self):
+        """When both cursors are passed, ObjectId wins. Sync wires
+        both during the first cycle after migration 054; we must NOT
+        AND them together (would re-introduce the backfill miss)."""
+        c = _make_client()
+        since = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_entries(
+                since=since,
+                since_object_id="6a001f288e31759edc8c0d25",
+            )
+        params = mock_request.call_args.kwargs["params"]
+        assert "find[_id][$gt]" in params
+        assert "find[dateString][$gte]" not in params
+
+    @pytest.mark.asyncio
+    async def test_invalid_object_id_raises_value_error(self):
+        """Bad cursor value should fail loud at the client boundary
+        rather than send junk to NS. Sync code catches and retries
+        the next cycle with the time-window fallback."""
+        c = _make_client()
+        with pytest.raises(ValueError, match="24-character hex ObjectId"):
+            await c.fetch_entries(since_object_id="not-an-object-id")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_datestring_when_no_object_id(self):
+        """First sync after migration 054 has no ObjectId cursor yet.
+        Client falls back to the legacy dateString filter so we still
+        get a bounded window."""
+        c = _make_client()
+        since = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        mock_request = AsyncMock(return_value=_resp(200, []))
+        with patch.object(c._client, "request", new=mock_request):
+            await c.fetch_entries(since=since)
+        params = mock_request.call_args.kwargs["params"]
+        assert params["find[dateString][$gte]"] == "2026-05-01T12:00:00Z"
+        assert "find[_id][$gt]" not in params
+
+
 # ---------------------------------------------------------------------------
 # fetch_profile
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_nightscout_sync.py
+++ b/apps/api/tests/test_nightscout_sync.py
@@ -282,3 +282,123 @@ class TestSyncOutcome:
             .all()
         )
         assert len(rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# Entries ObjectId cursor (issue #598)
+# ---------------------------------------------------------------------------
+
+
+class TestEntriesObjectIdCursor:
+    """Issue #598: entries cursor switched from `dateString` (recorded
+    time, vulnerable to backfill) to NS Mongo `_id` (insertion time,
+    monotonic). These tests pin the sync flow's wiring so a future
+    refactor can't silently regress us back to the old behavior."""
+
+    _VALID_OBJECT_ID = "6a001f288e31759edc8c0d25"
+    _NEW_OBJECT_ID = "6a001f338e31759edc8c0d74"  # larger than the first
+
+    @pytest.mark.asyncio
+    async def test_first_sync_passes_no_object_id(self, sync_ctx):
+        """No cursor yet -> sync passes since_object_id=None, client
+        falls back to the dateString-window filter."""
+        session, conn = sync_ctx
+        assert conn.last_entry_object_id is None
+
+        client_mock = _mk_client_mock(
+            entries=[
+                {
+                    "_id": self._VALID_OBJECT_ID,
+                    "type": "sgv",
+                    "sgv": 120,
+                    "dateString": "2026-05-10T12:00:00.000Z",
+                    "device": "xdrip",
+                }
+            ],
+        )
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            await sync_nightscout_for_connection(session, conn)
+
+        # The first sync calls with since_object_id=None (the column
+        # was NULL going in).
+        kwargs = client_mock.fetch_entries.call_args.kwargs
+        assert kwargs.get("since_object_id") is None
+        # After the sync the cursor is locked in for future cycles.
+        await session.refresh(conn)
+        assert conn.last_entry_object_id == self._VALID_OBJECT_ID
+
+    @pytest.mark.asyncio
+    async def test_subsequent_sync_uses_object_id_cursor(self, sync_ctx):
+        """Second sync passes the stored ObjectId, bypassing the
+        backfill-vulnerable dateString filter."""
+        session, conn = sync_ctx
+        conn.last_entry_object_id = self._VALID_OBJECT_ID
+        await session.commit()
+
+        client_mock = _mk_client_mock(
+            entries=[
+                {
+                    "_id": self._NEW_OBJECT_ID,
+                    "type": "sgv",
+                    "sgv": 130,
+                    "dateString": "2026-05-10T12:05:00.000Z",
+                    "device": "xdrip",
+                }
+            ],
+        )
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            await sync_nightscout_for_connection(session, conn)
+
+        kwargs = client_mock.fetch_entries.call_args.kwargs
+        assert kwargs.get("since_object_id") == self._VALID_OBJECT_ID
+        await session.refresh(conn)
+        assert conn.last_entry_object_id == self._NEW_OBJECT_ID
+
+    @pytest.mark.asyncio
+    async def test_cursor_stays_put_on_failure(self, sync_ctx):
+        """Same guarantee as `last_synced_at`: failed sync does NOT
+        advance the cursor. Next attempt re-fetches from the same
+        starting point so we don't lose entries to a transient blip."""
+        session, conn = sync_ctx
+        conn.last_entry_object_id = self._VALID_OBJECT_ID
+        await session.commit()
+
+        client_mock = _mk_client_mock(
+            fetch_exception=NightscoutNetworkError("connection reset")
+        )
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            result = await sync_nightscout_for_connection(session, conn)
+
+        assert result.status == NightscoutSyncStatus.NETWORK
+        await session.refresh(conn)
+        assert conn.last_entry_object_id == self._VALID_OBJECT_ID
+
+    @pytest.mark.asyncio
+    async def test_empty_response_keeps_existing_cursor(self, sync_ctx):
+        """When NS returns zero entries (no new data this cycle), the
+        cursor must not get clobbered to NULL -- next cycle would
+        re-fetch a wide window and burn bandwidth. Existing cursor
+        stays in place."""
+        session, conn = sync_ctx
+        conn.last_entry_object_id = self._VALID_OBJECT_ID
+        await session.commit()
+
+        client_mock = _mk_client_mock(entries=[])
+        with patch(
+            "src.services.integrations.nightscout.sync.NightscoutClient.create",
+            new=AsyncMock(return_value=client_mock),
+        ):
+            result = await sync_nightscout_for_connection(session, conn)
+
+        assert result.status == NightscoutSyncStatus.OK
+        await session.refresh(conn)
+        assert conn.last_entry_object_id == self._VALID_OBJECT_ID

--- a/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
+++ b/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
@@ -122,3 +122,113 @@ describe("NightscoutIntegrationsSection -- is_active filter", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe("NightscoutIntegrationsSection -- re-import button (43.7d)", () => {
+  it("renders a re-import link on every active connection", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[
+          makeConn({ id: "c1", name: "Primary" }),
+          makeConn({ id: "c2", name: "Spouse" }),
+        ]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    const link1 = screen.getByTestId("nightscout-reimport-c1");
+    const link2 = screen.getByTestId("nightscout-reimport-c2");
+    expect(link1).toHaveAttribute(
+      "href",
+      "/dashboard/settings/integrations/nightscout/connect?connection=c1"
+    );
+    expect(link2).toHaveAttribute(
+      "href",
+      "/dashboard/settings/integrations/nightscout/connect?connection=c2"
+    );
+  });
+
+  it("URL-encodes the connection id in the re-import href", () => {
+    // Real ids are UUIDs (no special chars), but the encoder
+    // belt-and-suspenders against odd ids leaking in from future flows.
+    render(
+      <NightscoutIntegrationsSection
+        connections={[makeConn({ id: "id with spaces", name: "Weird" })]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+    const link = screen.getByTestId("nightscout-reimport-id with spaces");
+    expect(link.getAttribute("href")).toContain(
+      "connection=id%20with%20spaces"
+    );
+  });
+
+  it("disables the re-import link when offline -- pulls out of tab order and blocks keyboard activation", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[makeConn({ id: "c1", name: "Primary" })]}
+        isOffline={true}
+        {...noopHandlers}
+      />
+    );
+
+    const link = screen.getByTestId("nightscout-reimport-c1");
+    expect(link).toHaveAttribute("aria-disabled", "true");
+    // `aria-disabled` alone is advisory -- Tab + Enter would still
+    // navigate. tabIndex=-1 removes the link from keyboard tab order.
+    expect(link).toHaveAttribute("tabindex", "-1");
+
+    // Pressing Enter must not trigger navigation. We assert by spying
+    // on the keydown event and confirming defaultPrevented flips
+    // to true via our onKeyDown handler.
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    link.dispatchEvent(keyEvent);
+    expect(keyEvent.defaultPrevented).toBe(true);
+
+    // Same for Space.
+    const spaceEvent = new KeyboardEvent("keydown", {
+      key: " ",
+      bubbles: true,
+      cancelable: true,
+    });
+    link.dispatchEvent(spaceEvent);
+    expect(spaceEvent.defaultPrevented).toBe(true);
+
+    // And a click is still blocked (the mouse path).
+    const clickEvent = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    link.dispatchEvent(clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+
+  it("keeps the re-import link tab-able and interactive when online", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[makeConn({ id: "c1", name: "Primary" })]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    const link = screen.getByTestId("nightscout-reimport-c1");
+    expect(link).toHaveAttribute("aria-disabled", "false");
+    // No explicit tabIndex when enabled -- inherits anchor's default (0).
+    expect(link.getAttribute("tabindex")).toBeNull();
+
+    // Enter does NOT get preventDefault'd in the enabled state.
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    link.dispatchEvent(keyEvent);
+    expect(keyEvent.defaultPrevented).toBe(false);
+  });
+});

--- a/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
+++ b/apps/web/__tests__/components/nightscout-integrations-section.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for NightscoutIntegrationsSection.
+ *
+ * Specifically validates that soft-deleted (`is_active=false`) connections
+ * are hidden from the list. The backend's DELETE endpoint deactivates
+ * rather than hard-deleting to preserve attribution on historical
+ * pump_events (`source = "nightscout:<id>"`), but the list endpoint
+ * still returns those rows -- the UI is responsible for filtering.
+ *
+ * Regression coverage for: users reported clicking Delete appeared to do
+ * nothing because the soft-deleted row immediately re-appeared on refetch.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { NightscoutIntegrationsSection } from "../../src/components/integrations/nightscout-integrations-section";
+import type { NightscoutConnectionResponse } from "../../src/lib/api";
+
+// framer-motion shows up via CollapsibleSection -- mock to avoid jsdom
+// animation noise.
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode;
+      [key: string]: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+function makeConn(
+  overrides: Partial<NightscoutConnectionResponse>
+): NightscoutConnectionResponse {
+  return {
+    id: "00000000-0000-0000-0000-000000000000",
+    name: "Test connection",
+    base_url: "https://example.org",
+    auth_type: "auto",
+    api_version: "v1",
+    is_active: true,
+    has_credential: true,
+    sync_interval_minutes: 5,
+    initial_sync_window_days: 7,
+    last_sync_status: "ok",
+    last_synced_at: "2026-05-11T00:00:00Z",
+    last_sync_error: null,
+    detected_uploaders_json: null,
+    last_evaluated_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const noopHandlers = {
+  onCreate: jest.fn(),
+  onDelete: jest.fn(),
+  onTest: jest.fn(),
+  onSync: jest.fn(),
+  onUpdate: jest.fn(),
+};
+
+describe("NightscoutIntegrationsSection -- is_active filter", () => {
+  it("renders only active connections in the list", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[
+          makeConn({ id: "active-1", name: "Active One" }),
+          makeConn({ id: "inactive-1", name: "Soft Deleted", is_active: false }),
+          makeConn({ id: "active-2", name: "Active Two" }),
+        ]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    // Active rows are present.
+    expect(screen.getByText("Active One")).toBeInTheDocument();
+    expect(screen.getByText("Active Two")).toBeInTheDocument();
+
+    // Soft-deleted row is gone (this is the regression -- previously it
+    // rendered alongside the active ones).
+    expect(screen.queryByText("Soft Deleted")).not.toBeInTheDocument();
+  });
+
+  it("reports the count of active connections only", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[
+          makeConn({ id: "a", name: "Alpha" }),
+          makeConn({ id: "b", name: "Beta", is_active: false }),
+          makeConn({ id: "c", name: "Gamma", is_active: false }),
+        ]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    // "1 connection" (singular) -- because only Alpha is active.
+    expect(screen.getByText(/1 connection/)).toBeInTheDocument();
+    expect(screen.queryByText(/3 connection/)).not.toBeInTheDocument();
+  });
+
+  it("hides the connections list entirely when all connections are inactive", () => {
+    render(
+      <NightscoutIntegrationsSection
+        connections={[
+          makeConn({ id: "a", name: "Alpha", is_active: false }),
+          makeConn({ id: "b", name: "Beta", is_active: false }),
+        ]}
+        isOffline={false}
+        {...noopHandlers}
+      />
+    );
+
+    expect(
+      screen.queryByTestId("nightscout-connections-list")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/dashboard/settings/integrations/nightscout/connect/page.tsx
+++ b/apps/web/src/app/dashboard/settings/integrations/nightscout/connect/page.tsx
@@ -1,11 +1,33 @@
 "use client";
 
+import { Suspense } from "react";
+import { Loader2 } from "lucide-react";
 import { NightscoutOnboardingWizard } from "@/components/integrations/nightscout-onboarding-wizard";
 
 // Bookmark/refresh-resilient route for the smart-onboarding wizard.
 // Step 4 (first sync) can take ~20s, so this is a real route rather
 // than a modal -- losing the wizard mid-sync to an accidental Esc
 // or click-outside would be bad UX.
+//
+// The wizard calls `useSearchParams()` to support the `?connection=<id>`
+// re-import deep link (Story 43.7d). Next 15 requires that consumer
+// to be inside a Suspense boundary; the fallback below is what the
+// page shows during the static-shell render.
 export default function NightscoutConnectPage() {
-  return <NightscoutOnboardingWizard />;
+  return (
+    <Suspense
+      fallback={
+        <div
+          role="status"
+          aria-live="polite"
+          className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center"
+        >
+          <Loader2 className="h-6 w-6 text-blue-500 animate-spin" aria-hidden="true" />
+          <span className="sr-only">Loading Nightscout connection wizard…</span>
+        </div>
+      }
+    >
+      <NightscoutOnboardingWizard />
+    </Suspense>
+  );
 }

--- a/apps/web/src/components/integrations/nightscout-integrations-section.tsx
+++ b/apps/web/src/components/integrations/nightscout-integrations-section.tsx
@@ -482,7 +482,51 @@ export function NightscoutIntegrationsSection({
                             </p>
                           )}
                         </div>
-                        <div className="flex gap-2 shrink-0">
+                        <div className="flex gap-2 shrink-0 flex-wrap">
+                          {(() => {
+                            const reimportDisabled =
+                              isOffline || isBusy(conn.id);
+                            return (
+                              <Link
+                                href={`/dashboard/settings/integrations/nightscout/connect?connection=${encodeURIComponent(conn.id)}`}
+                                data-testid={`nightscout-reimport-${conn.id}`}
+                                aria-disabled={reimportDisabled}
+                                // `aria-disabled` alone is advisory --
+                                // the Link stays in tab order and
+                                // Enter/Space still navigates. Pull
+                                // it out of tab order AND block
+                                // keyboard activation (Enter/Space)
+                                // when disabled, so keyboard users
+                                // get the same gate as mouse users.
+                                tabIndex={reimportDisabled ? -1 : undefined}
+                                onClick={(e) => {
+                                  if (reimportDisabled) {
+                                    e.preventDefault();
+                                  }
+                                }}
+                                onKeyDown={(e) => {
+                                  if (
+                                    reimportDisabled &&
+                                    (e.key === "Enter" || e.key === " ")
+                                  ) {
+                                    e.preventDefault();
+                                  }
+                                }}
+                                className={clsx(
+                                  "px-3 py-1.5 rounded-lg text-xs font-medium",
+                                  "border border-purple-500/30 text-purple-400",
+                                  "hover:bg-purple-500/10",
+                                  "transition-colors flex items-center gap-1",
+                                  reimportDisabled &&
+                                    "opacity-50 cursor-not-allowed pointer-events-none"
+                                )}
+                                title="Re-read this Nightscout's profile and pick which updated settings to bring into GlycemicGPT"
+                              >
+                                <Sparkles className="h-3 w-3" />
+                                Re-import
+                              </Link>
+                            );
+                          })()}
                           <button
                             type="button"
                             onClick={() => handleSync(conn.id)}

--- a/apps/web/src/components/integrations/nightscout-integrations-section.tsx
+++ b/apps/web/src/components/integrations/nightscout-integrations-section.tsx
@@ -107,6 +107,14 @@ export function NightscoutIntegrationsSection({
   onSync,
   onUpdate,
 }: NightscoutIntegrationsSectionProps) {
+  // The backend DELETE is a soft-delete that flips `is_active = false`
+  // (preserves `source = "nightscout:<id>"` attribution on historical
+  // pump_events). The list endpoint intentionally returns inactive
+  // rows so the UI can group them. Until a dedicated "deactivated
+  // history" affordance ships, we hide them entirely -- otherwise
+  // clicking Delete appears to fail because the soft-deleted row
+  // immediately re-appears on refetch.
+  const activeConnections = connections.filter((c) => c.is_active);
   const [name, setName] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [credential, setCredential] = useState("");
@@ -352,8 +360,8 @@ export function NightscoutIntegrationsSection({
           variant="subsection"
           badge={
             <span className="ml-2 text-xs font-medium text-slate-500">
-              {connections.length} connection
-              {connections.length === 1 ? "" : "s"}
+              {activeConnections.length} connection
+              {activeConnections.length === 1 ? "" : "s"}
             </span>
           }
         >
@@ -367,14 +375,14 @@ export function NightscoutIntegrationsSection({
               uploader).
             </p>
 
-            {connections.length > 0 && (
+            {activeConnections.length > 0 && (
               <ul
                 role="list"
                 aria-label="Nightscout connections"
                 className="space-y-3"
                 data-testid="nightscout-connections-list"
               >
-                {connections.map((conn) => {
+                {activeConnections.map((conn) => {
                   const result = perConnectionResult[conn.id];
                   const showConfirm = confirmDeleteId === conn.id;
                   return (

--- a/apps/web/src/components/integrations/nightscout-onboarding-wizard.tsx
+++ b/apps/web/src/components/integrations/nightscout-onboarding-wizard.tsx
@@ -23,7 +23,7 @@ import {
   X,
 } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import clsx from "clsx";
 import {
   applyNightscoutOnboarding,
@@ -109,6 +109,11 @@ interface WizardState {
   formError: string | null;
   isCreating: boolean;
   credentialVisible: boolean;
+  // True when the wizard was entered via the re-import deep link
+  // (`/connect?connection=<id>`). Skips Step 1; the credentials
+  // form is unused. Used by the header / cancel UX to hint at
+  // the different intent.
+  isReimport: boolean;
   // Step 2
   connectionId: string | null;
   derivation: OnboardingDerivation | null;
@@ -143,6 +148,7 @@ const INITIAL_STATE: WizardState = {
   formError: null,
   isCreating: false,
   credentialVisible: false,
+  isReimport: false,
   connectionId: null,
   derivation: null,
   discovery: null,
@@ -334,9 +340,42 @@ function anyGlucoseDomainImported(imports: ImportFlags): boolean {
 // Wizard
 // ----------------------------------------------------------------------------
 
+// 36 hex chars + 4 hyphens. Cheap shape-check before we trust an
+// untrusted query-param value enough to seed wizard state with it.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function deriveInitialState(connectionParam: string | null): WizardState {
+  if (connectionParam && UUID_RE.test(connectionParam)) {
+    // Re-import deep link: skip Step 1 (credentials already exist on
+    // the connection), seed the connection id, jump straight to the
+    // evaluating step. The effect that fires on `step === "evaluating"`
+    // picks it up from there.
+    return {
+      ...INITIAL_STATE,
+      isReimport: true,
+      connectionId: connectionParam,
+      step: "evaluating",
+    };
+  }
+  return INITIAL_STATE;
+}
+
 export function NightscoutOnboardingWizard() {
   const router = useRouter();
-  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+  const searchParams = useSearchParams();
+  // Read once at mount. Changing the URL mid-wizard doesn't re-seed
+  // (intentional: avoids state thrash if the user copy-pastes a link
+  // into the same tab while the wizard is in flight).
+  const initialConnection = useMemo(
+    () => searchParams?.get("connection") ?? null,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+  const [state, dispatch] = useReducer(
+    reducer,
+    initialConnection,
+    deriveInitialState
+  );
 
   // Kick the evaluate + derive chain when we enter step 2. Using
   // ref-as-cache-key so React-strict-mode double-mount in dev
@@ -524,7 +563,7 @@ export function NightscoutOnboardingWizard() {
       data-testid="nightscout-wizard"
     >
       <div className="max-w-3xl mx-auto px-4 sm:px-6 py-8">
-        <WizardHeader currentStep={state.step} />
+        <WizardHeader currentStep={state.step} isReimport={state.isReimport} />
         <div className="mt-6">
           {state.step === "credentials" && (
             <CredentialsStep
@@ -576,6 +615,7 @@ export function NightscoutOnboardingWizard() {
           {state.step === "done" && state.applyResult && (
             <DoneStep
               result={state.applyResult}
+              isReimport={state.isReimport}
               onGoToIntegrations={() =>
                 router.push("/dashboard/settings/integrations")
               }
@@ -592,17 +632,26 @@ export function NightscoutOnboardingWizard() {
 // Header / stepper
 // ----------------------------------------------------------------------------
 
-function WizardHeader({ currentStep }: { currentStep: StepId }) {
+function WizardHeader({
+  currentStep,
+  isReimport,
+}: {
+  currentStep: StepId;
+  isReimport: boolean;
+}) {
   const currentIndex = STEPS.findIndex((s) => s.id === currentStep);
   return (
     <div>
       <div className="flex items-center gap-3 text-slate-700 dark:text-slate-200">
         <Wifi className="h-5 w-5 text-blue-500" />
-        <h1 className="text-xl font-semibold">Connect Nightscout</h1>
+        <h1 className="text-xl font-semibold">
+          {isReimport ? "Re-import from Nightscout" : "Connect Nightscout"}
+        </h1>
       </div>
       <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-        Read your existing Nightscout profile and pre-fill your GlycemicGPT
-        settings so you don&apos;t start from a blank dashboard.
+        {isReimport
+          ? "Re-read your Nightscout profile and pick which updated values to bring into GlycemicGPT. Your existing connection isn't recreated."
+          : "Read your existing Nightscout profile and pre-fill your GlycemicGPT settings so you don't start from a blank dashboard."}
       </p>
       <ol
         className="mt-5 flex items-center gap-2 text-xs"
@@ -1563,12 +1612,14 @@ function ApplyingStep() {
 
 interface DoneStepProps {
   result: NightscoutApplyOnboardingResponse;
+  isReimport: boolean;
   onGoToIntegrations: () => void;
   onGoToDashboard: () => void;
 }
 
 function DoneStep({
   result,
+  isReimport,
   onGoToIntegrations,
   onGoToDashboard,
 }: DoneStepProps) {
@@ -1595,14 +1646,14 @@ function DoneStep({
       <div className="flex items-center gap-2 text-green-500">
         <Check className="h-5 w-5" />
         <h2 className="text-base font-medium text-slate-700 dark:text-slate-200">
-          Connected
+          {isReimport ? "Settings updated" : "Connected"}
         </h2>
       </div>
 
       {appliedFields.length > 0 ? (
         <div className="mt-3">
           <p className="text-sm text-slate-500 dark:text-slate-400">
-            We imported:
+            {isReimport ? "We refreshed:" : "We imported:"}
           </p>
           <ul
             className="mt-1 space-y-1"
@@ -1621,8 +1672,9 @@ function DoneStep({
         </div>
       ) : (
         <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
-          No settings were imported. Your connection is saved -- you can sync
-          data without changing any settings.
+          {isReimport
+            ? "No setting changes were applied. Your existing settings are unchanged."
+            : "No settings were imported. Your connection is saved -- you can sync data without changing any settings."}
         </p>
       )}
 

--- a/assets/buttons/star-on-github.svg
+++ b/assets/buttons/star-on-github.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 668 96" width="668" height="96" role="img" aria-label="Star on GitHub">
+  <title>Star on GitHub</title>
+  <rect x="3" y="3" width="662" height="90" rx="45" ry="45" fill="#0D1117" stroke="#FBBF24" stroke-width="4"/>
+  <!-- Gold star, left -->
+  <path transform="translate(100 30) scale(1.5)" fill="#FBBF24" d="M12 .587l3.668 7.568L24 9.75l-6 5.852 1.42 8.275L12 19.771l-7.42 4.106L6 15.602 0 9.75l8.332-1.595z"/>
+  <!-- Text, centered between gold star and octocat -->
+  <text x="346" y="59" text-anchor="middle" fill="#FFFFFF" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" letter-spacing="3">STAR ON GITHUB</text>
+  <!-- GitHub octocat, white, far right (matching OC logo placement) -->
+  <path transform="translate(580 12) scale(3)" fill="#FFFFFF" d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+</svg>

--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,77 @@
+{
+  "version": "v1.0.0",
+  "entity": {
+    "type": "group",
+    "role": "owner",
+    "name": "GlycemicGPT",
+    "email": "funding@glycemicgpt.org",
+    "description": "GlycemicGPT is an open source diabetes platform with AI-powered analysis at its core. It gives people living with diabetes -- and the family members and caregivers who support them -- real-time glucose monitoring, daily AI-generated briefs that explain what their numbers mean, pattern detection across days and weeks, a conversational AI assistant grounded in their own data, and tiered alerts that loop in trusted contacts when something needs attention. Because no one should manage diabetes alone.",
+    "webpageUrl": {
+      "url": "https://glycemicgpt.org",
+      "wellKnown": "https://glycemicgpt.org/.well-known/funding-manifest-urls"
+    }
+  },
+  "projects": [
+    {
+      "guid": "github.com/glycemicgpt/glycemicgpt",
+      "name": "GlycemicGPT",
+      "description": "Open source diabetes platform with AI-powered analysis. Real-time monitoring, daily AI briefs, pattern detection, and caregiver alerts -- built around the principle that no one should manage diabetes alone.",
+      "webpageUrl": {
+        "url": "https://glycemicgpt.org",
+        "wellKnown": "https://glycemicgpt.org/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/GlycemicGPT/GlycemicGPT",
+        "wellKnown": "https://glycemicgpt.org/.well-known/funding-manifest-urls"
+      },
+      "licenses": ["spdx:GPL-3.0-only"],
+      "tags": [
+        "diabetes",
+        "healthcare",
+        "health",
+        "ai",
+        "cgm",
+        "insulin-pump",
+        "medical",
+        "monitoring",
+        "caregiver",
+        "open-source",
+        "self-hosted",
+        "privacy-first"
+      ]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "glycemicgpt-opencollective",
+        "type": "payment-provider",
+        "address": "https://opencollective.com/glycemicgpt",
+        "description": "Transparent fund hosted by Open Source Collective. All income and expenses are public on Open Collective. Donations of any size, recurring or one-time, are accepted in USD."
+      }
+    ],
+    "plans": [
+      {
+        "guid": "project-operations",
+        "status": "active",
+        "name": "Project operations",
+        "description": "Sustains the operating costs of GlycemicGPT: GitHub organization seats for maintainers and committers, the project domain (glycemicgpt.org), project email, and headroom for paid code review tooling if current open-source sponsorships end. As pull request and CI traffic grows, this plan also absorbs GitHub Actions runner overages beyond the free org-plan tier. Funds at this level keep the project running and let it absorb a small number of additional maintainers without strain.",
+        "amount": 5000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": ["glycemicgpt-opencollective"]
+      },
+      {
+        "guid": "managed-cloud-platform",
+        "status": "active",
+        "name": "Managed cloud platform",
+        "description": "Funds the buildout and ongoing operation of the project's planned Hosted Service for Non-Technical Users (see project roadmap). Covers managed PostgreSQL, application hosting for the API, AI sidecar, and web front end, observability and monitoring, transactional email, and backups and object storage. The hosted service follows the same BYOAI model as the self-hosted product -- users supply their own AI credential -- so this plan funds platform infrastructure rather than AI inference costs. The goal is to lower the entry barrier for users who cannot run their own infrastructure, without fragmenting the product into hosted-only features.",
+        "amount": 30000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": ["glycemicgpt-opencollective"]
+      }
+    ],
+    "history": []
+  }
+}


### PR DESCRIPTION
## Promotion: develop → main

Promotes the accumulated work on `develop` since the last release (#604, v0.6.0) to `main`.

## Notable changes in this promotion

### User-visible fixes

- **#611** — `fix(nightscout): swap entries cursor to NS Mongo _id`. Closes [#598](https://github.com/GlycemicGPT/GlycemicGPT/issues/598) (Dexcom-via-Nightscout chart gaps). Root cause: the entries cursor used `dateString` (recorded time), which uploaders backfill with old timestamps below the cursor. Switched to Mongo `_id` (insertion-time monotonic) via `find[_id][$gt]=<lastSeen>`. Includes migration 054 (`last_entry_object_id` column) and 8 new tests.
- **#610** — `fix(web): hide soft-deleted Nightscout connections from the list`. Backend already soft-deletes (`is_active=false`); frontend now filters those out so users see a clean list after delete.
- **#612** — `feat(web): Nightscout re-import entry point on existing connection cards` (Story 43.7d). Users can re-trigger import on a previously-created connection from the same UI surface.

### Backend / schema groundwork (no user-visible behavior yet)

- **#613** — `feat(api): forecast_snapshots + forecast_evaluations schema` (Story 43.12 PR 1). Adds the storage layer for closed-loop BG forecasts (Loop / AAPS / Trio / oref0 / iAPS). Schema-only; populated by PR 2 (#615, not in this promotion).

### Docs / governance

- **#614** — `docs: add funding.json manifest and align funding sections with Open Source Collective`. Aligns README / GOVERNANCE / ROADMAP with the OSC fiscal-hosting model.

### Infra

- **#605** — `fix(ci): single-shot release-body extraction`. Fixes the recurring-sed bug that caused v0.6.0 release notes to include the entire CHANGELOG history.

## Excluded from this promotion

- **#615** — Story 43.12 PR 2 (forecast translator). Open and CI-green; deferred to a future promotion because PR 2's translator has no user-visible surface until PR 3 (read endpoint), PR 4 (frontend overlay), and PR 5 (AI context) land.

## Merge strategy

**Create a merge commit** (per CLAUDE.md). Maintains the develop→main ancestry link and prevents conflicts on subsequent promotions. The label-based changelog (`changelog-pr.yml`) generates granular entries from PR labels and contributor credits regardless of merge type.

## Post-merge automation

1. `changelog-pr.yml` detects the promotion and generates a CHANGELOG PR; `glycemicgpt-merge` auto-merges it.
2. release-please detects releasable commits and creates a version bump PR on main; `glycemicgpt-merge` auto-merges it.
3. GitHub Release published with signed APKs and versioned Docker images.
4. `sync-main-to-develop.yml` cherry-picks the version-bump and changelog commits from main back to develop. No manual intervention needed.