### PR TITLE
Pin requests-oidc floor to >=0.6.0 to block silent downgrade

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -20,6 +20,12 @@ dependencies = [
     "pydexcom>=0.2.0",
     "apscheduler>=3.10.0",
     "tconnectsync>=2.3.0",
+    # tconnectsync.api.tandemsource imports requests_oidc.make_auth_code_session,
+    # which only exists in requests-oidc>=0.5.0. Renovate's lock-file maintenance
+    # has been silently downgrading to 0.4.x and breaking the build; this floor
+    # blocks the regression. (Bumped to >=0.6.0 to match what we already have
+    # installed and tested against.)
+    "requests-oidc>=0.6.0",
     "anthropic>=0.40.0",
     "openai>=1.50.0",
     "setuptools>=69.0.0,<82",  # tconnectsync needs pkg_resources, removed in setuptools 82

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "glycemicgpt-api"
-version = "0.5.0"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -660,6 +660,7 @@ dependencies = [
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "redis" },
+    { name = "requests-oidc" },
     { name = "setuptools" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -701,6 +702,7 @@ requires-dist = [
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "redis", specifier = ">=5.0.0" },
+    { name = "requests-oidc", specifier = ">=0.6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "setuptools", specifier = ">=69.0.0,<82" },
     { name = "slowapi", specifier = ">=0.1.9" },


### PR DESCRIPTION
## Summary

`tconnectsync.api.tandemsource` does `from requests_oidc import make_auth_code_session`. That symbol was added in `requests-oidc` 0.5.0; versions 0.4.x only export `make_device_code_session`.

`requests-oidc` was previously unpinned in `apps/api/pyproject.toml`, so the Renovate \"lock file maintenance\" PR ([#557](https://github.com/GlycemicGPT/GlycemicGPT/pull/557)) was silently resolving down to 0.4.2 every refresh, which broke the API at import time:

```
ImportError: cannot import name 'make_auth_code_session' from 'requests_oidc'.
Did you mean: 'make_device_code_session'?
```

This >=0.6.0 floor matches the version we already have installed and tested against. The lock file regenerates cleanly with `requests-oidc==0.6.2` (no change vs current develop).

## Why it matters

`#557` carries all the routine transitive bumps Renovate has collected and gets retried on every commit to develop. Until this floor lands, every refresh of `#557` re-downgrades `requests-oidc` and re-breaks the build. Pinning the floor unblocks `#557` so the rest of those bumps can land normally.

## Test plan

- [x] `uv lock` regenerates without surprises (still resolves to 0.6.2)
- [x] `uv run python -c \"from tconnectsync.api.tandemsource import TandemSourceApi\"` imports cleanly
- [x] `uv run ruff check` + `uv run ruff format --check` pass
- [ ] CI green
- [ ] After merge: confirm `#557` recomputes and no longer breaks the build