### PR TITLE
fix(funding): make funding.json compliant with fundingjson.org v1.1.0 schema

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,5 +1,6 @@
 {
-  "version": "v1.0.0",
+  "$schema": "https://fundingjson.org/schema/v1.1.0.json",
+  "version": "v1.1.0",
   "entity": {
     "type": "group",
     "role": "owner",
@@ -13,7 +14,7 @@
   },
   "projects": [
     {
-      "guid": "github.com/glycemicgpt/glycemicgpt",
+      "guid": "glycemicgpt",
       "name": "GlycemicGPT",
       "description": "Open source diabetes platform with AI-powered analysis. Real-time monitoring, daily AI briefs, pattern detection, and caregiver alerts -- built around the principle that no one should manage diabetes alone.",
       "webpageUrl": {
@@ -21,19 +22,16 @@
         "wellKnown": "https://glycemicgpt.org/.well-known/funding-manifest-urls"
       },
       "repositoryUrl": {
-        "url": "https://github.com/GlycemicGPT/GlycemicGPT",
-        "wellKnown": "https://glycemicgpt.org/.well-known/funding-manifest-urls"
+        "url": "https://github.com/GlycemicGPT/GlycemicGPT"
       },
       "licenses": ["spdx:GPL-3.0-only"],
       "tags": [
         "diabetes",
         "healthcare",
-        "health",
         "ai",
         "cgm",
         "insulin-pump",
         "medical",
-        "monitoring",
         "caregiver",
         "open-source",
         "self-hosted",


### PR DESCRIPTION
## Why

The existing `funding.json` on main is syntactically valid JSON but fails FLOSS Fund's schema validator during submission. We discovered this when trying to register the project at `https://dir.floss.fund/`. Validator errors observed:

1. `projects[github.com/glycemicgpt/glycemicgpt].guid` should be of length 3 - 32
2. `projects[glycemicgpt].repositoryUrl.url and projects[glycemicgpt].repositoryUrl.wellKnown hostnames do not match`

Plus follow-on issues that the v1.1.0 JSON schema would have caught: tags > 10 items, missing `$schema` reference.

## Audit against the v1.1.0 schema

Pulled the authoritative schema from `https://fundingjson.org/schema/v1.1.0.json` and validated locally. Five concrete fixes:

### 1. Add `$schema` field

Lets any validator (FLOSS Fund or other) resolve the schema automatically.

```json
"$schema": "https://fundingjson.org/schema/v1.1.0.json"
```

### 2. Fix `projects[0].guid` — pattern + length violation

| Before | After |
|---|---|
| `"github.com/glycemicgpt/glycemicgpt"` (34 chars, contains `.` and `/`) | `"glycemicgpt"` (11 chars) |

Schema requires `pattern: "^[a-z0-9-]+$"` and `maxLength: 32`. The previous value was 34 chars and contained disallowed characters. The new value satisfies both constraints. GUIDs only need to be unique within the manifest, not globally — `"glycemicgpt"` is fine.

### 3. Remove `projects[0].repositoryUrl.wellKnown`

The `wellKnown` URL for any URL field must be hosted on the same hostname as the URL it verifies. Our `repositoryUrl.url` is `https://github.com/GlycemicGPT/GlycemicGPT` (hostname `github.com`), but the `wellKnown` was at `glycemicgpt.org`. Different hostnames -> validator rejected.

We can't host `.well-known/funding-manifest-urls` on `github.com`, so the correct move is to drop the wellKnown field on repositoryUrl. The repository stays declared but is reported as "unverified" by the spec's definition. Verification still works for `entity.webpageUrl` and `projects[0].webpageUrl` because both point at `glycemicgpt.org` where we DO host the well-known file (in the website repo, at `public/.well-known/funding-manifest-urls`).

### 4. Trim `projects[0].tags` from 12 to 10

Schema enforces `maxItems: 10`. Dropped:

- `"health"` -- redundant with `"healthcare"`
- `"monitoring"` -- less specific than the other tags

### 5. Bump `version` from `v1.0.0` to `v1.1.0`

Cosmetic. Keeps the version field in sync with the `$schema` URL we now declare. The `version` field is optional metadata and arbitrary, so this is just consistency.

## What does NOT change

- Project description and entity description (well under their `maxLength: 2000`)
- Funding plans amounts ($5k operations + $30k cloud platform) and frequencies
- Channel descriptor (well under `maxLength: 500`)
- All wellKnown URLs that pass validation today
- Email contact (`funding@glycemicgpt.org`) — already verified working

## Verification

Locally validated against the live v1.1.0 schema via `jsonschema.validate(manifest, schema)`. Passes.

Once this lands on `develop` and is promoted to `main`, the FLOSS Fund submission can proceed.

## Follow-up after merge + promotion

1. Re-validate at `https://dir.floss.fund/validate` -> should now return clean
2. Submit at `https://dir.floss.fund/submit`