### PR TITLE
feat(api, web): vendor-agnostic data-flow disclosures for BYOAI

### DIFF
--- a/MEDICAL-DISCLAIMER.md
+++ b/MEDICAL-DISCLAIMER.md
@@ -25,9 +25,14 @@ This software processes health data including:
 - Pump hardware status (battery, reservoir levels)
 - User-configured therapy parameters (target glucose ranges, insulin ratios)
 
-Users are responsible for understanding the privacy and security implications of their deployment. The self-hosted architecture means users control where their data resides.
+Users are responsible for understanding the privacy and security implications of their deployment. The self-hosted GlycemicGPT platform stores user data on infrastructure the user controls. **However, whether health data leaves that infrastructure depends on which AI provider the user configures**, and is not determined by the platform itself.
 
-When using the BYOAI (Bring Your Own AI) feature, glucose data context is sent to the configured AI provider (Anthropic, OpenAI, Ollama, or a self-hosted endpoint). Users should review their AI provider's data handling policies.
+When using the BYOAI (Bring Your Own AI) feature:
+
+- **Cloud-hosted AI providers** (any AI service that processes requests on third-party servers, including hosted APIs, subscription products, and AI router or gateway services that forward traffic to upstream cloud models) receive the user's glucose, insulin, pump, and therapy data context for inference. That data is then subject to the provider's data-handling policy and the policies of any upstream providers it routes to.
+- **Local AI providers** (models running on infrastructure the user controls -- e.g., Ollama, vLLM, or llama.cpp on the user's own hardware or network) keep that data on the user's network.
+
+It is the user's responsibility to verify where their configured AI endpoint routes traffic and to review the data-handling policy of any provider that will receive their health data before configuring it. The GlycemicGPT platform does not proxy or intercept AI requests on behalf of users.
 
 ## AI Limitations
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@
 
 ---
 
+> **DATA HANDLING -- READ BEFORE CONFIGURING AN AI PROVIDER**
+>
+> GlycemicGPT is BYOAI. You choose the AI provider, and that choice determines where your health data is processed:
+>
+> - **Local AI providers** (running on your own infrastructure -- Ollama, vLLM, llama.cpp, or any other model on hardware you control) -- your glucose, insulin, and pump data never leave your network.
+> - **Cloud AI providers** (any AI service that processes requests on third-party servers, including hosted APIs, subscription products, and AI router/gateway services that forward traffic to upstream cloud models) -- your glucose, insulin, pump, and therapy data are transmitted to that provider for inference, subject to their data-handling policy.
+>
+> The GlycemicGPT platform itself does not route AI traffic through GlycemicGPT-operated servers; requests go directly from your deployment to your configured provider. The decision about whether health data leaves your network is entirely the user's, made when configuring a provider. See [`docs/concepts/privacy.md`](docs/concepts/privacy.md) for the full breakdown.
+
+---
+
 ## Overview
 
 GlycemicGPT is an open source diabetes platform built around AI-powered analysis. It connects directly to your CGM and insulin pump for a full standalone experience — real-time monitoring, daily AI briefs, pattern detection, conversational AI chat, and caregiver alerting. Already running Nightscout? GlycemicGPT can also pull data from your existing instance and add AI analysis on top, no changes required to your current setup. See the [Relationship to other tools](https://glycemicgpt.org/docs/platform/concepts/relationship-to-other-tools) page for the honest comparison.
@@ -85,8 +96,8 @@ Support for reading data from additional pumps and CGMs is planned. The mobile a
 **Key Principles:**
 
 - **Suggestions only** -- does not control medical devices
-- **BYOAI architecture** -- bring your own AI provider (Claude, OpenAI, Ollama, or any OpenAI-compatible endpoint)
-- **Self-hosted** -- your data stays on your infrastructure (Docker or Kubernetes)
+- **BYOAI architecture** -- bring your own AI provider; cloud-hosted providers receive your health data, local providers keep it on your network (see [`docs/concepts/privacy.md`](docs/concepts/privacy.md))
+- **Self-hosted platform** -- the GlycemicGPT services run on your infrastructure (Docker or Kubernetes); whether your data leaves your network for AI inference depends on the AI provider you configure
 - **Safety-first** -- pre-validation layer, emergency escalation, medical disclaimers
 
 ## Quick Start

--- a/apps/api/migrations/versions/056_reset_disclaimer_for_v1_1.py
+++ b/apps/api/migrations/versions/056_reset_disclaimer_for_v1_1.py
@@ -1,0 +1,59 @@
+"""Reset disclaimer_acknowledged for all users (disclaimer v1.1).
+
+Disclaimer v1.1 adds a substantive new acknowledgment about AI data
+processing -- specifically, that configuring a cloud-hosted AI provider
+transmits health data to that provider, while local AI providers keep
+data on the user's own network. Existing users acknowledged the v1.0
+disclaimer, which had no such language. Their prior consent does not
+cover the v1.1 wording, so they must re-acknowledge.
+
+This migration sets `users.disclaimer_acknowledged = False` for every
+existing row. On next dashboard load, the AuthDisclaimerGate sees the
+flag is false and shows the v1.1 modal. After they accept,
+`/api/disclaimer/acknowledge-auth` sets the flag back to true.
+
+The session-based pre-auth modal handles re-prompting via a separate
+mechanism: `/api/disclaimer/status` now treats stored acknowledgments
+with an outdated `disclaimer_version` as not-acknowledged. The User
+model has no version column to compare against, so we use this
+one-shot reset instead.
+
+Downgrade is a no-op: there is no safe way to know which users had
+acknowledged before the reset.
+
+Revision ID: 056_reset_disclaimer_for_v1_1
+Revises: 055_forecast_snapshots
+Create Date: 2026-05-14
+"""
+
+from alembic import op
+
+revision = "056_reset_disclaimer_for_v1_1"
+down_revision = "055_forecast_snapshots"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent by construction: re-running this migration on a database
+    # where every user already has disclaimer_acknowledged=False is a no-op
+    # (the WHERE clause matches zero rows). However, do NOT copy this
+    # migration verbatim for future disclaimer version bumps -- create a
+    # new migration with a fresh revision id. Reusing this one would
+    # blindly re-prompt users who already acknowledged the newer version
+    # in the gap between deploys, which is a worse UX than leaving them
+    # alone. For a future bump (e.g. v1.2), prefer adding a version
+    # column to the users table so the re-prompt can be scoped to users
+    # whose stored acknowledgment is for an outdated version, mirroring
+    # the session-based flow.
+    op.execute(
+        "UPDATE users SET disclaimer_acknowledged = FALSE "
+        "WHERE disclaimer_acknowledged = TRUE"
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: there is no safe way to know which users had
+    # acknowledged before the reset, so downgrading cannot restore their
+    # prior state.
+    pass

--- a/apps/api/src/routers/disclaimer.py
+++ b/apps/api/src/routers/disclaimer.py
@@ -26,13 +26,19 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/disclaimer", tags=["Disclaimer"])
 
-# Current disclaimer version - increment when disclaimer text changes
-DISCLAIMER_VERSION = "1.0"
+# Current disclaimer version - increment when disclaimer text changes.
+# 1.1: added AI data-handling acknowledgment (cloud vs local provider data flow).
+DISCLAIMER_VERSION = "1.1"
 
 
 @router.get("/status", response_model=DisclaimerStatusResponse)
 async def get_disclaimer_status(session_id: str) -> DisclaimerStatusResponse:
     """Check if the disclaimer has been acknowledged for a session.
+
+    A stored acknowledgment only counts when its version matches the current
+    DISCLAIMER_VERSION. When the disclaimer text adds a substantive new
+    acknowledgment (e.g., AI data-handling in 1.1), prior consent no longer
+    covers the new wording and users must re-acknowledge.
 
     Args:
         session_id: Unique session identifier (UUID from localStorage)
@@ -48,7 +54,7 @@ async def get_disclaimer_status(session_id: str) -> DisclaimerStatusResponse:
         )
         acknowledgment = result.scalar_one_or_none()
 
-        if acknowledgment:
+        if acknowledgment and acknowledgment.disclaimer_version == DISCLAIMER_VERSION:
             return DisclaimerStatusResponse(
                 acknowledged=True,
                 acknowledged_at=acknowledgment.acknowledged_at,
@@ -81,11 +87,15 @@ async def acknowledge_disclaimer(
     Raises:
         HTTPException: If checkboxes are not both checked
     """
-    # Validate both checkboxes are checked
-    if not data.checkbox_experimental or not data.checkbox_not_medical_advice:
+    # Validate all checkboxes are checked
+    if (
+        not data.checkbox_experimental
+        or not data.checkbox_not_medical_advice
+        or not data.checkbox_ai_data_flow
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Both acknowledgment checkboxes must be checked",
+            detail="All acknowledgment checkboxes must be checked",
         )
 
     # Get client info for audit purposes
@@ -228,6 +238,19 @@ async def get_disclaimer_content() -> dict[str, Any]:
                 "title": "Consult Your Healthcare Provider",
                 "text": "Always consult your healthcare provider before making any changes to your diabetes management regimen.",
             },
+            {
+                "icon": "cloud",
+                "title": "AI Data Processing",
+                "text": (
+                    "GlycemicGPT is BYOAI -- you choose the AI provider. If you "
+                    "configure a cloud-hosted AI provider, your glucose, insulin, "
+                    "pump, and therapy data will be transmitted to that provider's "
+                    "servers for analysis, subject to their data-handling policy. "
+                    "If you configure a local AI provider running on your own "
+                    "infrastructure, your data stays on your network. Review your "
+                    "chosen provider's policy before configuring it."
+                ),
+            },
         ],
         "checkboxes": [
             {
@@ -237,6 +260,10 @@ async def get_disclaimer_content() -> dict[str, Any]:
             {
                 "id": "checkbox_not_medical_advice",
                 "label": "I understand this is not medical advice and I will consult my healthcare provider before making any changes",
+            },
+            {
+                "id": "checkbox_ai_data_flow",
+                "label": "I understand that configuring a cloud-hosted AI provider transmits my health data to that provider, and that only local AI providers keep my data on my own network",
             },
         ],
         "button_text": "I Understand & Accept",

--- a/apps/api/src/schemas/disclaimer.py
+++ b/apps/api/src/schemas/disclaimer.py
@@ -38,6 +38,9 @@ class DisclaimerAcknowledgeRequest(BaseModel):
     checkbox_not_medical_advice: bool = Field(
         description="User checked the not medical advice acknowledgment",
     )
+    checkbox_ai_data_flow: bool = Field(
+        description="User checked the AI data-handling acknowledgment (cloud vs local provider data flow)",
+    )
 
 
 class DisclaimerAcknowledgeResponse(BaseModel):

--- a/apps/api/tests/test_disclaimer.py
+++ b/apps/api/tests/test_disclaimer.py
@@ -59,15 +59,17 @@ class TestDisclaimerStatus:
             data = response.json()
             assert data["acknowledged"] is False
             assert data["acknowledged_at"] is None
-            assert data["disclaimer_version"] == "1.0"
+            assert data["disclaimer_version"] == "1.1"
 
     @pytest.mark.asyncio
     async def test_returns_acknowledged_for_existing_session(self, client):
         """
         Status returns acknowledged=True for a session that has
-        previously acknowledged the disclaimer.
+        previously acknowledged the current disclaimer version.
         """
         from datetime import datetime
+
+        from src.routers.disclaimer import DISCLAIMER_VERSION
 
         session_id = str(uuid.uuid4())
         acknowledged_at = datetime.now(UTC)
@@ -77,7 +79,7 @@ class TestDisclaimerStatus:
         ) as mock_get_session_maker:
             mock_acknowledgment = MagicMock()
             mock_acknowledgment.acknowledged_at = acknowledged_at
-            mock_acknowledgment.disclaimer_version = "1.0"
+            mock_acknowledgment.disclaimer_version = DISCLAIMER_VERSION
 
             mock_session = AsyncMock()
             mock_result = MagicMock()
@@ -95,33 +97,114 @@ class TestDisclaimerStatus:
             data = response.json()
             assert data["acknowledged"] is True
             assert data["acknowledged_at"] is not None
-            assert data["disclaimer_version"] == "1.0"
+            assert data["disclaimer_version"] == DISCLAIMER_VERSION
+
+    @pytest.mark.asyncio
+    async def test_returns_not_acknowledged_when_stored_version_is_outdated(
+        self, client
+    ):
+        """
+        Status returns acknowledged=False when the stored acknowledgment is
+        for a previous disclaimer version. This forces users who acknowledged
+        an older disclaimer to re-acknowledge when substantive new wording
+        (e.g., AI data-handling in 1.1) is added.
+        """
+        from datetime import datetime
+
+        session_id = str(uuid.uuid4())
+        acknowledged_at = datetime.now(UTC)
+
+        with patch(
+            "src.routers.disclaimer.get_session_maker"
+        ) as mock_get_session_maker:
+            mock_acknowledgment = MagicMock()
+            mock_acknowledgment.acknowledged_at = acknowledged_at
+            # Stored version is older than current DISCLAIMER_VERSION
+            mock_acknowledgment.disclaimer_version = "1.0"
+
+            mock_session = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_acknowledgment
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+            mock_get_session_maker.return_value.return_value = mock_session
+
+            response = await client.get(
+                f"/api/disclaimer/status?session_id={session_id}"
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["acknowledged"] is False
+            assert data["acknowledged_at"] is None
+            assert data["disclaimer_version"] == "1.1"
 
 
 class TestDisclaimerAcknowledge:
     """Tests for POST /api/disclaimer/acknowledge endpoint."""
 
     @pytest.mark.asyncio
-    async def test_requires_both_checkboxes_checked(self, client):
+    async def test_requires_all_checkboxes_checked(self, client):
         """
-        AC2: User must check both acknowledgment checkboxes.
-        Returns 400 if not both checked.
+        User must check all acknowledgment checkboxes.
+        Returns 400 if not all checked.
         """
         session_id = str(uuid.uuid4())
 
-        # Only one checkbox checked
+        # All three required, one unchecked -> 400
         response = await client.post(
             "/api/disclaimer/acknowledge",
             json={
                 "session_id": session_id,
                 "checkbox_experimental": True,
                 "checkbox_not_medical_advice": False,
+                "checkbox_ai_data_flow": True,
             },
         )
 
         assert response.status_code == 400
         data = response.json()
-        assert "both" in data["detail"].lower()
+        assert "all" in data["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_requires_ai_data_flow_checkbox_checked(self, client):
+        """
+        Specifically: the AI data-handling checkbox must be checked.
+        Returns 400 if it is unchecked even when the other two are.
+        """
+        session_id = str(uuid.uuid4())
+
+        response = await client.post(
+            "/api/disclaimer/acknowledge",
+            json={
+                "session_id": session_id,
+                "checkbox_experimental": True,
+                "checkbox_not_medical_advice": True,
+                "checkbox_ai_data_flow": False,
+            },
+        )
+
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_ai_data_flow_field(self, client):
+        """
+        Request schema requires checkbox_ai_data_flow. Missing field -> 422.
+        Guards against clients silently downgrading to the v1.0 payload.
+        """
+        session_id = str(uuid.uuid4())
+
+        response = await client.post(
+            "/api/disclaimer/acknowledge",
+            json={
+                "session_id": session_id,
+                "checkbox_experimental": True,
+                "checkbox_not_medical_advice": True,
+            },
+        )
+
+        assert response.status_code == 422
 
     @pytest.mark.asyncio
     async def test_stores_acknowledgment_with_timestamp(self, client):
@@ -162,6 +245,7 @@ class TestDisclaimerAcknowledge:
                     "session_id": session_id,
                     "checkbox_experimental": True,
                     "checkbox_not_medical_advice": True,
+                    "checkbox_ai_data_flow": True,
                 },
             )
 
@@ -254,13 +338,14 @@ class TestDisclaimerContent:
     async def test_returns_disclaimer_content(self, client):
         """
         AC1: Disclaimer content includes all required warnings.
+        v1.1 adds an AI Data Processing warning.
         """
         response = await client.get("/api/disclaimer/content")
 
         assert response.status_code == 200
         data = response.json()
 
-        assert data["version"] == "1.0"
+        assert data["version"] == "1.1"
         assert data["title"] == "Important Safety Information"
 
         # Check all required warnings are present
@@ -269,6 +354,7 @@ class TestDisclaimerContent:
         assert "AI Limitations" in warning_titles
         assert "Not FDA Approved" in warning_titles
         assert "Consult Your Healthcare Provider" in warning_titles
+        assert "AI Data Processing" in warning_titles
 
         # Check warning text contains required phrases
         warning_texts = " ".join([w["text"] for w in data["warnings"]])
@@ -276,21 +362,26 @@ class TestDisclaimerContent:
         assert "ai" in warning_texts.lower()
         assert "fda" in warning_texts.lower()
         assert "healthcare provider" in warning_texts.lower()
+        # v1.1: AI data-flow disclosure uses vendor-agnostic cloud/local framing
+        assert "cloud" in warning_texts.lower()
+        assert "local" in warning_texts.lower()
+        assert "byoai" in warning_texts.lower()
 
     @pytest.mark.asyncio
-    async def test_returns_two_checkboxes(self, client):
+    async def test_returns_three_checkboxes(self, client):
         """
-        AC2: There are two acknowledgment checkboxes.
+        v1.1: Three acknowledgment checkboxes, including AI data-flow.
         """
         response = await client.get("/api/disclaimer/content")
 
         assert response.status_code == 200
         data = response.json()
 
-        assert len(data["checkboxes"]) == 2
+        assert len(data["checkboxes"]) == 3
         checkbox_ids = [c["id"] for c in data["checkboxes"]]
         assert "checkbox_experimental" in checkbox_ids
         assert "checkbox_not_medical_advice" in checkbox_ids
+        assert "checkbox_ai_data_flow" in checkbox_ids
 
     @pytest.mark.asyncio
     async def test_returns_accept_button(self, client):

--- a/apps/web/__tests__/auth-disclaimer-gate.test.tsx
+++ b/apps/web/__tests__/auth-disclaimer-gate.test.tsx
@@ -59,6 +59,9 @@ jest.mock("lucide-react", () => ({
   Check: ({ className }: { className?: string }) => (
     <span data-testid="check-icon" className={className} />
   ),
+  Cloud: ({ className }: { className?: string }) => (
+    <span data-testid="cloud-icon" className={className} />
+  ),
   Loader2: ({ className }: { className?: string }) => (
     <span data-testid="loader-icon" className={className} />
   ),
@@ -83,13 +86,18 @@ jest.mock("@/lib/api", () => ({
 import { AuthDisclaimerGate } from "@/components/auth-disclaimer-gate";
 
 const mockDisclaimerContent = {
-  version: "1.0",
+  version: "1.1",
   title: "Important Safety Information",
   warnings: [
     {
       icon: "flask",
       title: "Experimental Software",
       text: "This is experimental software.",
+    },
+    {
+      icon: "cloud",
+      title: "AI Data Processing",
+      text: "BYOAI: cloud providers receive your data; local providers do not.",
     },
   ],
   checkboxes: [
@@ -100,6 +108,10 @@ const mockDisclaimerContent = {
     {
       id: "checkbox_not_medical_advice",
       label: "I understand this is not medical advice",
+    },
+    {
+      id: "checkbox_ai_data_flow",
+      label: "I understand the AI data-flow implications",
     },
   ],
   button_text: "I Understand & Accept",
@@ -219,7 +231,7 @@ describe("AuthDisclaimerGate - Unacknowledged User", () => {
     expect(screen.queryByTestId("dashboard-content")).not.toBeInTheDocument();
   });
 
-  it("renders both required checkboxes", async () => {
+  it("renders all required checkboxes", async () => {
     render(
       <AuthDisclaimerGate>
         <div>Dashboard</div>
@@ -235,9 +247,12 @@ describe("AuthDisclaimerGate - Unacknowledged User", () => {
     expect(
       screen.getByText("I understand this is not medical advice")
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("I understand the AI data-flow implications")
+    ).toBeInTheDocument();
   });
 
-  it("disables the accept button until both checkboxes are checked", async () => {
+  it("disables the accept button until all checkboxes are checked", async () => {
     render(
       <AuthDisclaimerGate>
         <div>Dashboard</div>
@@ -255,13 +270,17 @@ describe("AuthDisclaimerGate - Unacknowledged User", () => {
     });
     expect(button).toBeDisabled();
 
-    // Check first checkbox
     const checkboxes = screen.getAllByRole("checkbox");
+    // Check first
     await userEvent.click(checkboxes[0]);
     expect(button).toBeDisabled();
 
-    // Check second checkbox
+    // Check second -- still disabled (3rd is required)
     await userEvent.click(checkboxes[1]);
+    expect(button).toBeDisabled();
+
+    // Check third -- now enabled
+    await userEvent.click(checkboxes[2]);
     expect(button).not.toBeDisabled();
   });
 
@@ -302,9 +321,10 @@ describe("AuthDisclaimerGate - Unacknowledged User", () => {
       name: "I Understand & Accept",
     });
 
-    // Check both
+    // Check all three
     await userEvent.click(checkboxes[0]);
     await userEvent.click(checkboxes[1]);
+    await userEvent.click(checkboxes[2]);
     expect(button).not.toBeDisabled();
 
     // Uncheck one
@@ -344,10 +364,11 @@ describe("AuthDisclaimerGate - Acknowledgment Flow", () => {
       ).toBeInTheDocument();
     });
 
-    // Check both checkboxes
+    // Check all required checkboxes
     const checkboxes = screen.getAllByRole("checkbox");
     await userEvent.click(checkboxes[0]);
     await userEvent.click(checkboxes[1]);
+    await userEvent.click(checkboxes[2]);
 
     // Click accept
     const button = screen.getByRole("button", {
@@ -395,10 +416,11 @@ describe("AuthDisclaimerGate - Acknowledgment Flow", () => {
       ).toBeInTheDocument();
     });
 
-    // Check both checkboxes
+    // Check all required checkboxes
     const checkboxes = screen.getAllByRole("checkbox");
     await userEvent.click(checkboxes[0]);
     await userEvent.click(checkboxes[1]);
+    await userEvent.click(checkboxes[2]);
 
     // Click accept
     await userEvent.click(
@@ -441,10 +463,11 @@ describe("AuthDisclaimerGate - Acknowledgment Flow", () => {
       ).toBeInTheDocument();
     });
 
-    // Check both checkboxes
+    // Check all required checkboxes
     const checkboxes = screen.getAllByRole("checkbox");
     await userEvent.click(checkboxes[0]);
     await userEvent.click(checkboxes[1]);
+    await userEvent.click(checkboxes[2]);
 
     // Click accept
     await userEvent.click(
@@ -484,8 +507,8 @@ describe("AuthDisclaimerGate - Fallback Content", () => {
       ).toBeInTheDocument();
     });
 
-    // Fallback should still have both checkboxes
-    expect(screen.getAllByRole("checkbox")).toHaveLength(2);
+    // Fallback should have all required checkboxes (v1.1 -> 3)
+    expect(screen.getAllByRole("checkbox")).toHaveLength(3);
   });
 });
 

--- a/apps/web/__tests__/settings/ai-provider.test.tsx
+++ b/apps/web/__tests__/settings/ai-provider.test.tsx
@@ -167,10 +167,13 @@ describe("Story 14.3: AI Provider Configuration Page", () => {
         ).toBeInTheDocument();
       });
 
-      // Check for all 3 categories
+      // Check for all 3 categories (section header renamed in v1.1
+      // disclosure work: "Self-Hosted" -> "Custom Endpoint", since
+      // this section also accepts cloud-routing endpoints like
+      // OpenRouter, not just local self-hosted models).
       expect(screen.getByText("Subscription Plans")).toBeInTheDocument();
       expect(screen.getByText("Pay-Per-Token APIs")).toBeInTheDocument();
-      expect(screen.getByText("Self-Hosted")).toBeInTheDocument();
+      expect(screen.getByText("Custom Endpoint")).toBeInTheDocument();
     });
 
     it("shows all 5 provider options", async () => {

--- a/apps/web/src/app/dashboard/settings/ai-provider/page.tsx
+++ b/apps/web/src/app/dashboard/settings/ai-provider/page.tsx
@@ -17,6 +17,7 @@ import {
   ArrowLeft,
   Brain,
   CheckCircle2,
+  Cloud,
   Eye,
   EyeOff,
   Globe,
@@ -526,6 +527,29 @@ export default function AIProviderPage() {
         </div>
       </div>
 
+      {/* Data-handling banner -- vendor-agnostic disclosure. Rendered
+          regardless of configured state so returning users with a
+          cloud provider already configured also see this. */}
+      <div
+        role="note"
+        aria-label="Data handling notice"
+        className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4 flex gap-3"
+      >
+        <Cloud className="h-5 w-5 text-amber-400 shrink-0 mt-0.5" aria-hidden="true" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-amber-300">
+            Your choice below determines where your data is processed.
+          </p>
+          <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
+            Cloud-hosted AI providers receive your glucose, insulin, pump,
+            and therapy data for analysis, subject to that provider&apos;s
+            data-handling policy. Locally-hosted AI providers keep that
+            data on your own network. Review the notes on each section
+            below before choosing.
+          </p>
+        </div>
+      </div>
+
       {/* Offline banner */}
       {isOffline && (
         <OfflineBanner
@@ -729,7 +753,7 @@ export default function AIProviderPage() {
           <div className="space-y-4">
             {/* Subscription Plans */}
             <div>
-              <div className="flex items-center gap-2 mb-2">
+              <div className="flex items-center gap-2 mb-2 flex-wrap">
                 <Globe className="h-4 w-4 text-blue-400" />
                 <label className="text-sm font-medium text-slate-600 dark:text-slate-300">
                   Subscription Plans
@@ -737,7 +761,15 @@ export default function AIProviderPage() {
                 <span className="text-xs text-blue-400 bg-blue-500/10 px-2 py-0.5 rounded-full">
                   Unlimited usage
                 </span>
+                <span className="text-xs text-amber-400 bg-amber-500/10 px-2 py-0.5 rounded-full">
+                  Cloud
+                </span>
               </div>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mb-2 leading-relaxed">
+                Your glucose, insulin, pump, and therapy data are transmitted
+                to the AI provider&apos;s servers for analysis. Review the
+                provider&apos;s data-handling policy before configuring.
+              </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 {SUBSCRIPTION_PROVIDERS.map((option) => (
                   <button
@@ -762,7 +794,7 @@ export default function AIProviderPage() {
 
             {/* Pay-Per-Token APIs */}
             <div>
-              <div className="flex items-center gap-2 mb-2">
+              <div className="flex items-center gap-2 mb-2 flex-wrap">
                 <Key className="h-4 w-4 text-amber-400" />
                 <label className="text-sm font-medium text-slate-600 dark:text-slate-300">
                   Pay-Per-Token APIs
@@ -770,7 +802,15 @@ export default function AIProviderPage() {
                 <span className="text-xs text-amber-400 bg-amber-500/10 px-2 py-0.5 rounded-full">
                   Usage-based pricing
                 </span>
+                <span className="text-xs text-amber-400 bg-amber-500/10 px-2 py-0.5 rounded-full">
+                  Cloud
+                </span>
               </div>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mb-2 leading-relaxed">
+                Your glucose, insulin, pump, and therapy data are transmitted
+                to the AI provider&apos;s servers for analysis. Review the
+                provider&apos;s data-handling policy before configuring.
+              </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 {API_PROVIDERS.map((option) => (
                   <button
@@ -793,17 +833,32 @@ export default function AIProviderPage() {
               </div>
             </div>
 
-            {/* Self-Hosted */}
+            {/* Custom Endpoint (self-hosted local OR cloud router) */}
             <div>
-              <div className="flex items-center gap-2 mb-2">
-                <Server className="h-4 w-4 text-green-400" />
+              <div className="flex items-center gap-2 mb-2 flex-wrap">
+                <Server className="h-4 w-4 text-amber-400" />
                 <label className="text-sm font-medium text-slate-600 dark:text-slate-300">
-                  Self-Hosted
+                  Custom Endpoint
                 </label>
-                <span className="text-xs text-green-400 bg-green-500/10 px-2 py-0.5 rounded-full">
-                  Free (self-hosted)
+                <span className="text-xs text-amber-400 bg-amber-500/10 px-2 py-0.5 rounded-full">
+                  Local or cloud (depends on endpoint)
                 </span>
               </div>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mb-2 leading-relaxed">
+                Your data is sent to whatever endpoint you configure here.
+                If you run a model locally on your own hardware (e.g., Ollama,
+                vLLM, llama.cpp on your own machine or network), your data
+                stays on your network.{" "}
+                <strong className="text-amber-400">
+                  If you point this at a cloud AI router or hosted gateway
+                  (any third-party service that forwards requests to upstream
+                  cloud models), your data will leave your network and be
+                  processed by that service and its upstream providers
+                </strong>{" "}
+                -- even though this section is labelled for self-hosting.
+                You are responsible for understanding where your configured
+                endpoint routes traffic.
+              </p>
               <div className="grid grid-cols-1 gap-2">
                 {SELF_HOSTED_PROVIDERS.map((option) => (
                   <button

--- a/apps/web/src/components/auth-disclaimer-gate.tsx
+++ b/apps/web/src/components/auth-disclaimer-gate.tsx
@@ -17,6 +17,7 @@ import {
   Stethoscope,
   AlertTriangle,
   Check,
+  Cloud,
   Loader2,
 } from "lucide-react";
 import { useUserContext } from "@/providers/user-provider";
@@ -31,6 +32,7 @@ const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   brain: Brain,
   "shield-x": ShieldOff,
   stethoscope: Stethoscope,
+  cloud: Cloud,
 };
 
 export function AuthDisclaimerGate({
@@ -69,6 +71,7 @@ export function AuthDisclaimerGate({
         setCheckboxes({
           checkbox_experimental: false,
           checkbox_not_medical_advice: false,
+          checkbox_ai_data_flow: false,
         });
       } finally {
         setContentLoading(false);
@@ -115,7 +118,7 @@ export function AuthDisclaimerGate({
 
   const handleAccept = async () => {
     if (!allChecked) {
-      setError("Please check both acknowledgment boxes to continue");
+      setError("Please check all acknowledgment boxes to continue");
       return;
     }
 
@@ -138,7 +141,7 @@ export function AuthDisclaimerGate({
 
   // Fallback content if API failed
   const displayContent: DisclaimerContent = content ?? {
-    version: "1.0",
+    version: "1.1",
     title: "Important Safety Information",
     warnings: [
       {
@@ -161,6 +164,12 @@ export function AuthDisclaimerGate({
         title: "Consult Your Healthcare Provider",
         text: "Always consult your healthcare provider before making any changes to your diabetes management regimen.",
       },
+      {
+        icon: "cloud",
+        title: "AI Data Processing",
+        text:
+          "GlycemicGPT is BYOAI -- you choose the AI provider. If you configure a cloud-hosted AI provider, your glucose, insulin, pump, and therapy data will be transmitted to that provider's servers for analysis, subject to their data-handling policy. If you configure a local AI provider running on your own infrastructure, your data stays on your network. Review your chosen provider's policy before configuring it.",
+      },
     ],
     checkboxes: [
       {
@@ -172,6 +181,11 @@ export function AuthDisclaimerGate({
         id: "checkbox_not_medical_advice",
         label:
           "I understand this is not medical advice and I will consult my healthcare provider before making any changes",
+      },
+      {
+        id: "checkbox_ai_data_flow",
+        label:
+          "I understand that configuring a cloud-hosted AI provider transmits my health data to that provider, and that only local AI providers keep my data on my own network",
       },
     ],
     button_text: "I Understand & Accept",

--- a/apps/web/src/components/disclaimer-modal.tsx
+++ b/apps/web/src/components/disclaimer-modal.tsx
@@ -17,6 +17,7 @@ import {
   Stethoscope,
   AlertTriangle,
   Check,
+  Cloud,
 } from "lucide-react";
 import {
   acknowledgeDisclaimer,
@@ -35,6 +36,7 @@ const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   brain: Brain,
   "shield-x": ShieldOff,
   stethoscope: Stethoscope,
+  cloud: Cloud,
 };
 
 export function DisclaimerModal({ onAcknowledge }: DisclaimerModalProps) {
@@ -107,7 +109,7 @@ export function DisclaimerModal({ onAcknowledge }: DisclaimerModalProps) {
 
   const handleAccept = async () => {
     if (!allChecked) {
-      setError("Please check both acknowledgment boxes to continue");
+      setError("Please check all acknowledgment boxes to continue");
       return;
     }
 
@@ -126,6 +128,7 @@ export function DisclaimerModal({ onAcknowledge }: DisclaimerModalProps) {
         checkbox_experimental: checkboxes.checkbox_experimental ?? false,
         checkbox_not_medical_advice:
           checkboxes.checkbox_not_medical_advice ?? false,
+        checkbox_ai_data_flow: checkboxes.checkbox_ai_data_flow ?? false,
       });
 
       setIsOpen(false);
@@ -148,7 +151,7 @@ export function DisclaimerModal({ onAcknowledge }: DisclaimerModalProps) {
 
   // Fallback content if API fails
   const displayContent: DisclaimerContent = content ?? {
-    version: "1.0",
+    version: "1.1",
     title: "Important Safety Information",
     warnings: [
       {
@@ -171,6 +174,12 @@ export function DisclaimerModal({ onAcknowledge }: DisclaimerModalProps) {
         title: "Consult Your Healthcare Provider",
         text: "Always consult your healthcare provider before making any changes to your diabetes management regimen.",
       },
+      {
+        icon: "cloud",
+        title: "AI Data Processing",
+        text:
+          "GlycemicGPT is BYOAI -- you choose the AI provider. If you configure a cloud-hosted AI provider, your glucose, insulin, pump, and therapy data will be transmitted to that provider's servers for analysis, subject to their data-handling policy. If you configure a local AI provider running on your own infrastructure, your data stays on your network. Review your chosen provider's policy before configuring it.",
+      },
     ],
     checkboxes: [
       {
@@ -182,6 +191,11 @@ export function DisclaimerModal({ onAcknowledge }: DisclaimerModalProps) {
         id: "checkbox_not_medical_advice",
         label:
           "I understand this is not medical advice and I will consult my healthcare provider before making any changes",
+      },
+      {
+        id: "checkbox_ai_data_flow",
+        label:
+          "I understand that configuring a cloud-hosted AI provider transmits my health data to that provider, and that only local AI providers keep my data on my own network",
       },
     ],
     button_text: "I Understand & Accept",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -182,6 +182,7 @@ export interface DisclaimerAcknowledgeRequest {
   session_id: string;
   checkbox_experimental: boolean;
   checkbox_not_medical_advice: boolean;
+  checkbox_ai_data_flow: boolean;
 }
 
 export interface DisclaimerAcknowledgeResponse {

--- a/scripts/docker-integration-test.sh
+++ b/scripts/docker-integration-test.sh
@@ -235,7 +235,7 @@ if [ "$STATUS" = "200" ]; then pass "Get current user (authenticated)"; else fai
 
 # 2d. Acknowledge disclaimer
 DISCLAIMER_SESSION=$(python3 -c "import uuid; print(uuid.uuid4())" 2>/dev/null || echo "00000000-0000-0000-0000-000000000000")
-STATUS=$(api_post "/api/disclaimer/acknowledge" "{\"session_id\":\"$DISCLAIMER_SESSION\",\"checkbox_experimental\":true,\"checkbox_not_medical_advice\":true}")
+STATUS=$(api_post "/api/disclaimer/acknowledge" "{\"session_id\":\"$DISCLAIMER_SESSION\",\"checkbox_experimental\":true,\"checkbox_not_medical_advice\":true,\"checkbox_ai_data_flow\":true}")
 if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then pass "Acknowledge disclaimer"; else fail "Acknowledge disclaimer (got $STATUS)"; fi
 
 echo ""


### PR DESCRIPTION
## Summary

Adds explicit disclosures across the product so users understand that configuring a cloud-hosted AI provider transmits their health data to that provider, while local providers keep data on their own network. Triggered by external feedback that the prior copy did not make this trade-off visible at the points where users actually make the choice.

Wording is intentionally vendor-agnostic throughout -- no Anthropic / OpenAI / OpenRouter mentions in disclosure copy -- so the disclosure stays correct as the supported provider set evolves and so it covers cloud AI router / hosted-gateway services that route through a "self-hosted" endpoint.

## What changed

**Disclaimer v1.1 (server-driven content)**
- New `AI Data Processing` warning and `checkbox_ai_data_flow` field, both required for acknowledgment.
- `/api/disclaimer/status` now treats stored acknowledgments whose `disclaimer_version` does not match the current `DISCLAIMER_VERSION` as not-acknowledged, so pre-auth users with outdated session acknowledgments are re-prompted with the new wording.

**Migration `056_reset_disclaimer_for_v1_1`**
- One-shot reset of `users.disclaimer_acknowledged = False` so authenticated users who acknowledged v1.0 see the v1.1 modal via `AuthDisclaimerGate` on next dashboard load. The `User` model has no version column to gate on, so a reset is the minimum-blast-radius approach. Documented as non-reusable for future bumps; the migration body explains the longer-term path.

**Web disclaimer modals**
- Both the pre-auth `DisclaimerModal` and the post-auth `AuthDisclaimerGate` render the new warning + checkbox, with matching fallback content if `/api/disclaimer/content` is unreachable.

**AI Provider settings page**
- Top-level amber banner with cloud icon: "Your choice below determines where your data is processed." Rendered above the page content regardless of configured state, so returning users with cloud providers already configured also see the disclosure.
- "Cloud" badges on Subscription Plans and Pay-Per-Token APIs sections, with explicit "data is transmitted to the AI provider's servers" copy below each section header.
- Renamed "Self-Hosted" -> "Custom Endpoint" with amber "Local or cloud (depends on endpoint)" badge. Section body text explicitly warns that pointing this at a cloud AI router or hosted gateway will route health data to upstream cloud models, even though the section is labelled for self-hosting.

**Top-level docs**
- `README.md`: prominent "DATA HANDLING" callout above Overview, plus tightened the misleading "Self-hosted -- your data stays on your infrastructure" key-principle bullet (self-hosting the platform does not equal data sovereignty when a cloud AI provider is configured).
- `MEDICAL-DISCLAIMER.md`: rewrote the BYOAI paragraph with the same vendor-agnostic cloud/local framing.

**Other**
- `scripts/docker-integration-test.sh`: add `checkbox_ai_data_flow` to its POST body so the integration test does not 422 against the new schema.

## Known follow-ups (not in this PR)

- **Mobile onboarding** still has the 4-card v1.0 disclaimer with no AI data-flow disclosure. Mobile does not call `/api/disclaimer/acknowledge` (the schema bump is safe for it), but the disclosure itself should be added to the Android onboarding flow in a follow-up.
- **Telegram chat** does not check `user.disclaimer_acknowledged` before invoking AI. Adding a `/disclaimer` command or first-message gate is its own feature.
- **Security workflows** (`.github/workflows/security-{scan,full-suite}.yml`) POST to `/api/disclaimer/acknowledge` with no body and pipe to `|| true`, so they were already silently 422-ing pre-change. Unchanged here; tracked as a pre-existing bug.

## Test plan

- [x] Backend pytest suite for disclaimer: 13/13 pass (covers version-mismatch reprompt, missing-field 422, all-checkboxes-required path)
- [x] Frontend Jest suite for AuthDisclaimerGate: 15/15 pass (3-checkbox flow, fallback content)
- [x] `ruff check` clean on changed Python files
- [x] `next lint` clean
- [x] Visual verification (Playwright): pre-auth modal renders 5 warnings + 3 checkboxes including the new "AI Data Processing" warning; existing authenticated user with disclaimer_acknowledged=true was successfully re-prompted after the migration; AI Provider settings page shows the data-handling banner regardless of configured state, with Cloud badges on Subscription/API sections and the amber Local-or-cloud badge + AI router warning on Custom Endpoint.
- [x] Migration applied cleanly (055 -> 056) in the dev stack on container restart.
- [x] Adversarial review pass + all HIGH-priority findings addressed in-PR (banner placement for configured users, integration-test script payload, migration safety doc, badge wording).
- [x] CodeRabbit CLI review: 0 findings.
- [x] Security review of staged diff: PASS (no secrets, no injection, no auth regressions, no new dependencies).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI data flow acknowledgment checkbox to medical disclaimer
  * Added data handling notice to AI provider settings page

* **Documentation**
  * Enhanced medical disclaimer distinguishing cloud vs. local AI provider data handling
  * Updated README with data handling and privacy guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/634)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->