### PR TITLE
feat(api, web): hero card closed-loop surfaces (43.12 PR 6)

### DIFF
--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -61,6 +61,8 @@ from src.schemas.pump import (
     ControlIQActivityResponse,
     InsulinSummaryResponse,
     IoBProjectionResponse,
+    LoopStatusResponse,
+    OverrideStatusResponse,
     PumpEventHistoryResponse,
     PumpEventResponse,
     PumpPushRequest,
@@ -84,6 +86,7 @@ from src.services.dexcom_sync import (
     sync_dexcom_for_user,
 )
 from src.services.iob_projection import get_iob_projection, get_user_dia
+from src.services.loop_state_extractor import get_latest_loop_state
 from src.services.tandem_sync import (
     TandemAuthError,
     TandemConnectionError,
@@ -1353,6 +1356,31 @@ async def get_pump_status(
     battery_event = status.get("battery")
     reservoir_event = status.get("reservoir")
 
+    # PR 6: closed-loop surfaces from the latest NS devicestatus snapshot.
+    # Independent query path (DeviceStatusSnapshot, not PumpEvent) -- a
+    # user with only direct integrations (Tandem cloud, etc.) gets the
+    # pump fields populated and the loop fields all None, which is the
+    # correct read.
+    loop_state = await get_latest_loop_state(db, current_user.id)
+    loop_status_resp: LoopStatusResponse | None = None
+    if loop_state.loop_status is not None:
+        loop_status_resp = LoopStatusResponse(
+            state=loop_state.loop_status.state,
+            source=loop_state.loop_status.source,
+            issued_at=loop_state.loop_status.issued_at,
+            failure_reason=loop_state.loop_status.failure_reason,
+        )
+    override_resp: OverrideStatusResponse | None = None
+    if loop_state.override is not None:
+        override_resp = OverrideStatusResponse(
+            name=loop_state.override.name,
+            started_at=loop_state.override.started_at,
+            ends_at=loop_state.override.ends_at,
+            multiplier=loop_state.override.multiplier,
+            target_low_mgdl=loop_state.override.target_low_mgdl,
+            target_high_mgdl=loop_state.override.target_high_mgdl,
+        )
+
     return PumpStatusResponse(
         basal=PumpStatusBasal(
             rate=basal_event.units or 0.0,
@@ -1374,6 +1402,9 @@ async def get_pump_status(
         )
         if reservoir_event
         else None,
+        loop_status=loop_status_resp,
+        override=override_resp,
+        cob_grams=loop_state.cob_grams,
     )
 
 

--- a/apps/api/src/schemas/pump.py
+++ b/apps/api/src/schemas/pump.py
@@ -5,6 +5,7 @@ including pump activity mode data.
 """
 
 from datetime import UTC, datetime, timedelta
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -61,12 +62,82 @@ class PumpStatusReservoir(BaseModel):
     timestamp: datetime
 
 
+class LoopStatusResponse(BaseModel):
+    """Closed-loop runtime state for the hero card badge.
+
+    Story 43.12 PR 6. Surfaces what the user's closed-loop algorithm
+    (Loop / AAPS / Trio / oref0 / iAPS) is doing right now -- whether
+    it's actively looping, paused, or has failed a cycle. Read-only
+    projection over the latest `device_status_snapshots` row;
+    suppressed when the snapshot is older than the staleness threshold
+    in `loop_state_extractor.py`.
+    """
+
+    state: Literal["looping", "not_looping", "failed"] = Field(
+        ...,
+        description="'looping' | 'not_looping' | 'failed'",
+    )
+    source: Literal["loop", "aaps", "trio", "oref0", "iaps"] = Field(
+        ...,
+        description="'loop' | 'aaps' | 'trio' | 'oref0' | 'iaps'",
+    )
+    issued_at: datetime = Field(
+        ...,
+        description="When the source loop emitted the cycle this state reflects.",
+    )
+    failure_reason: str | None = Field(
+        default=None,
+        description="Populated only when state == 'failed'.",
+    )
+
+
+class OverrideStatusResponse(BaseModel):
+    """Active workout / pre-meal / sleep override on the hero card.
+
+    Loop-only in PR 6 -- AAPS / Trio publish overrides via Temp Target
+    treatments, not devicestatus, and are deferred to a follow-up. The
+    schema is general enough to accept those once their extractor lands.
+    """
+
+    name: str = Field(..., description="User-facing override name (e.g. 'Pre-meal').")
+    started_at: datetime
+    ends_at: datetime | None = Field(
+        default=None,
+        description="None for indefinite overrides.",
+    )
+    multiplier: float | None = Field(
+        default=None,
+        description="Loop's `insulinNeedsScaleFactor`.",
+    )
+    target_low_mgdl: float | None = None
+    target_high_mgdl: float | None = None
+
+
 class PumpStatusResponse(BaseModel):
-    """Aggregated latest pump status (basal, battery, reservoir)."""
+    """Aggregated latest pump status (basal, battery, reservoir).
+
+    PR 6 added closed-loop surfaces (`loop_status`, `override`,
+    `cob_grams`) sourced from Nightscout devicestatus snapshots. They
+    are nullable and read-only -- absence means "no NS devicestatus
+    data" or "stale" or "this closed-loop isn't publishing the field".
+    Existing pump_event-derived fields (basal/battery/reservoir) are
+    unchanged.
+    """
 
     basal: PumpStatusBasal | None = None
     battery: PumpStatusBattery | None = None
     reservoir: PumpStatusReservoir | None = None
+
+    # PR 6 additions. Suppressed when no recent NS devicestatus exists.
+    loop_status: LoopStatusResponse | None = None
+    override: OverrideStatusResponse | None = None
+    # COB is bounded at the schema layer (not just the extractor)
+    # because the value flows verbatim from `device_status_snapshots.cob_grams`
+    # without intermediate sanitation. 500 g is far above any
+    # clinically plausible carb count; rejection here means a buggy
+    # mapper bug surfaces as a 500 rather than silently sending
+    # nonsense to the user.
+    cob_grams: float | None = Field(default=None, ge=0, le=500)
 
 
 class TandemSyncResponse(BaseModel):

--- a/apps/api/src/services/integrations/nightscout/_forecast_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_forecast_mapper.py
@@ -31,9 +31,9 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from src.services.integrations.nightscout.models import (
-    NightscoutDeviceStatus,
-    detect_uploader,
+from src.services.integrations.nightscout.models import NightscoutDeviceStatus
+from src.services.integrations.nightscout.source_detection import (
+    detect_openaps_engine,
 )
 
 logger = logging.getLogger(__name__)
@@ -45,14 +45,6 @@ logger = logging.getLogger(__name__)
 # heuristic so the chart's default line matches what the source's own
 # UI shows.
 _OPENAPS_DEFAULT_CURVE_PRIORITY = ("IOB", "COB", "UAM", "ZT")
-
-# OpenAPS-family engines this mapper can attribute. Loop is handled
-# by a separate code path (`_extract_loop_forecast`) and is
-# intentionally NOT in this set even though the migration CHECK
-# accepts it. The migration's `source_engine` allow-list is the
-# superset of "engines the schema permits"; this frozenset is the
-# subset "engines the OpenAPS classification path can produce."
-_OPENAPS_ENGINES = frozenset({"aaps", "trio", "oref0", "iaps"})
 
 # Physiologically plausible glucose range, mg/dL. Curves with any
 # value outside this band are rejected wholesale (same strict policy
@@ -212,7 +204,7 @@ def _extract_openaps_forecast(
     # is guaranteed; no fallback needed.
     default_curve = next(n for n in _OPENAPS_DEFAULT_CURVE_PRIORITY if n in curves)
 
-    source_engine = _detect_openaps_engine(ds)
+    source_engine = detect_openaps_engine(ds.device, ds.openaps)
     if source_engine is None:
         # Indeterminate -- log and skip rather than guess. The CHECK
         # constraint would reject an unknown value anyway, but logging
@@ -281,58 +273,6 @@ def _coerce_curve(value: Any) -> list[float] | None:
             return None
         out.append(coerced)
     return out
-
-
-def _detect_openaps_engine(ds: NightscoutDeviceStatus) -> str | None:
-    """Classify an OpenAPS-family devicestatus as AAPS / Trio / oref0 / iAPS.
-
-    Returns `None` for indeterminate payloads rather than guessing --
-    a mis-attributed forecast misleads both the chart legend and the
-    AI context. The migration CHECK constraint would reject an
-    unknown value anyway, but skipping at the mapper boundary
-    surfaces the unrecognized uploader cleanly via the warning log.
-
-    Detection order (most-specific first):
-
-    1. **`detect_uploader()` shared heuristic** for canonical AAPS /
-       Trio / oref0 device strings. Returns the lowercase tag.
-       Hybrids like `openaps://AndroidAPS-iAPS-bridge` correctly
-       classify as `aaps` here (the URI scheme + AAPS prefix win).
-    2. **iAPS substring fallback** when `detect_uploader()` returns
-       "unknown" but the device string contains `iaps`.
-       `detect_uploader()` has no iAPS branch yet; checking inline
-       avoids touching PR 1's shared helper. iAPS device strings
-       carry `iAPS` as a literal substring (`"iAPS-2.7.0"`).
-    3. **Trio determination-block fallback** when neither path
-       classifies but the payload carries `openaps.determination`
-       (a Trio-specific subtree). Older Trio builds occasionally
-       ship without a recognizable device string.
-
-    NOTE: `detect_uploader()` reads `device` only -- `enteredBy` is
-    discarded for devicestatus. Real-world devicestatus rarely carries
-    enteredBy; documented limitation, not a current correctness issue.
-    """
-    uploader = detect_uploader(None, ds.device)
-    if uploader in _OPENAPS_ENGINES:
-        return uploader
-
-    # iAPS fallback. `detect_uploader()` has returned "unknown" by
-    # this point -- it doesn't classify hybrids that include both
-    # `androidaps` and `iaps` substrings as `aaps`, it routes them
-    # through `parse_openaps_uri()`. We add the `"aaps" not in
-    # device_lower` guard as a belt-and-braces local safety net so
-    # the iAPS attribution can't silently flip if a future tweak to
-    # `detect_uploader()` ever stops handling hybrids (regression
-    # protection -- the test docstrings reference this guard).
-    device_lower = (ds.device or "").lower()
-    if "iaps" in device_lower and "aaps" not in device_lower:
-        return "iaps"
-
-    # Trio fallback via determination block.
-    if ds.openaps and isinstance(ds.openaps.get("determination"), dict):
-        return "trio"
-
-    return None
 
 
 def _parse_iso_timestamp(value: Any) -> datetime | None:

--- a/apps/api/src/services/integrations/nightscout/source_detection.py
+++ b/apps/api/src/services/integrations/nightscout/source_detection.py
@@ -1,0 +1,79 @@
+"""Closed-loop source-engine detection -- shared between PR 2 (forecast
+mapper) and PR 6 (loop state extractor).
+
+Story 43.12 PR 6. Both extractors classify the OpenAPS-family source
+(`aaps` / `trio` / `oref0` / `iaps`) from the same signals -- the
+NS `device` string + a determination-block fallback for older Trio
+builds. They MUST agree, or the chart legend and hero card will
+attribute the same row to different engines.
+
+This module owns the canonical chain. Both call sites import from
+here so a future heuristic change can't drift between the two.
+
+`detect_uploader()` in `models.py` (PR 43.3) is the shared base layer;
+this module adds the OpenAPS-specific refinements (iAPS substring
+fallback, Trio determination-block fallback) needed by both
+forecast-row and hero-card-row code paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from src.services.integrations.nightscout.models import detect_uploader
+
+# OpenAPS-family engines this module can classify. Loop is NOT in this
+# set: Loop has its own subtree presence check (`ds.loop.predicted`
+# for forecasts; `ds.loop.{enacted,suggested}` for runtime state) and
+# doesn't need an OpenAPS-style fallback chain.
+_OPENAPS_ENGINES = frozenset({"aaps", "trio", "oref0", "iaps"})
+
+OpenapsEngine = Literal["aaps", "trio", "oref0", "iaps"]
+
+
+def detect_openaps_engine(
+    device: str | None, openaps_subtree: dict[str, Any] | None
+) -> OpenapsEngine | None:
+    """Classify an OpenAPS-family devicestatus as AAPS / Trio / oref0 / iAPS.
+
+    Detection chain (most-specific first):
+
+    1. **`detect_uploader()` shared heuristic** for canonical device
+       strings. Returns the lowercase tag for AAPS / Trio / oref0.
+       Hybrids like `openaps://AndroidAPS-iAPS-bridge` correctly
+       classify as `aaps` here (the URI scheme + AAPS prefix win
+       through `parse_openaps_uri`).
+    2. **iAPS substring fallback** when `detect_uploader()` returns
+       "unknown" but the device string contains `iaps`. The shared
+       helper has no iAPS branch yet; checking inline avoids touching
+       PR 1's shared file. The `"aaps" not in device_lower` guard is
+       belt-and-braces local protection -- today the canonical AAPS
+       device strings (`androidaps`) don't contain `iaps`, but the
+       guard makes the local logic self-evident.
+    3. **Trio determination-block fallback** when neither path
+       classifies but the payload carries `openaps.determination`
+       (a Trio-specific subtree). Older Trio builds occasionally
+       ship without a recognizable device string; the determination
+       block is the next-best signal.
+
+    Returns None for indeterminate payloads -- the caller's UI should
+    hide the attribution rather than guess.
+
+    NOTE: `detect_uploader()` reads `device` only -- `enteredBy` is
+    discarded for devicestatus. Real-world devicestatus rarely carries
+    enteredBy; documented limitation, not a current correctness issue.
+    """
+    uploader = detect_uploader(None, device)
+    if uploader in _OPENAPS_ENGINES:
+        return uploader  # type: ignore[return-value]
+
+    device_lower = (device or "").lower()
+    if "iaps" in device_lower and "aaps" not in device_lower:
+        return "iaps"
+
+    if openaps_subtree is not None and isinstance(
+        openaps_subtree.get("determination"), dict
+    ):
+        return "trio"
+
+    return None

--- a/apps/api/src/services/loop_state_extractor.py
+++ b/apps/api/src/services/loop_state_extractor.py
@@ -91,6 +91,22 @@ _MULTIPLIER_MAX = 10.0
 _TARGET_GLUCOSE_MIN_MGDL = 30.0
 _TARGET_GLUCOSE_MAX_MGDL = 500.0
 
+# Override duration ceiling. The NS payload's `duration` field flows
+# straight into `timedelta(seconds=...)`, which raises OverflowError
+# for values exceeding `timedelta.max.days = 999_999_999`. The
+# subsequent `started_at + timedelta(...)` raises a separate
+# OverflowError once the result lands beyond `datetime.max`. A
+# malicious / buggy uploader posting `"duration": 1e20` would 500
+# every `/pump/status` call for that user until the snapshot ages
+# out (15-min staleness boundary).
+#
+# Loop's own UI caps override duration at 24h; AAPS / Trio overrides
+# don't flow through this path at all (they ride Temp Target
+# treatments, not devicestatus). 7 days is generous headroom for any
+# clinically plausible value while keeping pathological values from
+# reaching the timedelta/datetime arithmetic.
+_OVERRIDE_DURATION_MAX_SECONDS = 7 * 24 * 3600
+
 
 LoopStatusState = Literal["looping", "not_looping", "failed"]
 LoopSourceEngine = Literal["loop", "aaps", "trio", "oref0", "iaps"]
@@ -381,8 +397,12 @@ def _extract_override(
     if (
         isinstance(duration_seconds, int | float)
         and not isinstance(duration_seconds, bool)
-        and duration_seconds > 0
+        and 0 < float(duration_seconds) <= _OVERRIDE_DURATION_MAX_SECONDS
     ):
+        # The upper bound also prevents NaN / +inf from sneaking in:
+        # both fail the `<= max` comparison. Bool was already rejected
+        # by the isinstance guard above (Python's `True`/`False`
+        # subclass int).
         ends_at = started_at + timedelta(seconds=float(duration_seconds))
 
     # Past-end guard. A stale snapshot can carry `active: true` for

--- a/apps/api/src/services/loop_state_extractor.py
+++ b/apps/api/src/services/loop_state_extractor.py
@@ -1,0 +1,480 @@
+"""Closed-loop runtime state extraction for the dashboard hero card.
+
+Story 43.12 PR 6. Surfaces three additional pieces of information from
+the latest `device_status_snapshots` row to the hero card:
+
+1. **Loop status** -- "looping" / "not_looping" / "failed". Driven by
+   `loop.failureReason` (set = failed) or the presence of
+   `openaps.enacted` (= looping).
+2. **Override** -- Loop's `override` subtree describing an active
+   workout / pre-meal / sleep mode override. Loop-only in this PR;
+   AAPS overrides are deferred (they ride on Temp Target treatments,
+   not devicestatus -- different code path).
+3. **COB** -- carbs-on-board in grams. Already extracted by
+   `_devicestatus_mapper` into `device_status_snapshots.cob_grams` --
+   this module just passes it through.
+
+All data is read-only -- this module never writes to the DB and never
+calls the Nightscout client. It is purely a projection over rows the
+PR 43.3 / PR 43.12 translator already landed.
+
+Staleness rule: if the latest devicestatus snapshot is older than
+`_LOOP_STATUS_STALE_THRESHOLD`, the loop_status field is suppressed
+(returned as None). Showing a "Looping" badge for a 30-minute-old
+snapshot would lie to the user -- their loop may have stopped looping
+since. COB is left numeric regardless because the chart already
+handles freshness elsewhere via `received_at` cues, and a stale COB
+value at the boundary is informationally useful ("you had ~24g
+absorbing 18 min ago") rather than misleading.
+
+Source attribution is preserved end-to-end so the AI context (PR 5)
+and chart legend can talk honestly: "your Loop says..." not "your
+glucose system says...".
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.device_status_snapshot import DeviceStatusSnapshot
+from src.services.integrations.nightscout.source_detection import (
+    detect_openaps_engine,
+)
+
+# Beyond this age, `loop_status` is suppressed. 15 min = 3 missed sync
+# cycles at the default 5-min interval. Tunable if real-world cadence
+# differs.
+_LOOP_STATUS_STALE_THRESHOLD = timedelta(minutes=15)
+
+# Future-clock safety margin. A user device or NS uploader with a
+# clock set ahead of real time (rare, but seen in the wild) would
+# otherwise post devicestatus rows with timestamps in our future,
+# bypassing the staleness check (negative delta < 15 min positive
+# threshold). We allow up to this much lead before rejecting the
+# loop_status -- accommodates ordinary millisecond-scale skew between
+# the user's phone and our server without rejecting legitimate rows.
+_LOOP_STATUS_FUTURE_TOLERANCE = timedelta(minutes=2)
+
+# Bounds for free-text strings flowing from the NS payload through to
+# the UI tooltip. The badge's `title` attribute renders verbatim; a
+# malicious or buggy uploader posting a 100KB string would make the
+# tooltip unwieldy or slow the page. Truncate at the boundary.
+_FAILURE_REASON_MAX_LEN = 200
+_OVERRIDE_NAME_MAX_LEN = 80
+
+# Bounds for COB. The DB column `device_status_snapshots.cob_grams`
+# is a permissive float -- the schema-layer Field(ge=0, le=500) would
+# 500 the whole /pump/status response if a bad value somehow got
+# stored. Clamp at the extractor to None so the rest of the bundle
+# (loop_status / override) still renders.
+_COB_MAX_GRAMS = 500.0
+
+# Bounds for medical-adjacent numeric fields in an override. Out-of-
+# range values from a buggy / malicious uploader are dropped at the
+# extractor (returned as None on the OverrideStatus) rather than
+# 500-ing the entire `/pump/status` request. The override's text
+# fields remain renderable even when its numeric details are dirty.
+#
+# Bounds chosen to admit all clinically plausible Loop overrides:
+# - multiplier: Loop's `insulinNeedsScaleFactor` is bounded by the
+#   app's UI at ~0.05-10.0; clinical use rarely exceeds 0.5-2.0.
+# - target_*_mgdl: physiological glucose targets. 30-500 matches the
+#   wider band used in PR 2's forecast clamp.
+_MULTIPLIER_MIN = 0.05
+_MULTIPLIER_MAX = 10.0
+_TARGET_GLUCOSE_MIN_MGDL = 30.0
+_TARGET_GLUCOSE_MAX_MGDL = 500.0
+
+
+LoopStatusState = Literal["looping", "not_looping", "failed"]
+LoopSourceEngine = Literal["loop", "aaps", "trio", "oref0", "iaps"]
+
+
+@dataclass(frozen=True)
+class LoopStatus:
+    """Closed-loop runtime state extracted from a devicestatus snapshot."""
+
+    state: LoopStatusState
+    source: LoopSourceEngine
+    issued_at: datetime
+    failure_reason: str | None = None  # populated only when state == "failed"
+
+
+@dataclass(frozen=True)
+class OverrideStatus:
+    """Active override (workout / pre-meal / sleep mode) -- Loop-only in PR 6.
+
+    AAPS / Trio publish overrides as Temp Target treatments rather than
+    on devicestatus. Deferred to a follow-up; this PR ships with the
+    Loop wire format only. Multi-source priority is moot until AAPS
+    support lands.
+    """
+
+    name: str
+    started_at: datetime
+    multiplier: float | None = None  # Loop's `insulinNeedsScaleFactor`
+    target_low_mgdl: float | None = None
+    target_high_mgdl: float | None = None
+    ends_at: datetime | None = None  # None for indefinite overrides
+
+
+@dataclass(frozen=True)
+class LoopStateBundle:
+    """The three hero-card-bound fields, packaged together.
+
+    Each field is independently nullable: a user might have a `cob`
+    reading but no active override; a healthy loop but a stale
+    snapshot; etc. The endpoint surfaces them as nullable JSON.
+    """
+
+    loop_status: LoopStatus | None
+    override: OverrideStatus | None
+    cob_grams: float | None
+
+
+async def get_latest_loop_state(
+    db: AsyncSession, user_id: uuid.UUID
+) -> LoopStateBundle:
+    """Project the latest closed-loop state for the hero card.
+
+    Returns an all-None bundle when:
+    - The user has no NS-imported devicestatus snapshots (CGM-only or
+      no integration).
+    - The latest snapshot has no loop / openaps subtree at all
+      (xDrip+ pure CGM relay).
+
+    Returns a partial bundle when only some fields are populated
+    (e.g., a Loop user with no active override returns
+    `loop_status != None` + `override == None`).
+    """
+    # NOTE: multi-connection users (e.g., Loop on connection A AND
+    # AAPS on connection B reporting at staggered cadences) will see
+    # the badge attributed to whichever connection sync'd most
+    # recently. Story 43.10's primary-source picker will deterministic
+    # this; until then, accept the LRU behavior. The test suite pins
+    # the current shape so a future refactor can't silently change it.
+    latest = await _fetch_latest_snapshot(db, user_id)
+    if latest is None:
+        return LoopStateBundle(loop_status=None, override=None, cob_grams=None)
+
+    now = datetime.now(UTC)
+    snapshot_at = _ensure_aware(latest.snapshot_timestamp)
+    age = now - snapshot_at
+
+    # Two staleness gates:
+    # - Past: > 15 min old -> loop may have stopped since; suppress.
+    # - Future: > 2 min ahead of now -> uploader clock skew; we cannot
+    #   honestly claim a state from data that hasn't happened.
+    is_stale = (
+        age > _LOOP_STATUS_STALE_THRESHOLD or age < -_LOOP_STATUS_FUTURE_TOLERANCE
+    )
+
+    loop_status = None if is_stale else _extract_loop_status(latest)
+    override = _extract_override(latest, now=now)
+
+    # COB sanity clamp. Match the schema-layer Field(ge=0, le=500)
+    # bounds so an out-of-range DB value drops cleanly to None
+    # rather than 500-ing the entire /pump/status response.
+    cob = latest.cob_grams
+    if cob is not None and not (0 <= cob <= _COB_MAX_GRAMS):
+        cob = None
+
+    return LoopStateBundle(
+        loop_status=loop_status,
+        override=override,
+        cob_grams=cob,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-piece extractors (pure functions; trivially unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _extract_loop_status(ds: DeviceStatusSnapshot) -> LoopStatus | None:
+    """Classify the loop runtime state from a single snapshot.
+
+    Loop publishes `loop.failureReason` only when the loop has failed
+    a cycle. Absence + presence of `loop` subtree = looping. OpenAPS
+    family classifies by `enacted` subtree presence (= acted on the
+    suggestion this cycle) vs `suggested` only (= computed but didn't
+    enact -- which means not looping per the AAPS convention).
+
+    Returns None when the payload has no closed-loop signal at all
+    (xDrip+, CGM-only relays).
+    """
+    loop_subtree = _as_dict(ds.loop_subtree_json)
+    if loop_subtree is not None:
+        return _extract_loop_status_from_loop_subtree(
+            loop_subtree, issued_at=ds.snapshot_timestamp
+        )
+
+    openaps_subtree = _as_dict(ds.openaps_subtree_json)
+    if openaps_subtree is not None:
+        return _extract_loop_status_from_openaps_subtree(
+            openaps_subtree,
+            device=ds.source_device,
+            issued_at=ds.snapshot_timestamp,
+        )
+
+    return None
+
+
+def _extract_loop_status_from_loop_subtree(
+    loop_subtree: dict[str, Any], *, issued_at: datetime
+) -> LoopStatus | None:
+    """Loop's `loop.{failureReason,enacted}` -> state machine.
+
+    - `failureReason` present and non-empty -> "failed" with reason.
+    - `enacted` subtree present -> "looping".
+    - `suggested` subtree only (no enacted) -> "not_looping".
+    - Neither -> None (not a forecast-publishing loop cycle).
+    """
+    failure_reason = loop_subtree.get("failureReason")
+    if isinstance(failure_reason, str) and failure_reason.strip():
+        # Cap free-text length at the boundary. The badge's `title`
+        # tooltip renders verbatim in the browser; a malicious or
+        # buggy NS uploader posting a 100KB string would make the
+        # tooltip unwieldy. 200 chars covers every real Loop failure
+        # message (typically < 80 chars).
+        return LoopStatus(
+            state="failed",
+            source="loop",
+            issued_at=_ensure_aware(issued_at),
+            failure_reason=failure_reason.strip()[:_FAILURE_REASON_MAX_LEN],
+        )
+
+    if isinstance(loop_subtree.get("enacted"), dict):
+        return LoopStatus(
+            state="looping",
+            source="loop",
+            issued_at=_ensure_aware(issued_at),
+        )
+
+    if isinstance(loop_subtree.get("suggested"), dict):
+        return LoopStatus(
+            state="not_looping",
+            source="loop",
+            issued_at=_ensure_aware(issued_at),
+        )
+
+    return None
+
+
+def _extract_loop_status_from_openaps_subtree(
+    openaps_subtree: dict[str, Any],
+    *,
+    device: str | None,
+    issued_at: datetime,
+) -> LoopStatus | None:
+    """AAPS / Trio / oref0 / iAPS state via `openaps.{enacted,suggested}`.
+
+    Same conventions as Loop:
+    - `enacted` present -> "looping".
+    - `suggested` only -> "not_looping".
+    - Neither -> None.
+
+    No `failureReason` equivalent exists in the OpenAPS wire format;
+    failures surface as "not_looping" with the human-readable reason
+    inside the `suggested.reason` text -- not promoted to a separate
+    state because the OpenAPS family doesn't have the discrete
+    failed-vs-not-looping distinction Loop carries.
+    """
+    source = detect_openaps_engine(device, openaps_subtree)
+    if source is None:
+        return None
+
+    if isinstance(openaps_subtree.get("enacted"), dict):
+        return LoopStatus(
+            state="looping",
+            source=source,
+            issued_at=_ensure_aware(issued_at),
+        )
+
+    if isinstance(openaps_subtree.get("suggested"), dict):
+        return LoopStatus(
+            state="not_looping",
+            source=source,
+            issued_at=_ensure_aware(issued_at),
+        )
+
+    return None
+
+
+def _extract_override(
+    ds: DeviceStatusSnapshot, *, now: datetime | None = None
+) -> OverrideStatus | None:
+    """Pull an active override from Loop's `loop.override` subtree.
+
+    Loop's `override` subtree shape (per `LoopKit/NightscoutKit`
+    `OverrideTreatment.swift`):
+
+    ```
+    {
+      "active": true,
+      "name": "Pre-meal",
+      "timestamp": "2026-05-13T14:00:00Z",      // started
+      "duration": 1800,                          // SECONDS, not minutes
+      "multiplier": 0.7,                         // optional
+      "currentCorrectionRange": {
+        "minValue": 70, "maxValue": 90
+      }
+    }
+    ```
+
+    AAPS / Trio overrides live on Temp Target *treatments* rather than
+    devicestatus; supporting those is a separate code path and
+    deferred to a follow-up. This extractor only consults the
+    `loop_subtree_json` -- a snapshot with only `openaps_subtree_json`
+    populated (AAPS-only user) returns None even if AAPS had an
+    override running at that moment.
+
+    Three independent rejection guards run alongside the canonical
+    `active: true` check:
+
+    1. **Past-end override**: if `ends_at < now`, the override has
+       already ended even though Loop hasn't flipped `active`. Common
+       when NS sync is delayed.
+    2. **Future-start override**: if `started_at > now`, the
+       uploader's clock is ahead and the override hasn't begun yet
+       from our reference frame.
+    3. **Name length cap**: protects the badge tooltip from
+       malicious / buggy uploaders posting huge strings.
+
+    The `now` parameter is injected for deterministic testing and so
+    the caller can use a single `now` across all loop-state fields.
+    """
+    reference_now = now if now is not None else datetime.now(UTC)
+    loop_subtree = _as_dict(ds.loop_subtree_json)
+    if loop_subtree is None:
+        return None
+
+    override = loop_subtree.get("override")
+    if not isinstance(override, dict):
+        return None
+
+    if override.get("active") is not True:
+        return None
+
+    name = override.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+
+    started_at = _parse_iso(override.get("timestamp"))
+    if started_at is None:
+        return None
+
+    # Future-start guard. Allow a small tolerance for ordinary clock
+    # skew; reuse the loop-status future tolerance to keep the policy
+    # consistent across both surfaces.
+    if started_at > reference_now + _LOOP_STATUS_FUTURE_TOLERANCE:
+        return None
+
+    duration_seconds = override.get("duration")
+    ends_at: datetime | None = None
+    if (
+        isinstance(duration_seconds, int | float)
+        and not isinstance(duration_seconds, bool)
+        and duration_seconds > 0
+    ):
+        ends_at = started_at + timedelta(seconds=float(duration_seconds))
+
+    # Past-end guard. A stale snapshot can carry `active: true` for
+    # an override that ended minutes ago; suppress rather than render
+    # "ends in -5 min" or claim "ongoing" for finished work.
+    if ends_at is not None and ends_at < reference_now:
+        return None
+
+    multiplier = override.get("multiplier")
+    if not (isinstance(multiplier, int | float) and not isinstance(multiplier, bool)):
+        multiplier = None
+    elif not (_MULTIPLIER_MIN <= float(multiplier) <= _MULTIPLIER_MAX):
+        # Out-of-range multiplier from a buggy uploader (e.g. NaN
+        # serialized as 0, or a misread units conversion). Drop the
+        # numeric detail; keep the override's name/start/end so the
+        # user still sees "Pre-meal active, ends in 30 min" rather
+        # than the whole override disappearing.
+        multiplier = None
+
+    correction_range = override.get("currentCorrectionRange")
+    target_low: float | None = None
+    target_high: float | None = None
+    if isinstance(correction_range, dict):
+        low_raw = correction_range.get("minValue")
+        high_raw = correction_range.get("maxValue")
+        if isinstance(low_raw, int | float) and not isinstance(low_raw, bool):
+            low_candidate = float(low_raw)
+            if _TARGET_GLUCOSE_MIN_MGDL <= low_candidate <= _TARGET_GLUCOSE_MAX_MGDL:
+                target_low = low_candidate
+        if isinstance(high_raw, int | float) and not isinstance(high_raw, bool):
+            high_candidate = float(high_raw)
+            if _TARGET_GLUCOSE_MIN_MGDL <= high_candidate <= _TARGET_GLUCOSE_MAX_MGDL:
+                target_high = high_candidate
+
+    # Logical consistency: if both targets parsed cleanly but
+    # target_low > target_high, the band is inverted -- drop both.
+    if target_low is not None and target_high is not None and target_low > target_high:
+        target_low = None
+        target_high = None
+
+    return OverrideStatus(
+        name=name.strip()[:_OVERRIDE_NAME_MAX_LEN],
+        started_at=started_at,
+        multiplier=float(multiplier) if multiplier is not None else None,
+        target_low_mgdl=target_low,
+        target_high_mgdl=target_high,
+        ends_at=ends_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_latest_snapshot(
+    db: AsyncSession, user_id: uuid.UUID
+) -> DeviceStatusSnapshot | None:
+    """Latest devicestatus snapshot across all NS connections for the user.
+
+    Picks by `snapshot_timestamp` desc -- not `received_at` -- so a
+    backfilled snapshot doesn't outrank a newer real-time one just
+    because it was synced later. This matches the chart's
+    glucose-reading ordering convention.
+    """
+    stmt = (
+        select(DeviceStatusSnapshot)
+        .where(DeviceStatusSnapshot.user_id == user_id)
+        .order_by(DeviceStatusSnapshot.snapshot_timestamp.desc())
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+def _as_dict(value: Any) -> dict[str, Any] | None:
+    """Coerce a JSONB column read to a dict, tolerating None / non-dict."""
+    return value if isinstance(value, dict) else None
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """ISO 8601 string -> aware datetime (UTC). Returns None on garbage."""
+    if not isinstance(value, str) or not value:
+        return None
+    s = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    return dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def _ensure_aware(dt: datetime) -> datetime:
+    """Postgres TIMESTAMPTZ returns aware; safety net for naive sentinels."""
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)

--- a/apps/api/tests/test_loop_state_extractor.py
+++ b/apps/api/tests/test_loop_state_extractor.py
@@ -1061,3 +1061,102 @@ class TestMedicalFieldBounds:
         await session.commit()
         bundle = await get_latest_loop_state(session, user_id)
         assert bundle.cob_grams is None
+
+
+class TestOverrideDurationOverflowGuard:
+    """Pins the duration clamp added in response to CR's PR-6 review.
+
+    Without the clamp, a malicious or buggy NS uploader posting a
+    pathological `duration` (e.g., `1e20`) raises `OverflowError`
+    from `timedelta(seconds=...)`. That exception propagates out of
+    `_extract_override`, into `get_latest_loop_state`, into the
+    `/pump/status` handler, and 500s the hero card for that user
+    until the snapshot ages out (15 min later).
+    """
+
+    def test_overflow_duration_dropped_not_raises(self):
+        """`duration: 1e20` would overflow `timedelta` -> propagating
+        OverflowError -> 500 on every /pump/status call. The clamp
+        catches it before any timedelta arithmetic; the override is
+        rendered indefinite (`ends_at=None`) while `name` / `started_at`
+        stay intact. Same fail-soft policy as the multiplier / targets
+        clamps -- bad numeric detail dropped, surrounding row renders."""
+        now = datetime(2026, 5, 13, 14, 1, tzinfo=UTC)
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Pre-meal",
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 1e20,  # would overflow timedelta
+                }
+            },
+        )
+        # Critically: must not raise. The previous shape would have
+        # produced an uncaught OverflowError out of /pump/status.
+        override = _extract_override(ds, now=now)
+        assert override is not None
+        assert override.name == "Pre-meal"
+        assert override.ends_at is None
+
+    def test_seven_day_duration_accepted(self):
+        """The 7-day ceiling is inclusive. Loop's UI caps at 24h, so
+        7 days is generous; this test pins the boundary."""
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Extended workout",
+                    "timestamp": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+                    "duration": 7 * 24 * 3600,  # exactly at the cap
+                }
+            },
+        )
+        override = _extract_override(ds, now=datetime.now(UTC))
+        assert override is not None
+        assert override.ends_at is not None
+
+    def test_eight_day_duration_rejected(self):
+        """Past the 7-day ceiling -> clamp drops the duration; the
+        override is rendered as indefinite (`ends_at = None`).
+        Documented behavior: better to lose end-time precision than
+        to risk overflow."""
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Marathon training",
+                    "timestamp": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+                    "duration": 8 * 24 * 3600,  # just past the cap
+                }
+            },
+        )
+        override = _extract_override(ds, now=datetime.now(UTC))
+        assert override is not None
+        assert override.ends_at is None  # cap-rejection drops to None
+
+    def test_infinite_duration_dropped(self):
+        """`+inf` and `NaN` both fail `<= max` -> override rendered
+        indefinite. The previous shape would have produced
+        ValueError from timedelta."""
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Pre-meal",
+                    "timestamp": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+                    "duration": float("inf"),
+                }
+            },
+        )
+        override = _extract_override(ds, now=datetime.now(UTC))
+        assert override is not None
+        assert override.ends_at is None

--- a/apps/api/tests/test_loop_state_extractor.py
+++ b/apps/api/tests/test_loop_state_extractor.py
@@ -1,0 +1,1063 @@
+"""Unit + integration tests for `loop_state_extractor`.
+
+Story 43.12 PR 6. Three things to pin:
+
+1. **State-machine correctness per source engine** — `_extract_loop_status`
+   classifies looping / not_looping / failed per the Loop and OpenAPS
+   wire formats. This is the core projection.
+2. **Override extraction** — `_extract_override` only fires when Loop's
+   `loop.override.active == true`, and pulls the right fields out of
+   the canonical shape.
+3. **Staleness suppression** — `get_latest_loop_state` returns
+   `loop_status=None` when the snapshot is older than the threshold,
+   even though `cob_grams` continues through.
+
+DB integration tests use a per-test user + clean-up like the other
+test files in this codebase.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.encryption import encrypt_credential
+from src.database import get_session_maker
+from src.models.device_status_snapshot import DeviceStatusSnapshot
+from src.models.nightscout_connection import (
+    NightscoutAuthType,
+    NightscoutConnection,
+)
+from src.models.user import User
+from src.services.loop_state_extractor import (
+    LoopStatus,
+    OverrideStatus,
+    _extract_loop_status,
+    _extract_loop_status_from_loop_subtree,
+    _extract_loop_status_from_openaps_subtree,
+    _extract_override,
+    get_latest_loop_state,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def loop_ctx() -> AsyncGenerator[tuple[AsyncSession, uuid.UUID, uuid.UUID], None]:
+    """Per-test session + fresh user + NS connection.
+
+    `device_status_snapshots.nightscout_connection_id` is NOT NULL, so
+    every test needs a connection row to attach snapshots to. Cleans
+    up snapshots, connection, and user on teardown so cross-test
+    leakage can't flip the latest-snapshot query result.
+
+    Unlike PR 2's translator fixture, this one does NOT pre-yield
+    TRUNCATE `forecast_snapshots` (and doesn't need an analogous
+    TRUNCATE on `device_status_snapshots`). The query path is
+    user-scoped (`WHERE user_id = ...`) and each test gets a fresh
+    user_id, so other tests' snapshot rows for OTHER users can't
+    influence the latest-snapshot read. Per-connection uniqueness
+    (`ns_id`) is local because each test creates its own connection.
+    """
+    session_maker = get_session_maker()
+    session = session_maker()
+    email = f"loop_state_{uuid.uuid4().hex[:10]}@example.com"
+    user = User(email=email, hashed_password="not-a-real-hash")
+    session.add(user)
+    await session.flush()
+    user_id = user.id
+
+    conn = NightscoutConnection(
+        user_id=user_id,
+        name="test-loop-state",
+        base_url="https://example.com",
+        auth_type=NightscoutAuthType.SECRET,
+        encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+        initial_sync_window_days=7,
+    )
+    session.add(conn)
+    await session.flush()
+    connection_id = conn.id
+    await session.commit()
+
+    try:
+        yield session, user_id, connection_id
+    finally:
+        try:
+            await session.rollback()
+            await session.execute(
+                delete(DeviceStatusSnapshot).where(
+                    DeviceStatusSnapshot.user_id == user_id
+                )
+            )
+            # Delete ALL connections for the test user, not just the
+            # fixture-yielded one. The multi-connection test
+            # `test_latest_snapshot_wins_across_connections` creates
+            # an additional connection; cleaning up by user_id covers
+            # it without per-test cleanup boilerplate.
+            await session.execute(
+                delete(NightscoutConnection).where(
+                    NightscoutConnection.user_id == user_id
+                )
+            )
+            await session.execute(delete(User).where(User.id == user_id))
+            await session.commit()
+        except RuntimeError:
+            pass
+        finally:
+            try:
+                await session.close()
+            except RuntimeError:
+                pass
+
+
+def _make_snapshot(
+    user_id: uuid.UUID,
+    *,
+    snapshot_timestamp: datetime,
+    connection_id: uuid.UUID | None = None,
+    loop_subtree: dict | None = None,
+    openaps_subtree: dict | None = None,
+    cob_grams: float | None = None,
+    source_device: str | None = None,
+) -> DeviceStatusSnapshot:
+    """Build a DeviceStatusSnapshot for tests. ns_id is randomized to
+    avoid colliding with the per-connection uniqueness constraint.
+    Pure-function tests pass `connection_id=None` to skip DB writes;
+    DB tests pass the fixture's connection_id so the FK satisfies the
+    NOT NULL constraint."""
+    return DeviceStatusSnapshot(
+        user_id=user_id,
+        nightscout_connection_id=connection_id,
+        snapshot_timestamp=snapshot_timestamp,
+        received_at=datetime.now(UTC),
+        source_uploader=None,
+        source_device=source_device,
+        ns_id=f"test_{uuid.uuid4().hex}",
+        iob_units=None,
+        cob_grams=cob_grams,
+        pump_battery_percent=None,
+        pump_reservoir_units=None,
+        pump_suspended=None,
+        loop_failure_reason=None,
+        loop_subtree_json=loop_subtree,
+        openaps_subtree_json=openaps_subtree,
+        pump_subtree_json=None,
+        uploader_subtree_json=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests: loop status state machine
+# ---------------------------------------------------------------------------
+
+
+class TestLoopStatusFromLoopSubtree:
+    """`loop.{failureReason,enacted,suggested}` -> state machine.
+
+    Loop is the simpler path because the `failureReason` field is a
+    discrete signal not present in the OpenAPS wire format.
+    """
+
+    def test_failure_reason_classifies_as_failed(self):
+        issued = datetime(2026, 5, 13, 12, 0, tzinfo=UTC)
+        status = _extract_loop_status_from_loop_subtree(
+            {"failureReason": "Glucose data is unavailable"},
+            issued_at=issued,
+        )
+        assert status is not None
+        assert status.state == "failed"
+        assert status.failure_reason == "Glucose data is unavailable"
+        assert status.source == "loop"
+        assert status.issued_at == issued
+
+    def test_enacted_subtree_classifies_as_looping(self):
+        status = _extract_loop_status_from_loop_subtree(
+            {"enacted": {"timestamp": "2026-05-13T12:00:00Z"}},
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is not None
+        assert status.state == "looping"
+        assert status.failure_reason is None
+
+    def test_suggested_only_classifies_as_not_looping(self):
+        """Suggested without enacted means the algorithm computed a
+        suggestion but didn't act on it -- the canonical not-looping
+        signal."""
+        status = _extract_loop_status_from_loop_subtree(
+            {"suggested": {"rate": 1.0}},
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is not None
+        assert status.state == "not_looping"
+
+    def test_empty_loop_subtree_returns_none(self):
+        """No failureReason / enacted / suggested -> not a forecast-
+        publishing cycle -> no badge."""
+        status = _extract_loop_status_from_loop_subtree(
+            {},
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is None
+
+    def test_empty_string_failure_reason_does_not_trigger_failed(self):
+        """Some uploaders emit `failureReason: ""` even when no failure
+        occurred. Treat as if absent."""
+        status = _extract_loop_status_from_loop_subtree(
+            {"failureReason": "   ", "enacted": {"timestamp": "x"}},
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is not None
+        assert status.state == "looping"
+
+    def test_failed_wins_over_enacted(self):
+        """A cycle that recorded both a failure AND an enacted block
+        (rare but possible) is failed -- the failure is the stronger
+        signal for the user."""
+        status = _extract_loop_status_from_loop_subtree(
+            {"failureReason": "Pump unreachable", "enacted": {"rate": 1.0}},
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is not None
+        assert status.state == "failed"
+
+
+class TestLoopStatusFromOpenapsSubtree:
+    """`openaps.{enacted,suggested}` for AAPS / Trio / oref0 / iAPS.
+
+    No failureReason equivalent in the OpenAPS wire format -- failures
+    surface as not_looping with the explanation in `suggested.reason`
+    text.
+    """
+
+    def test_aaps_enacted_classifies_as_looping_aaps(self):
+        status = _extract_loop_status_from_openaps_subtree(
+            {"enacted": {"rate": 1.0}},
+            device="openaps://AndroidAPS",
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is not None
+        assert status.state == "looping"
+        assert status.source == "aaps"
+
+    def test_aaps_suggested_only_classifies_as_not_looping(self):
+        status = _extract_loop_status_from_openaps_subtree(
+            {"suggested": {"reason": "in range"}},
+            device="openaps://AndroidAPS",
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is not None
+        assert status.state == "not_looping"
+        assert status.source == "aaps"
+
+    def test_oref0_device_uri_classifies_correctly(self):
+        """oref0 uses `openaps://<host>/<pump-ref>` (two-segment URI),
+        distinguished from AAPS's single-segment form."""
+        status = _extract_loop_status_from_openaps_subtree(
+            {"enacted": {}},
+            device="openaps://edison-rig/medtronic-722",
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is not None
+        assert status.source == "oref0"
+
+    def test_iaps_substring_classifies_correctly(self):
+        status = _extract_loop_status_from_openaps_subtree(
+            {"enacted": {}},
+            device="iAPS-2.7.0",
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is not None
+        assert status.source == "iaps"
+
+    def test_trio_via_determination_fallback(self):
+        """Older Trio builds emit a `determination` block characteristic
+        of Trio. When the device string doesn't classify (legacy NS
+        bridges that strip the device field), the determination block
+        is the fallback signal."""
+        status = _extract_loop_status_from_openaps_subtree(
+            {
+                "determination": {},
+                "enacted": {"rate": 1.0},
+            },
+            device="",  # No classifiable device string
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is not None
+        assert status.source == "trio"
+
+    def test_unknown_source_returns_none(self):
+        """Indeterminate source -> no badge. Better to hide than
+        mis-attribute."""
+        status = _extract_loop_status_from_openaps_subtree(
+            {"enacted": {"rate": 1.0}},
+            device="some-future-uploader",
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is None
+
+    def test_empty_openaps_subtree_returns_none(self):
+        """No enacted, no suggested -> nothing to report."""
+        status = _extract_loop_status_from_openaps_subtree(
+            {},
+            device="openaps://AndroidAPS",
+            issued_at=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+        )
+        assert status is None
+
+
+class TestLoopStatusRouting:
+    """`_extract_loop_status` picks Loop > OpenAPS when both present.
+
+    Same priority as the forecast mapper (PR 2) -- Loop's subtree
+    presence is unambiguous and wins over the OpenAPS fallback path.
+    """
+
+    def test_loop_subtree_wins_over_openaps(self):
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={"enacted": {}},
+            openaps_subtree={"suggested": {"reason": "stale"}},
+            source_device="loop://iPhone",
+        )
+        status = _extract_loop_status(ds)
+        assert status is not None
+        assert status.source == "loop"
+        assert status.state == "looping"
+
+    def test_no_subtree_returns_none(self):
+        """xDrip+ / CGM-only relays publish neither -> no badge."""
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+        )
+        assert _extract_loop_status(ds) is None
+
+
+# ---------------------------------------------------------------------------
+# Override extractor (Loop-only in PR 6)
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideExtractor:
+    """Loop's `loop.override.{active,name,timestamp,duration,multiplier,
+    currentCorrectionRange}` -> OverrideStatus. AAPS / Trio override
+    paths are deferred."""
+
+    def test_active_override_extracts_all_fields(self):
+        # Pin `now` to one minute past the override start so the
+        # past-end / future-start guards both pass. Tests need to
+        # inject `now` whenever they use hardcoded timestamps so the
+        # guards don't reject as time passes.
+        now = datetime(2026, 5, 13, 14, 1, tzinfo=UTC)
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Pre-meal",
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 1800,
+                    "multiplier": 0.7,
+                    "currentCorrectionRange": {
+                        "minValue": 70,
+                        "maxValue": 90,
+                    },
+                }
+            },
+        )
+        override = _extract_override(ds, now=now)
+        assert override is not None
+        assert override.name == "Pre-meal"
+        assert override.started_at == datetime(2026, 5, 13, 14, 0, tzinfo=UTC)
+        # duration is SECONDS in Loop's wire format -> ends_at is +30 min
+        assert override.ends_at == datetime(2026, 5, 13, 14, 30, tzinfo=UTC)
+        assert override.multiplier == 0.7
+        assert override.target_low_mgdl == 70.0
+        assert override.target_high_mgdl == 90.0
+
+    def test_inactive_override_returns_none(self):
+        """`active: false` means the override has expired or was
+        cancelled. Most common shape in production payloads -- Loop
+        keeps emitting the most recent override even after it ends."""
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": False,
+                    "name": "Pre-meal",
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 1800,
+                }
+            },
+        )
+        assert _extract_override(ds) is None
+
+    def test_indefinite_override_has_no_end(self):
+        """Loop encodes indefinite overrides as `duration: 0`. The
+        UI should render "ongoing" rather than computing a phantom
+        end time."""
+        now = datetime(2026, 5, 13, 14, 1, tzinfo=UTC)
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Workout",
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 0,
+                }
+            },
+        )
+        override = _extract_override(ds, now=now)
+        assert override is not None
+        assert override.ends_at is None
+
+    def test_missing_optional_fields_pass_as_none(self):
+        """`multiplier` and `currentCorrectionRange` are optional in
+        Loop's wire format. Their absence is normal, not malformed."""
+        now = datetime(2026, 5, 13, 22, 1, tzinfo=UTC)
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Sleep",
+                    "timestamp": "2026-05-13T22:00:00Z",
+                    "duration": 28800,
+                }
+            },
+        )
+        override = _extract_override(ds, now=now)
+        assert override is not None
+        assert override.multiplier is None
+        assert override.target_low_mgdl is None
+        assert override.target_high_mgdl is None
+
+    def test_missing_name_returns_none(self):
+        """Without a name we have nothing to render -- skip."""
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 1800,
+                }
+            },
+        )
+        assert _extract_override(ds) is None
+
+    def test_no_loop_subtree_returns_none(self):
+        """AAPS-only user -- no Loop override path. Returns None for
+        now; AAPS overrides come from Temp Target treatments, not
+        devicestatus, and are deferred to a follow-up PR."""
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            openaps_subtree={"suggested": {"reason": "in range"}},
+        )
+        assert _extract_override(ds) is None
+
+    def test_bool_multiplier_rejected(self):
+        """`isinstance(True, int)` is True in Python; reject explicitly."""
+        now = datetime(2026, 5, 13, 14, 1, tzinfo=UTC)
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Pre-meal",
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 1800,
+                    "multiplier": True,  # bogus
+                }
+            },
+        )
+        override = _extract_override(ds, now=now)
+        assert override is not None
+        assert override.multiplier is None
+
+
+# ---------------------------------------------------------------------------
+# DB integration: staleness + COB pass-through + multi-snapshot ordering
+# ---------------------------------------------------------------------------
+
+
+class TestGetLatestLoopState:
+    @pytest.mark.asyncio
+    async def test_no_snapshots_returns_all_none(self, loop_ctx):
+        """User with no NS data gets a clean all-None bundle. The
+        hero card renders zero new surfaces."""
+        session, user_id, _conn_id = loop_ctx
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is None
+        assert bundle.override is None
+        assert bundle.cob_grams is None
+
+    @pytest.mark.asyncio
+    async def test_fresh_snapshot_populates_loop_status(self, loop_ctx):
+        session, user_id, conn_id = loop_ctx
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=2),
+            loop_subtree={"enacted": {"rate": 1.0}},
+            source_device="loop://iPhone",
+            cob_grams=24.0,
+        )
+        session.add(snap)
+        await session.commit()
+
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is not None
+        assert bundle.loop_status.state == "looping"
+        assert bundle.loop_status.source == "loop"
+        assert bundle.cob_grams == 24.0
+
+    @pytest.mark.asyncio
+    async def test_stale_snapshot_suppresses_loop_status_only(self, loop_ctx):
+        """Beyond 15 min the loop_status badge would be lying ("Looping"
+        for a loop that may have stopped). Suppress the badge but keep
+        COB numeric -- a stale COB at the boundary is informationally
+        useful, not misleading."""
+        session, user_id, conn_id = loop_ctx
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=20),
+            loop_subtree={"enacted": {"rate": 1.0}},
+            source_device="loop://iPhone",
+            cob_grams=12.0,
+        )
+        session.add(snap)
+        await session.commit()
+
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is None
+        assert bundle.cob_grams == 12.0  # preserved across the staleness boundary
+
+    @pytest.mark.asyncio
+    async def test_latest_by_snapshot_timestamp_not_received_at(self, loop_ctx):
+        """Order by snapshot_timestamp DESC, not received_at. A backfill
+        landing a 6-hour-old snapshot must not outrank a real-time one
+        just because it was synced more recently."""
+        session, user_id, conn_id = loop_ctx
+        # Older snapshot received recently (backfill scenario)
+        old_snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(hours=3),
+            loop_subtree={"failureReason": "Old failure"},
+            source_device="loop://iPhone",
+        )
+        old_snap.received_at = datetime.now(UTC)
+        # Newer real-time snapshot
+        new_snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=2),
+            loop_subtree={"enacted": {"rate": 1.0}},
+            source_device="loop://iPhone",
+        )
+        new_snap.received_at = datetime.now(UTC) - timedelta(minutes=1)
+        session.add_all([old_snap, new_snap])
+        await session.commit()
+
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is not None
+        # The newer snapshot's state wins -- looping, not failed.
+        assert bundle.loop_status.state == "looping"
+
+    @pytest.mark.asyncio
+    async def test_active_override_surfaces(self, loop_ctx):
+        session, user_id, conn_id = loop_ctx
+        # Use a relative `started` so the past-end guard doesn't
+        # reject the override based on test-run wall-clock time. 5
+        # min ago + 60 min duration -> still active for ~55 min.
+        started = datetime.now(UTC) - timedelta(minutes=5)
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=1),
+            loop_subtree={
+                "enacted": {"rate": 1.0},
+                "override": {
+                    "active": True,
+                    "name": "Workout",
+                    "timestamp": started.isoformat(),
+                    "duration": 3600,
+                    "multiplier": 0.5,
+                },
+            },
+            source_device="loop://iPhone",
+        )
+        session.add(snap)
+        await session.commit()
+
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.override is not None
+        assert bundle.override.name == "Workout"
+        assert bundle.override.multiplier == 0.5
+
+    @pytest.mark.asyncio
+    async def test_cgm_only_snapshot_yields_no_loop_status(self, loop_ctx):
+        """xDrip+ regression guard: a payload with only uploader battery
+        and no loop/openaps subtree returns no loop_status even though
+        a snapshot row exists."""
+        session, user_id, conn_id = loop_ctx
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC),
+            source_device="xdrip-android",
+        )
+        snap.uploader_subtree_json = {"battery": 80}
+        session.add(snap)
+        await session.commit()
+
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is None
+        assert bundle.override is None
+        assert bundle.cob_grams is None
+
+    @pytest.mark.asyncio
+    async def test_loop_failure_surfaces_reason(self, loop_ctx):
+        session, user_id, conn_id = loop_ctx
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=3),
+            loop_subtree={"failureReason": "Glucose data is unavailable"},
+            source_device="loop://iPhone",
+        )
+        session.add(snap)
+        await session.commit()
+
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is not None
+        assert bundle.loop_status.state == "failed"
+        assert bundle.loop_status.failure_reason == "Glucose data is unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Smoke test for the dataclasses (frozen / immutable)
+# ---------------------------------------------------------------------------
+
+
+class TestDataclasses:
+    def test_loop_status_is_frozen(self):
+        """Frozen dataclasses keep the API neutral -- the projection
+        consumer can't accidentally mutate the bundle and confuse the
+        next consumer."""
+        s = LoopStatus(
+            state="looping",
+            source="loop",
+            issued_at=datetime.now(UTC),
+        )
+        with pytest.raises(Exception):  # noqa: B017 (FrozenInstanceError)
+            s.state = "failed"  # type: ignore[misc]
+
+    def test_override_status_is_frozen(self):
+        o = OverrideStatus(
+            name="Pre-meal",
+            started_at=datetime.now(UTC),
+        )
+        with pytest.raises(Exception):  # noqa: B017
+            o.name = "Workout"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review follow-up: bounds, future-clock, multi-connection
+# ---------------------------------------------------------------------------
+
+
+class TestLoopStateBoundsAndClockSkew:
+    """Pins the defensive guards added in response to PR 6's
+    adversarial review. Three classes of concern: free-text length
+    bounds, future-dated timestamps from upstream clock skew, and
+    past-end overrides that NS hasn't flipped to inactive yet.
+    """
+
+    @pytest.mark.asyncio
+    async def test_failure_reason_capped_at_boundary(self, loop_ctx):
+        """A malicious / buggy NS server posts a giant failureReason.
+        The mapper must truncate at the extractor so the badge
+        tooltip stays usable and the response payload bounded."""
+        session, user_id, conn_id = loop_ctx
+        huge = "A" * 5000
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=1),
+            loop_subtree={"failureReason": huge},
+            source_device="loop://iPhone",
+        )
+        session.add(snap)
+        await session.commit()
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is not None
+        assert bundle.loop_status.state == "failed"
+        # 200-char cap. The reason itself is `A * 5000`; truncated
+        # form keeps the surface bounded for the UI.
+        assert bundle.loop_status.failure_reason is not None
+        assert len(bundle.loop_status.failure_reason) <= 200
+
+    @pytest.mark.asyncio
+    async def test_override_name_capped_at_boundary(self, loop_ctx):
+        """Same DoS-shield rule for override names, which flow into
+        the same `title` tooltip path."""
+        session, user_id, conn_id = loop_ctx
+        huge_name = "Override-" + ("X" * 2000)
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=1),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": huge_name,
+                    "timestamp": (datetime.now(UTC) - timedelta(minutes=2)).isoformat(),
+                    "duration": 3600,
+                }
+            },
+            source_device="loop://iPhone",
+        )
+        session.add(snap)
+        await session.commit()
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.override is not None
+        assert len(bundle.override.name) <= 80
+
+    @pytest.mark.asyncio
+    async def test_future_snapshot_suppresses_loop_status(self, loop_ctx):
+        """An uploader with a clock set 10 min in the future would
+        post `created_at` ahead of now. Naive staleness math
+        (`now - ts > 15 min`) returns False because the delta is
+        negative; the badge would render claims from the future.
+        Guard: reject loop_status when the snapshot leads now by
+        more than the future-tolerance margin."""
+        session, user_id, conn_id = loop_ctx
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) + timedelta(minutes=10),
+            loop_subtree={"enacted": {"rate": 1.0}},
+            source_device="loop://iPhone",
+            cob_grams=18.0,
+        )
+        session.add(snap)
+        await session.commit()
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is None
+        # COB stays numeric -- a stale-direction-future cob value is
+        # data, not a state claim, and follows the same policy as the
+        # past-stale path (cob preserved, loop_status suppressed).
+        assert bundle.cob_grams == 18.0
+
+    @pytest.mark.asyncio
+    async def test_near_future_snapshot_still_accepted(self, loop_ctx):
+        """Ordinary millisecond-scale clock skew between the user's
+        phone and our server should NOT suppress the badge.
+        Snapshots within the 2-min future tolerance pass through."""
+        session, user_id, conn_id = loop_ctx
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) + timedelta(seconds=30),
+            loop_subtree={"enacted": {"rate": 1.0}},
+            source_device="loop://iPhone",
+        )
+        session.add(snap)
+        await session.commit()
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is not None
+        assert bundle.loop_status.state == "looping"
+
+    @pytest.mark.asyncio
+    async def test_past_end_override_suppressed(self, loop_ctx):
+        """A stale snapshot carrying `active: true` for an override
+        whose end time is already in the past. The frontend's
+        formatter renders "ongoing" in that case which would lie;
+        the server-side guard suppresses the override entirely."""
+        session, user_id, conn_id = loop_ctx
+        # Override started 2h ago with 30 min duration -> ended 1h30m ago
+        started = datetime.now(UTC) - timedelta(hours=2)
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=1),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Pre-meal",
+                    "timestamp": started.isoformat(),
+                    "duration": 1800,  # 30 min in seconds
+                }
+            },
+            source_device="loop://iPhone",
+        )
+        session.add(snap)
+        await session.commit()
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.override is None
+
+    @pytest.mark.asyncio
+    async def test_future_start_override_suppressed(self, loop_ctx):
+        """Symmetric to the past-end case: an override whose
+        `started_at` is in the future (uploader clock skew). We can't
+        honestly claim an override is running before its start time."""
+        session, user_id, conn_id = loop_ctx
+        started_future = datetime.now(UTC) + timedelta(minutes=30)
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=1),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Workout",
+                    "timestamp": started_future.isoformat(),
+                    "duration": 3600,
+                }
+            },
+            source_device="loop://iPhone",
+        )
+        session.add(snap)
+        await session.commit()
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.override is None
+
+    @pytest.mark.asyncio
+    async def test_indefinite_override_with_recent_start_accepted(self, loop_ctx):
+        """Indefinite overrides (duration=0) have ends_at=None; the
+        past-end guard must NOT fire when ends_at is None. Regression
+        guard against an over-eager `ends_at < now` check."""
+        session, user_id, conn_id = loop_ctx
+        started = datetime.now(UTC) - timedelta(minutes=5)
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=1),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Workout",
+                    "timestamp": started.isoformat(),
+                    "duration": 0,  # indefinite
+                }
+            },
+            source_device="loop://iPhone",
+        )
+        session.add(snap)
+        await session.commit()
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.override is not None
+        assert bundle.override.ends_at is None
+
+
+class TestMultiConnectionLatestSnapshot:
+    """Pins the current LRU-style multi-connection behavior so a
+    future refactor (e.g., wiring to Story 43.10's primary-source
+    picker) can't silently change it without test pressure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_latest_snapshot_wins_across_connections(self, loop_ctx):
+        """User has TWO NS connections (rare but possible -- e.g.,
+        Loop on connection A and AAPS on connection B). The
+        latest-by-snapshot-timestamp row determines the badge.
+        Documented LRU; replace with primary-source preference in
+        43.10."""
+        session, user_id, conn_a = loop_ctx
+        # Create a second NS connection for the same user.
+        conn_b_row = NightscoutConnection(
+            user_id=user_id,
+            name="test-loop-state-2",
+            base_url="https://example2.com",
+            auth_type=NightscoutAuthType.SECRET,
+            encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+            initial_sync_window_days=7,
+        )
+        session.add(conn_b_row)
+        await session.flush()
+        conn_b = conn_b_row.id
+
+        # Connection A: Loop, snapshot 3 min ago
+        snap_a = _make_snapshot(
+            user_id,
+            connection_id=conn_a,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=3),
+            loop_subtree={"enacted": {"rate": 1.0}},
+            source_device="loop://iPhone",
+        )
+        # Connection B: AAPS, snapshot 1 min ago (newer)
+        snap_b = _make_snapshot(
+            user_id,
+            connection_id=conn_b,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=1),
+            openaps_subtree={"enacted": {"rate": 1.2}},
+            source_device="openaps://AndroidAPS",
+        )
+        session.add_all([snap_a, snap_b])
+        await session.commit()
+
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.loop_status is not None
+        # AAPS wins because its snapshot is newer.
+        assert bundle.loop_status.source == "aaps"
+
+
+class TestMedicalFieldBounds:
+    """Pins the extractor-level clamps for medical-adjacent fields.
+    Out-of-range values fail soft (drop the field, keep the rest of
+    the override / bundle renderable) rather than 500-ing the whole
+    /pump/status response.
+    """
+
+    def test_out_of_range_multiplier_dropped(self):
+        """A `multiplier` outside [0.05, 10.0] is a serialization bug
+        or an absurd value -- drop it but keep the override's
+        name/timestamps so the user still sees the override running."""
+        now = datetime(2026, 5, 13, 14, 1, tzinfo=UTC)
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Pre-meal",
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 1800,
+                    "multiplier": 100.0,  # absurd
+                }
+            },
+        )
+        override = _extract_override(ds, now=now)
+        assert override is not None
+        assert override.name == "Pre-meal"  # rest of override intact
+        assert override.multiplier is None  # bad numeric dropped
+
+    def test_zero_multiplier_dropped(self):
+        """Below the 0.05 floor -- catches the common NaN-serialized-
+        as-0 bug."""
+        now = datetime(2026, 5, 13, 14, 1, tzinfo=UTC)
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Pre-meal",
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 1800,
+                    "multiplier": 0.0,
+                }
+            },
+        )
+        override = _extract_override(ds, now=now)
+        assert override is not None
+        assert override.multiplier is None
+
+    def test_out_of_range_targets_dropped(self):
+        """Target values outside the physiological band are dropped."""
+        now = datetime(2026, 5, 13, 14, 1, tzinfo=UTC)
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Pre-meal",
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 1800,
+                    "currentCorrectionRange": {
+                        "minValue": -100,  # impossible
+                        "maxValue": 9999,  # impossible
+                    },
+                }
+            },
+        )
+        override = _extract_override(ds, now=now)
+        assert override is not None
+        assert override.target_low_mgdl is None
+        assert override.target_high_mgdl is None
+
+    def test_inverted_target_band_dropped(self):
+        """If target_low > target_high after parsing, the band is
+        inverted -- drop both rather than render a confused tooltip."""
+        now = datetime(2026, 5, 13, 14, 1, tzinfo=UTC)
+        ds = _make_snapshot(
+            uuid.uuid4(),
+            snapshot_timestamp=datetime.now(UTC),
+            loop_subtree={
+                "override": {
+                    "active": True,
+                    "name": "Pre-meal",
+                    "timestamp": "2026-05-13T14:00:00Z",
+                    "duration": 1800,
+                    "currentCorrectionRange": {
+                        "minValue": 120,
+                        "maxValue": 80,  # inverted
+                    },
+                }
+            },
+        )
+        override = _extract_override(ds, now=now)
+        assert override is not None
+        assert override.target_low_mgdl is None
+        assert override.target_high_mgdl is None
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_cob_clamped_to_none(self, loop_ctx):
+        """A DB row with cob_grams = 9999 (impossible) drops to None
+        on the bundle. The schema-layer Field(le=500) would 500 the
+        endpoint; the extractor's clamp keeps the rest of the bundle
+        renderable."""
+        session, user_id, conn_id = loop_ctx
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=1),
+            loop_subtree={"enacted": {"rate": 1.0}},
+            source_device="loop://iPhone",
+            cob_grams=9999.0,  # out-of-bounds
+        )
+        session.add(snap)
+        await session.commit()
+        bundle = await get_latest_loop_state(session, user_id)
+        # loop_status still renders; cob is dropped.
+        assert bundle.loop_status is not None
+        assert bundle.cob_grams is None
+
+    @pytest.mark.asyncio
+    async def test_negative_cob_clamped_to_none(self, loop_ctx):
+        """Negative carbs are impossible; same clamp policy."""
+        session, user_id, conn_id = loop_ctx
+        snap = _make_snapshot(
+            user_id,
+            connection_id=conn_id,
+            snapshot_timestamp=datetime.now(UTC) - timedelta(minutes=1),
+            cob_grams=-5.0,
+            source_device="loop://iPhone",
+            loop_subtree={"enacted": {"rate": 1.0}},
+        )
+        session.add(snap)
+        await session.commit()
+        bundle = await get_latest_loop_state(session, user_id)
+        assert bundle.cob_grams is None

--- a/apps/web/__tests__/components/dashboard/glucose-hero.test.tsx
+++ b/apps/web/__tests__/components/dashboard/glucose-hero.test.tsx
@@ -8,6 +8,8 @@ import { render, screen } from "@testing-library/react";
 import {
   GlucoseHero,
   classifyGlucose,
+  parseLoopState,
+  prettySourceName,
   shouldPulse,
   GLUCOSE_THRESHOLDS,
   type TrendDirection,
@@ -471,5 +473,271 @@ describe("GlucoseHero", () => {
 
       expect(screen.getByTestId("glucose-value")).toBeInTheDocument();
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // Story 43.12 PR 6 -- closed-loop runtime surfaces
+  // -------------------------------------------------------------------------
+
+  describe("loop status badge (PR 6)", () => {
+    it("renders nothing when loopStatus is null", () => {
+      render(<GlucoseHero {...defaultProps} loopStatus={null} />);
+      expect(screen.queryByTestId("loop-status-badge")).not.toBeInTheDocument();
+    });
+
+    it("renders 'Looping' for state='looping'", () => {
+      render(
+        <GlucoseHero
+          {...defaultProps}
+          loopStatus={{
+            state: "looping",
+            source: "loop",
+            issuedAt: "2026-05-13T14:00:00Z",
+          }}
+        />
+      );
+      const badge = screen.getByTestId("loop-status-badge");
+      expect(badge).toHaveAttribute("data-state", "looping");
+      expect(badge).toHaveTextContent("Looping");
+      expect(badge).toHaveTextContent("Loop");
+    });
+
+    it("renders 'Not looping' for state='not_looping'", () => {
+      render(
+        <GlucoseHero
+          {...defaultProps}
+          loopStatus={{
+            state: "not_looping",
+            source: "aaps",
+            issuedAt: "2026-05-13T14:00:00Z",
+          }}
+        />
+      );
+      const badge = screen.getByTestId("loop-status-badge");
+      expect(badge).toHaveAttribute("data-state", "not_looping");
+      expect(badge).toHaveTextContent("Not looping");
+      expect(badge).toHaveTextContent("AAPS");
+    });
+
+    it("renders 'Loop failed' with failure reason in tooltip", () => {
+      render(
+        <GlucoseHero
+          {...defaultProps}
+          loopStatus={{
+            state: "failed",
+            source: "loop",
+            issuedAt: "2026-05-13T14:00:00Z",
+            failureReason: "Glucose data is unavailable",
+          }}
+        />
+      );
+      const badge = screen.getByTestId("loop-status-badge");
+      expect(badge).toHaveAttribute("data-state", "failed");
+      expect(badge).toHaveTextContent("Loop failed");
+      // Failure reason flows into the title tooltip (visible on hover);
+      // ariaLabel describes the state separately for screen readers.
+      expect(badge).toHaveAttribute(
+        "title",
+        "Loop: Glucose data is unavailable"
+      );
+    });
+
+    it("displays known source names with proper casing", () => {
+      const sources: Array<[string, string]> = [
+        ["loop", "Loop"],
+        ["aaps", "AAPS"],
+        ["trio", "Trio"],
+        ["oref0", "oref0"],
+        ["iaps", "iAPS"],
+      ];
+      for (const [source, display] of sources) {
+        const { unmount } = render(
+          <GlucoseHero
+            {...defaultProps}
+            loopStatus={{
+              state: "looping",
+              source,
+              issuedAt: "2026-05-13T14:00:00Z",
+            }}
+          />
+        );
+        expect(screen.getByTestId("loop-status-badge")).toHaveTextContent(
+          display
+        );
+        unmount();
+      }
+    });
+  });
+
+  describe("override row (PR 6)", () => {
+    it("renders nothing when override is null", () => {
+      render(<GlucoseHero {...defaultProps} override={null} />);
+      expect(screen.queryByTestId("override-row")).not.toBeInTheDocument();
+    });
+
+    it("renders override name and time remaining", () => {
+      // Pin "now" to one minute past the override start so the
+      // duration math is stable across CI clocks.
+      const now = new Date("2026-05-13T14:01:00Z");
+      jest.useFakeTimers();
+      jest.setSystemTime(now);
+      try {
+        render(
+          <GlucoseHero
+            {...defaultProps}
+            override={{
+              name: "Pre-meal",
+              startedAt: "2026-05-13T14:00:00Z",
+              endsAt: "2026-05-13T14:30:00Z",
+              multiplier: 0.7,
+            }}
+          />
+        );
+        const row = screen.getByTestId("override-row");
+        expect(row).toHaveTextContent("Override: Pre-meal");
+        // 29 minutes remaining (rounded)
+        expect(row).toHaveTextContent("ends in 29 min");
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("renders 'ongoing' for indefinite overrides (endsAt=null)", () => {
+      render(
+        <GlucoseHero
+          {...defaultProps}
+          override={{
+            name: "Workout",
+            startedAt: "2026-05-13T14:00:00Z",
+            endsAt: null,
+          }}
+        />
+      );
+      expect(screen.getByTestId("override-row")).toHaveTextContent("ongoing");
+    });
+
+    it("renders 'ongoing' for past-end overrides (clock skew safety)", () => {
+      // If a stale snapshot still has `active: true` but the end time
+      // is already in the past (clock skew across the user's devices),
+      // the formatter returns null and we fall back to "ongoing"
+      // rather than rendering "ends in -5 min".
+      const now = new Date("2026-05-13T15:00:00Z");
+      jest.useFakeTimers();
+      jest.setSystemTime(now);
+      try {
+        render(
+          <GlucoseHero
+            {...defaultProps}
+            override={{
+              name: "Workout",
+              startedAt: "2026-05-13T13:00:00Z",
+              endsAt: "2026-05-13T14:00:00Z",
+            }}
+          />
+        );
+        expect(screen.getByTestId("override-row")).toHaveTextContent("ongoing");
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("renders hours+minutes for long overrides", () => {
+      const now = new Date("2026-05-13T14:00:00Z");
+      jest.useFakeTimers();
+      jest.setSystemTime(now);
+      try {
+        render(
+          <GlucoseHero
+            {...defaultProps}
+            override={{
+              name: "Sleep",
+              startedAt: "2026-05-13T14:00:00Z",
+              endsAt: "2026-05-13T16:30:00Z",
+            }}
+          />
+        );
+        expect(screen.getByTestId("override-row")).toHaveTextContent(
+          "ends in 2h 30m"
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe("COB metric (PR 6)", () => {
+    it("renders nothing when cobGrams is null", () => {
+      render(<GlucoseHero {...defaultProps} cobGrams={null} />);
+      expect(screen.queryByTestId("cob-value")).not.toBeInTheDocument();
+    });
+
+    it("renders nothing when cobGrams is undefined (back-compat)", () => {
+      render(<GlucoseHero {...defaultProps} />);
+      expect(screen.queryByTestId("cob-value")).not.toBeInTheDocument();
+    });
+
+    it("renders rounded grams when cobGrams is present", () => {
+      render(<GlucoseHero {...defaultProps} cobGrams={24.4} />);
+      expect(screen.getByTestId("cob-value")).toHaveTextContent("24g");
+    });
+
+    it("renders zero cleanly", () => {
+      // Zero is a valid COB reading ("no carbs absorbing right now");
+      // distinct from "no data" which is null/undefined.
+      render(<GlucoseHero {...defaultProps} cobGrams={0} />);
+      expect(screen.getByTestId("cob-value")).toHaveTextContent("0g");
+    });
+
+    it("rejects negative cob via sanitizer", () => {
+      // Carbs grams can't be negative; defensive sanitization should
+      // hide the column rather than render -5g.
+      render(<GlucoseHero {...defaultProps} cobGrams={-5} />);
+      expect(screen.queryByTestId("cob-value")).not.toBeInTheDocument();
+    });
+  });
+});
+
+
+describe("parseLoopState (PR 6 adversarial fix)", () => {
+  it("accepts canonical loop states", () => {
+    expect(parseLoopState("looping")).toBe("looping");
+    expect(parseLoopState("not_looping")).toBe("not_looping");
+    expect(parseLoopState("failed")).toBe("failed");
+  });
+
+  it("returns null for unknown states", () => {
+    // Future-proofing -- if the backend ever returns "warming_up"
+    // or "unknown", the page-level mapper will short-circuit to
+    // null rather than letting `LOOP_STATE_STYLE[unknown]` crash.
+    expect(parseLoopState("warming_up")).toBeNull();
+    expect(parseLoopState("LOOPING")).toBeNull(); // case-sensitive
+    expect(parseLoopState("")).toBeNull();
+  });
+});
+
+describe("prettySourceName (PR 6 adversarial fix)", () => {
+  it("maps known sources to friendly display names", () => {
+    expect(prettySourceName("loop")).toBe("Loop");
+    expect(prettySourceName("aaps")).toBe("AAPS");
+    expect(prettySourceName("trio")).toBe("Trio");
+    expect(prettySourceName("oref0")).toBe("oref0");
+    expect(prettySourceName("iaps")).toBe("iAPS");
+  });
+
+  it("falls back to a generic label for unknown sources", () => {
+    // Defensive: an unrecognized string from the backend renders
+    // as "Closed loop" rather than echoing whatever value the
+    // server sent. Backend contract is bounded today; this is
+    // forward-protection.
+    expect(prettySourceName("future-engine")).toBe("Closed loop");
+    expect(prettySourceName("")).toBe("Closed loop");
+  });
+
+  it("treats casing strictly (parity with parseLoopState)", () => {
+    // Backend's Pydantic `Literal` emits lowercase canonical values
+    // and this is mirrored on the API type. Mixed-case input is a
+    // contract drift, not something to paper over.
+    expect(prettySourceName("LOOP")).toBe("Closed loop");
+    expect(prettySourceName("Loop")).toBe("Closed loop");
   });
 });

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -31,6 +31,8 @@ import { PageTransition } from "@/components/ui/page-transition";
 
 import {
   GlucoseHero,
+  parseLoopState,
+  type LoopStatusInfo,
   TimeInRangeBar,
   ConnectionStatusBanner,
   GlucoseTrendChart,
@@ -46,6 +48,27 @@ import { useTimeInRangeDetailStats } from "@/hooks/use-time-in-range-stats";
 import { useGlucoseStats } from "@/hooks/use-glucose-stats";
 import { useGlucoseRange } from "@/hooks/use-glucose-range";
 import { usePumpStatus } from "@/hooks/use-pump-status";
+import type { LoopStatusResponse } from "@/lib/api";
+
+/**
+ * Map the backend's loop_status payload to the component's
+ * LoopStatusInfo shape. `parseLoopState` fails closed on unknown
+ * states so a future backend addition (e.g. "warming_up") doesn't
+ * crash the badge renderer.
+ */
+function mapLoopStatus(
+  raw: LoopStatusResponse | null | undefined
+): LoopStatusInfo | null {
+  if (!raw) return null;
+  const state = parseLoopState(raw.state);
+  if (state === null) return null;
+  return {
+    state,
+    source: raw.source,
+    issuedAt: raw.issued_at,
+    failureReason: raw.failure_reason,
+  };
+}
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -193,7 +216,7 @@ export default function DashboardPage() {
         </div>
       </AnimatedCard>
 
-      {/* Glucose hero - Story 4.2, 4.6 */}
+      {/* Glucose hero - Story 4.2, 4.6, 43.12 PR 6 */}
       <AnimatedCard delay={0.05}>
         <GlucoseHero
           value={glucoseValue}
@@ -202,6 +225,22 @@ export default function DashboardPage() {
           basalRate={pumpStatus.basal?.rate ?? null}
           batteryPct={pumpStatus.battery?.percentage ?? null}
           reservoirUnits={pumpStatus.reservoir?.units_remaining ?? null}
+          // PR 6: closed-loop runtime surfaces. snake_case from the
+          // backend, camelCase on the component. All optional.
+          cobGrams={pumpStatus.cobGrams}
+          loopStatus={mapLoopStatus(pumpStatus.loopStatus)}
+          override={
+            pumpStatus.override
+              ? {
+                  name: pumpStatus.override.name,
+                  startedAt: pumpStatus.override.started_at,
+                  endsAt: pumpStatus.override.ends_at,
+                  multiplier: pumpStatus.override.multiplier,
+                  targetLowMgdl: pumpStatus.override.target_low_mgdl,
+                  targetHighMgdl: pumpStatus.override.target_high_mgdl,
+                }
+              : null
+          }
           isLoading={!isLive && !glucose}
           thresholds={glucoseThresholds}
         />

--- a/apps/web/src/components/dashboard/glucose-hero.tsx
+++ b/apps/web/src/components/dashboard/glucose-hero.tsx
@@ -39,6 +39,53 @@ export const GLUCOSE_THRESHOLDS = {
   URGENT_HIGH: 250,
 } as const;
 
+/**
+ * Story 43.12 PR 6 -- closed-loop runtime state surfaces.
+ *
+ * These come from the backend's `/api/integrations/pump/status` and are
+ * sourced from the latest Nightscout devicestatus snapshot. All three
+ * are independently nullable -- absence means the underlying data
+ * isn't present (no NS integration, no active override, no carbs
+ * absorbing, snapshot stale, etc.) and we render nothing.
+ */
+export type LoopState = "looping" | "not_looping" | "failed";
+
+/**
+ * Narrow a free-form string from the backend into a LoopState. Returns
+ * null for unrecognized values so the caller can render nothing
+ * rather than crashing on `LOOP_STATE_STYLE[undefined]`.
+ *
+ * If a future translator surfaces a new state ("warming_up",
+ * "unknown", etc.), this guard fails closed -- the badge stays hidden
+ * until the frontend adds an explicit style for the new state.
+ */
+export function parseLoopState(value: string): LoopState | null {
+  return value === "looping" || value === "not_looping" || value === "failed"
+    ? value
+    : null;
+}
+
+export interface LoopStatusInfo {
+  state: LoopState;
+  /** 'loop' | 'aaps' | 'trio' | 'oref0' | 'iaps' */
+  source: string;
+  /** ISO 8601 string from the backend. */
+  issuedAt: string;
+  /** Populated only when state === 'failed'. */
+  failureReason?: string | null;
+}
+
+export interface OverrideInfo {
+  name: string;
+  /** ISO 8601 string. */
+  startedAt: string;
+  /** Null for indefinite overrides. */
+  endsAt?: string | null;
+  multiplier?: number | null;
+  targetLowMgdl?: number | null;
+  targetHighMgdl?: number | null;
+}
+
 export interface GlucoseHeroProps {
   /** Current glucose value in mg/dL */
   value: number | null;
@@ -52,6 +99,19 @@ export interface GlucoseHeroProps {
   batteryPct: number | null;
   /** Reservoir insulin remaining in units */
   reservoirUnits: number | null;
+  /** Carbs on Board in grams. PR 6 addition. */
+  cobGrams?: number | null;
+  /**
+   * Closed-loop runtime state badge. PR 6 addition.
+   * Null = no NS-sourced closed-loop data, or snapshot is stale.
+   */
+  loopStatus?: LoopStatusInfo | null;
+  /**
+   * Active override (workout / pre-meal / sleep mode). PR 6 addition,
+   * Loop-only. AAPS/Trio overrides ride on Temp Target treatments and
+   * are deferred to a follow-up. Null = no active override.
+   */
+  override?: OverrideInfo | null;
   /** Unit label (default: mg/dL) */
   unit?: string;
   /** Minutes since last reading */
@@ -177,6 +237,150 @@ function sanitizeValue(value: number | null, allowNegative = false): number | nu
   return value;
 }
 
+// ---------------------------------------------------------------------------
+// Story 43.12 PR 6 helpers
+// ---------------------------------------------------------------------------
+
+const LOOP_STATE_STYLE: Record<
+  LoopState,
+  { label: string; pill: string; ariaLabel: (source: string) => string }
+> = {
+  looping: {
+    label: "Looping",
+    pill: "bg-emerald-500/15 text-emerald-400 border-emerald-500/30",
+    ariaLabel: (source) => `${prettySourceName(source)} is actively looping`,
+  },
+  not_looping: {
+    label: "Not looping",
+    pill: "bg-amber-500/15 text-amber-400 border-amber-500/30",
+    ariaLabel: (source) =>
+      `${prettySourceName(source)} is not currently looping`,
+  },
+  failed: {
+    label: "Loop failed",
+    pill: "bg-red-500/15 text-red-400 border-red-500/30",
+    ariaLabel: (source) =>
+      `${prettySourceName(source)} reported a loop cycle failure`,
+  },
+};
+
+/**
+ * Display name for the source engine in user-visible strings.
+ *
+ * Case-sensitive lookup -- the backend's Pydantic `Literal` always
+ * emits lowercase canonical values, and this contract is mirrored on
+ * the API type (`LoopApiSource` in `lib/api.ts`). Consistent with
+ * `parseLoopState`'s case-sensitive gate: both rely on the same
+ * backend contract and don't paper over upstream casing drift.
+ *
+ * Falls through to a generic "Closed loop" label for unknown values
+ * rather than echoing whatever string the backend sent.
+ */
+export function prettySourceName(source: string): string {
+  const map: Record<string, string> = {
+    loop: "Loop",
+    aaps: "AAPS",
+    trio: "Trio",
+    oref0: "oref0",
+    iaps: "iAPS",
+  };
+  return map[source] ?? "Closed loop";
+}
+
+/**
+ * Compute a human-friendly "ends in N min" string from an ISO ends_at
+ * relative to now. Returns null when ends_at is null (indefinite
+ * override) or already in the past (clock-skew safety net).
+ */
+export function formatOverrideRemaining(
+  endsAt: string | null | undefined,
+  now: Date = new Date()
+): string | null {
+  if (!endsAt) return null;
+  const end = new Date(endsAt);
+  if (Number.isNaN(end.getTime())) return null;
+  const minutes = Math.round((end.getTime() - now.getTime()) / 60000);
+  if (minutes <= 0) return null;
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  if (remainder === 0) return `${hours}h`;
+  return `${hours}h ${remainder}m`;
+}
+
+interface LoopStatusBadgeProps {
+  status: LoopStatusInfo;
+}
+
+function LoopStatusBadge({ status }: LoopStatusBadgeProps) {
+  const style = LOOP_STATE_STYLE[status.state];
+  const sourceName = prettySourceName(status.source);
+  // Tooltip carries the failure reason when present; absent for the
+  // happy path. Source is always shown so users with multiple closed
+  // loops (rare) can tell which one the badge belongs to.
+  const tooltip =
+    status.state === "failed" && status.failureReason
+      ? `${sourceName}: ${status.failureReason}`
+      : sourceName;
+  return (
+    <div
+      className={clsx(
+        "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full",
+        "text-xs font-medium border",
+        style.pill
+      )}
+      role="status"
+      aria-label={style.ariaLabel(status.source)}
+      title={tooltip}
+      data-testid="loop-status-badge"
+      data-state={status.state}
+    >
+      <span
+        className="inline-block w-1.5 h-1.5 rounded-full bg-current"
+        aria-hidden="true"
+      />
+      <span>{style.label}</span>
+      <span
+        className="text-slate-400 font-normal border-l border-slate-700 pl-1.5 ml-0.5"
+        aria-hidden="true"
+      >
+        {sourceName}
+      </span>
+    </div>
+  );
+}
+
+interface OverrideRowProps {
+  override: OverrideInfo;
+}
+
+function OverrideRow({ override }: OverrideRowProps) {
+  const remaining = formatOverrideRemaining(override.endsAt);
+  // Indefinite overrides show "ongoing" instead of computing a
+  // phantom end time. Past-end overrides are filtered out by the
+  // backend's `active: true` guard, but the formatter is the second
+  // line of defense (returns null for past timestamps).
+  const detail = remaining ? `ends in ${remaining}` : "ongoing";
+  return (
+    <div
+      className="mt-3 flex items-center justify-center gap-2 text-xs text-slate-300"
+      role="status"
+      aria-label={`Override active: ${override.name}, ${detail}`}
+      data-testid="override-row"
+    >
+      <span
+        className="inline-block w-2 h-2 rounded-full bg-purple-400"
+        aria-hidden="true"
+      />
+      <span className="font-medium">Override: {override.name}</span>
+      <span className="text-slate-500" aria-hidden="true">
+        &middot;
+      </span>
+      <span className="text-slate-400">{detail}</span>
+    </div>
+  );
+}
+
 export function GlucoseHero({
   value,
   trend,
@@ -184,6 +388,9 @@ export function GlucoseHero({
   basalRate,
   batteryPct,
   reservoirUnits,
+  cobGrams,
+  loopStatus,
+  override,
   unit = "mg/dL",
   minutesAgo,
   isStale = false,
@@ -219,6 +426,10 @@ export function GlucoseHero({
   const safeBasal = sanitizeValue(basalRate);
   const safeBattery = sanitizeValue(batteryPct);
   const safeReservoir = sanitizeValue(reservoirUnits);
+  // PR 6: COB is a one-way pass-through (already validated server-side
+  // by the staleness + numeric checks). Negative is impossible
+  // (carbs grams aren't negative); reuse the default sanitizer.
+  const safeCob = sanitizeValue(cobGrams ?? null);
 
   const range = classifyGlucose(safeValue, thresholds);
   const colors = rangeColors[range];
@@ -246,6 +457,14 @@ export function GlucoseHero({
       aria-label="Current glucose reading"
       tabIndex={0}
     >
+      {/* PR 6: closed-loop badge in the top-right. Absent when the user
+          has no NS-sourced closed loop or the snapshot is stale. */}
+      {loopStatus && (
+        <div className="flex justify-end -mt-2 mb-2">
+          <LoopStatusBadge status={loopStatus} />
+        </div>
+      )}
+
       <div className="flex flex-col items-center justify-center text-center">
         {/* Main glucose display with dynamic aria-live priority */}
         <div
@@ -299,7 +518,10 @@ export function GlucoseHero({
           </p>
         )}
 
-        {/* Secondary metrics: IoB, Basal, Battery, Reservoir */}
+        {/* PR 6: active override pill row. Absent when no override. */}
+        {override && <OverrideRow override={override} />}
+
+        {/* Secondary metrics: IoB, Basal, Battery, Reservoir, COB (PR 6) */}
         <div
           className="flex items-center gap-4 mt-4 text-sm"
           role="group"
@@ -373,6 +595,32 @@ export function GlucoseHero({
               {safeReservoir !== null ? `${Math.round(safeReservoir)}u` : "--"}
             </span>
           </div>
+          {/* PR 6: COB column. Only renders when present so the row
+              stays the same width for users without active carbs. */}
+          {safeCob !== null && (
+            <>
+              <div className="w-px h-6 bg-slate-700" aria-hidden="true" />
+              <div
+                className="flex flex-col items-center"
+                aria-label={`Carbs on board: ${Math.round(safeCob)} grams`}
+              >
+                <span
+                  className="text-slate-500 text-xs uppercase tracking-wide"
+                  aria-hidden="true"
+                >
+                  COB
+                </span>
+                <span className="sr-only">Carbs on board</span>
+                <span
+                  className="text-slate-300 font-medium"
+                  data-testid="cob-value"
+                  aria-hidden="true"
+                >
+                  {Math.round(safeCob)}g
+                </span>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -8,8 +8,14 @@ export {
   GlucoseHero,
   type GlucoseHeroProps,
   type GlucoseRange,
+  type LoopState,
+  type LoopStatusInfo,
+  type OverrideInfo,
   classifyGlucose,
   shouldPulse,
+  parseLoopState,
+  prettySourceName,
+  formatOverrideRemaining,
   GLUCOSE_THRESHOLDS,
 } from "./glucose-hero";
 

--- a/apps/web/src/hooks/use-pump-status.ts
+++ b/apps/web/src/hooks/use-pump-status.ts
@@ -10,6 +10,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import {
   getPumpStatus,
+  type LoopStatusResponse,
+  type OverrideStatusResponse,
   type PumpStatusBasal,
   type PumpStatusBattery,
   type PumpStatusReservoir,
@@ -19,6 +21,10 @@ export interface UsePumpStatusReturn {
   basal: PumpStatusBasal | null;
   battery: PumpStatusBattery | null;
   reservoir: PumpStatusReservoir | null;
+  // Story 43.12 PR 6 additions.
+  loopStatus: LoopStatusResponse | null;
+  override: OverrideStatusResponse | null;
+  cobGrams: number | null;
   isLoading: boolean;
 }
 
@@ -26,6 +32,9 @@ export function usePumpStatus(refreshKey: number): UsePumpStatusReturn {
   const [basal, setBasal] = useState<PumpStatusBasal | null>(null);
   const [battery, setBattery] = useState<PumpStatusBattery | null>(null);
   const [reservoir, setReservoir] = useState<PumpStatusReservoir | null>(null);
+  const [loopStatus, setLoopStatus] = useState<LoopStatusResponse | null>(null);
+  const [override, setOverride] = useState<OverrideStatusResponse | null>(null);
+  const [cobGrams, setCobGrams] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const fetchGenRef = useRef(0);
 
@@ -38,6 +47,11 @@ export function usePumpStatus(refreshKey: number): UsePumpStatusReturn {
         setBasal(data.basal);
         setBattery(data.battery);
         setReservoir(data.reservoir);
+        // PR 6 fields are optional on the wire; default to null so
+        // an older backend without these fields renders cleanly.
+        setLoopStatus(data.loop_status ?? null);
+        setOverride(data.override ?? null);
+        setCobGrams(data.cob_grams ?? null);
       }
     } catch (err) {
       if (process.env.NODE_ENV === "development") {
@@ -54,5 +68,13 @@ export function usePumpStatus(refreshKey: number): UsePumpStatusReturn {
     fetchData();
   }, [fetchData, refreshKey]);
 
-  return { basal, battery, reservoir, isLoading };
+  return {
+    basal,
+    battery,
+    reservoir,
+    loopStatus,
+    override,
+    cobGrams,
+    isLoading,
+  };
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2952,10 +2952,42 @@ export interface PumpStatusReservoir {
   timestamp: string;
 }
 
+// Story 43.12 PR 6 -- closed-loop runtime state added to the
+// pump-status response. All three are nullable; absence means the
+// underlying data isn't present or the snapshot is stale.
+//
+// `state` and `source` mirror the backend's Pydantic `Literal` types
+// (`apps/api/src/schemas/pump.py`). Keep these unions in sync if the
+// backend's allowed set ever expands -- a frontend that accepts a
+// broader string than the backend emits is a quiet contract bug.
+export type LoopApiState = "looping" | "not_looping" | "failed";
+export type LoopApiSource = "loop" | "aaps" | "trio" | "oref0" | "iaps";
+
+export interface LoopStatusResponse {
+  state: LoopApiState;
+  source: LoopApiSource;
+  issued_at: string;
+  failure_reason: string | null;
+}
+
+export interface OverrideStatusResponse {
+  name: string;
+  started_at: string;
+  ends_at: string | null;
+  multiplier: number | null;
+  target_low_mgdl: number | null;
+  target_high_mgdl: number | null;
+}
+
 export interface PumpStatusResponse {
   basal: PumpStatusBasal | null;
   battery: PumpStatusBattery | null;
   reservoir: PumpStatusReservoir | null;
+  // PR 6 additions. Optional in the type (default null) so older
+  // backend responses without these fields don't break the client.
+  loop_status?: LoopStatusResponse | null;
+  override?: OverrideStatusResponse | null;
+  cob_grams?: number | null;
 }
 
 export async function getPumpStatus(): Promise<PumpStatusResponse> {


### PR DESCRIPTION
## Summary

Sixth (and independent) PR in the 43.12 series. Surfaces three new pieces of closed-loop runtime state on the dashboard hero card by reading the latest `device_status_snapshots` row that PR 43.3 + PR 43.12 PR 2 already populate. Read-only end-to-end -- no new DB writes, no Nightscout client calls, no new endpoints; only extends `GET /api/integrations/pump/status`.

User-visible value lands immediately for every Loop / AAPS / Trio / oref0 / iAPS user. Independent of PRs 3-5 (read endpoint / frontend overlay / AI context) which can ship in any order after this.

## What users see

1. **Loop status badge** -- top-right of the hero card. Green "Looping", amber "Not looping", or red "Loop failed" with failure reason in the tooltip. Source-attributed.
2. **Override row** -- "Override: Pre-meal · ends in 32 min" appears below the trend when an active override is published. Loop-only in this PR; AAPS/Trio overrides ride on Temp Target treatments and are deferred to a follow-up.
3. **COB display** -- fifth metric in the secondary-metrics row, next to IoB/Basal/Battery/Reservoir. Only renders when carbs are absorbing.

## Backend changes

- `apps/api/src/services/loop_state_extractor.py` (new) -- pure-function state-machine extractors + a single user-scoped SELECT.
- `apps/api/src/services/integrations/nightscout/source_detection.py` (new) -- shared OpenAPS-engine classifier lifted from PR 2's `_forecast_mapper`. PR 2 and PR 6 now use the same function so chart legend and hero card can't disagree on attribution.
- `apps/api/src/schemas/pump.py` -- new `LoopStatusResponse` + `OverrideStatusResponse`. `state`/`source` typed as `Literal` (enums on OpenAPI); `cob_grams` bounded `[0, 500]`.
- `apps/api/src/routers/integrations.py` -- wires into `/pump/status`.

## Frontend changes

- `apps/web/src/components/dashboard/glucose-hero.tsx` -- new `LoopStatusBadge` + `OverrideRow` subcomponents, helpers (`prettySourceName`, `formatOverrideRemaining`, `parseLoopState`).
- `apps/web/src/hooks/use-pump-status.ts`, `apps/web/src/lib/api.ts` (literal-union types), `apps/web/src/app/dashboard/page.tsx` (`mapLoopStatus` bridges API → component shape via `parseLoopState` runtime gate).

## Defense-in-depth (adversarial + security review responses)

| Concern | Defense |
|---|---|
| Stale snapshot showing fresh "Looping" | 15-min past staleness threshold |
| Future-dated snapshot from uploader clock skew | 2-min future tolerance |
| Tooltip DoS from huge `failureReason` / `name` | Extractor caps `[:200]` / `[:80]` |
| Stale `active: true` override past its end | Extractor drops when `ends_at < now` |
| Future-start override | Extractor drops when `started_at > now + tolerance` |
| Bad `multiplier` value | Extractor clamps `[0.05, 10.0]` |
| Bad `target_low/high_mgdl` | Extractor clamps `[30, 500]` mg/dL; inverted band drops both |
| Bad `cob_grams` | Extractor clamps `[0, 500]`; schema `Field(ge=0, le=500)` for defense in depth |
| Frontend crash on unknown `state` | `parseLoopState` fails closed |
| Frontend echo of arbitrary `source` string | `prettySourceName` falls back to "Closed loop" |
| Source-attribution drift between PR 2 and PR 6 | Shared `detect_openaps_engine` helper |
| Multi-connection LRU oscillation | Documented + test-pinned; real fix deferred to Story 43.10 primary-source picker |

## Tests (67 new)

**Backend (45)**: per-source state machine (Loop / AAPS / Trio / oref0 / iAPS); override extraction with all bound guards; staleness boundary; future-clock rejection; multi-connection LRU shape; medical-field clamps (multiplier / targets / inverted bands); COB schema + extractor defenses; multi-connection fixture cleanup.

**Frontend (22)**: badge render per state; "Closed loop" fallback for unknown source; override row formatting (relative time, indefinite, past-end safety, hours+minutes); COB column show/hide; `parseLoopState` strict case-sensitive behavior; `prettySourceName` strict case-sensitive behavior.

## Test plan

- [x] 45 backend tests pass (`pytest tests/test_loop_state_extractor.py`)
- [x] 22 new frontend tests pass (`jest __tests__/components/dashboard/glucose-hero.test.tsx` -- 84 total in file)
- [x] Full NS+forecast+loop suite passes: 313 passed, 13 skipped
- [x] `ruff check` + `ruff format --check` clean
- [x] API `/health` 200; OpenAPI schema verified to expose new fields with literal enums and `cob_grams` `[0, 500]` constraint
- [x] Adversarial review: HIGH none, MEDIUM 6 addressed (string caps, future-clock, multi-connection, shared helper, parseLoopState guard, override clamps), LOW addressed inline or deferred with rationale
- [x] CodeRabbit CLI: 4 major findings on PR files fixed (literal frontend types, parseLoopState/prettySourceName case-handling consistency, medical-field bounds at extractor + schema, multi-connection fixture cleanup)
- [x] Security review: clean (no HIGH/MEDIUM); 2 informational LOW notes accepted (literal-union drift handled by fail-closed; tooltip text accepted UX trade-off)

## Visual verification gap

Playwright MCP went down mid-PR. Verified instead by:
- OpenAPI schema dump confirms new fields with correct constraints
- API health 200, web 200
- Curl of `/dashboard` SSRs cleanly (redirects to `/login` when unauthenticated, expected)
- 22 component tests exercise every render path

A follow-up Playwright pass would be useful but is non-blocking; the rendering logic is well-covered by unit tests.

## What's next in 43.12

- PR 3 -- backend read endpoint `GET /api/v1/dashboard/forecast`
- PR 4 -- frontend forecast overlay (per-user picker + dotted-line chart)
- PR 5 -- AI chat context: forecast section with explicit "predicted, not historical" framing

Design doc: `_bmad-output/planning-artifacts/story-43.12-forecast-overlay-design.md` (local).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard: closed-loop status badge (running / not looping / failed) with system source, active override row with remaining time, and carbs-on-board (COB) metric.
* **Bug Fixes / Robustness**
  * Safer handling of missing, stale, or malformed loop/COB/override data; preserves backward compatibility with older responses.
* **Tests**
  * Extensive tests added covering loop state, overrides, timing, bounds, and edge-case sanitization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/633)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->