### PR TITLE
chore(web): bump ws to 8.20.1 to patch GHSA-58qx-3vcg-4xpx

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glycemicgpt-web",
-  "version": "0.7.2",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glycemicgpt-web",
-      "version": "0.7.2",
+      "version": "0.8.1",
       "dependencies": {
         "@tanstack/react-query": "^5.60.0",
         "class-variance-authority": "^0.7.1",
@@ -12112,9 +12112,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,5 +40,8 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
## Summary

Adds an npm `overrides` entry in `apps/web/package.json` to force `ws` to `^8.20.1`, patching GHSA-58qx-3vcg-4xpx (CVSS 4.4 Medium, DoS via crafted HTTP request) that OSV-Scanner started flagging today against `ws@8.19.0`.

`ws` is a dev-only transitive: `jest-environment-jsdom@29.7.0 → jsdom@20.0.3 → ws`. `jsdom@20.0.3` declares its own `ws` dependency as `^8.11.0`, so `8.20.1` is well within its supported range.

The lockfile also picks up a cosmetic top-level `"version": 0.7.2 → 0.8.1` bump (npm install syncing to package.json after the v0.8.1 release). No functional change.

## Why this PR exists separately

Promotion PR #661 was blocked by the Dependency Scan Gate flagging this CVE. Landing the fix in a small focused PR keeps the promotion bisectable and re-triggers CI on develop, which then re-flows up to the promotion branch.

## Test plan

- [x] `npm test` — 819/819 passed, 39 suites
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm ls ws` confirms `ws@8.20.1 overridden` via jsdom path
- [x] Adversarial review — zero HIGH/MEDIUM findings
- [x] Security review of staged diff — PASS on all 5 checks (no secrets, official registry URL + sha512 integrity hash, scoped override, CVE actually fixed, no injection surface)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to enforce a specific version of a core dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->