### PR TITLE
Fix Tandem cloud upload silent-success + scheduler diagnostics

### DIFF
--- a/apps/api/src/core/tandem_regions.py
+++ b/apps/api/src/core/tandem_regions.py
@@ -10,6 +10,14 @@ The country list was determined empirically by probing
 on 2026-05-17. Any country not listed here is not provisioned by Tandem.
 """
 
+TANDEM_EPOCH_OFFSET_SECONDS: int = 1_199_145_600
+"""Seconds between the UNIX epoch (1970-01-01T00:00:00 UTC) and the Tandem
+pump epoch (2008-01-01T00:00:00 UTC). The pump reports event timestamps as
+seconds since the Tandem epoch; add this offset to convert to UNIX time.
+
+Mirrors ``plugins/shipped/tandem/.../StatusResponseParser.kt:TANDEM_EPOCH_OFFSET``.
+"""
+
 TANDEM_COUNTRY_TO_CLOUD: dict[str, str] = {
     # US cloud (tdcservices.tandemdiabetes.com)
     "US": "US",

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -553,10 +553,13 @@ async def connect_tandem(
         #     "missing pumper_id" errors is to reconnect; if we don't clear
         #     the cache, they get the same stale token back and the error
         #     keeps surfacing until the natural token expiry.
+        # ``with_for_update()`` serializes against a concurrent upload
+        # holding the same row's lock so the clear isn't immediately
+        # repopulated by a mid-flight auth-cache write.
         state_result = await db.execute(
-            select(TandemUploadState).where(
-                TandemUploadState.user_id == current_user.id
-            )
+            select(TandemUploadState)
+            .where(TandemUploadState.user_id == current_user.id)
+            .with_for_update()
         )
         state = state_result.scalar_one_or_none()
         if state is not None:

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -532,11 +532,12 @@ async def connect_tandem(
     )
     existing = result.scalar_one_or_none()
 
+    previous_country = existing.region if existing else ""
+    country_changed = bool(existing) and previous_country != request.country
+
     if existing:
         # Update existing credentials. region column stores the country code
         # for Tandem (see model comment in src/models/integration.py).
-        previous_country = existing.region or ""
-        country_changed = previous_country != request.country
         existing.encrypted_username = encrypt_credential(request.username)
         existing.encrypted_password = encrypt_credential(request.password)
         existing.region = request.country
@@ -544,36 +545,6 @@ async def connect_tandem(
         existing.last_error = None
         existing.updated_at = datetime.now(UTC)
         credential = existing
-
-        # Clear cached OAuth state on every reconnect, not just when the
-        # country changes. Reasons:
-        #  1. Country change -- the cached token was minted against the old
-        #     cloud bucket and will 401 against the new endpoints.
-        #  2. Same-country reconnect -- the user's stated remediation for
-        #     "missing pumper_id" errors is to reconnect; if we don't clear
-        #     the cache, they get the same stale token back and the error
-        #     keeps surfacing until the natural token expiry.
-        # ``with_for_update()`` serializes against a concurrent upload
-        # holding the same row's lock so the clear isn't immediately
-        # repopulated by a mid-flight auth-cache write.
-        state_result = await db.execute(
-            select(TandemUploadState)
-            .where(TandemUploadState.user_id == current_user.id)
-            .with_for_update()
-        )
-        state = state_result.scalar_one_or_none()
-        if state is not None:
-            state.tandem_access_token = None
-            state.tandem_refresh_token = None
-            state.tandem_token_expires_at = None
-            state.tandem_pumper_id = None
-            logger.info(
-                "Cleared cached Tandem auth on reconnect",
-                user_id=str(current_user.id),
-                old_country=previous_country,
-                new_country=request.country,
-                country_changed=country_changed,
-            )
     else:
         credential = IntegrationCredential(
             user_id=current_user.id,
@@ -584,6 +555,46 @@ async def connect_tandem(
             status=IntegrationStatus.CONNECTED,
         )
         db.add(credential)
+
+    # Clear cached OAuth state on every reconnect, including the
+    # disconnect → reconnect flow where ``existing`` is None. Reasons:
+    #  1. Country change -- the cached token was minted against the old
+    #     cloud bucket and will 401 against the new endpoints.
+    #  2. Same-country reconnect -- the user's stated remediation for
+    #     "missing pumper_id" errors is to reconnect; if we don't clear
+    #     the cache, they get the same stale token back and the error
+    #     keeps surfacing until the natural token expiry.
+    #  3. disconnect_tandem() deletes the IntegrationCredential but
+    #     leaves TandemUploadState in place, so a re-connect after a
+    #     disconnect would otherwise reuse the prior tandem_access_token
+    #     and tandem_pumper_id values.
+    # ``with_for_update()`` serializes against a concurrent upload
+    # holding the same row's lock so the clear isn't immediately
+    # repopulated by a mid-flight auth-cache write.
+    state_result = await db.execute(
+        select(TandemUploadState)
+        .where(TandemUploadState.user_id == current_user.id)
+        .with_for_update()
+    )
+    state = state_result.scalar_one_or_none()
+    if state is not None and (
+        state.tandem_access_token is not None
+        or state.tandem_refresh_token is not None
+        or state.tandem_token_expires_at is not None
+        or state.tandem_pumper_id is not None
+    ):
+        state.tandem_access_token = None
+        state.tandem_refresh_token = None
+        state.tandem_token_expires_at = None
+        state.tandem_pumper_id = None
+        logger.info(
+            "Cleared cached Tandem auth on reconnect",
+            user_id=str(current_user.id),
+            old_country=previous_country,
+            new_country=request.country,
+            country_changed=country_changed,
+            had_existing_credential=bool(existing),
+        )
 
     await db.commit()
     await db.refresh(credential)

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -545,28 +545,32 @@ async def connect_tandem(
         existing.updated_at = datetime.now(UTC)
         credential = existing
 
-        # If the country (and therefore the Tandem cloud bucket) changed, the
-        # cached OAuth token is bound to the old cloud and will fail with an
-        # opaque 401 against the new endpoints. Clear it so the next upload
-        # re-authenticates fresh.
-        if country_changed:
-            state_result = await db.execute(
-                select(TandemUploadState).where(
-                    TandemUploadState.user_id == current_user.id
-                )
+        # Clear cached OAuth state on every reconnect, not just when the
+        # country changes. Reasons:
+        #  1. Country change -- the cached token was minted against the old
+        #     cloud bucket and will 401 against the new endpoints.
+        #  2. Same-country reconnect -- the user's stated remediation for
+        #     "missing pumper_id" errors is to reconnect; if we don't clear
+        #     the cache, they get the same stale token back and the error
+        #     keeps surfacing until the natural token expiry.
+        state_result = await db.execute(
+            select(TandemUploadState).where(
+                TandemUploadState.user_id == current_user.id
             )
-            state = state_result.scalar_one_or_none()
-            if state is not None:
-                state.tandem_access_token = None
-                state.tandem_refresh_token = None
-                state.tandem_token_expires_at = None
-                state.tandem_pumper_id = None
-                logger.info(
-                    "Cleared cached Tandem auth on country change",
-                    user_id=str(current_user.id),
-                    old_country=previous_country,
-                    new_country=request.country,
-                )
+        )
+        state = state_result.scalar_one_or_none()
+        if state is not None:
+            state.tandem_access_token = None
+            state.tandem_refresh_token = None
+            state.tandem_token_expires_at = None
+            state.tandem_pumper_id = None
+            logger.info(
+                "Cleared cached Tandem auth on reconnect",
+                user_id=str(current_user.id),
+                old_country=previous_country,
+                new_country=request.country,
+                country_changed=country_changed,
+            )
     else:
         credential = IntegrationCredential(
             user_id=current_user.id,

--- a/apps/api/src/services/scheduler.py
+++ b/apps/api/src/services/scheduler.py
@@ -448,6 +448,12 @@ def start_scheduler() -> AsyncIOScheduler:
             "Scheduled Tandem sync job",
             interval_minutes=settings.tandem_sync_interval_minutes,
         )
+    else:
+        logger.warning(
+            "Tandem sync scheduler DISABLED via TANDEM_SYNC_ENABLED env var. "
+            "Manual sync via POST /api/integrations/tandem/sync still works; "
+            "scheduled pulls will not run."
+        )
 
     # Add Nightscout sync tick job if enabled (Story 43.4)
     # Single global tick; the per-connection cadence is honored inside
@@ -534,6 +540,12 @@ def start_scheduler() -> AsyncIOScheduler:
         logger.info(
             "Scheduled Tandem cloud upload job",
             interval_minutes=settings.tandem_upload_check_interval_minutes,
+        )
+    else:
+        logger.warning(
+            "Tandem cloud upload scheduler DISABLED via TANDEM_UPLOAD_ENABLED env var. "
+            "Manual uploads via POST /api/integrations/tandem/cloud-upload/trigger "
+            "still work; scheduled pushes will not run."
         )
 
     # Add stale device cleanup job (Story 16.11)

--- a/apps/api/src/services/tandem_upload.py
+++ b/apps/api/src/services/tandem_upload.py
@@ -632,6 +632,12 @@ async def upload_to_tandem(
         state.tandem_refresh_token = None
         state.tandem_token_expires_at = None
         state.tandem_pumper_id = None
+        # Defer the next scheduler tick by stamping last_upload_at so a
+        # stuck empty-pumper_id user doesn't hammer Tandem OAuth on every
+        # 1-minute scheduler tick. The user's configured upload_interval
+        # already throttles steady-state runs; this just makes failure
+        # cases match that cadence instead of amplifying.
+        state.last_upload_at = now
         public_msg = (
             "Tandem authentication did not return a pumper ID. "
             "The next upload attempt will re-authenticate; if it keeps "

--- a/apps/api/src/services/tandem_upload.py
+++ b/apps/api/src/services/tandem_upload.py
@@ -24,6 +24,7 @@ from src.config import settings
 from src.core.encryption import decrypt_credential, encrypt_credential
 from src.core.tandem_regions import (
     SUPPORTED_TANDEM_COUNTRIES,
+    TANDEM_EPOCH_OFFSET_SECONDS,
     TandemLegacyRegionError,
     resolve_country_or_raise,
 )
@@ -372,6 +373,53 @@ async def get_last_event_uploaded(
         return data.get("maxPumpEventIndex", 0)
 
 
+def _resolve_pump_datetime(raw_events: list[PumpRawEvent]) -> datetime:
+    """Pick the wall-clock pumpDateTime value to send with this upload batch.
+
+    ``PumpRawEvent.pump_time_seconds`` is in *Tandem epoch* (seconds since
+    2008-01-01T00:00:00 UTC), captured raw from the pump's BLE history log
+    and stored unchanged by the mobile push pipeline (see the mirror
+    constant in ``StatusResponseParser.kt``). Convert to UNIX time by
+    adding ``TANDEM_EPOCH_OFFSET_SECONDS`` before handing to
+    ``datetime.fromtimestamp``; treating the raw value as UNIX time would
+    place pumpDateTime around 1988 and Tandem silently rejects it the same
+    way it rejects ``datetime.now(UTC)``.
+
+    Defensively drop events whose timestamp falls outside a sane window
+    (between the Tandem epoch itself and ~5 years in the future). A bogus
+    event with a clock-skew of years past the window can otherwise
+    dominate ``max(...)`` and poison the entire upload.
+    """
+    now_utc = datetime.now(UTC)
+    earliest = datetime(2008, 1, 1, tzinfo=UTC)
+    latest_allowed = now_utc + timedelta(days=365 * 5)
+
+    def _candidate(ev: PumpRawEvent) -> datetime | None:
+        unix_seconds = ev.pump_time_seconds + TANDEM_EPOCH_OFFSET_SECONDS
+        try:
+            dt = datetime.fromtimestamp(unix_seconds, tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+        if dt < earliest or dt > latest_allowed:
+            return None
+        return dt
+
+    candidates = [c for ev in raw_events if (c := _candidate(ev)) is not None]
+    if candidates:
+        return max(candidates)
+    if raw_events:
+        # Every event had a bogus timestamp -- log so prod operators can
+        # spot upstream BLE / clock-sync issues, then fall back to now()
+        # so the upload still ships rather than crashing the worker.
+        logger.warning(
+            "All raw events had out-of-range pump_time_seconds; "
+            "falling back to now() for pumpDateTime",
+            event_count=len(raw_events),
+            sample_pump_time_seconds=raw_events[0].pump_time_seconds,
+        )
+    return now_utc
+
+
 def build_upload_payload(
     pump_info: PumpHardwareInfo,
     raw_events: list[PumpRawEvent],
@@ -381,7 +429,16 @@ def build_upload_payload(
     """Build the Tandem upload payload JSON matching the official app schema.
 
     Schema: UploadPayload > Package > Device > Data (misc, settings, events)
+
+    ``device_assignment_id`` is the user's Tandem pumperId (from the OAuth
+    token's claims). Tandem accepts uploads with a blank value but silently
+    drops them, so callers must populate it. Empty values are accepted here
+    only for back-compat with the test fixtures; production callers go
+    through ``upload_to_tandem`` which refuses to invoke this with a blank
+    ID.
     """
+    pump_dt = _resolve_pump_datetime(raw_events)
+
     # Build misc object
     misc = {
         "platform": "GlycemicGPT Mobile [Android]",
@@ -389,7 +446,7 @@ def build_upload_payload(
         "pumpAPIVersion": "",
         "appVersion": "2.9.1 (3368rb)",
         "uploaderClient": "mobile_tconnect",
-        "pumpDateTime": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S"),
+        "pumpDateTime": pump_dt.strftime("%Y-%m-%dT%H:%M:%S"),
         "clientDateTimeWithOffset": datetime.now(UTC).strftime(
             "%Y-%m-%dT%H:%M:%S+00:00"
         ),
@@ -448,18 +505,50 @@ async def _post_upload(
 
     async with httpx.AsyncClient(timeout=_UPLOAD_TIMEOUT_SECONDS) as client:
         resp = await client.post(url, content=json_bytes, headers=headers)
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError:
+            # Capture Tandem's response body before re-raising so callers can
+            # diagnose why the upload failed. Body should not contain user
+            # PHI -- it's an upload ack -- but truncate defensively in case
+            # Tandem ever echoes payload fragments back to us.
+            logger.error(
+                "Tandem upload HTTP failure",
+                http_status=resp.status_code,
+                response_body=(resp.text or "")[:2048],
+            )
+            raise
         body = resp.json() if resp.content else {}
         # A 200 from Tandem can still report per-event errors in the body.
         # Treat any populated `errors` array as a failure so we don't mark
-        # those events as uploaded -- otherwise we'd silently drop them on
-        # the floor, exactly the kind of silent-success bug the bundled fix
-        # is meant to eliminate.
-        if isinstance(body, dict) and body.get("errors"):
-            raise RuntimeError(
-                f"Tandem cloud accepted the request but reported "
-                f"{len(body['errors'])} per-event error(s)."
-            )
+        # those events as uploaded.
+        #
+        # ``processingStatus`` is documented in the reverse-engineering
+        # notes only for the ``getLastEventUploaded`` endpoint, not for the
+        # upload response. We log it when present so production traces can
+        # confirm whether Tandem actually returns it for uploads (and what
+        # values it uses), but do NOT fail-close on it -- doing so risks
+        # hard-rejecting valid uploads against a Tandem schema variance we
+        # haven't confirmed.
+        if isinstance(body, dict):
+            processing_status = body.get("processingStatus")
+            if processing_status is not None and processing_status != 0:
+                logger.warning(
+                    "Tandem upload returned non-zero processingStatus; "
+                    "treating as success but capturing for future audit",
+                    processing_status=processing_status,
+                    response_body=json.dumps(body, separators=(",", ":"))[:2048],
+                )
+            if body.get("errors"):
+                logger.error(
+                    "Tandem upload returned per-event errors",
+                    error_count=len(body["errors"]),
+                    response_body=json.dumps(body, separators=(",", ":"))[:2048],
+                )
+                raise RuntimeError(
+                    f"Tandem cloud accepted the request but reported "
+                    f"{len(body['errors'])} per-event error(s)."
+                )
         return body
 
 
@@ -527,6 +616,36 @@ async def upload_to_tandem(
     access_token = auth_result["access_token"]
     pumper_id = auth_result.get("pumper_id", "")
     country = auth_result["country"]
+
+    # Refuse to upload with an empty deviceAssignmentId. tconnectsync silently
+    # defaults pumperId to "" when the JWT lacks the claim, and Tandem's cloud
+    # appears to accept such uploads with HTTP 200 but never persist them --
+    # the user sees "events sent" but t:connect's portal stays empty.
+    # Mark the run as failed and surface a re-connect prompt instead.
+    #
+    # Self-healing: invalidate the cached auth state before returning so the
+    # next run re-authenticates fresh. Without this, an empty `pumper_id`
+    # cached from a prior fresh-auth attempt would keep blocking every
+    # subsequent upload for the cached-token lifetime (~1 hour).
+    if not pumper_id:
+        state.tandem_access_token = None
+        state.tandem_refresh_token = None
+        state.tandem_token_expires_at = None
+        state.tandem_pumper_id = None
+        public_msg = (
+            "Tandem authentication did not return a pumper ID. "
+            "The next upload attempt will re-authenticate; if it keeps "
+            "failing, disconnect and reconnect Tandem in Settings."
+        )
+        state.last_upload_status = "error"
+        state.last_error = public_msg
+        await db.commit()
+        logger.error(
+            "Tandem upload blocked: empty pumper_id from auth",
+            user_id=str(user_id),
+            country=country,
+        )
+        return {"message": public_msg, "events_uploaded": 0, "status": "error"}
 
     # Fetch per-country endpoint config
     try:
@@ -645,6 +764,8 @@ async def upload_to_tandem(
         user_id=str(user_id),
         events_uploaded=len(raw_events),
         max_sequence=max_seq,
+        pumper_id_present=bool(pumper_id),
+        pump_datetime=payload["package"]["device"]["data"]["misc"]["pumpDateTime"],
     )
 
     return {

--- a/apps/api/tests/test_tandem_upload.py
+++ b/apps/api/tests/test_tandem_upload.py
@@ -946,21 +946,22 @@ class TestSchedulerStartupLogs:
     production "scheduler not firing" reports can be diagnosed by a single
     log grep without code spelunking."""
 
-    def test_logs_disabled_state_for_tandem_upload_and_sync(self, caplog):
+    def test_logs_disabled_state_for_tandem_upload_and_sync(self, caplog, monkeypatch):
         import logging
 
         import src.services.scheduler as scheduler_module
         from src.config import settings as global_settings
 
-        original_upload = global_settings.tandem_upload_enabled
-        original_sync = global_settings.tandem_sync_enabled
+        # ``monkeypatch.setattr`` auto-restores even if the test crashes,
+        # which is safer than try/finally under pytest-xdist parallel
+        # workers that share the same global settings singleton.
+        monkeypatch.setattr(global_settings, "tandem_upload_enabled", False)
+        monkeypatch.setattr(global_settings, "tandem_sync_enabled", False)
+        # Reset the module-level singleton so start_scheduler() runs the
+        # registration block again instead of short-circuiting.
         original_scheduler = scheduler_module.scheduler
+        monkeypatch.setattr(scheduler_module, "scheduler", None)
         try:
-            global_settings.tandem_upload_enabled = False
-            global_settings.tandem_sync_enabled = False
-            # Reset the module-level singleton so start_scheduler() runs the
-            # registration block again instead of short-circuiting.
-            scheduler_module.scheduler = None
             # Capture across all loggers; our structlog-wrapped logger routes
             # via stdlib logging but the named filter on caplog.at_level
             # doesn't always catch the wrapped path.
@@ -978,11 +979,11 @@ class TestSchedulerStartupLogs:
             assert "Tandem cloud upload scheduler DISABLED" in caplog.text
             assert "Tandem sync scheduler DISABLED" in caplog.text
         finally:
-            global_settings.tandem_upload_enabled = original_upload
-            global_settings.tandem_sync_enabled = original_sync
-            if scheduler_module.scheduler is not None:
+            if (
+                scheduler_module.scheduler is not None
+                and scheduler_module.scheduler is not original_scheduler
+            ):
                 try:
                     scheduler_module.scheduler.shutdown(wait=False)
                 except Exception:
                     pass
-            scheduler_module.scheduler = original_scheduler

--- a/apps/api/tests/test_tandem_upload.py
+++ b/apps/api/tests/test_tandem_upload.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from src.core.encryption import encrypt_credential
 from src.core.tandem_regions import TandemLegacyRegionError
@@ -805,10 +805,27 @@ class TestUploadSilentSuccessRegression:
     async def test_upload_refuses_when_pumper_id_missing(self):
         """Empty pumper_id means deviceAssignmentId would be ``""`` in the
         upload payload, which Tandem accepts (200 OK) but silently drops.
-        Refuse to upload and surface a re-connect prompt instead."""
+        Refuse to upload, surface a re-connect prompt, invalidate the
+        cached auth so the next run re-authenticates fresh, and stamp
+        last_upload_at so the scheduler doesn't hammer Tandem OAuth on
+        every tick."""
         async with await _own_session() as session:
             user_id = await _seed_upload_fixtures(
                 session, region="US", seq_numbers=(1, 2)
+            )
+            # Seed STALE cached auth state -- this is the scenario the
+            # self-heal path is for. Without these the test wouldn't
+            # exercise the cache-clearing side-effect at all.
+            stale_expiry = datetime.now(UTC) + timedelta(minutes=30)
+            await session.execute(
+                update(TandemUploadState)
+                .where(TandemUploadState.user_id == user_id)
+                .values(
+                    tandem_access_token=encrypt_credential("stale-token"),
+                    tandem_refresh_token=encrypt_credential("stale-refresh"),
+                    tandem_token_expires_at=stale_expiry,
+                    tandem_pumper_id="stale-pumper",
+                )
             )
             await session.commit()
 
@@ -848,9 +865,28 @@ class TestUploadSilentSuccessRegression:
         assert result["status"] == "error", result
         assert result["events_uploaded"] == 0
         assert "pumper id" in result["message"].lower()
-        # And critically: _post_upload must NOT have been called -- we should
-        # refuse to send the payload at all rather than risk a silent drop.
+        # _post_upload must NOT have been called -- we refuse to send the
+        # payload at all rather than risk a silent drop.
         assert post_mock.await_count == 0
+
+        # Side effects: the stale cache must be cleared on the way out so
+        # the next call re-authenticates fresh instead of being stuck on
+        # the same broken cached pumper_id for the cached-token TTL.
+        async with await _own_session() as session:
+            state = (
+                await session.execute(
+                    select(TandemUploadState).where(
+                        TandemUploadState.user_id == user_id
+                    )
+                )
+            ).scalar_one()
+            assert state.tandem_access_token is None
+            assert state.tandem_refresh_token is None
+            assert state.tandem_token_expires_at is None
+            assert state.tandem_pumper_id is None
+            # And the scheduler-throttling stamp must be set so a stuck
+            # user can't amplify failed auth into 60 requests/hour.
+            assert state.last_upload_at is not None
 
     @pytest.mark.asyncio
     async def test_post_upload_logs_non_zero_processing_status(self, caplog):

--- a/apps/api/tests/test_tandem_upload.py
+++ b/apps/api/tests/test_tandem_upload.py
@@ -148,6 +148,80 @@ class TestBuildUploadPayload:
         assert misc["appVersion"] == "2.9.1 (3368rb)"
         assert "pumpFeatures" in misc
 
+    def test_payload_uses_pump_time_when_events_present(self):
+        """``pumpDateTime`` must reflect the latest event's pump time, not
+        the backend's wall-clock at upload time. The stored
+        ``pump_time_seconds`` value is in *Tandem epoch* (seconds since
+        2008-01-01); converting it correctly requires adding
+        ``TANDEM_EPOCH_OFFSET_SECONDS``. Sending the raw value as if it
+        were UNIX time would render every event in the late 1980s, which
+        Tandem silently rejects the same way it rejects ``now()``.
+        """
+        pump_info = self._make_mock_pump_info()
+        # Realistic Tandem-epoch values. 564_941_700 + 1_199_145_600
+        # = 1_764_087_300 UNIX = 2025-11-25T16:15:00 UTC.
+        events = [self._make_mock_raw_event(seq=10) for _ in range(3)]
+        for ev, ts in zip(
+            events,
+            [564_940_800, 564_941_100, 564_941_700],
+            strict=True,
+        ):
+            ev.pump_time_seconds = ts
+        payload = build_upload_payload(pump_info, events)
+        misc = payload["package"]["device"]["data"]["misc"]
+        # Latest event wins; if the epoch offset is missing we'd render
+        # this as 1987-11-22 instead (which is exactly the failure mode
+        # the original "fix" shipped before the adversarial-review catch).
+        assert misc["pumpDateTime"] == "2025-11-25T16:15:00"
+
+    def test_payload_falls_back_to_now_when_no_events(self):
+        """With no events to anchor pump time, fall back to wall-clock so
+        we still send a valid (if approximate) timestamp."""
+        pump_info = self._make_mock_pump_info()
+        before = datetime.now(UTC).replace(microsecond=0)
+        payload = build_upload_payload(pump_info, [])
+        after = datetime.now(UTC).replace(microsecond=0)
+        misc = payload["package"]["device"]["data"]["misc"]
+        rendered = datetime.strptime(misc["pumpDateTime"], "%Y-%m-%dT%H:%M:%S").replace(
+            tzinfo=UTC
+        )
+        assert before <= rendered <= after
+
+    def test_payload_skips_bogus_pump_times(self):
+        """Events with timestamps outside [2008, now+5y] are filtered before
+        computing the max so a single bad event can't poison the batch."""
+        pump_info = self._make_mock_pump_info()
+        events = [self._make_mock_raw_event(seq=i) for i in range(3)]
+        # Valid event from late 2025
+        events[0].pump_time_seconds = 564_940_800
+        # Bogus future event (~ year 2999 if treated naively)
+        events[1].pump_time_seconds = 31_000_000_000
+        # Another valid event from late 2025 (slightly later than events[0])
+        events[2].pump_time_seconds = 564_941_100
+        payload = build_upload_payload(pump_info, events)
+        misc = payload["package"]["device"]["data"]["misc"]
+        # The bogus one is discarded; max of remaining = 564_941_100
+        # 564_941_100 + 1_199_145_600 = 1_764_086_700 = 2025-11-25T16:05:00 UTC
+        assert misc["pumpDateTime"] == "2025-11-25T16:05:00"
+
+    def test_payload_falls_back_when_every_event_is_bogus(self):
+        """If every event is out of range, fall back to now() instead of
+        crashing or sending garbage."""
+        pump_info = self._make_mock_pump_info()
+        events = [self._make_mock_raw_event(seq=i) for i in range(2)]
+        # Negative pump time renders before the Tandem epoch (filtered).
+        events[0].pump_time_seconds = -100_000_000
+        # Far-future pump time, well past now()+5y (filtered).
+        events[1].pump_time_seconds = 999_999_999_999
+        before = datetime.now(UTC).replace(microsecond=0)
+        payload = build_upload_payload(pump_info, events)
+        after = datetime.now(UTC).replace(microsecond=0)
+        misc = payload["package"]["device"]["data"]["misc"]
+        rendered = datetime.strptime(misc["pumpDateTime"], "%Y-%m-%dT%H:%M:%S").replace(
+            tzinfo=UTC
+        )
+        assert before <= rendered <= after
+
     def test_events_included(self):
         pump_info = self._make_mock_pump_info()
         events = [self._make_mock_raw_event(i) for i in range(3)]
@@ -715,3 +789,200 @@ class TestUploadEmptySetRegression:
                 .all()
             )
             assert all(not r.uploaded_to_tandem for r in rows)
+
+
+class TestUploadSilentSuccessRegression:
+    """Regression tests for the v0.8.2 silent-success bug.
+
+    Production user pressed "Upload Now" three times, each returned
+    "500 events sent to tandem" success, the local counter went down,
+    but no events ever appeared in the official t:connect web portal.
+    Two value-level payload bugs and one missing response-body check
+    were responsible.
+    """
+
+    @pytest.mark.asyncio
+    async def test_upload_refuses_when_pumper_id_missing(self):
+        """Empty pumper_id means deviceAssignmentId would be ``""`` in the
+        upload payload, which Tandem accepts (200 OK) but silently drops.
+        Refuse to upload and surface a re-connect prompt instead."""
+        async with await _own_session() as session:
+            user_id = await _seed_upload_fixtures(
+                session, region="US", seq_numbers=(1, 2)
+            )
+            await session.commit()
+
+        mock_api = MagicMock()
+        mock_api.accessToken = "tok"
+        mock_api.accessTokenExpiresAt = None
+        mock_api.pumperId = None  # <-- the bug condition
+
+        post_mock = AsyncMock(return_value={})
+
+        async with await _own_session() as session:
+            with (
+                patch(
+                    "tconnectsync.api.tandemsource.TandemSourceApi",
+                    return_value=mock_api,
+                ),
+                patch(
+                    "src.services.tandem_upload.fetch_tandem_config",
+                    AsyncMock(
+                        return_value={
+                            "postUploadUrl": "https://example.test/upload",
+                            "getLastEventUploadedUrl": "https://example.test/last",
+                        }
+                    ),
+                ),
+                patch(
+                    "src.services.tandem_upload.get_last_event_uploaded",
+                    AsyncMock(return_value=0),
+                ),
+                patch(
+                    "src.services.tandem_upload._post_upload",
+                    post_mock,
+                ),
+            ):
+                result = await upload_to_tandem(session, user_id)
+
+        assert result["status"] == "error", result
+        assert result["events_uploaded"] == 0
+        assert "pumper id" in result["message"].lower()
+        # And critically: _post_upload must NOT have been called -- we should
+        # refuse to send the payload at all rather than risk a silent drop.
+        assert post_mock.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_post_upload_logs_non_zero_processing_status(self, caplog):
+        """``processingStatus`` is documented for the getLastEventUploaded
+        endpoint but not for upload responses; we log non-zero values
+        when they appear so production traces can confirm whether Tandem
+        actually returns the field for uploads, but do NOT fail-close on
+        it (avoids hard-rejecting valid uploads against a schema variance
+        we haven't observed in the wild).
+        """
+        import logging
+
+        from src.services.tandem_upload import _post_upload
+
+        class _MockResp:
+            status_code = 200
+            content = b'{"processingStatus": 1}'
+            text = '{"processingStatus": 1}'
+            headers = {"Content-Type": "application/json"}
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"processingStatus": 1}
+
+        class _MockClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            async def post(self, url, content, headers):
+                return _MockResp()
+
+        with (
+            patch("httpx.AsyncClient", lambda **kwargs: _MockClient()),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = await _post_upload(
+                access_token="t",
+                config={"postUploadUrl": "https://x.test/u"},
+                payload={"client": "mHealth", "package": {}},
+            )
+        # Returns the body (no exception), but emits a WARNING for audit
+        assert result == {"processingStatus": 1}
+        assert "non-zero processingStatus" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_post_upload_raises_on_per_event_errors(self):
+        """A 200 with a populated ``errors`` array IS a hard failure --
+        Tandem accepted the request but rejected individual events. We
+        refuse to mark them as uploaded so they stay queued for retry.
+        """
+        from src.services.tandem_upload import _post_upload
+
+        class _MockResp:
+            status_code = 200
+            content = b'{"errors": [{"code": "bad"}]}'
+            text = '{"errors": [{"code": "bad"}]}'
+            headers = {"Content-Type": "application/json"}
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"errors": [{"code": "bad"}]}
+
+        class _MockClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            async def post(self, url, content, headers):
+                return _MockResp()
+
+        with (
+            patch("httpx.AsyncClient", lambda **kwargs: _MockClient()),
+            pytest.raises(RuntimeError, match="per-event error"),
+        ):
+            await _post_upload(
+                access_token="t",
+                config={"postUploadUrl": "https://x.test/u"},
+                payload={"client": "mHealth", "package": {}},
+            )
+
+
+class TestSchedulerStartupLogs:
+    """The scheduler must announce its enable/disable state at startup so
+    production "scheduler not firing" reports can be diagnosed by a single
+    log grep without code spelunking."""
+
+    def test_logs_disabled_state_for_tandem_upload_and_sync(self, caplog):
+        import logging
+
+        import src.services.scheduler as scheduler_module
+        from src.config import settings as global_settings
+
+        original_upload = global_settings.tandem_upload_enabled
+        original_sync = global_settings.tandem_sync_enabled
+        original_scheduler = scheduler_module.scheduler
+        try:
+            global_settings.tandem_upload_enabled = False
+            global_settings.tandem_sync_enabled = False
+            # Reset the module-level singleton so start_scheduler() runs the
+            # registration block again instead of short-circuiting.
+            scheduler_module.scheduler = None
+            # Capture across all loggers; our structlog-wrapped logger routes
+            # via stdlib logging but the named filter on caplog.at_level
+            # doesn't always catch the wrapped path.
+            with caplog.at_level(logging.WARNING):
+                # start_scheduler() ends with scheduler.start() which needs a
+                # running event loop. We only care about the registration
+                # log lines emitted before that, so swallow the RuntimeError.
+                try:
+                    scheduler_module.start_scheduler()
+                except RuntimeError:
+                    pass
+            # `caplog.text` is the joined human-readable rendering of all
+            # captured records and is the most reliable way to assert
+            # against structlog output.
+            assert "Tandem cloud upload scheduler DISABLED" in caplog.text
+            assert "Tandem sync scheduler DISABLED" in caplog.text
+        finally:
+            global_settings.tandem_upload_enabled = original_upload
+            global_settings.tandem_sync_enabled = original_sync
+            if scheduler_module.scheduler is not None:
+                try:
+                    scheduler_module.scheduler.shutdown(wait=False)
+                except Exception:
+                    pass
+            scheduler_module.scheduler = original_scheduler

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "glycemicgpt-api"
-version = "0.7.2"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Production user on v0.8.2 reported the Tandem cloud upload feature looked broken: pressing "Upload Now" three times each returned "500 events sent to tandem" success and the local pending counter went down, but no events ever appeared in t:connect's official web portal. The automatic scheduler also never fired on its own.

Audit (deep dive against the reverse-engineering doc + adversarial review pass) identified the root cause: the upload payload was structurally valid but **value-level wrong** in two ways, causing Tandem's cloud to accept the HTTP request and then silently drop the events:

1. **`pumpDateTime` was `datetime.now(UTC)`** — every uploaded event got timestamped "right now" rather than when it actually happened.
2. **Empty `deviceAssignmentId`** when `tconnectsync` didn't populate `pumperId` in the auth response — Tandem 200s the request but never persists.

Both are now fixed backend-only. A separate follow-up (PR1b) will be opened only if these don't resolve the production symptom against a real upload.

## What changed

**`pumpDateTime` from pump's actual time (with the right epoch).** Sourced from the latest event's `pump_time_seconds`. Critically: that field stores **Tandem epoch** (seconds since 2008-01-01 UTC), not UNIX — adversarial review caught a v1 of this fix that would have rendered events in 1987. New `TANDEM_EPOCH_OFFSET_SECONDS = 1_199_145_600` constant in `core/tandem_regions.py` (mirrored from the Kotlin `StatusResponseParser.TANDEM_EPOCH_OFFSET`). New `_resolve_pump_datetime` helper filters bogus timestamps (anything outside `[2008-01-01, now+5y]`) before computing the batch max, so a single clock-skewed event can't poison the entire upload.

**Refuse to upload with empty `deviceAssignmentId`.** When the OAuth `pumperId` is empty, `upload_to_tandem` short-circuits with a clear error instead of sending a doomed payload. The guard is **self-healing**: it invalidates the cached auth state on its way out so the next call re-authenticates fresh rather than staying stuck on the same empty pumperId for the cached-token TTL (~1 hour). The Tandem reconnect endpoint also unconditionally invalidates cached auth on every reconnect now, so the user-facing "reconnect Tandem" remediation actually does something.

**Better diagnostic logging.** Tandem's response body (truncated to 2KB) is now captured on HTTP failures, on populated `errors` arrays, and on non-zero `processingStatus` values. Plus `pump_datetime` and `pumper_id_present` on the success log line so future "did this upload have everything it needed?" questions are one log grep away.

**`processingStatus` is log-only, not fail-close.** The RE doc documents `processingStatus` for the `getLastEventUploaded` endpoint but not for upload responses. v1 of this PR hard-failed on non-zero; adversarial review flagged that as speculative. Logging-only lets us observe Tandem's actual behavior in prod before we treat it as a real signal.

**Per-event `errors` array IS hard-fail.** That one is documented and behaviorally clear.

**Scheduler startup-log assertion.** `scheduler.py` now logs an explicit WARNING when `tandem_upload_enabled` or `tandem_sync_enabled` is gated off via env var. Previously the absence of a registration line silently meant "disabled" — now production "scheduler not firing" reports are diagnosable by a single log grep.

**Race-safety improvements.** Both upload and reconnect now take `SELECT ... FOR UPDATE` on `TandemUploadState`, and the empty-pumperId guard stamps `last_upload_at = now` so a stuck user can't amplify into 60 OAuth requests per hour against Tandem.

## Files

- `apps/api/src/core/tandem_regions.py` — `TANDEM_EPOCH_OFFSET_SECONDS` constant
- `apps/api/src/services/tandem_upload.py` — `_resolve_pump_datetime`, empty-pumperId guard, `_post_upload` body inspection + logging
- `apps/api/src/services/scheduler.py` — DISABLED warnings
- `apps/api/src/routers/integrations.py` — unconditional auth-cache clear on Tandem reconnect; row lock on the SELECT
- `apps/api/tests/test_tandem_upload.py` — 9 new regression tests covering the epoch offset, the bogus-event filter, the empty-pumperId guard + cache invalidation, the processingStatus log-only path, per-event errors, and scheduler startup logs

## Test plan

- [x] `uv run ruff check src/ tests/` + `uv run ruff format --check src/ tests/` clean
- [x] Affected test suites green: `test_tandem_upload.py` + `test_tandem_regions.py` + `test_integrations.py` + `test_tandem_sync.py` (172 passed)
- [x] Adversarial review caught a critical epoch-offset bug in v1; v2 includes the fix + regression test that proves the rendered date is in 2025 (not 1987)
- [x] Security review: 3 MEDIUM findings addressed (auth amplification, missing row lock, test settings pollution); 1 LOW deferred (commit-window in self-heal)
- [x] CodeRabbit CLI on committed: no findings
- [ ] CI green on this PR
- [ ] **Load-bearing manual test**: deploy this image to user's k8s, `Reset upload state & re-queue events`, press "Upload Now", confirm events appear in t:connect web portal. If they don't, the new diagnostic logs will tell us which of the remaining value-level mismatches (real `pumpAPIVersion`, real `data.settings`, real device `platform`, user timezone) is required — that work would land as PR1b.

## Rollout

- No migration. No new schema fields. No mobile changes.
- Existing rows with cached `tandem_pumper_id`/`tandem_access_token` get cleared on next reconnect — users mid-flight see one forced re-auth on next upload attempt, handled gracefully by the new self-heal path.
- Existing `pump_time_seconds` values are interpreted with the right epoch immediately on deploy; no backfill required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Tandem pump timestamp handling so uploads use valid event times and filter out bogus timestamps.
  * Improved upload failure detection to avoid silent successes and now refuse uploads when a required remote identifier is missing.
  * Ensure cached Tandem tokens/IDs are cleared on reconnect attempts to prevent stale auth state.

* **Improvements**
  * Startup now logs clear, multi-line notices when Tandem sync or cloud-upload schedulers are disabled.

* **Tests**
  * Added tests covering timestamp selection, upload failure cases, and scheduler disabled logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->