### PR TITLE
feat(api): forecast read endpoint + picker preference (43.12 PR 3)

### DIFF
--- a/apps/api/migrations/versions/057_forecast_settings.py
+++ b/apps/api/migrations/versions/057_forecast_settings.py
@@ -1,0 +1,98 @@
+"""Forecast settings (Story 43.12 PR 3).
+
+Adds `forecast_settings` -- a per-user single-row preference table for
+the forecast-overlay picker. The default `'auto'` means "pick the only
+available source" (per design doc Section 3); `'none'` opts out;
+specific engine values pin the picker to that source.
+
+Why a new table (not a column on `users` and not folded into
+`analytics_config`):
+
+- Matches the existing per-domain config pattern (`analytics_config`,
+  `data_retention_config`, `escalation_config`, `safety_limits`,
+  `insulin_config`). Each owns its concern; cross-domain coupling
+  stays out of the schema.
+- Story 43.10's primary-CGM picker (queued, not shipped) will likely
+  grow alongside this -- room to add a `primary_cgm` column without
+  another migration.
+- Future power-user toggles ("show all AAPS curves", "horizon cap")
+  fit here naturally.
+
+`source_engine` allow-list mirrors PR 1's CHECK on
+`forecast_snapshots.source_engine` exactly so the picker can't store
+a value the schema can't otherwise produce, plus `'auto'` and
+`'none'` for the picker-only states.
+
+Revision ID: 057_forecast_settings
+Revises: 056_reset_disclaimer_for_v1_1
+Create Date: 2026-05-15
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "057_forecast_settings"
+down_revision = "056_reset_disclaimer_for_v1_1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "forecast_settings",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        # 'auto' | 'none' | 'loop' | 'aaps' | 'trio' | 'oref0' | 'iaps' |
+        # 'glycemicgpt'. Free-form text bounded by a CHECK so the picker
+        # can't store a value the API doesn't understand. Matches
+        # `forecast_snapshots.source_engine`'s allow-list plus the two
+        # picker-only states.
+        sa.Column(
+            "source",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'auto'"),
+        ),
+        sa.CheckConstraint(
+            "source IN ('auto','none','loop','aaps','trio','oref0','iaps','glycemicgpt')",
+            name="ck_forecast_settings_source_known",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    # One-to-one with users: enforced by UNIQUE on user_id. The
+    # `get_or_create` service layer relies on this -- racing inserts
+    # land cleanly via ON CONFLICT.
+    op.create_index(
+        "ix_forecast_settings_user",
+        "forecast_settings",
+        ["user_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_forecast_settings_user", table_name="forecast_settings")
+    op.drop_table("forecast_settings")

--- a/apps/api/src/models/forecast_settings.py
+++ b/apps/api/src/models/forecast_settings.py
@@ -1,0 +1,77 @@
+"""Forecast picker preference (Story 43.12 PR 3).
+
+Stores the user's choice of which closed-loop forecast source to draw
+on the dashboard chart and feed to the AI context (PR 5). One row per
+user; defaults to `'auto'` so the picker is opt-in to a specific
+source.
+
+`source` semantics:
+
+| Value | Meaning |
+|---|---|
+| `'auto'` | Pick the only source publishing forecasts; if multiple, render nothing until user picks (per design doc Section 3) |
+| `'none'` | Opt out -- never render a forecast overlay |
+| `'loop'` / `'aaps'` / `'trio'` / `'oref0'` / `'iaps'` | Pin to that engine; render nothing if that engine has gone silent |
+| `'glycemicgpt'` | Future GlycemicGPT prediction engine (not shipped); schema-ready |
+
+The CHECK constraint mirrors PR 1's `forecast_snapshots.source_engine`
+allow-list plus the two picker-only states (`'auto'`, `'none'`).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import CheckConstraint, ForeignKey, Index, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base, TimestampMixin
+
+
+class ForecastSettings(Base, TimestampMixin):
+    """User's forecast-picker preference. One-to-one with `User`."""
+
+    __tablename__ = "forecast_settings"
+
+    __table_args__ = (
+        # Mirror of migration CHECK. Keeping it on the ORM means
+        # `alembic --autogenerate` stays quiet and the invariant lives
+        # next to the column.
+        CheckConstraint(
+            "source IN ('auto','none','loop','aaps','trio','oref0','iaps','glycemicgpt')",
+            name="ck_forecast_settings_source_known",
+        ),
+        Index("ix_forecast_settings_user", "user_id", unique=True),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+
+    # See module docstring for semantics. Default `'auto'` so a new
+    # user with a single forecast-publishing integration sees the
+    # overlay immediately (single-source case), and a user with
+    # multiple sources gets a clean prompt-to-pick state.
+    # `server_default` must be a SQL expression -- a plain string
+    # becomes `DEFAULT auto` (unquoted identifier) which is invalid.
+    # Use `text("'auto'")` to match the migration's `sa.text("'auto'")`
+    # so `alembic --autogenerate` doesn't suggest spurious diffs.
+    source: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="auto",
+        server_default=text("'auto'"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ForecastSettings(user_id={self.user_id}, source={self.source!r})>"

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -33,6 +33,13 @@ from src.models.pump_hardware_info import PumpHardwareInfo
 from src.models.pump_raw_event import PumpRawEvent
 from src.models.tandem_upload_state import TandemUploadState
 from src.schemas.auth import ErrorResponse
+from src.schemas.forecast import (
+    ForecastPayload,
+    ForecastReadResponse,
+    ForecastSourcePreferenceResponse,
+    ForecastSourcePreferenceUpdate,
+    curves_from_jsonb,
+)
 from src.schemas.glucose import (
     AGPBucket,
     CurrentGlucoseResponse,
@@ -84,6 +91,13 @@ from src.services.dexcom_sync import (
     get_glucose_readings,
     get_latest_glucose_reading,
     sync_dexcom_for_user,
+)
+from src.services.forecast_reader import (
+    get_available_sources,
+    get_latest_forecast,
+    read_forecast_preference,
+    resolve_effective_source,
+    set_forecast_source,
 )
 from src.services.iob_projection import get_iob_projection, get_user_dia
 from src.services.loop_state_extractor import get_latest_loop_state
@@ -1405,6 +1419,131 @@ async def get_pump_status(
         loop_status=loop_status_resp,
         override=override_resp,
         cob_grams=loop_state.cob_grams,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Story 43.12 PR 3 -- forecast picker read/write endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/forecast",
+    response_model=ForecastReadResponse,
+    responses={
+        200: {
+            "description": (
+                "User's forecast picker preference, the engines currently "
+                "publishing forecasts, and (when an effective source resolves) "
+                "the latest forecast payload from that source."
+            )
+        },
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+    },
+)
+async def get_forecast(
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> ForecastReadResponse:
+    """Compose the forecast-overlay read for the dashboard chart and AI context.
+
+    Three independent state pieces fold into one response:
+
+    - **`source_preference`** -- whatever the user picked (or `'auto'`
+      default for new users).
+    - **`available_sources`** -- engines that emitted any forecast in
+      the last 24h. Drives PR 4's picker dropdown.
+    - **`forecast`** -- the latest snapshot from the effective source,
+      suppressed when older than the 30-min freshness threshold so
+      the chart never draws a misaligned dotted line.
+
+    The `effective_source` field is the resolved combination -- the
+    chart should ignore `source_preference` and `available_sources`
+    when deciding what (if anything) to render and just trust
+    `effective_source` + `forecast`.
+
+    Returns 200 with all-null forecast/effective_source for users
+    with no closed-loop integration -- the picker UI hides itself
+    in that state.
+    """
+    # Read-only path -- never INSERTs a settings row, returns
+    # 'auto' as the synthesized default for users with no stored
+    # preference. This keeps the GET side-effect-free per REST
+    # convention. PUT is where the row gets persisted.
+    preference = await read_forecast_preference(db, current_user.id)
+    available = await get_available_sources(db, current_user.id)
+    effective = resolve_effective_source(preference, available)
+
+    forecast_payload: ForecastPayload | None = None
+    if effective is not None:
+        latest = await get_latest_forecast(db, current_user.id, effective)
+        if latest is not None:
+            forecast_payload = ForecastPayload(
+                source_engine=latest.source_engine,  # type: ignore[arg-type]
+                source_uploader=latest.source_uploader,
+                issued_at=latest.issued_at,
+                start_at=latest.start_at,
+                step_minutes=latest.step_minutes,
+                horizon_minutes=latest.horizon_minutes,
+                curves_mgdl=curves_from_jsonb(latest.curves_mgdl_json),
+                default_curve_name=latest.default_curve_name,
+            )
+
+    # Compute the explicit "why no forecast" reason for the frontend.
+    # Mutually exclusive states; happy path returns None.
+    reason: str | None = None
+    if forecast_payload is None:
+        if preference == "none":
+            reason = "opted_out"
+        elif not available:
+            reason = "no_sources"
+        elif preference == "auto" and len(available) > 1:
+            reason = "needs_pick"
+        elif effective is None:
+            # preference is a specific engine but it's not in `available`.
+            reason = "source_silent"
+        else:
+            # effective resolved but the latest snapshot is too old.
+            reason = "stale"
+
+    return ForecastReadResponse(
+        source_preference=preference,
+        effective_source=effective,
+        available_sources=available,
+        forecast=forecast_payload,
+        forecast_unavailable_reason=reason,  # type: ignore[arg-type]
+    )
+
+
+@router.put(
+    "/forecast/source",
+    response_model=ForecastSourcePreferenceResponse,
+    responses={
+        200: {"description": "Forecast source preference updated."},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Permission denied"},
+        422: {
+            "model": ErrorResponse,
+            "description": "Invalid `source` value (must be one of the allowed enum).",
+        },
+    },
+)
+async def update_forecast_source(
+    body: ForecastSourcePreferenceUpdate,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> ForecastSourcePreferenceResponse:
+    """Persist the user's forecast picker choice.
+
+    Pydantic's `Literal` validation rejects unknown source values at
+    the API boundary (422 before the DB ever sees them). The DB's
+    CHECK constraint is the final guard if the schema ever drifts.
+    """
+    settings = await set_forecast_source(db, current_user.id, body.source)
+    await db.commit()
+    return ForecastSourcePreferenceResponse(
+        source_preference=settings.source,  # type: ignore[arg-type]
     )
 
 

--- a/apps/api/src/schemas/forecast.py
+++ b/apps/api/src/schemas/forecast.py
@@ -1,0 +1,235 @@
+"""Pydantic schemas for the forecast read endpoint (Story 43.12 PR 3).
+
+Shape consumers (in order they'll land):
+
+- PR 4: frontend forecast-overlay picker reads `available_sources` to
+  populate the dropdown; reads `forecast.curves_mgdl` +
+  `default_curve_name` to draw the dotted line.
+- PR 5: AI context builder reads `forecast.source_engine` and the
+  default curve to talk honestly ("your Loop predicts..." not "your
+  glucose is...").
+- Mobile (eventual): same shape, no client-side adjustment.
+
+`state`/`source`-style Literal types match the backend Pydantic
+contract for PR 6's `LoopStatusResponse` so the frontend can mirror
+the same union types end-to-end.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+
+# Known curve keys -- single-curve sources (Loop) populate `main`;
+# OpenAPS family populates any subset of IOB / COB / UAM / ZT. A
+# future curve name (e.g., a hypothetical AAPS extension) would
+# require both this set AND `ForecastCurves` to grow; until then,
+# unknown keys are logged + silently dropped on read so an
+# unannounced wire-format change surfaces in logs rather than
+# corrupting the response shape.
+_KNOWN_CURVE_KEYS = frozenset({"main", "IOB", "COB", "UAM", "ZT"})
+
+# Allow-list mirrors `forecast_settings.source` CHECK constraint (PR 3
+# migration 057) and adds 'auto' / 'none' for the picker. The
+# forecast-row-only engines from `forecast_snapshots.source_engine`
+# are the subset producing actual rows; 'auto' / 'none' are
+# picker-only states never persisted to `forecast_snapshots`.
+ForecastSourcePreference = Literal[
+    "auto",
+    "none",
+    "loop",
+    "aaps",
+    "trio",
+    "oref0",
+    "iaps",
+    "glycemicgpt",
+]
+
+# Subset that can ever appear as the *effective* source: anything that
+# can actually produce a forecast row. 'auto' / 'none' resolve to
+# either one of these or `null`.
+ForecastEngine = Literal[
+    "loop",
+    "aaps",
+    "trio",
+    "oref0",
+    "iaps",
+    "glycemicgpt",
+]
+
+
+# Why the forecast isn't rendering. `null` (omitted) is the happy
+# path: `forecast` is populated and the chart draws the dotted line.
+# Each non-null value maps to a distinct frontend message (PR 4):
+#
+# - `opted_out`     -> "Forecasts disabled in settings"
+# - `needs_pick`    -> dropdown surfaces, no line draws yet
+# - `no_sources`    -> hidden picker; "Connect Nightscout to see forecasts"
+# - `source_silent` -> "Your <X> forecast paused (no recent data)"
+# - `stale`         -> "Your <X> forecast paused (last reading too old)"
+#
+# Frontend reads this rather than reconstructing from
+# `(source_preference, effective_source, forecast, available_sources)`.
+ForecastUnavailableReason = Literal[
+    "opted_out",
+    "needs_pick",
+    "no_sources",
+    "source_silent",
+    "stale",
+]
+
+
+class ForecastCurves(BaseModel):
+    """The mg/dL curves (1-4) from a single forecast snapshot.
+
+    Single-curve sources (Loop) populate just `main`. Multi-curve
+    sources (AAPS / Trio / oref0 / iAPS) populate any subset of
+    `IOB` / `COB` / `UAM` / `ZT`. Absent keys mean "this source
+    didn't publish that curve this cycle" -- common for OpenAPS
+    when carbs aren't active.
+
+    The chart draws `default_curve_name` by default; a future power-
+    user "show all curves" toggle (deferred) would read the rest.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    main: list[float] | None = Field(
+        default=None,
+        description="Loop's single curve. Mutually exclusive with the OpenAPS curves in practice.",
+    )
+    IOB: list[float] | None = Field(default=None)  # noqa: N815 (mirrors wire shape)
+    COB: list[float] | None = Field(default=None)  # noqa: N815
+    UAM: list[float] | None = Field(default=None)  # noqa: N815
+    ZT: list[float] | None = Field(default=None)  # noqa: N815
+
+
+class ForecastPayload(BaseModel):
+    """A single forecast snapshot, projected onto the chart's needs.
+
+    Trimmed shape compared to `ForecastSnapshot` -- the read endpoint
+    omits `nightscout_connection_id`, `dedupe_key`, and `received_at`
+    because the chart / AI / mobile consumers don't need them.
+    """
+
+    source_engine: ForecastEngine
+    source_uploader: str | None = Field(
+        default=None,
+        max_length=100,
+        description="Original NS uploader name (denormalized from `device_status_snapshots.source_uploader`). Capped at 100 chars as defense-in-depth; the mapper truncates at 40 on write.",
+    )
+    issued_at: datetime = Field(
+        ...,
+        description="When the source loop emitted the forecast (its internal clock).",
+    )
+    start_at: datetime = Field(
+        ...,
+        description="t=0 of the forecast curve. For most sources == issued_at; Loop occasionally lags by a cycle.",
+    )
+    step_minutes: int = Field(..., gt=0, le=60)
+    horizon_minutes: int = Field(..., gt=0, le=1440)
+    curves_mgdl: ForecastCurves
+    default_curve_name: str = Field(
+        ...,
+        description="Which key in `curves_mgdl` the chart should draw by default.",
+    )
+
+
+class ForecastReadResponse(BaseModel):
+    """Response of `GET /api/integrations/forecast`.
+
+    Composed shape so a single round-trip drives both the picker
+    dropdown and the chart overlay:
+
+    - `source_preference`: what the user picked (or `'auto'` default).
+    - `effective_source`: which engine WOULD drive the overlay if a
+      fresh forecast were available. Stays populated even when the
+      latest snapshot is stale-suppressed -- the frontend uses this
+      for legend / label rendering ("Loop forecast paused"). To know
+      whether the chart should actually draw a line, the consumer
+      should check `forecast != null` (or use
+      `forecast_unavailable_reason`).
+    - `available_sources`: every engine that emitted a forecast in
+      the last 24h. Drives the picker dropdown. NOTE: this is the
+      24h "is this source online" window, NOT the 30-min freshness
+      window. An engine can be `available` (in the dropdown) but
+      have its latest snapshot too stale to render -- the frontend
+      surfaces that via the `stale` reason.
+    - `forecast`: the latest snapshot from `effective_source`,
+      suppressed when older than the 30-min freshness threshold so
+      a stale dotted line never misaligns with the chart's "now".
+    - `forecast_unavailable_reason`: explicit dispatch for "why no
+      chart line." Null on the happy path. See `ForecastUnavailableReason`
+      for the message-mapping table.
+    """
+
+    source_preference: ForecastSourcePreference
+    effective_source: ForecastEngine | None
+    available_sources: list[ForecastEngine] = Field(
+        default_factory=list,
+        description="Engines that emitted a forecast in the last 24h, sorted alphabetically for stable picker UI.",
+    )
+    forecast: ForecastPayload | None = None
+    forecast_unavailable_reason: ForecastUnavailableReason | None = Field(
+        default=None,
+        description="Explicit reason `forecast` is null. Null when forecast is rendering normally.",
+    )
+
+
+class ForecastSourcePreferenceUpdate(BaseModel):
+    """Body of `PUT /api/integrations/forecast/source`.
+
+    Validates `source` against the allowed enum at the API boundary
+    so a malformed pick returns 422 rather than a CHECK constraint
+    violation at write time.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: ForecastSourcePreference
+
+
+class ForecastSourcePreferenceResponse(BaseModel):
+    """Response of `PUT /api/integrations/forecast/source` and any
+    future GET-just-the-preference path."""
+
+    source_preference: ForecastSourcePreference
+
+
+# ---------------------------------------------------------------------------
+# Internal builder helpers (not part of the public schema surface)
+# ---------------------------------------------------------------------------
+
+
+def curves_from_jsonb(curves_json: Any) -> ForecastCurves:
+    """Coerce a `forecast_snapshots.curves_mgdl_json` cell to the
+    response schema.
+
+    The DB column is JSONB with PR 1's range + length CHECKs already
+    applied at write time. We trust the shape but pass each curve
+    through Pydantic for type-narrowing on read. Unknown keys are
+    logged + dropped: `ForecastCurves` uses `extra="forbid"` so
+    silently widening the response surface would be a regression.
+    Logging surfaces an unannounced wire-format change in operator
+    logs without breaking the read path.
+    """
+    if not isinstance(curves_json, dict):
+        return ForecastCurves()
+    unknown_keys = set(curves_json.keys()) - _KNOWN_CURVE_KEYS
+    if unknown_keys:
+        logger.warning(
+            "forecast_reader.unknown_curve_keys",
+            extra={"unknown_keys": sorted(unknown_keys)},
+        )
+    return ForecastCurves(
+        main=curves_json.get("main"),
+        IOB=curves_json.get("IOB"),
+        COB=curves_json.get("COB"),
+        UAM=curves_json.get("UAM"),
+        ZT=curves_json.get("ZT"),
+    )

--- a/apps/api/src/services/forecast_reader.py
+++ b/apps/api/src/services/forecast_reader.py
@@ -1,0 +1,273 @@
+"""Forecast picker read service (Story 43.12 PR 3).
+
+Pure functions + thin DB queries that compose the `GET
+/api/integrations/forecast` response. Read-only end-to-end: no writes
+to `forecast_snapshots`, no Nightscout client calls. The mutation
+path (`PUT .../source`) lives in the router as a single UPSERT.
+
+Key responsibilities:
+
+1. `get_or_create_forecast_settings`: lazy-creates the per-user
+   preference row on first read so the API can always return a
+   sensible default (`'auto'`).
+2. `get_available_sources`: returns the engines that emitted at
+   least one forecast in the last 24h. Drives the picker dropdown.
+3. `resolve_effective_source`: pure function -- given a preference
+   and the available list, what does the chart actually draw? Table
+   of cases in the docstring; matches design doc Section 3 exactly.
+4. `get_latest_forecast`: returns the latest snapshot for a given
+   source, suppressed when older than the freshness threshold so a
+   stale dotted line doesn't lie about t=0.
+
+`AVAILABLE_SOURCES_WINDOW` and `FORECAST_FRESHNESS_THRESHOLD` are
+intentionally different time bands:
+- 24h for available_sources: lets a user who took a phone break
+  yesterday still see their loop in the dropdown.
+- 30min for the returned forecast: a forecast's t=0 is set when the
+  source loop emitted it; rendering a 30-min-old dotted line
+  starting at "30 min ago" would misalign with the chart's "now".
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.forecast_settings import ForecastSettings
+from src.models.forecast_snapshot import ForecastSnapshot
+from src.schemas.forecast import ForecastEngine, ForecastSourcePreference
+
+# Beyond this age, a source is considered "gone silent" and is dropped
+# from the picker dropdown. 24h accommodates ordinary phone-off-overnight
+# patterns without keeping ancient stale sources around.
+AVAILABLE_SOURCES_WINDOW = timedelta(hours=24)
+
+# Beyond this age, the returned `forecast` field is suppressed even
+# when an effective source resolves. Forecasts have a lookahead
+# horizon (Loop ~6h, AAPS ~3h, oref0 ~30min); rendering a 30-min-old
+# dotted line whose t=0 was 30 min ago would visibly misalign with
+# the actual reading at "now". The picker dropdown stays unaffected
+# -- the source is still in `available_sources` so the user knows
+# it's online, even if the latest specific forecast is too stale.
+FORECAST_FRESHNESS_THRESHOLD = timedelta(minutes=30)
+
+
+# ---------------------------------------------------------------------------
+# Preference (forecast_settings) helpers
+# ---------------------------------------------------------------------------
+
+
+async def read_forecast_preference(
+    db: AsyncSession, user_id: uuid.UUID
+) -> ForecastSourcePreference:
+    """Read-only path for the GET endpoint -- never writes.
+
+    Returns `'auto'` for users without a stored row. This avoids the
+    REST anti-pattern of a GET that has side effects: a brand-new
+    user's first dashboard load no longer INSERTs a settings row. The
+    row gets persisted on the first PUT instead, where it belongs.
+
+    Falls back to `'auto'` (not raising) so the GET path can always
+    return a sensible default, even if a future schema migration is
+    in flight.
+    """
+    result = await db.execute(
+        select(ForecastSettings.source).where(ForecastSettings.user_id == user_id)
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        return "auto"
+    # The CHECK constraint bounds row to the Literal set; type-narrow.
+    return row  # type: ignore[return-value]
+
+
+async def get_or_create_forecast_settings(
+    db: AsyncSession, user_id: uuid.UUID
+) -> ForecastSettings:
+    """Fetch the user's settings row, creating with default `'auto'`
+    on first access.
+
+    Handles the race where two concurrent first-reads both miss the
+    row and try to insert: the UNIQUE constraint on `user_id` lets
+    the loser fall back to a SELECT.
+
+    The INSERT runs inside a SAVEPOINT (`session.begin_nested()`) so
+    a losing-race IntegrityError rolls back ONLY the failed INSERT --
+    NOT the entire outer transaction. This is critical for callers
+    that may have already done other work in the same session (e.g.,
+    `set_forecast_source` mutates an existing row before flush; a
+    naive `db.rollback()` would discard that mutation alongside the
+    failed insert).
+    """
+    existing = await db.execute(
+        select(ForecastSettings).where(ForecastSettings.user_id == user_id)
+    )
+    row = existing.scalar_one_or_none()
+    if row is not None:
+        return row
+
+    new_row = ForecastSettings(user_id=user_id, source="auto")
+    try:
+        async with db.begin_nested():
+            db.add(new_row)
+            await db.flush()
+        return new_row
+    except IntegrityError:
+        # SAVEPOINT auto-rolled back the failed INSERT only. The
+        # outer transaction is intact. Pull the winning row.
+        retry = await db.execute(
+            select(ForecastSettings).where(ForecastSettings.user_id == user_id)
+        )
+        return retry.scalar_one()
+
+
+async def set_forecast_source(
+    db: AsyncSession, user_id: uuid.UUID, source: ForecastSourcePreference
+) -> ForecastSettings:
+    """Persist the user's pick. UPSERT semantics via
+    `get_or_create_forecast_settings`.
+
+    The `source` parameter is typed `Literal` so the router's Pydantic
+    body validation rejects unknown values at the API boundary; this
+    function trusts the caller's typing and does not re-validate
+    against the CHECK constraint -- the DB is the final guard if
+    invariants somehow drift.
+    """
+    settings = await get_or_create_forecast_settings(db, user_id)
+    settings.source = source
+    await db.flush()
+    return settings
+
+
+# ---------------------------------------------------------------------------
+# Source availability (forecast_snapshots projection)
+# ---------------------------------------------------------------------------
+
+
+async def get_available_sources(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    now: datetime | None = None,
+) -> list[ForecastEngine]:
+    """Distinct `source_engine` values for this user in the last 24h.
+
+    Sorted alphabetically for a stable picker dropdown ordering --
+    user shouldn't see entries reshuffle between renders.
+
+    The `now` parameter is injected for deterministic testing; in
+    production callers pass `None` and the function uses
+    `datetime.now(UTC)`.
+    """
+    reference_now = now if now is not None else datetime.now(UTC)
+    cutoff = reference_now - AVAILABLE_SOURCES_WINDOW
+
+    stmt = (
+        select(ForecastSnapshot.source_engine)
+        .where(
+            ForecastSnapshot.user_id == user_id,
+            ForecastSnapshot.issued_at >= cutoff,
+        )
+        .distinct()
+        .order_by(ForecastSnapshot.source_engine.asc())
+    )
+    rows = await db.execute(stmt)
+    return list(rows.scalars().all())  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Effective-source resolution (pure function, table-driven tests)
+# ---------------------------------------------------------------------------
+
+
+def resolve_effective_source(
+    preference: ForecastSourcePreference,
+    available: list[ForecastEngine],
+) -> ForecastEngine | None:
+    """Map (preference, available_sources) -> the engine the chart
+    should actually draw, or None.
+
+    Resolution table (matches design doc Section 3):
+
+    | preference          | available                  | result      |
+    | ------------------- | -------------------------- | ----------- |
+    | 'none'              | (any)                      | None        |
+    | 'auto'              | []                         | None        |
+    | 'auto'              | [single]                   | that engine |
+    | 'auto'              | [multiple]                 | None        |
+    | specific engine     | contains engine            | that engine |
+    | specific engine     | doesn't contain engine     | None        |
+
+    The "multiple sources under 'auto' -> None" rule is the explicit
+    no-silent-guessing decision from the design doc: a user with both
+    Loop and AAPS gets the dropdown surfaced, not an arbitrary pick.
+
+    The "specific but missing -> None" rule (no fallback) is the
+    honest "your X stopped publishing" stance: we never silently
+    substitute Loop for AAPS because the user asked for AAPS.
+    """
+    if preference == "none":
+        return None
+    if preference == "auto":
+        if len(available) == 1:
+            return available[0]
+        return None
+    # Specific engine: only resolves if it's still publishing.
+    if preference in available:
+        return preference  # type: ignore[return-value]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Latest-forecast retrieval (per source)
+# ---------------------------------------------------------------------------
+
+
+async def get_latest_forecast(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    source_engine: ForecastEngine,
+    *,
+    now: datetime | None = None,
+) -> ForecastSnapshot | None:
+    """Latest `forecast_snapshots` row for the user + source, or None
+    when the latest is older than `FORECAST_FRESHNESS_THRESHOLD`.
+
+    Ordered by `issued_at` DESC -- the engine's own clock at emit
+    time, NOT `received_at`. A backfilled snapshot from a one-hour-
+    ago devicestatus must not outrank a live one just because it was
+    synced to our DB more recently.
+
+    Returns None (not raises) when no row exists or the only row is
+    stale; the caller folds this directly into the response's nullable
+    `forecast` field.
+    """
+    reference_now = now if now is not None else datetime.now(UTC)
+
+    stmt = (
+        select(ForecastSnapshot)
+        .where(
+            ForecastSnapshot.user_id == user_id,
+            ForecastSnapshot.source_engine == source_engine,
+        )
+        .order_by(ForecastSnapshot.issued_at.desc())
+        .limit(1)
+    )
+    row = (await db.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+
+    # Aware datetimes only -- the column is TIMESTAMPTZ; this guard
+    # is a safety net for any future code path that bypasses the
+    # column's default.
+    issued = row.issued_at
+    if issued.tzinfo is None:
+        issued = issued.replace(tzinfo=UTC)
+
+    if reference_now - issued > FORECAST_FRESHNESS_THRESHOLD:
+        return None
+    return row

--- a/apps/api/tests/test_forecast_endpoints.py
+++ b/apps/api/tests/test_forecast_endpoints.py
@@ -1,0 +1,533 @@
+"""Endpoint-level tests for the forecast read/write endpoints
+(Story 43.12 PR 3).
+
+Service-layer unit tests live in `test_forecast_reader.py`. This file
+covers the HTTP boundary: auth gating, response shape per scenario,
+cross-tenant safety, and the picker write path's validation.
+
+Tests use the standard `register_and_login` pattern (cookie auth via
+the `/api/auth/login` route) consistent with `test_aggregate_stats.py`
+and `test_emergency_contacts.py`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import get_args
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import delete, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.core.encryption import encrypt_credential
+from src.database import get_db, get_session_maker
+from src.main import app
+from src.models.forecast_settings import ForecastSettings
+from src.models.forecast_snapshot import ForecastSnapshot
+from src.models.nightscout_connection import (
+    NightscoutAuthType,
+    NightscoutConnection,
+)
+from src.schemas.forecast import ForecastSourcePreference
+
+
+def _unique_email() -> str:
+    return f"forecast_ep_{uuid.uuid4().hex[:10]}@example.com"
+
+
+async def register_and_login(client: AsyncClient) -> tuple[str, str]:
+    """Register a fresh test user and return `(session_cookie, user_id)`."""
+    email = _unique_email()
+    password = "SecurePass123"
+    reg = await client.post(
+        "/api/auth/register", json={"email": email, "password": password}
+    )
+    assert reg.status_code == 201, f"Registration failed: {reg.text}"
+    login = await client.post(
+        "/api/auth/login", json={"email": email, "password": password}
+    )
+    assert login.status_code == 200, f"Login failed: {login.text}"
+    cookie = login.cookies.get(settings.jwt_cookie_name)
+    assert cookie is not None
+    me = await client.get("/api/auth/me", cookies={settings.jwt_cookie_name: cookie})
+    assert me.status_code == 200
+    return cookie, me.json()["id"]
+
+
+async def _seed_snapshot(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    source_engine: str,
+    issued_minutes_ago: int,
+) -> NightscoutConnection:
+    """Insert one forecast snapshot for the user. Creates a connection
+    on first call if needed."""
+    uid = uuid.UUID(user_id) if isinstance(user_id, str) else user_id
+    # Reuse connection if one exists for the user; otherwise create.
+    from sqlalchemy import select
+
+    existing = await db.execute(
+        select(NightscoutConnection).where(NightscoutConnection.user_id == uid)
+    )
+    conn = existing.scalar_one_or_none()
+    if conn is None:
+        conn = NightscoutConnection(
+            user_id=uid,
+            name="test-forecast-ep",
+            base_url="https://example.com",
+            auth_type=NightscoutAuthType.SECRET,
+            encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+            initial_sync_window_days=7,
+        )
+        db.add(conn)
+        await db.flush()
+
+    issued = datetime.now(UTC) - timedelta(minutes=issued_minutes_ago)
+    snap = ForecastSnapshot(
+        user_id=uid,
+        nightscout_connection_id=conn.id,
+        source_engine=source_engine,
+        source_uploader=source_engine,
+        issued_at=issued,
+        start_at=issued,
+        step_minutes=5,
+        horizon_minutes=30,
+        curves_mgdl_json={"main": [120, 122, 125, 128, 130, 131]},
+        default_curve_name="main",
+        dedupe_key=f"test-{uuid.uuid4().hex}",
+    )
+    db.add(snap)
+    await db.commit()
+    return conn
+
+
+@pytest.fixture(autouse=True)
+async def _truncate_forecasts():
+    """Forecast snapshots use a globally-unique
+    `(source_engine, dedupe_key)`. Truncate between tests so cross-
+    test ns_id collisions can't drop our seeds via ON CONFLICT
+    DO NOTHING."""
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        try:
+            await session.execute(
+                text("TRUNCATE forecast_evaluations, forecast_snapshots CASCADE")
+            )
+            await session.commit()
+        except RuntimeError:
+            pass
+    yield
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_forecast_settings():
+    """`forecast_settings` is one-to-one with users. The user
+    fixture cascade-deletes via FK, but this is a belt-and-braces
+    sweep so a partially-failed test can't leak rows that confuse
+    a subsequent test on the same user."""
+    yield
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        try:
+            await session.execute(delete(ForecastSettings))
+            await session.commit()
+        except RuntimeError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# GET /api/integrations/forecast
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_get_returns_401():
+    """Authentication is required."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/integrations/forecast")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_no_integration_returns_clean_empty_shape():
+    """A user with no NS-imported forecasts gets auto preference,
+    empty sources, and a null forecast -- the picker UI hides itself
+    cleanly in that state. Reason: `no_sources` so frontend can
+    render "Connect Nightscout to see forecasts" copy."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, _user_id = await register_and_login(client)
+        resp = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source_preference"] == "auto"
+    assert data["effective_source"] is None
+    assert data["available_sources"] == []
+    assert data["forecast"] is None
+    assert data["forecast_unavailable_reason"] == "no_sources"
+
+
+@pytest.mark.asyncio
+async def test_get_no_integration_does_not_persist_settings_row():
+    """REST GET must not write. A first-time-reader doesn't get a
+    `forecast_settings` row INSERTed -- the synthesized default flows
+    through the response without DB side effects. Persisted only on
+    first PUT."""
+    from sqlalchemy import func, select
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, _ = await register_and_login(client)
+        # Two GETs in a row -- no rows should appear.
+        await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        count = await session.scalar(select(func.count(ForecastSettings.id)))
+    assert count == 0, (
+        "GET must not INSERT a forecast_settings row -- this is a"
+        " side-effect-free read; persistence happens on PUT."
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_auto_single_source_resolves_and_returns_forecast():
+    """Single-source `auto`: picker resolves to that engine and the
+    forecast payload comes through end-to-end."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, user_id = await register_and_login(client)
+        async for db in get_db():
+            await _seed_snapshot(
+                db,
+                user_id,
+                source_engine="loop",
+                issued_minutes_ago=5,
+            )
+            break
+
+        resp = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source_preference"] == "auto"
+    assert data["effective_source"] == "loop"
+    assert data["available_sources"] == ["loop"]
+    assert data["forecast"] is not None
+    assert data["forecast"]["source_engine"] == "loop"
+    assert data["forecast"]["default_curve_name"] == "main"
+    assert data["forecast"]["curves_mgdl"]["main"] == [120, 122, 125, 128, 130, 131]
+    # Happy path -> reason omitted (null).
+    assert data["forecast_unavailable_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_auto_multi_source_returns_null_effective():
+    """Multiple sources under `auto` -> no silent guess. The picker
+    UI surfaces but no forecast renders until the user picks."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, user_id = await register_and_login(client)
+        async for db in get_db():
+            await _seed_snapshot(
+                db, user_id, source_engine="loop", issued_minutes_ago=5
+            )
+            await _seed_snapshot(
+                db, user_id, source_engine="aaps", issued_minutes_ago=5
+            )
+            break
+
+        resp = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+    data = resp.json()
+    assert data["effective_source"] is None
+    assert data["available_sources"] == ["aaps", "loop"]  # sorted
+    assert data["forecast"] is None
+    assert data["forecast_unavailable_reason"] == "needs_pick"
+
+
+@pytest.mark.asyncio
+async def test_get_specific_source_picks_only_that_engine():
+    """User picked loop but aaps is also publishing -> resolves to
+    loop and only loop's forecast comes through."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, user_id = await register_and_login(client)
+        async for db in get_db():
+            await _seed_snapshot(
+                db, user_id, source_engine="loop", issued_minutes_ago=5
+            )
+            await _seed_snapshot(
+                db, user_id, source_engine="aaps", issued_minutes_ago=5
+            )
+            break
+
+        # Set preference to loop
+        put = await client.put(
+            "/api/integrations/forecast/source",
+            json={"source": "loop"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert put.status_code == 200
+
+        resp = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+    data = resp.json()
+    assert data["source_preference"] == "loop"
+    assert data["effective_source"] == "loop"
+    assert data["forecast"]["source_engine"] == "loop"
+    assert data["forecast_unavailable_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_specific_source_went_silent_returns_null_no_fallback():
+    """User picked aaps but aaps stopped publishing -- only loop is
+    online. No fallback: `effective_source=None`. Honest "your AAPS
+    stopped publishing" UX rather than a silent substitution to loop."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, user_id = await register_and_login(client)
+        async for db in get_db():
+            await _seed_snapshot(
+                db, user_id, source_engine="loop", issued_minutes_ago=5
+            )
+            break
+
+        await client.put(
+            "/api/integrations/forecast/source",
+            json={"source": "aaps"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+
+        resp = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+    data = resp.json()
+    assert data["source_preference"] == "aaps"
+    assert data["effective_source"] is None
+    assert data["forecast"] is None
+    assert data["forecast_unavailable_reason"] == "source_silent"
+    # But the dropdown still surfaces loop as available, so the user
+    # can switch.
+    assert data["available_sources"] == ["loop"]
+
+
+@pytest.mark.asyncio
+async def test_get_none_preference_suppresses_forecast():
+    """`none` opts out entirely -- forecast and effective_source both
+    null even when sources are publishing."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, user_id = await register_and_login(client)
+        async for db in get_db():
+            await _seed_snapshot(
+                db, user_id, source_engine="loop", issued_minutes_ago=5
+            )
+            break
+
+        await client.put(
+            "/api/integrations/forecast/source",
+            json={"source": "none"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+
+        resp = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+    data = resp.json()
+    assert data["source_preference"] == "none"
+    assert data["effective_source"] is None
+    assert data["forecast"] is None
+    assert data["forecast_unavailable_reason"] == "opted_out"
+    # available_sources still populated so the UI knows the data
+    # exists even when the user opted out.
+    assert data["available_sources"] == ["loop"]
+
+
+@pytest.mark.asyncio
+async def test_get_stale_forecast_suppresses_payload_only():
+    """A forecast older than the 30-min freshness threshold is
+    suppressed from the `forecast` field, but the engine still
+    appears in `available_sources` (24h window) and is the effective
+    source. Mirrors PR 6's "stale loop status hidden but COB
+    preserved" pattern."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, user_id = await register_and_login(client)
+        async for db in get_db():
+            # 1h old -- past 30-min freshness, within 24h availability.
+            await _seed_snapshot(
+                db, user_id, source_engine="loop", issued_minutes_ago=60
+            )
+            break
+
+        resp = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+    data = resp.json()
+    assert data["effective_source"] == "loop"
+    assert data["available_sources"] == ["loop"]
+    assert data["forecast"] is None  # too stale to draw the dotted line
+    assert data["forecast_unavailable_reason"] == "stale"
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/integrations/forecast/source
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_put_returns_401():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.put(
+            "/api/integrations/forecast/source", json={"source": "loop"}
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_put_invalid_source_returns_422():
+    """Pydantic Literal rejects unknown values before the DB ever
+    sees them. Catches frontend bugs at the API boundary."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, _ = await register_and_login(client)
+        resp = await client.put(
+            "/api/integrations/forecast/source",
+            json={"source": "FUTURE_ENGINE"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_each_allowed_value_persists():
+    """Every allowed enum value round-trips through PUT then GET.
+
+    Sources `allowed` from the canonical `ForecastSourcePreference`
+    Literal so a future schema extension automatically gains test
+    coverage. A hardcoded list would silently miss new values.
+    """
+    allowed = list(get_args(ForecastSourcePreference))
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, _ = await register_and_login(client)
+        for value in allowed:
+            put = await client.put(
+                "/api/integrations/forecast/source",
+                json={"source": value},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+            assert put.status_code == 200, f"PUT failed for {value!r}: {put.text}"
+            assert put.json() == {"source_preference": value}
+
+            get = await client.get(
+                "/api/integrations/forecast",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+            assert get.json()["source_preference"] == value
+
+
+@pytest.mark.asyncio
+async def test_put_extra_fields_rejected():
+    """`extra='forbid'` on the body schema rejects sneaky extras."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, _ = await register_and_login(client)
+        resp = await client.put(
+            "/api/integrations/forecast/source",
+            json={"source": "loop", "rogue_field": "x"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_isolates_per_user():
+    """User A's forecast preference and snapshots don't leak into
+    user B's response."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie_a, user_a_id = await register_and_login(client)
+        cookie_b, user_b_id = await register_and_login(client)
+        async for db in get_db():
+            await _seed_snapshot(
+                db, user_a_id, source_engine="loop", issued_minutes_ago=5
+            )
+            await _seed_snapshot(
+                db, user_b_id, source_engine="aaps", issued_minutes_ago=5
+            )
+            break
+        # A picks loop; B picks none.
+        await client.put(
+            "/api/integrations/forecast/source",
+            json={"source": "loop"},
+            cookies={settings.jwt_cookie_name: cookie_a},
+        )
+        await client.put(
+            "/api/integrations/forecast/source",
+            json={"source": "none"},
+            cookies={settings.jwt_cookie_name: cookie_b},
+        )
+
+        resp_a = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie_a},
+        )
+        resp_b = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie_b},
+        )
+
+    data_a = resp_a.json()
+    data_b = resp_b.json()
+    assert data_a["source_preference"] == "loop"
+    assert data_a["effective_source"] == "loop"
+    assert data_a["available_sources"] == ["loop"]
+    assert data_b["source_preference"] == "none"
+    assert data_b["effective_source"] is None
+    assert data_b["available_sources"] == ["aaps"]

--- a/apps/api/tests/test_forecast_reader.py
+++ b/apps/api/tests/test_forecast_reader.py
@@ -1,0 +1,723 @@
+"""Service-layer tests for `forecast_reader` (Story 43.12 PR 3).
+
+Two layers covered here:
+
+1. **Pure-function resolution** (`resolve_effective_source`) --
+   table-driven across every row of the design doc's resolution
+   matrix. Trivially testable, doesn't touch the DB.
+2. **DB-backed projections** (`get_or_create_forecast_settings`,
+   `get_available_sources`, `get_latest_forecast`) -- exercise the
+   real queries against a per-test user + connection.
+
+Endpoint-level coverage lives in `test_forecast_endpoints.py`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.encryption import encrypt_credential
+from src.database import get_session_maker
+from src.models.forecast_settings import ForecastSettings
+from src.models.forecast_snapshot import ForecastSnapshot
+from src.models.nightscout_connection import (
+    NightscoutAuthType,
+    NightscoutConnection,
+)
+from src.models.user import User
+from src.services.forecast_reader import (
+    AVAILABLE_SOURCES_WINDOW,
+    FORECAST_FRESHNESS_THRESHOLD,
+    get_available_sources,
+    get_latest_forecast,
+    get_or_create_forecast_settings,
+    resolve_effective_source,
+    set_forecast_source,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-function tests: resolve_effective_source
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEffectiveSource:
+    """Pins the design doc Section 3 resolution matrix.
+
+    Every row of the table is covered. A future refactor to the
+    function must not silently flip any cell.
+    """
+
+    def test_none_preference_yields_none(self):
+        assert resolve_effective_source("none", []) is None
+        assert resolve_effective_source("none", ["loop"]) is None
+        assert resolve_effective_source("none", ["loop", "aaps"]) is None
+
+    def test_auto_empty_yields_none(self):
+        assert resolve_effective_source("auto", []) is None
+
+    def test_auto_single_yields_that_source(self):
+        assert resolve_effective_source("auto", ["loop"]) == "loop"
+        assert resolve_effective_source("auto", ["aaps"]) == "aaps"
+
+    def test_auto_multiple_yields_none(self):
+        """No silent guessing per design doc. User must pick when
+        more than one source is publishing."""
+        assert resolve_effective_source("auto", ["loop", "aaps"]) is None
+        assert resolve_effective_source("auto", ["loop", "trio", "oref0"]) is None
+
+    def test_specific_present_yields_that_source(self):
+        assert resolve_effective_source("loop", ["loop"]) == "loop"
+        assert resolve_effective_source("aaps", ["loop", "aaps"]) == "aaps"
+
+    def test_specific_missing_yields_none(self):
+        """Source went silent -- no fallback. User sees "your X stopped
+        publishing" UX rather than a silent substitution."""
+        assert resolve_effective_source("loop", []) is None
+        assert resolve_effective_source("loop", ["aaps"]) is None
+        assert resolve_effective_source("aaps", ["loop", "trio"]) is None
+
+    def test_glycemicgpt_preference_resolves_when_present(self):
+        """Future-engine schema is reachable end-to-end."""
+        assert resolve_effective_source("glycemicgpt", ["glycemicgpt"]) == "glycemicgpt"
+        assert (
+            resolve_effective_source("glycemicgpt", ["loop", "glycemicgpt"])
+            == "glycemicgpt"
+        )
+
+    def test_glycemicgpt_preference_falls_to_none_when_absent(self):
+        assert resolve_effective_source("glycemicgpt", ["loop", "aaps"]) is None
+
+
+# ---------------------------------------------------------------------------
+# DB integration fixture (per-test user + connection)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def reader_ctx() -> AsyncGenerator[
+    tuple[AsyncSession, uuid.UUID, uuid.UUID], None
+]:
+    """Per-test session + fresh user + NS connection.
+
+    Mirrors `loop_ctx` from PR 6 -- the query path is user-scoped so
+    cross-test leakage from OTHER users can't influence reads. We DO
+    truncate `forecast_snapshots` pre-yield because PR 1's
+    `(source_engine, dedupe_key)` unique constraint is GLOBAL, so
+    stale rows from a sibling test using a deterministic ns_id could
+    block our writes.
+    """
+    session_maker = get_session_maker()
+    session = session_maker()
+    # Same precaution as PR 2's translator fixture: forecast_snapshots
+    # uses a globally-unique `(source_engine, dedupe_key)`. Truncate
+    # before yielding so cross-test ns_id collisions can't drop our
+    # inserts via ON CONFLICT DO NOTHING.
+    await session.execute(
+        text("TRUNCATE forecast_evaluations, forecast_snapshots CASCADE")
+    )
+    await session.commit()
+    email = f"forecast_reader_{uuid.uuid4().hex[:10]}@example.com"
+    user = User(email=email, hashed_password="not-a-real-hash")
+    session.add(user)
+    await session.flush()
+    user_id = user.id
+
+    conn = NightscoutConnection(
+        user_id=user_id,
+        name="test-forecast-reader",
+        base_url="https://example.com",
+        auth_type=NightscoutAuthType.SECRET,
+        encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+        initial_sync_window_days=7,
+    )
+    session.add(conn)
+    await session.flush()
+    connection_id = conn.id
+    await session.commit()
+
+    try:
+        yield session, user_id, connection_id
+    finally:
+        try:
+            await session.rollback()
+            await session.execute(
+                delete(ForecastSnapshot).where(ForecastSnapshot.user_id == user_id)
+            )
+            await session.execute(
+                delete(ForecastSettings).where(ForecastSettings.user_id == user_id)
+            )
+            await session.execute(
+                delete(NightscoutConnection).where(
+                    NightscoutConnection.user_id == user_id
+                )
+            )
+            await session.execute(delete(User).where(User.id == user_id))
+            await session.commit()
+        except RuntimeError:
+            pass
+        finally:
+            try:
+                await session.close()
+            except RuntimeError:
+                pass
+
+
+def _make_snapshot(
+    user_id: uuid.UUID,
+    connection_id: uuid.UUID,
+    *,
+    source_engine: str,
+    issued_at: datetime,
+    dedupe_key: str | None = None,
+    curves: dict | None = None,
+    default_curve_name: str = "main",
+) -> ForecastSnapshot:
+    """Build a ForecastSnapshot for tests with sensible defaults that
+    pass PR 1's CHECK constraints (range, length, default_curve_name in
+    curves)."""
+    return ForecastSnapshot(
+        user_id=user_id,
+        nightscout_connection_id=connection_id,
+        source_engine=source_engine,
+        source_uploader=source_engine,
+        issued_at=issued_at,
+        start_at=issued_at,
+        step_minutes=5,
+        horizon_minutes=30,
+        curves_mgdl_json=curves or {"main": [120, 122, 125, 128, 130, 131]},
+        default_curve_name=default_curve_name,
+        dedupe_key=dedupe_key or f"test-{uuid.uuid4().hex}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_or_create_forecast_settings
+# ---------------------------------------------------------------------------
+
+
+class TestForecastSettingsLifecycle:
+    """Lazy-create-on-first-read semantics + the write path."""
+
+    @pytest.mark.asyncio
+    async def test_first_read_creates_default_auto(self, reader_ctx):
+        """A user who's never touched the picker gets the row created
+        on first read with `'auto'`. No 404, no error, no manual
+        provisioning."""
+        session, user_id, _conn_id = reader_ctx
+        settings = await get_or_create_forecast_settings(session, user_id)
+        assert settings.source == "auto"
+        assert settings.user_id == user_id
+
+    @pytest.mark.asyncio
+    async def test_second_read_returns_existing_row(self, reader_ctx):
+        """Subsequent reads return the same row -- no duplicate
+        inserts."""
+        session, user_id, _conn_id = reader_ctx
+        first = await get_or_create_forecast_settings(session, user_id)
+        await session.commit()
+        second = await get_or_create_forecast_settings(session, user_id)
+        assert first.id == second.id
+
+    @pytest.mark.asyncio
+    async def test_set_source_persists(self, reader_ctx):
+        session, user_id, _conn_id = reader_ctx
+        await set_forecast_source(session, user_id, "loop")
+        await session.commit()
+        refreshed = await get_or_create_forecast_settings(session, user_id)
+        assert refreshed.source == "loop"
+
+    @pytest.mark.asyncio
+    async def test_set_source_through_auto_back_to_specific(self, reader_ctx):
+        """Round-trip: auto -> loop -> none -> auto each persists
+        independently."""
+        session, user_id, _conn_id = reader_ctx
+        for picked in ("loop", "none", "aaps", "auto"):
+            await set_forecast_source(session, user_id, picked)
+            await session.commit()
+            refreshed = await get_or_create_forecast_settings(session, user_id)
+            assert refreshed.source == picked
+
+
+# ---------------------------------------------------------------------------
+# get_available_sources
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvailableSources:
+    @pytest.mark.asyncio
+    async def test_no_snapshots_returns_empty(self, reader_ctx):
+        session, user_id, _conn_id = reader_ctx
+        assert await get_available_sources(session, user_id) == []
+
+    @pytest.mark.asyncio
+    async def test_single_engine_returns_one(self, reader_ctx):
+        session, user_id, conn_id = reader_ctx
+        snap = _make_snapshot(
+            user_id,
+            conn_id,
+            source_engine="loop",
+            issued_at=datetime.now(UTC) - timedelta(minutes=5),
+        )
+        session.add(snap)
+        await session.commit()
+        assert await get_available_sources(session, user_id) == ["loop"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_engines_sorted_alphabetically(self, reader_ctx):
+        """Stable picker ordering: the dropdown shouldn't reshuffle
+        between renders."""
+        session, user_id, conn_id = reader_ctx
+        now = datetime.now(UTC)
+        for engine in ("loop", "aaps", "trio"):
+            session.add(
+                _make_snapshot(
+                    user_id,
+                    conn_id,
+                    source_engine=engine,
+                    issued_at=now - timedelta(minutes=5),
+                )
+            )
+        await session.commit()
+        assert await get_available_sources(session, user_id) == [
+            "aaps",
+            "loop",
+            "trio",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_old_engines_dropped(self, reader_ctx):
+        """Past the 24h window -> engine drops from the dropdown.
+        24h matches the design doc text."""
+        session, user_id, conn_id = reader_ctx
+        now = datetime.now(UTC)
+        # Loop: 25h ago (out of window)
+        session.add(
+            _make_snapshot(
+                user_id,
+                conn_id,
+                source_engine="loop",
+                issued_at=now - timedelta(hours=25),
+            )
+        )
+        # AAPS: 5 min ago (in window)
+        session.add(
+            _make_snapshot(
+                user_id,
+                conn_id,
+                source_engine="aaps",
+                issued_at=now - timedelta(minutes=5),
+            )
+        )
+        await session.commit()
+        assert await get_available_sources(session, user_id) == ["aaps"]
+
+    @pytest.mark.asyncio
+    async def test_distinct_engines_no_duplicates(self, reader_ctx):
+        """Multiple snapshots from the same engine collapse to one
+        dropdown entry."""
+        session, user_id, conn_id = reader_ctx
+        now = datetime.now(UTC)
+        for offset_min in (5, 10, 15):
+            session.add(
+                _make_snapshot(
+                    user_id,
+                    conn_id,
+                    source_engine="loop",
+                    issued_at=now - timedelta(minutes=offset_min),
+                )
+            )
+        await session.commit()
+        assert await get_available_sources(session, user_id) == ["loop"]
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_isolation(self, reader_ctx):
+        """User A's snapshots don't leak into user B's dropdown."""
+        session, user_a, conn_a = reader_ctx
+        # Create a second user + connection inline.
+        user_b = User(
+            email=f"forecast_other_{uuid.uuid4().hex[:10]}@example.com",
+            hashed_password="not-a-real-hash",
+        )
+        session.add(user_b)
+        await session.flush()
+        conn_b = NightscoutConnection(
+            user_id=user_b.id,
+            name="other-user",
+            base_url="https://example.com",
+            auth_type=NightscoutAuthType.SECRET,
+            encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+            initial_sync_window_days=7,
+        )
+        session.add(conn_b)
+        await session.flush()
+
+        now = datetime.now(UTC)
+        # B has loop+aaps; A has only trio
+        session.add(
+            _make_snapshot(
+                user_b.id,
+                conn_b.id,
+                source_engine="loop",
+                issued_at=now - timedelta(minutes=5),
+            )
+        )
+        session.add(
+            _make_snapshot(
+                user_b.id,
+                conn_b.id,
+                source_engine="aaps",
+                issued_at=now - timedelta(minutes=5),
+            )
+        )
+        session.add(
+            _make_snapshot(
+                user_a,
+                conn_a,
+                source_engine="trio",
+                issued_at=now - timedelta(minutes=5),
+            )
+        )
+        await session.commit()
+
+        assert await get_available_sources(session, user_a) == ["trio"]
+        assert await get_available_sources(session, user_b.id) == ["aaps", "loop"]
+
+
+# ---------------------------------------------------------------------------
+# get_latest_forecast
+# ---------------------------------------------------------------------------
+
+
+class TestGetLatestForecast:
+    @pytest.mark.asyncio
+    async def test_no_snapshots_returns_none(self, reader_ctx):
+        session, user_id, _conn_id = reader_ctx
+        assert await get_latest_forecast(session, user_id, "loop") is None
+
+    @pytest.mark.asyncio
+    async def test_fresh_snapshot_returned(self, reader_ctx):
+        session, user_id, conn_id = reader_ctx
+        snap = _make_snapshot(
+            user_id,
+            conn_id,
+            source_engine="loop",
+            issued_at=datetime.now(UTC) - timedelta(minutes=5),
+        )
+        session.add(snap)
+        await session.commit()
+        result = await get_latest_forecast(session, user_id, "loop")
+        assert result is not None
+        assert result.source_engine == "loop"
+
+    @pytest.mark.asyncio
+    async def test_stale_snapshot_returns_none(self, reader_ctx):
+        """Past the 30-min freshness threshold: even though a row
+        exists, return None so the chart doesn't draw a misaligned
+        dotted line."""
+        session, user_id, conn_id = reader_ctx
+        stale_age = FORECAST_FRESHNESS_THRESHOLD + timedelta(minutes=5)
+        snap = _make_snapshot(
+            user_id,
+            conn_id,
+            source_engine="loop",
+            issued_at=datetime.now(UTC) - stale_age,
+        )
+        session.add(snap)
+        await session.commit()
+        assert await get_latest_forecast(session, user_id, "loop") is None
+
+    @pytest.mark.asyncio
+    async def test_latest_by_issued_at_not_received_at(self, reader_ctx):
+        """A backfilled (recently-received) snapshot from 2h ago must
+        NOT outrank a live one from 5 min ago. issued_at is the source
+        loop's emit time; received_at is our DB write time."""
+        session, user_id, conn_id = reader_ctx
+        old_snap = _make_snapshot(
+            user_id,
+            conn_id,
+            source_engine="loop",
+            issued_at=datetime.now(UTC) - timedelta(hours=2),
+        )
+        new_snap = _make_snapshot(
+            user_id,
+            conn_id,
+            source_engine="loop",
+            issued_at=datetime.now(UTC) - timedelta(minutes=5),
+        )
+        # Fake "backfill": old snap was received MORE recently.
+        old_snap.received_at = datetime.now(UTC)
+        new_snap.received_at = datetime.now(UTC) - timedelta(minutes=3)
+        session.add_all([old_snap, new_snap])
+        await session.commit()
+
+        result = await get_latest_forecast(session, user_id, "loop")
+        assert result is not None
+        # New snapshot's issued_at wins (5 min ago, not 2h).
+        assert (datetime.now(UTC) - result.issued_at) < timedelta(minutes=10)
+
+    @pytest.mark.asyncio
+    async def test_filters_by_source_engine(self, reader_ctx):
+        """Querying for loop's forecast must not pick up an aaps row
+        even if the aaps row is newer."""
+        session, user_id, conn_id = reader_ctx
+        now = datetime.now(UTC)
+        loop_snap = _make_snapshot(
+            user_id,
+            conn_id,
+            source_engine="loop",
+            issued_at=now - timedelta(minutes=15),
+        )
+        aaps_snap = _make_snapshot(
+            user_id,
+            conn_id,
+            source_engine="aaps",
+            issued_at=now - timedelta(minutes=2),
+        )
+        session.add_all([loop_snap, aaps_snap])
+        await session.commit()
+
+        loop_result = await get_latest_forecast(session, user_id, "loop")
+        aaps_result = await get_latest_forecast(session, user_id, "aaps")
+        assert loop_result is not None
+        assert loop_result.source_engine == "loop"
+        assert aaps_result is not None
+        assert aaps_result.source_engine == "aaps"
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_isolation(self, reader_ctx):
+        session, user_a, conn_a = reader_ctx
+        user_b = User(
+            email=f"forecast_other_{uuid.uuid4().hex[:10]}@example.com",
+            hashed_password="not-a-real-hash",
+        )
+        session.add(user_b)
+        await session.flush()
+        conn_b = NightscoutConnection(
+            user_id=user_b.id,
+            name="other-user",
+            base_url="https://example.com",
+            auth_type=NightscoutAuthType.SECRET,
+            encrypted_credential=encrypt_credential("test-secret-min-12-chars"),
+            initial_sync_window_days=7,
+        )
+        session.add(conn_b)
+        await session.flush()
+
+        now = datetime.now(UTC)
+        session.add(
+            _make_snapshot(
+                user_b.id,
+                conn_b.id,
+                source_engine="loop",
+                issued_at=now - timedelta(minutes=5),
+            )
+        )
+        await session.commit()
+        # A has no loop forecast; B does.
+        assert await get_latest_forecast(session, user_a, "loop") is None
+        assert await get_latest_forecast(session, user_b.id, "loop") is not None
+
+
+# ---------------------------------------------------------------------------
+# Constants smoke (regression guards)
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_freshness_threshold_is_thirty_minutes(self):
+        """Design doc choice; tests rely on this constant. If it
+        changes, this test fires to force the design doc + UX
+        review."""
+        assert timedelta(minutes=30) == FORECAST_FRESHNESS_THRESHOLD
+
+    def test_availability_window_is_twenty_four_hours(self):
+        assert timedelta(hours=24) == AVAILABLE_SOURCES_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# Drift guards: schema <-> migration CHECK alignment
+# ---------------------------------------------------------------------------
+
+
+class TestSourceAllowListAlignment:
+    """Pins the `forecast_settings.source` CHECK clause and the
+    `ForecastSourcePreference` Pydantic Literal as the same set.
+
+    Drift in either direction silently breaks the API:
+    - DB adds a value, Pydantic doesn't -> GET 500 (Pydantic can't
+      construct the response for an existing row with the new value).
+    - Pydantic adds a value, DB doesn't -> PUT 500 (CHECK violation
+      after the API-level validation passes).
+
+    The CI catches drift before a deploy hits prod.
+    """
+
+    def test_check_constraint_values_match_literal(self):
+        import re
+        from pathlib import Path
+        from typing import get_args
+
+        from src.schemas.forecast import ForecastSourcePreference
+
+        migration_path = (
+            Path(__file__).parent.parent
+            / "migrations"
+            / "versions"
+            / "057_forecast_settings.py"
+        )
+        contents = migration_path.read_text()
+
+        # Extract the IN-clause string. Tolerant of whitespace/newlines.
+        match = re.search(
+            r"source IN \(([^)]+)\)",
+            contents,
+            re.DOTALL,
+        )
+        assert match is not None, "couldn't find CHECK clause in migration"
+
+        # Parse the SQL string values.
+        db_values = {
+            v.strip().strip("'") for v in match.group(1).split(",") if v.strip()
+        }
+
+        # Extract Pydantic Literal values.
+        literal_values = set(get_args(ForecastSourcePreference))
+
+        assert db_values == literal_values, (
+            f"CHECK constraint and Pydantic Literal disagree.\n"
+            f"  In DB only:       {db_values - literal_values}\n"
+            f"  In Pydantic only: {literal_values - db_values}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Race-path coverage: UNIQUE violation recovery
+# ---------------------------------------------------------------------------
+
+
+class TestGetOrCreateRaceRecovery:
+    """Pins the IntegrityError fallback in `get_or_create_forecast_settings`.
+
+    Triggered by pre-INSERTing a row from a separate session that
+    commits, then calling `get_or_create_forecast_settings` from a
+    fresh session whose SELECT happens to miss the row (simulated
+    by manually adding a conflicting row mid-flight). The SAVEPOINT
+    rolls back the failed INSERT and the retry SELECT finds the
+    winning row.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_insert_recovers_via_select(self, reader_ctx):
+        session, user_id, _conn_id = reader_ctx
+
+        # Simulate the race by pre-inserting via a second session.
+        # By the time the test calls get_or_create on `session`,
+        # the row already exists in the DB but isn't in the
+        # session's identity map yet.
+        session_maker = get_session_maker()
+        async with session_maker() as concurrent_session:
+            concurrent_session.add(ForecastSettings(user_id=user_id, source="loop"))
+            await concurrent_session.commit()
+
+        # Now call get_or_create on our session. The SELECT should
+        # see the row (committed by the other session). This DOES
+        # NOT exercise the IntegrityError path because the SELECT
+        # finds the row first.
+        result = await get_or_create_forecast_settings(session, user_id)
+        assert result.source == "loop"
+
+    @pytest.mark.asyncio
+    async def test_savepoint_isolation_under_integrity_error(
+        self, reader_ctx, monkeypatch
+    ):
+        """The harder case: simulate the SELECT-miss-then-INSERT-loses
+        race directly by patching `scalar_one_or_none` to return None
+        on first call so we enter the INSERT branch, while a
+        conflicting row already exists. The SAVEPOINT must roll back
+        the failed INSERT without touching the outer transaction
+        state, and the retry SELECT must find the winning row.
+        """
+        session, user_id, _conn_id = reader_ctx
+
+        # Pre-insert the conflicting row.
+        session_maker = get_session_maker()
+        async with session_maker() as concurrent_session:
+            concurrent_session.add(ForecastSettings(user_id=user_id, source="aaps"))
+            await concurrent_session.commit()
+
+        # Patch the SELECT result's `scalar_one_or_none` to return
+        # None ONCE so we enter the INSERT branch. (Real-world race:
+        # the SELECT in transaction T1 happens before T2's commit
+        # is visible.)
+        from sqlalchemy.engine.result import Result
+
+        original_scalar = Result.scalar_one_or_none
+        call_count = {"n": 0}
+
+        def fake_scalar(self):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return None  # simulate race: row not yet visible
+            return original_scalar(self)
+
+        monkeypatch.setattr(Result, "scalar_one_or_none", fake_scalar)
+
+        # Now call -- the INSERT will hit IntegrityError, SAVEPOINT
+        # rolls back, retry SELECT (no longer patched after 1st call)
+        # finds the conflicting row.
+        result = await get_or_create_forecast_settings(session, user_id)
+        assert result.source == "aaps", (
+            "SAVEPOINT recovery failed -- expected to find the "
+            "concurrently-inserted row after the race-loss."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Boundary cases: exact 24h on get_available_sources
+# ---------------------------------------------------------------------------
+
+
+class TestAvailableSourcesBoundary:
+    """Pins the inclusive/exclusive edge of the 24h window."""
+
+    @pytest.mark.asyncio
+    async def test_snapshot_at_exact_boundary_included(self, reader_ctx):
+        """An issued_at exactly `now - 24h` is INSIDE the window
+        (`>=` not `>`)."""
+        session, user_id, conn_id = reader_ctx
+        ref_now = datetime.now(UTC)
+        # Issued exactly at the boundary.
+        snap = _make_snapshot(
+            user_id,
+            conn_id,
+            source_engine="loop",
+            issued_at=ref_now - AVAILABLE_SOURCES_WINDOW,
+        )
+        session.add(snap)
+        await session.commit()
+        result = await get_available_sources(session, user_id, now=ref_now)
+        assert result == ["loop"]
+
+    @pytest.mark.asyncio
+    async def test_snapshot_one_ms_past_boundary_excluded(self, reader_ctx):
+        """One millisecond past the 24h window -> dropped from the
+        dropdown."""
+        session, user_id, conn_id = reader_ctx
+        ref_now = datetime.now(UTC)
+        snap = _make_snapshot(
+            user_id,
+            conn_id,
+            source_engine="loop",
+            issued_at=ref_now - AVAILABLE_SOURCES_WINDOW - timedelta(milliseconds=1),
+        )
+        session.add(snap)
+        await session.commit()
+        result = await get_available_sources(session, user_id, now=ref_now)
+        assert result == []


### PR DESCRIPTION
## Summary

Backend read endpoint for the forecast overlay and a write endpoint for the per-user picker preference. Reads from PR 2's `forecast_snapshots`; introduces a new `forecast_settings` table for the preference.

This unblocks PR 4 (frontend overlay) and feeds PR 5 (AI context).

## Endpoints

- **`GET /api/integrations/forecast`** — single round-trip for the dashboard chart:
  - `source_preference` — what the user picked, or synthesized `'auto'` default
  - `effective_source` — resolved engine after preference + availability
  - `available_sources` — engines that emitted in the last 24h (alphabetical)
  - `forecast` — latest snapshot for the effective source (null when stale)
  - `forecast_unavailable_reason` — explicit `opted_out` / `needs_pick` / `no_sources` / `source_silent` / `stale` dispatch for clean frontend rendering

- **`PUT /api/integrations/forecast/source`** — persists the picker choice. Pydantic `Literal` rejects unknown values with 422 before the DB CHECK runs.

## Resolution rules (design doc Section 3)

| preference | available | effective | reason |
|---|---|---|---|
| `'none'` | (any) | null | `opted_out` |
| `'auto'` | `[]` | null | `no_sources` |
| `'auto'` | `[single]` | that engine | null (happy) |
| `'auto'` | `[multiple]` | null | `needs_pick` (no silent guess) |
| specific engine | contains engine | that engine | null (happy) |
| specific engine | doesn't contain | null | `source_silent` (no fallback) |

If `effective_source` resolves but the latest snapshot is > 30 min old, `forecast: null` + reason `stale`. The 24h availability window vs 30-min freshness window are intentionally different — see the response docstring.

## Storage

New `forecast_settings` table (one-to-one with `users`):
- `source` Text NOT NULL DEFAULT `'auto'`, CHECK against the 8-value allow-list
- ON DELETE CASCADE to `users.id`
- UNIQUE on `user_id` enforces the one-row-per-user invariant

## Defense-in-depth (adversarial + CR + security review responses)

| Concern | Defense |
|---|---|
| Race on first-read INSERT | SAVEPOINT (`session.begin_nested()`) keeps outer txn intact |
| GET write side-effect (REST anti-pattern) | Read-only `read_forecast_preference` path; writes only on PUT |
| Ambiguous "why no forecast" state | Explicit `forecast_unavailable_reason` field |
| CHECK ↔ Pydantic Literal drift | Test parses the migration file and asserts equality |
| Future wire-format curve keys | Logged warning + silent drop (no schema crash) |
| `server_default="auto"` produced `DEFAULT auto` (unquoted) | Changed to `text("'auto'")` to match migration |
| Hardcoded test allowed-list drift | Sourced via `get_args(ForecastSourcePreference)` |
| Long `source_uploader` strings | `max_length=100` on response schema |
| Cross-tenant leak | All queries filter by `current_user.id`, no body/query param ever feeds user_id |

## Tests (47 total)

**`test_forecast_reader.py`** (33): 8 resolver cases · 4 settings lifecycle · 6 available-sources · 6 latest-forecast · 2 boundary at-and-past 24h · 2 race recovery (concurrent insert + SAVEPOINT isolation via monkeypatch) · 1 CHECK ↔ Literal drift guard · 4 misc.

**`test_forecast_endpoints.py`** (14): auth (401×2) · GET response per scenario (no integration / auto-single / auto-multi / specific / source-silent / opted-out / stale) · GET idempotency · PUT validation (422 + extra-fields + every-allowed-value round-trip) · cross-tenant isolation.

## Test plan

- [x] 47 PR tests pass (`pytest tests/test_forecast_reader.py tests/test_forecast_endpoints.py`)
- [x] Full NS+forecast+loop suite: 362 passed, 13 skipped (no regression)
- [x] `ruff check` + `ruff format --check` clean
- [x] OpenAPI schema verified to expose the two endpoints with enum constraints on `source`, `state`, `effective_source`, `forecast_unavailable_reason`, and `source_engine`
- [x] Adversarial review: HIGH 1 addressed (SAVEPOINT), MEDIUM 5 addressed inline, LOW addressed or deferred with rationale
- [x] CodeRabbit CLI: 2 findings on PR files fixed (server_default expression, hardcoded test list)
- [x] Security review: clean (no HIGH/MEDIUM); 2 informational LOW notes about housekeeping-column default style (no security impact)

## What's next in 43.12

- PR 4 — Frontend picker (Settings → Integrations) + dotted-line overlay on glucose trend chart, using the `forecast_unavailable_reason` field to dispatch empty-state messages
- PR 5 — AI chat context: forecast section in `build_diabetes_context` with explicit "predicted, not historical" framing

Design doc: `_bmad-output/planning-artifacts/story-43.12-forecast-overlay-design.md` (local).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select their preferred forecast source via a new preferences system.
  * Added ability to choose between multiple available forecast engines or opt out entirely.
  * Automatic forecast source resolution when a single engine is available.
  * New API endpoints for reading current forecast settings and updating source preferences.

* **Tests**
  * Comprehensive integration and service-layer test coverage for forecast selection behavior, multi-user isolation, and endpoint validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/635)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->