### PR TITLE
fix(ci): verify-release-tags case-sensitivity + dev-prerelease + JS pull URLs

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -249,7 +249,15 @@ jobs:
     name: Verify Release Tags Published
     runs-on: ubuntu-latest
     needs: [build-api, build-web, build-sidecar]
-    if: github.event_name == 'release'
+    # Only fire on the production release-please releases (semver-tagged,
+    # not pre-release). The Dev Pre-Release workflow publishes a
+    # `dev-latest` release whose container-build run also matches
+    # github.event_name == 'release', but its images only carry sha-XXXX
+    # tags (not semver), so verifying expected version tags on it would
+    # always falsely fail.
+    if: |
+      github.event_name == 'release' &&
+      github.event.release.prerelease == false
     timeout-minutes: 5
     concurrency:
       group: verify-release-tags-${{ github.event.release.tag_name }}
@@ -266,10 +274,29 @@ jobs:
       - name: Inspect each image for expected tags + digest consistency
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/glycemicgpt
+          # Case-preserved (e.g. "GlycemicGPT"). We MUST lowercase it
+          # before constructing image references -- OCI registry refs are
+          # case-sensitive and ghcr stores everything lowercase. See the
+          # comment around IMAGE_PREFIX construction below.
+          REPO_OWNER_RAW: ${{ github.repository_owner }}
         run: |
           set -uo pipefail
-          VERSION="${RELEASE_TAG#v}"                  # strip leading "v" -> 0.8.0
+
+          REPO_OWNER_LC="${REPO_OWNER_RAW,,}"          # bash 4+ Unicode-aware lowercase
+          IMAGE_PREFIX="ghcr.io/${REPO_OWNER_LC}/glycemicgpt"
+          VERSION="${RELEASE_TAG#v}"                   # strip leading "v" -> 0.8.0
+
+          # Gate: only verify semver-tagged production releases. Manual
+          # releases (e.g., "feature-release-2026Q3") and any other
+          # non-semver tags don't get the type=semver tags from
+          # metadata-action, so verifying them here would always falsely
+          # fail. The prerelease gate at the job level already excludes
+          # the dev-pre-release workflow's pre-release; this additional
+          # regex check catches future non-semver production releases.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::notice::Release tag '${RELEASE_TAG}' is not semver-conformant; skipping version-tag verification. metadata-action only emits version tags for semver releases."
+            exit 0
+          fi
 
           # Tag responsibility split between the two trigger events that
           # fire for every release commit. This run (release event) is
@@ -357,7 +384,12 @@ jobs:
         with:
           script: |
             const version = '${{ github.event.release.tag_name }}'.replace('v', '');
-            const imagePrefix = 'ghcr.io/${{ github.repository_owner }}/glycemicgpt';
+            // github.repository_owner is case-preserved (e.g. "GlycemicGPT"),
+            // but OCI registry references MUST be lowercase. Without
+            // .toLowerCase(), the release notes ship pull commands like
+            // `docker pull ghcr.io/GlycemicGPT/...` that fail with
+            // "invalid reference format". This is what shipped on v0.7.2.
+            const imagePrefix = 'ghcr.io/${{ github.repository_owner }}/glycemicgpt'.toLowerCase();
 
             const containerSection = `
 


### PR DESCRIPTION
## Why

Three bugs in PR #654's release-time tag verification that surfaced when v0.8.1 was released.

The good news: **the v0.8.1 release itself is healthy.** All three images built successfully (font fix worked!) and were pushed to ghcr.io with the right tags. Users can \`docker pull ghcr.io/glycemicgpt/glycemicgpt-{api,web,sidecar}:0.8.1\` and it works.

The bad news: my new verify-release-tags job reported FAILURE on the v0.8.1 release-event run for two reasons, AND I discovered a separate same-class bug in the JS that writes release notes. All three are now fixed.

## The three bugs

### 1. Case-sensitivity (root cause of v0.8.1 false failure)

\`\${{ github.repository_owner }}\` returns case-preserved (\"GlycemicGPT\"). OCI registry refs MUST be lowercase. Empirical reproduction:

\`\`\`
$ docker buildx imagetools inspect ghcr.io/GlycemicGPT/glycemicgpt-web:0.8.1
ERROR: invalid reference format: repository name (...) must be lowercase
\`\`\`

Every verify-release-tags lookup was failing with \"tag missing after 5 retries\" — a false positive. The actual tags exist at lowercase paths.

**Fix:** rename env var to \`REPO_OWNER_RAW\` (reflects what GHA gives us), then lowercase to a separate \`REPO_OWNER_LC\` shell local before constructing \`IMAGE_PREFIX\`.

### 2. Dev pre-release also triggers verify (was structurally impossible to pass)

\`if: github.event_name == 'release'\` matched both production release-please releases AND the Dev Pre-Release workflow's \`dev-latest\` pre-release. Dev pre-release images only carry \`sha-XXXX\` tags (not semver), so verifying version tags on them always falsely fails.

**Fix:** add \`&& github.event.release.prerelease == false\` to the job-level \`if:\`.

### 3. JS in Update Release Notes also missing toLowerCase (broader impact)

Same case-sensitivity pattern in \`Update Release Notes\` (line 374). The container-images section of every release notes body was being constructed with mixed-case URLs. Verified on v0.7.2:

\`\`\`
| \`ghcr.io/GlycemicGPT/glycemicgpt-api\` | \`0.7.2\`, \`latest\` |
docker pull ghcr.io/GlycemicGPT/glycemicgpt-api:0.7.2
\`\`\`

That literal command fails with \"invalid reference format\" because the registry path is mixed case. Users who copy-pasted from release notes got errors.

**Fix:** \`.toLowerCase()\` on the constructed prefix in the JS.

## Bonus: defense against future non-semver production releases

If someone manually creates a release with a non-semver tag (e.g., \`feature-release-2026Q3\`, \`lts-1.0\`), \`docker/metadata-action\` won't emit type=semver tags for it, and the verify job would falsely fail. Added a regex gate \`^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$\` on the post-v-stripped version that skips verification with a clear \`::notice::\` for non-semver releases.

## Verification

End-to-end simulation against the real v0.8.1 images (already in production):

\`\`\`
IMAGE_PREFIX=ghcr.io/glycemicgpt/glycemicgpt
EXPECTED_TAGS=(0.8.1 0.8)

=== ghcr.io/glycemicgpt/glycemicgpt-api ===
  OK   0.8.1 -> sha256:9882ab9...
  OK   0.8   -> sha256:9882ab9...
=== ghcr.io/glycemicgpt/glycemicgpt-web ===
  OK   0.8.1 -> sha256:1af568f...
  OK   0.8   -> sha256:1af568f...
=== ghcr.io/glycemicgpt/glycemicgpt-sidecar ===
  OK   0.8.1 -> sha256:cd72ce1...
  OK   0.8   -> sha256:cd72ce1...

RESULT: ✅ verify-release-tags would PASS for v0.8.1
\`\`\`

Semver regex tested against valid and invalid inputs:
- Matches: \`0.8.1\`, \`0.8.0\`, \`1.0.0-rc.1\`, \`0.8.1-dev.91\`
- Skips: \`feature-release\`, \`lts-1.0\`, empty string

Adversarial review surfaced 0 HIGH, 3 MEDIUM, 7 LOW. All 3 MEDIUM addressed (wider audit found the JS line 374 bug; non-semver gate added; variable renamed). Reasonable LOW addressed.

## Out of scope (deferred)

- The mixed-case URLs in the already-published v0.7.2 release notes could be patched via \`gh release edit\`. The affected text is documentation only; the actual images in the registry are correct. Manual touchup if/when noticed.
- A separate push-event-gated verification job for the \`latest\` tag (covered by metadata-action's own push-failure semantics today).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invalid docker pull commands in release notes caused by incorrect repository owner name casing in container image references.
* **Chores**
  * Updated release verification workflow to enforce lowercase handling for container image references and added semver-conformance validation for production releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->