### PR TITLE
fix(funding): trim managed-cloud-platform plan description to under 500 chars

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -63,7 +63,7 @@
         "guid": "managed-cloud-platform",
         "status": "active",
         "name": "Managed cloud platform",
-        "description": "Funds the buildout and ongoing operation of the project's planned Hosted Service for Non-Technical Users (see project roadmap). Covers managed PostgreSQL, application hosting for the API, AI sidecar, and web front end, observability and monitoring, transactional email, and backups and object storage. The hosted service follows the same BYOAI model as the self-hosted product -- users supply their own AI credential -- so this plan funds platform infrastructure rather than AI inference costs. The goal is to lower the entry barrier for users who cannot run their own infrastructure, without fragmenting the product into hosted-only features.",
+        "description": "Funds the buildout and operation of the project's planned Hosted Service for Non-Technical Users (see roadmap). Covers managed PostgreSQL, app hosting (API, AI sidecar, web), monitoring, transactional email, and backups. The hosted service is BYOAI -- users supply their own AI credential, so this plan funds platform infrastructure, not AI inference. Lowers the entry barrier for users who cannot self-host.",
         "amount": 30000,
         "currency": "USD",
         "frequency": "yearly",


### PR DESCRIPTION
## The bug

FLOSS Fund's validator returned: ``plans[managed-cloud-platform].description should be of length 0 - 500``

The previous description was 643 characters. The validator enforces a 500-char cap on plan descriptions even though the **published v1.1.0 JSON schema at https://fundingjson.org/schema/v1.1.0.json does NOT declare that constraint**. This is a hidden rule applied by the validator on top of the schema.

## The fix

Trim the description from 643 → 408 chars. Substantive content preserved:

- Hosted service scope (BYOAI, what platform infrastructure is funded)
- Explicit reference to the roadmap entry
- Goal of lowering entry barrier for users who cannot self-host

Removed:
- Redundant phrasing
- Sentence about "without fragmenting the product into hosted-only features" — implicit in the same-product framing already in the surrounding text

## Better validator going forward

I added an enforcement-aware local validator (`/tmp/validate-funding.py` on my side) that catches:

1. Standard JSON schema validation against the live v1.1.0 schema
2. Plan description maxLength 500 (hidden validator rule, not in published schema)
3. Channel description maxLength 500 (in schema)
4. Cross-field wellKnown hostname matching with parent URL
5. All other length caps

That validator now reports `VALID` on the trimmed file. Future changes can be checked against it locally before going to the FLOSS Fund validator.

## Post-merge

Same flow as the previous funding.json PR:
1. Merge to develop
2. Promotion PR develop → main (Create a merge commit)
3. Re-validate at https://dir.floss.fund/validate
4. Submit at https://dir.floss.fund/submit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the description text for the Managed cloud platform funding option to improve clarity and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/627)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->