### PR TITLE
feat: Medtronic CareLink manual historical import

### DIFF
--- a/apps/api/src/core/medtronic_regions.py
+++ b/apps/api/src/core/medtronic_regions.py
@@ -1,0 +1,36 @@
+"""Medtronic CareLink regional hosts.
+
+CareLink Personal is regionally split. ``US`` (carelink.minimed.com) is verified
+live. ``EU``/international (carelink.minimed.eu) is built from the same pattern
+but NOT yet verified against a real EU account -- the /patient REST surface +
+auth flow are almost certainly identical (same Auth0 SPA), but treat EU as
+"needs live verification by an EU user" until confirmed.
+
+The base_url is host-allowlisted again in CareLinkClient/CareLinkSession, so a
+bad value here fails closed rather than letting the bearer reach an arbitrary
+host.
+"""
+
+from __future__ import annotations
+
+#: Region code -> CareLink web host. Extend if Medtronic exposes more regional
+#: hosts; keep values under minimed.com / minimed.eu (the client's allowlist).
+MEDTRONIC_REGION_TO_BASE_URL: dict[str, str] = {
+    "US": "https://carelink.minimed.com",
+    "EU": "https://carelink.minimed.eu",
+}
+
+SUPPORTED_MEDTRONIC_REGIONS: frozenset[str] = frozenset(MEDTRONIC_REGION_TO_BASE_URL)
+
+
+def resolve_region_base_url(region: str) -> str:
+    """Map a region code to its CareLink base URL. Raises ValueError if the
+    region is unknown (callers map that to HTTP 400)."""
+    key = (region or "").strip().upper()
+    try:
+        return MEDTRONIC_REGION_TO_BASE_URL[key]
+    except KeyError as e:
+        raise ValueError(
+            f"Unsupported Medtronic region {region!r}; "
+            f"supported: {sorted(SUPPORTED_MEDTRONIC_REGIONS)}"
+        ) from e

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -171,6 +171,9 @@ app.add_middleware(
         "X-CSRF-Token",
         "X-Correlation-ID",
         "X-API-Key",
+        # Carries the captured CareLink session token for the Medtronic manual
+        # import (kept out of the request body so it can't leak via a 422 echo).
+        "X-CareLink-Token",
     ],
 )
 

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -19,6 +19,7 @@ from tconnectsync.api.tandemsource import TandemSourceApi
 
 from src.core.auth import CurrentUser, DiabeticOrAdminUser
 from src.core.encryption import encrypt_credential
+from src.core.medtronic_regions import resolve_region_base_url
 from src.core.tandem_regions import (
     country_to_cloud,
     is_legacy_tandem_region,
@@ -67,6 +68,12 @@ from src.schemas.integration import (
     IntegrationResponse,
     TandemCredentialsRequest,
 )
+from src.schemas.medtronic import (
+    MedtronicAvailabilityRequest,
+    MedtronicAvailabilityResponse,
+    MedtronicImportRequest,
+    MedtronicImportResponse,
+)
 from src.schemas.pump import (
     BolusReviewItem,
     BolusReviewResponse,
@@ -104,6 +111,13 @@ from src.services.forecast_reader import (
     resolve_effective_source,
     set_forecast_source,
 )
+from src.services.integrations.medtronic.client import (
+    CareLinkAuthError,
+    CareLinkClient,
+    CareLinkError,
+    CareLinkReportTimeoutError,
+)
+from src.services.integrations.medtronic.sync import sync_carelink_for_user
 from src.services.iob_projection import get_iob_projection, get_user_dia
 from src.services.loop_state_extractor import get_latest_loop_state
 from src.services.tandem_sync import (
@@ -1668,6 +1682,129 @@ async def import_tandem_range(
         events_stored=result["events_stored"],
         profiles_stored=result.get("profiles_stored", 0),
         last_event=last_event,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Medtronic CareLink -- manual historical import (feature B)
+#
+# Stateless: the request carries the captured auth_tmp_token bearer (the user
+# grabs it via the bookmarklet capture flow). We build a COOKIE-LESS
+# CareLinkClient (bearer header only -- verified sufficient for /patient/*),
+# import within the token's ~50-min life, and NEVER store the token. No
+# credential row / scheduler / sync-state (manual, on-demand).
+# ---------------------------------------------------------------------------
+
+
+def _build_carelink_client(region: str, token: str) -> CareLinkClient:
+    """Cookie-less CareLink client authed by the captured bearer only."""
+    base_url = resolve_region_base_url(region)  # ValueError -> 400 (bad region)
+
+    async def _bearer() -> str:
+        return token
+
+    return CareLinkClient(bearer_provider=_bearer, base_url=base_url)
+
+
+@router.post(
+    "/medtronic/availability",
+    response_model=MedtronicAvailabilityResponse,
+    responses={
+        200: {"description": "Available data date range"},
+        400: {"model": ErrorResponse, "description": "Invalid region"},
+        401: {"model": ErrorResponse, "description": "CareLink token invalid/expired"},
+        503: {"model": ErrorResponse, "description": "CareLink unavailable"},
+    },
+)
+@limiter.limit("10/minute")
+async def get_medtronic_availability(
+    body: MedtronicAvailabilityRequest,
+    request: Request,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> MedtronicAvailabilityResponse:
+    """Validate the captured CareLink token and report the available data range
+    (to bound the manual-import date picker). Stateless -- the token is used for
+    this call only and never stored.
+    """
+    client = _build_carelink_client(body.region, body.token)
+    try:
+        await client.get_patient_id()  # validates the bearer early
+        avail = await client.get_availability()
+    except CareLinkAuthError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="CareLink session is invalid or expired. Reconnect and try again.",
+        ) from e
+    except CareLinkError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to reach CareLink. Please try again later.",
+        ) from e
+    finally:
+        await client.aclose()
+
+    return MedtronicAvailabilityResponse(start=avail.start, end=avail.end)
+
+
+@router.post(
+    "/medtronic/import",
+    response_model=MedtronicImportResponse,
+    responses={
+        200: {"description": "Import completed"},
+        400: {"model": ErrorResponse, "description": "Invalid region"},
+        401: {"model": ErrorResponse, "description": "CareLink token invalid/expired"},
+        422: {"model": ErrorResponse, "description": "Invalid date range / timezone"},
+        503: {"model": ErrorResponse, "description": "CareLink unavailable"},
+        504: {"model": ErrorResponse, "description": "CareLink report timed out"},
+    },
+)
+@limiter.limit("5/minute")
+async def import_medtronic_range(
+    body: MedtronicImportRequest,
+    request: Request,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> MedtronicImportResponse:
+    """One-time manual import of a user-chosen CareLink date range. Builds a
+    cookie-less client from the captured bearer, exports the CSV, maps it, and
+    stores it idempotently (upsert on natural keys -- overlapping re-imports are
+    safe). The token is used only here and never persisted.
+    """
+    client = _build_carelink_client(body.region, body.token)
+    try:
+        result = await sync_carelink_for_user(
+            db,
+            current_user.id,
+            start_date=body.start_date,
+            end_date=body.end_date,
+            client=client,
+            tz=zoneinfo.ZoneInfo(body.tz),
+        )
+    except CareLinkAuthError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="CareLink session is invalid or expired. Reconnect and try again.",
+        ) from e
+    except CareLinkReportTimeoutError as e:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="CareLink took too long to generate the report. Try a smaller range.",
+        ) from e
+    except CareLinkError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to reach CareLink. Please try again later.",
+        ) from e
+    finally:
+        await client.aclose()
+
+    return MedtronicImportResponse(
+        message="Import completed successfully",
+        glucose_fetched=result.glucose_fetched,
+        glucose_stored=result.glucose_stored,
+        events_fetched=result.events_fetched,
+        events_stored=result.events_stored,
     )
 
 

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -8,7 +8,16 @@ import uuid
 import zoneinfo
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from pydexcom import Dexcom
 from pydexcom import errors as dexcom_errors
 from sqlalchemy import and_, case, func, select, text
@@ -69,6 +78,8 @@ from src.schemas.integration import (
     TandemCredentialsRequest,
 )
 from src.schemas.medtronic import (
+    CARELINK_TOKEN_HEADER,
+    MAX_TOKEN_LEN,
     MedtronicAvailabilityRequest,
     MedtronicAvailabilityResponse,
     MedtronicImportRequest,
@@ -1706,6 +1717,17 @@ def _build_carelink_client(region: str, token: str) -> CareLinkClient:
     return CareLinkClient(bearer_provider=_bearer, base_url=base_url)
 
 
+def _carelink_token_or_422(token: str | None) -> str:
+    """Validate the captured token from the X-CareLink-Token header. The error
+    message never echoes the token value (it must not land in logs/responses)."""
+    if not token or not (1 <= len(token) <= MAX_TOKEN_LEN):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Missing or malformed CareLink token.",
+        )
+    return token
+
+
 @router.post(
     "/medtronic/availability",
     response_model=MedtronicAvailabilityResponse,
@@ -1721,13 +1743,16 @@ async def get_medtronic_availability(
     body: MedtronicAvailabilityRequest,
     request: Request,
     current_user: DiabeticOrAdminUser,
+    carelink_token: str = Header(alias=CARELINK_TOKEN_HEADER),
     db: AsyncSession = Depends(get_db),
 ) -> MedtronicAvailabilityResponse:
     """Validate the captured CareLink token and report the available data range
-    (to bound the manual-import date picker). Stateless -- the token is used for
-    this call only and never stored.
+    (to bound the manual-import date picker). Stateless -- the token (sent in the
+    X-CareLink-Token header, never the body) is used for this call only and never
+    stored.
     """
-    client = _build_carelink_client(body.region, body.token)
+    token = _carelink_token_or_422(carelink_token)
+    client = _build_carelink_client(body.region, token)
     try:
         await client.get_patient_id()  # validates the bearer early
         avail = await client.get_availability()
@@ -1764,14 +1789,17 @@ async def import_medtronic_range(
     body: MedtronicImportRequest,
     request: Request,
     current_user: DiabeticOrAdminUser,
+    carelink_token: str = Header(alias=CARELINK_TOKEN_HEADER),
     db: AsyncSession = Depends(get_db),
 ) -> MedtronicImportResponse:
     """One-time manual import of a user-chosen CareLink date range. Builds a
     cookie-less client from the captured bearer, exports the CSV, maps it, and
     stores it idempotently (upsert on natural keys -- overlapping re-imports are
-    safe). The token is used only here and never persisted.
+    safe). The token (sent in the X-CareLink-Token header, never the body) is
+    used only here and never persisted.
     """
-    client = _build_carelink_client(body.region, body.token)
+    token = _carelink_token_or_422(carelink_token)
+    client = _build_carelink_client(body.region, token)
     try:
         result = await sync_carelink_for_user(
             db,

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -1708,8 +1708,17 @@ async def import_tandem_range(
 
 
 def _build_carelink_client(region: str, token: str) -> CareLinkClient:
-    """Cookie-less CareLink client authed by the captured bearer only."""
-    base_url = resolve_region_base_url(region)  # ValueError -> 400 (bad region)
+    """Cookie-less CareLink client authed by the captured bearer only.
+
+    Region is normally validated by the request schema (-> 422); this guards the
+    helper directly too so a bad region can never surface as an uncaught 500.
+    """
+    try:
+        base_url = resolve_region_base_url(region)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
 
     async def _bearer() -> str:
         return token
@@ -1733,8 +1742,8 @@ def _carelink_token_or_422(token: str | None) -> str:
     response_model=MedtronicAvailabilityResponse,
     responses={
         200: {"description": "Available data date range"},
-        400: {"model": ErrorResponse, "description": "Invalid region"},
         401: {"model": ErrorResponse, "description": "CareLink token invalid/expired"},
+        422: {"model": ErrorResponse, "description": "Invalid region or token"},
         503: {"model": ErrorResponse, "description": "CareLink unavailable"},
     },
 )
@@ -1777,9 +1786,11 @@ async def get_medtronic_availability(
     response_model=MedtronicImportResponse,
     responses={
         200: {"description": "Import completed"},
-        400: {"model": ErrorResponse, "description": "Invalid region"},
         401: {"model": ErrorResponse, "description": "CareLink token invalid/expired"},
-        422: {"model": ErrorResponse, "description": "Invalid date range / timezone"},
+        422: {
+            "model": ErrorResponse,
+            "description": "Invalid region, date range, timezone, or token",
+        },
         503: {"model": ErrorResponse, "description": "CareLink unavailable"},
         504: {"model": ErrorResponse, "description": "CareLink report timed out"},
     },

--- a/apps/api/src/schemas/medtronic.py
+++ b/apps/api/src/schemas/medtronic.py
@@ -1,0 +1,84 @@
+"""Schemas for the Medtronic CareLink manual historical-import (feature B).
+
+Stateless: the request carries the captured ``auth_tmp_token`` bearer (the user
+grabs it via the bookmarklet capture flow); the backend uses it per-request and
+never stores it. No credential storage / scheduler / sync-state -- a manual
+import completes within one ~50-min token life.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from src.core.medtronic_regions import SUPPORTED_MEDTRONIC_REGIONS
+
+#: Max span per manual import. Conservative start; CareLink CSV is CGM-dense, so
+#: re-measure the fetch time vs the web-proxy timeout on a real range and tune
+#: (mirrors the Tandem 31-day cap process).
+MAX_IMPORT_DAYS = 31
+
+
+def _validate_region(v: str) -> str:
+    key = (v or "").strip().upper()
+    if key not in SUPPORTED_MEDTRONIC_REGIONS:
+        raise ValueError(
+            f"Unsupported region {v!r}; supported: {sorted(SUPPORTED_MEDTRONIC_REGIONS)}"
+        )
+    return key
+
+
+class MedtronicAvailabilityRequest(BaseModel):
+    region: str
+    token: str = Field(min_length=1, description="Captured CareLink auth_tmp_token")
+
+    _region = field_validator("region")(_validate_region)
+
+
+class MedtronicAvailabilityResponse(BaseModel):
+    start: datetime | None
+    end: datetime | None
+
+
+class MedtronicImportRequest(BaseModel):
+    region: str
+    token: str = Field(min_length=1, description="Captured CareLink auth_tmp_token")
+    start_date: date
+    end_date: date
+    tz: str = Field(
+        description="IANA timezone of the pump's local time, e.g. America/Chicago"
+    )
+
+    _region = field_validator("region")(_validate_region)
+
+    @field_validator("tz")
+    @classmethod
+    def _valid_tz(cls, v: str) -> str:
+        try:
+            ZoneInfo(v)
+        except Exception as e:
+            raise ValueError(f"Invalid IANA timezone: {v!r}") from e
+        return v
+
+    @model_validator(mode="after")
+    def _valid_range(self) -> MedtronicImportRequest:
+        if self.end_date < self.start_date:
+            raise ValueError("end_date must be on or after start_date")
+        if self.end_date > datetime.now(UTC).date():
+            raise ValueError("end_date cannot be in the future")
+        span = (self.end_date - self.start_date).days
+        if span > MAX_IMPORT_DAYS:
+            raise ValueError(
+                f"Date range too large ({span} days); max {MAX_IMPORT_DAYS} days per import"
+            )
+        return self
+
+
+class MedtronicImportResponse(BaseModel):
+    message: str
+    glucose_fetched: int
+    glucose_stored: int
+    events_fetched: int
+    events_stored: int

--- a/apps/api/src/schemas/medtronic.py
+++ b/apps/api/src/schemas/medtronic.py
@@ -1,9 +1,10 @@
 """Schemas for the Medtronic CareLink manual historical-import (feature B).
 
-Stateless: the request carries the captured ``auth_tmp_token`` bearer (the user
-grabs it via the bookmarklet capture flow); the backend uses it per-request and
-never stores it. No credential storage / scheduler / sync-state -- a manual
-import completes within one ~50-min token life.
+Stateless: the captured ``auth_tmp_token`` is sent in the ``X-CareLink-Token``
+request HEADER (NOT the JSON body) so it can never land in a body-validation
+422 echo or in request-body logging. The backend uses it per-request and never
+stores it. No credential storage / scheduler / sync-state -- a manual import
+completes within one ~50-min token life.
 """
 
 from __future__ import annotations
@@ -20,6 +21,13 @@ from src.core.medtronic_regions import SUPPORTED_MEDTRONIC_REGIONS
 #: (mirrors the Tandem 31-day cap process).
 MAX_IMPORT_DAYS = 31
 
+#: Header carrying the captured CareLink session token (kept out of the body).
+CARELINK_TOKEN_HEADER = "X-CareLink-Token"
+
+#: Upper bound on the captured token length -- reject absurd payloads early. A
+#: real auth_tmp_token (a JWT) is ~1-2 KB.
+MAX_TOKEN_LEN = 8192
+
 
 def _validate_region(v: str) -> str:
     key = (v or "").strip().upper()
@@ -32,7 +40,6 @@ def _validate_region(v: str) -> str:
 
 class MedtronicAvailabilityRequest(BaseModel):
     region: str
-    token: str = Field(min_length=1, description="Captured CareLink auth_tmp_token")
 
     _region = field_validator("region")(_validate_region)
 
@@ -44,7 +51,6 @@ class MedtronicAvailabilityResponse(BaseModel):
 
 class MedtronicImportRequest(BaseModel):
     region: str
-    token: str = Field(min_length=1, description="Captured CareLink auth_tmp_token")
     start_date: date
     end_date: date
     tz: str = Field(

--- a/apps/api/src/schemas/medtronic.py
+++ b/apps/api/src/schemas/medtronic.py
@@ -74,10 +74,12 @@ class MedtronicImportRequest(BaseModel):
             raise ValueError("end_date must be on or after start_date")
         if self.end_date > datetime.now(UTC).date():
             raise ValueError("end_date cannot be in the future")
-        span = (self.end_date - self.start_date).days
-        if span > MAX_IMPORT_DAYS:
+        # Inclusive day count: 2025-01-01..2025-01-31 is 31 days, not 30.
+        span_days = (self.end_date - self.start_date).days + 1
+        if span_days > MAX_IMPORT_DAYS:
             raise ValueError(
-                f"Date range too large ({span} days); max {MAX_IMPORT_DAYS} days per import"
+                f"Date range too large ({span_days} days); "
+                f"max {MAX_IMPORT_DAYS} days per import"
             )
         return self
 

--- a/apps/api/src/services/integrations/medtronic/__init__.py
+++ b/apps/api/src/services/integrations/medtronic/__init__.py
@@ -1,0 +1,7 @@
+"""Medtronic CareLink integration (Cloud Sync, download direction).
+
+Clean-room implementation built from our own observation of the CareLink
+Personal web API and CSV data export -- not derived from any third-party
+source. Mirrors the Tandem Cloud Sync shape (availability + manual
+custom-range import) but for Medtronic CareLink.
+"""

--- a/apps/api/src/services/integrations/medtronic/carelink_csv.py
+++ b/apps/api/src/services/integrations/medtronic/carelink_csv.py
@@ -49,16 +49,15 @@ COL_SENSOR_STATE = "Sensor State"
 
 _HEADER_FIRST_COL = COL_INDEX
 
-# Date formats seen / plausible across locales. The US web export emits the
-# data-row date as YYYY/MM/DD with a 24h time; we try the observed format
-# first, then defensive fallbacks (EU day-first, dash separators).
+# Only UNAMBIGUOUS date formats. The US web export emits the data-row date as
+# YYYY/MM/DD; ISO (YYYY-MM-DD) is also year-first and unambiguous. We do NOT
+# guess between %d/%m and %m/%d -- ordering luck there would silently mis-date
+# events by months. A date that matches neither yields no timestamp (the row
+# is skipped, a visible failure) instead of being silently mis-parsed; other
+# locale formats must be added explicitly once confirmed live.
 _DATE_FORMATS = (
     "%Y/%m/%d",
-    "%d/%m/%Y",
-    "%m/%d/%Y",
     "%Y-%m-%d",
-    "%d-%m-%Y",
-    "%m-%d-%Y",
 )
 _TIME_FORMATS = ("%H:%M:%S", "%H:%M")
 
@@ -116,9 +115,12 @@ def _parse_float(value: str | None) -> float | None:
     v = _clean(value)
     if v is None:
         return None
-    # Tolerate a European decimal comma when it's unambiguously the decimal
-    # mark (no dot present), e.g. "1,5" -> 1.5.
-    if "," in v and "." not in v:
+    # Tolerate a European decimal comma only when it's unambiguously the
+    # decimal mark: exactly one comma, no dot (e.g. "1,5" -> 1.5). The single-
+    # comma guard avoids mangling a thousands-grouped value like "1,234,5".
+    # (A comma can only appear inside a value at all when the file is
+    # semicolon-delimited, since the csv reader splits on a comma delimiter.)
+    if v.count(",") == 1 and "." not in v:
         v = v.replace(",", ".")
     try:
         return float(v)
@@ -168,12 +170,17 @@ def _detect_delimiter(text: str) -> str:
     return ","
 
 
-def parse_carelink_csv(text: str) -> CareLinkExport:
+def parse_carelink_csv(text: str, *, keep_raw: bool = False) -> CareLinkExport:
     """Parse a CareLink Data Export (CSV) into a :class:`CareLinkExport`.
 
     Tolerant by design: unknown/extra columns are ignored, missing fields
     become ``None``, unparseable rows are skipped rather than raising. Rows
     are emitted in file order across all sections.
+
+    ``keep_raw=False`` (default) leaves ``CareLinkRow.raw`` empty -- the typed
+    fields cover everything the mapper needs, and a per-row dict of every cell
+    roughly doubles memory on a multi-year export. Pass ``keep_raw=True`` only
+    if a caller needs columns not lifted into the typed fields.
     """
     export = CareLinkExport()
     if not text:
@@ -219,7 +226,11 @@ def parse_carelink_csv(text: str) -> CareLinkExport:
         if idx is None and ts is None:
             continue
 
-        raw = {header[i]: fields_[i] for i in range(min(len(header), len(fields_)))}
+        raw = (
+            {header[i]: fields_[i] for i in range(min(len(header), len(fields_)))}
+            if keep_raw
+            else {}
+        )
         export.rows.append(
             CareLinkRow(
                 timestamp=ts,

--- a/apps/api/src/services/integrations/medtronic/carelink_csv.py
+++ b/apps/api/src/services/integrations/medtronic/carelink_csv.py
@@ -1,0 +1,268 @@
+"""Parser for the Medtronic CareLink "Data Export (CSV)" file.
+
+Clean-room: written from our own observation of the export format, not from
+any third-party library's source.
+
+The export is a *multi-section* CSV: a metadata preamble (patient/device
+header), then one or more data sections. Each section starts with a column
+header row beginning ``Index,Date,Time,...`` followed by its data rows
+(``Index`` restarts at 0 per section). Columns are mapped **by name**, so the
+parser is resilient to column re-ordering or additions across pump
+models/firmware.
+
+This module does ONE thing: turn the messy CSV into a clean stream of typed
+``CareLinkRow`` records (parsed timestamp + the fields we care about, plus the
+full raw row). Classifying rows into our PumpEvent/glucose model is a separate
+mapper, kept apart for testability (mirrors the Nightscout parser/mapper split).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass, field
+from datetime import datetime
+
+# --- Canonical CareLink column names (observed in the v15.x export header) ---
+COL_INDEX = "Index"
+COL_DATE = "Date"
+COL_TIME = "Time"
+COL_BG_SOURCE = "BG Source"
+COL_BG_READING = "BG Reading (mg/dL)"
+COL_BASAL_RATE = "Basal Rate (U/h)"
+COL_TEMP_BASAL_AMOUNT = "Temp Basal Amount"
+COL_TEMP_BASAL_TYPE = "Temp Basal Type"
+COL_TEMP_BASAL_DURATION = "Temp Basal Duration (h:mm:ss)"
+COL_BOLUS_TYPE = "Bolus Type"
+COL_BOLUS_SELECTED = "Bolus Volume Selected (U)"
+COL_BOLUS_DELIVERED = "Bolus Volume Delivered (U)"
+COL_BOLUS_SOURCE = "Bolus Source"
+COL_BWZ_CARB_INPUT = "BWZ Carb Input (grams)"
+COL_BWZ_ACTIVE_INSULIN = "BWZ Active Insulin (U)"
+COL_SENSOR_GLUCOSE = "Sensor Glucose (mg/dL)"
+COL_ISIG = "ISIG Value"
+COL_ALERT = "Alert"
+COL_SUSPEND = "Suspend"
+COL_REWIND = "Rewind"
+COL_EVENT_MARKER = "Event Marker"
+COL_SENSOR_STATE = "Sensor State"
+
+_HEADER_FIRST_COL = COL_INDEX
+
+# Date formats seen / plausible across locales. The US web export emits the
+# data-row date as YYYY/MM/DD with a 24h time; we try the observed format
+# first, then defensive fallbacks (EU day-first, dash separators).
+_DATE_FORMATS = (
+    "%Y/%m/%d",
+    "%d/%m/%Y",
+    "%m/%d/%Y",
+    "%Y-%m-%d",
+    "%d-%m-%Y",
+    "%m-%d-%Y",
+)
+_TIME_FORMATS = ("%H:%M:%S", "%H:%M")
+
+
+@dataclass
+class CareLinkRow:
+    """One parsed data row from a CareLink export section."""
+
+    timestamp: datetime | None
+    index: int | None
+    bg_source: str | None = None
+    bg_mgdl: int | None = None
+    sensor_glucose_mgdl: int | None = None
+    isig: float | None = None
+    basal_rate_uh: float | None = None
+    temp_basal_amount: float | None = None
+    temp_basal_type: str | None = None
+    temp_basal_duration: str | None = None
+    bolus_type: str | None = None
+    bolus_selected_u: float | None = None
+    bolus_delivered_u: float | None = None
+    bolus_source: str | None = None
+    carb_input_g: float | None = None
+    active_insulin_u: float | None = None
+    alert: str | None = None
+    suspend: str | None = None
+    rewind: str | None = None
+    event_marker: str | None = None
+    sensor_state: str | None = None
+    # Full original row (canonical-name -> raw string) for anything not lifted
+    # into a typed field above. Lets the mapper reach rarely-used columns
+    # without re-parsing.
+    raw: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class CareLinkExport:
+    """A parsed CareLink CSV export: device metadata + all data rows."""
+
+    rows: list[CareLinkRow] = field(default_factory=list)
+    device: str | None = None
+    serial_number: str | None = None
+    cgm: str | None = None
+    section_count: int = 0
+
+
+def _clean(value: str | None) -> str | None:
+    if value is None:
+        return None
+    v = value.strip()
+    return v or None
+
+
+def _parse_float(value: str | None) -> float | None:
+    v = _clean(value)
+    if v is None:
+        return None
+    # Tolerate a European decimal comma when it's unambiguously the decimal
+    # mark (no dot present), e.g. "1,5" -> 1.5.
+    if "," in v and "." not in v:
+        v = v.replace(",", ".")
+    try:
+        return float(v)
+    except ValueError:
+        return None
+
+
+def _parse_int(value: str | None) -> int | None:
+    f = _parse_float(value)
+    if f is None:
+        return None
+    try:
+        return int(round(f))
+    except (ValueError, OverflowError):
+        return None
+
+
+def _parse_timestamp(date_s: str | None, time_s: str | None) -> datetime | None:
+    d = _clean(date_s)
+    t = _clean(time_s)
+    if not d:
+        return None
+    # Time may be absent on some rows; default to midnight so the row still
+    # carries a usable date.
+    t = t or "00:00:00"
+    for df in _DATE_FORMATS:
+        for tf in _TIME_FORMATS:
+            try:
+                return datetime.strptime(f"{d} {t}", f"{df} {tf}")
+            except ValueError:
+                continue
+    # Date alone (no parseable time)
+    for df in _DATE_FORMATS:
+        try:
+            return datetime.strptime(d, df)
+        except ValueError:
+            continue
+    return None
+
+
+def _detect_delimiter(text: str) -> str:
+    """CareLink US exports are comma-delimited; some locales use semicolons.
+    Decide from the header row (the one starting with ``Index``)."""
+    for line in text.splitlines():
+        if line.startswith(_HEADER_FIRST_COL):
+            return ";" if line.count(";") > line.count(",") else ","
+    return ","
+
+
+def parse_carelink_csv(text: str) -> CareLinkExport:
+    """Parse a CareLink Data Export (CSV) into a :class:`CareLinkExport`.
+
+    Tolerant by design: unknown/extra columns are ignored, missing fields
+    become ``None``, unparseable rows are skipped rather than raising. Rows
+    are emitted in file order across all sections.
+    """
+    export = CareLinkExport()
+    if not text:
+        return export
+
+    # Strip a UTF-8 BOM if present (the export carries one).
+    if text and text[0] == "﻿":
+        text = text[1:]
+
+    delimiter = _detect_delimiter(text)
+    reader = csv.reader(io.StringIO(text), delimiter=delimiter)
+
+    header: list[str] | None = None
+    col: dict[str, int] = {}
+
+    def get(row: list[str], name: str) -> str | None:
+        i = col.get(name)
+        if i is None or i >= len(row):
+            return None
+        return row[i]
+
+    for fields_ in reader:
+        if not fields_:
+            continue
+        first = fields_[0].strip()
+
+        # A new section header row.
+        if first == _HEADER_FIRST_COL:
+            header = [c.strip() for c in fields_]
+            col = {name: i for i, name in enumerate(header)}
+            export.section_count += 1
+            continue
+
+        # Metadata preamble lines (before the first header). Lift a few useful
+        # device facts; ignore the rest.
+        if header is None:
+            _scan_metadata(fields_, export)
+            continue
+
+        # A data row: must have a numeric Index to count as one.
+        idx = _parse_int(get(fields_, COL_INDEX))
+        ts = _parse_timestamp(get(fields_, COL_DATE), get(fields_, COL_TIME))
+        if idx is None and ts is None:
+            continue
+
+        raw = {header[i]: fields_[i] for i in range(min(len(header), len(fields_)))}
+        export.rows.append(
+            CareLinkRow(
+                timestamp=ts,
+                index=idx,
+                bg_source=_clean(get(fields_, COL_BG_SOURCE)),
+                bg_mgdl=_parse_int(get(fields_, COL_BG_READING)),
+                sensor_glucose_mgdl=_parse_int(get(fields_, COL_SENSOR_GLUCOSE)),
+                isig=_parse_float(get(fields_, COL_ISIG)),
+                basal_rate_uh=_parse_float(get(fields_, COL_BASAL_RATE)),
+                temp_basal_amount=_parse_float(get(fields_, COL_TEMP_BASAL_AMOUNT)),
+                temp_basal_type=_clean(get(fields_, COL_TEMP_BASAL_TYPE)),
+                temp_basal_duration=_clean(get(fields_, COL_TEMP_BASAL_DURATION)),
+                bolus_type=_clean(get(fields_, COL_BOLUS_TYPE)),
+                bolus_selected_u=_parse_float(get(fields_, COL_BOLUS_SELECTED)),
+                bolus_delivered_u=_parse_float(get(fields_, COL_BOLUS_DELIVERED)),
+                bolus_source=_clean(get(fields_, COL_BOLUS_SOURCE)),
+                carb_input_g=_parse_float(get(fields_, COL_BWZ_CARB_INPUT)),
+                active_insulin_u=_parse_float(get(fields_, COL_BWZ_ACTIVE_INSULIN)),
+                alert=_clean(get(fields_, COL_ALERT)),
+                suspend=_clean(get(fields_, COL_SUSPEND)),
+                rewind=_clean(get(fields_, COL_REWIND)),
+                event_marker=_clean(get(fields_, COL_EVENT_MARKER)),
+                sensor_state=_clean(get(fields_, COL_SENSOR_STATE)),
+                raw=raw,
+            )
+        )
+
+    return export
+
+
+def _scan_metadata(fields_: list[str], export: CareLinkExport) -> None:
+    """Extract device/serial/CGM from the metadata preamble.
+
+    The preamble is a loose key,value layout, e.g.
+    ``...,Device,MiniMed 780G MMT-1884,...`` and ``"Serial Number",NG...``.
+    We scan for known labels and take the following cell.
+    """
+    cells = [c.strip().strip('"') for c in fields_]
+    for i, c in enumerate(cells):
+        nxt = cells[i + 1] if i + 1 < len(cells) else None
+        if c == "Device" and nxt and export.device is None:
+            export.device = nxt
+        elif c == "Serial Number" and nxt and export.serial_number is None:
+            export.serial_number = nxt
+        elif c == "CGM" and nxt and export.cgm is None:
+            export.cgm = nxt

--- a/apps/api/src/services/integrations/medtronic/carelink_mapper.py
+++ b/apps/api/src/services/integrations/medtronic/carelink_mapper.py
@@ -6,10 +6,18 @@ records (CGM glucose + pump events). A separate storage layer assigns
 persistence for testability (mirrors the Nightscout parser/mapper split).
 
 Mapping mirrors the Tandem conventions so the two integrations populate the
-same model the same way:
-- SmartGuard auto-bolus (``Bolus Source = CLOSED_LOOP_AUTO_BOLUS``) ->
-  CORRECTION + ``is_automated`` (analogous to Tandem Control-IQ corrections).
-- A manual/wizard bolus -> BOLUS.
+same shared model the same way (BASAL.units = U/h rate; BOLUS/CORRECTION.units =
+absolute units delivered):
+- SmartGuard auto-correction (``Bolus Source`` contains CORRECTION but not FOOD,
+  e.g. ``CLOSED_LOOP_BG_CORRECTION``) -> CORRECTION + ``is_automated`` (mirrors
+  Tandem Control-IQ corrections, so the shared AI/brief "auto-correction" rollups
+  include Medtronic).
+- A meal/manual/wizard bolus (incl. ``CLOSED_LOOP_BG_CORRECTION_AND_FOOD_BOLUS``)
+  -> BOLUS (user-initiated).
+- ``CLOSED_LOOP_AUTO_INSULIN`` is a DAILY auto-basal TOTAL (logged at 00:00), NOT
+  a bolus -> SKIPPED. As a bolus it inflates bolus insulin; as a BASAL event it
+  would be read as a U/h rate and multiplied by 24 in the rate-based TDD calc
+  (``daily_brief``). Basal comes from the scheduled ``Basal Rate (U/h)`` events.
 - Fingerstick meter reading -> BG_READING pump event (as Tandem does).
 - Continuous Sensor Glucose -> a glucose reading (Medtronic provides CGM
   inline, unlike Tandem where glucose comes from Dexcom).
@@ -27,8 +35,25 @@ from .carelink_csv import CareLinkExport, CareLinkRow
 #: Source tag written on every persisted Medtronic row.
 SOURCE = "medtronic"
 
-#: ``Bolus Source`` value Medtronic uses for a SmartGuard auto-correction bolus.
-_AUTO_BOLUS_SOURCE = "CLOSED_LOOP_AUTO_BOLUS"
+
+def _classify_bolus(
+    source: str | None,
+) -> tuple[PumpEventType, bool, str | None] | None:
+    """Classify a delivered bolus by its CareLink ``Bolus Source``.
+
+    Returns ``(event_type, is_automated, control_iq_reason)`` or ``None`` if the
+    row must NOT be recorded as a bolus. Source values verified against a live
+    780G SmartGuard export.
+    """
+    s = (source or "").upper()
+    # Daily auto-basal total -- not a discrete bolus (see module docstring).
+    if "AUTO_INSULIN" in s:
+        return None
+    # Closed-loop BG correction (no food) -> automated correction (like Tandem).
+    if "CORRECTION" in s and "FOOD" not in s:
+        return (PumpEventType.CORRECTION, True, "correction")
+    # Meal/food bolus, wizard, manual, preset -> user-initiated bolus.
+    return (PumpEventType.BOLUS, False, None)
 
 
 @dataclass
@@ -106,16 +131,22 @@ def _map_row(row: CareLinkRow) -> tuple[list[MappedGlucose], list[MappedPumpEven
             )
         )
 
-    # Bolus delivery.
-    if row.bolus_delivered_u is not None and row.bolus_delivered_u > 0:
-        auto = (row.bolus_source or "").upper() == _AUTO_BOLUS_SOURCE
+    # Bolus delivery. CLOSED_LOOP_AUTO_INSULIN (a daily auto-basal total) maps to
+    # None and is skipped -- it must not become a bolus or a basal-rate event.
+    bolus_class = (
+        _classify_bolus(row.bolus_source)
+        if row.bolus_delivered_u is not None and row.bolus_delivered_u > 0
+        else None
+    )
+    if bolus_class is not None:
+        etype, automated, reason = bolus_class
         events.append(
             MappedPumpEvent(
-                event_type=PumpEventType.CORRECTION if auto else PumpEventType.BOLUS,
+                event_type=etype,
                 timestamp=ts,
                 units=row.bolus_delivered_u,
-                is_automated=auto,
-                control_iq_reason="auto_correction" if auto else None,
+                is_automated=automated,
+                control_iq_reason=reason,
                 cob_at_event=row.carb_input_g,
                 iob_at_event=row.active_insulin_u,
             )

--- a/apps/api/src/services/integrations/medtronic/carelink_mapper.py
+++ b/apps/api/src/services/integrations/medtronic/carelink_mapper.py
@@ -1,0 +1,183 @@
+"""Map parsed CareLink rows into our normalized model.
+
+Pure function (no DB): turns a :class:`CareLinkExport` into neutral typed
+records (CGM glucose + pump events). A separate storage layer assigns
+``user_id``/``received_at`` and upserts. Kept apart from the parser and from
+persistence for testability (mirrors the Nightscout parser/mapper split).
+
+Mapping mirrors the Tandem conventions so the two integrations populate the
+same model the same way:
+- SmartGuard auto-bolus (``Bolus Source = CLOSED_LOOP_AUTO_BOLUS``) ->
+  CORRECTION + ``is_automated`` (analogous to Tandem Control-IQ corrections).
+- A manual/wizard bolus -> BOLUS.
+- Fingerstick meter reading -> BG_READING pump event (as Tandem does).
+- Continuous Sensor Glucose -> a glucose reading (Medtronic provides CGM
+  inline, unlike Tandem where glucose comes from Dexcom).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from src.models.pump_data import PumpEventType
+
+from .carelink_csv import CareLinkExport, CareLinkRow
+
+#: Source tag written on every persisted Medtronic row.
+SOURCE = "medtronic"
+
+#: ``Bolus Source`` value Medtronic uses for a SmartGuard auto-correction bolus.
+_AUTO_BOLUS_SOURCE = "CLOSED_LOOP_AUTO_BOLUS"
+
+
+@dataclass
+class MappedGlucose:
+    """A CGM sensor-glucose reading, ready for the glucose_readings table."""
+
+    timestamp: datetime
+    value_mgdl: int
+    source: str = SOURCE
+
+
+@dataclass
+class MappedPumpEvent:
+    """A normalized pump event, ready for the pump_events table."""
+
+    event_type: PumpEventType
+    timestamp: datetime
+    units: float | None = None
+    duration_minutes: int | None = None
+    is_automated: bool = False
+    control_iq_reason: str | None = None
+    iob_at_event: float | None = None
+    cob_at_event: float | None = None
+    bg_at_event: int | None = None
+    source: str = SOURCE
+
+
+@dataclass
+class MappedRecords:
+    glucose: list[MappedGlucose] = field(default_factory=list)
+    pump_events: list[MappedPumpEvent] = field(default_factory=list)
+
+
+def _duration_to_minutes(hms: str | None) -> int | None:
+    """Parse a CareLink ``h:mm:ss`` duration into whole minutes."""
+    if not hms:
+        return None
+    parts = hms.split(":")
+    try:
+        nums = [int(p) for p in parts]
+    except ValueError:
+        return None
+    if len(nums) == 3:
+        h, m, s = nums
+    elif len(nums) == 2:
+        h, m, s = 0, nums[0], nums[1]
+    else:
+        return None
+    return h * 60 + m + (1 if s >= 30 else 0)
+
+
+def _map_row(row: CareLinkRow) -> tuple[list[MappedGlucose], list[MappedPumpEvent]]:
+    """Map a single CareLink row to 0+ glucose readings and pump events.
+
+    One CSV row generally carries one fact, but a wizard bolus row also carries
+    carb/IOB context that we attach to the bolus event.
+    """
+    ts = row.timestamp
+    glucose: list[MappedGlucose] = []
+    events: list[MappedPumpEvent] = []
+    if ts is None:
+        return glucose, events
+
+    # Continuous sensor glucose -> CGM reading.
+    if row.sensor_glucose_mgdl is not None:
+        glucose.append(MappedGlucose(timestamp=ts, value_mgdl=row.sensor_glucose_mgdl))
+
+    # Fingerstick / meter BG -> BG_READING pump event (matches Tandem).
+    if row.bg_mgdl is not None:
+        events.append(
+            MappedPumpEvent(
+                event_type=PumpEventType.BG_READING,
+                timestamp=ts,
+                bg_at_event=row.bg_mgdl,
+            )
+        )
+
+    # Bolus delivery.
+    if row.bolus_delivered_u is not None and row.bolus_delivered_u > 0:
+        auto = (row.bolus_source or "").upper() == _AUTO_BOLUS_SOURCE
+        events.append(
+            MappedPumpEvent(
+                event_type=PumpEventType.CORRECTION if auto else PumpEventType.BOLUS,
+                timestamp=ts,
+                units=row.bolus_delivered_u,
+                is_automated=auto,
+                control_iq_reason="auto_correction" if auto else None,
+                cob_at_event=row.carb_input_g,
+                iob_at_event=row.active_insulin_u,
+            )
+        )
+    # Carb-only entry (carbs logged without a bolus on this row).
+    elif row.carb_input_g is not None and row.carb_input_g > 0:
+        events.append(
+            MappedPumpEvent(
+                event_type=PumpEventType.CARBS,
+                timestamp=ts,
+                cob_at_event=row.carb_input_g,
+                iob_at_event=row.active_insulin_u,
+            )
+        )
+
+    # Temp basal (SmartGuard auto-adjusts basal -> mark automated) takes
+    # precedence over a scheduled basal-rate change on the same row.
+    if row.temp_basal_amount is not None:
+        events.append(
+            MappedPumpEvent(
+                event_type=PumpEventType.BASAL,
+                timestamp=ts,
+                units=row.temp_basal_amount,
+                duration_minutes=_duration_to_minutes(row.temp_basal_duration),
+                is_automated=True,
+                control_iq_reason="temp_basal",
+            )
+        )
+    elif row.basal_rate_uh is not None:
+        events.append(
+            MappedPumpEvent(
+                event_type=PumpEventType.BASAL,
+                timestamp=ts,
+                units=row.basal_rate_uh,
+            )
+        )
+
+    # Suspend / resume.
+    suspend = (row.suspend or "").upper()
+    if suspend:
+        if "NORMAL" in suspend:  # NORMAL_PUMPING -> resumed
+            events.append(
+                MappedPumpEvent(event_type=PumpEventType.RESUME, timestamp=ts)
+            )
+        elif "SUSPEND" in suspend:
+            events.append(
+                MappedPumpEvent(event_type=PumpEventType.SUSPEND, timestamp=ts)
+            )
+
+    return glucose, events
+
+
+def map_carelink_export(export: CareLinkExport) -> MappedRecords:
+    """Map a parsed CareLink export to normalized glucose + pump-event records.
+
+    Storage dedupes on the natural keys (``user_id, reading_timestamp`` for
+    glucose; ``user_id, event_timestamp, event_type`` for pump events), so this
+    mapper does not need to dedupe -- it just maps in file order.
+    """
+    records = MappedRecords()
+    for row in export.rows:
+        glucose, events = _map_row(row)
+        records.glucose.extend(glucose)
+        records.pump_events.extend(events)
+    return records

--- a/apps/api/src/services/integrations/medtronic/carelink_mapper.py
+++ b/apps/api/src/services/integrations/medtronic/carelink_mapper.py
@@ -163,18 +163,23 @@ def _map_row(row: CareLinkRow) -> tuple[list[MappedGlucose], list[MappedPumpEven
         )
 
     # Temp basal (SmartGuard auto-adjusts basal -> mark automated) takes
-    # precedence over a scheduled basal-rate change on the same row.
+    # precedence over a scheduled basal-rate change on the same row. Only an
+    # ABSOLUTE temp basal is a U/h rate we can put in BASAL.units. A PERCENT
+    # temp basal (amount = % of the scheduled rate, e.g. 120) would be read as a
+    # U/h rate and multiplied by 24 in the rate-based TDD calc, so skip it -- we
+    # can't resolve % -> U/h without the active scheduled rate at that instant.
     if row.temp_basal_amount is not None:
-        events.append(
-            MappedPumpEvent(
-                event_type=PumpEventType.BASAL,
-                timestamp=ts,
-                units=row.temp_basal_amount,
-                duration_minutes=_duration_to_minutes(row.temp_basal_duration),
-                is_automated=True,
-                control_iq_reason="temp_basal",
+        if "PERCENT" not in (row.temp_basal_type or "").upper():
+            events.append(
+                MappedPumpEvent(
+                    event_type=PumpEventType.BASAL,
+                    timestamp=ts,
+                    units=row.temp_basal_amount,
+                    duration_minutes=_duration_to_minutes(row.temp_basal_duration),
+                    is_automated=True,
+                    control_iq_reason="temp_basal",
+                )
             )
-        )
     elif row.basal_rate_uh is not None:
         events.append(
             MappedPumpEvent(

--- a/apps/api/src/services/integrations/medtronic/client.py
+++ b/apps/api/src/services/integrations/medtronic/client.py
@@ -278,10 +278,12 @@ class CareLinkClient:
         # Validate it actually looks like a CareLink export. Because the
         # reportStatus "ready" shape is unconfirmed, a too-early/partial fetch
         # would otherwise parse to zero rows and silently under-import.
-        if "Index," not in text:
+        # Accept both comma and semicolon (EU-locale) delimited exports -- the
+        # parser handles either; this guard must not reject a valid one.
+        if "Index," not in text and "Index;" not in text:
             raise CareLinkError(
                 f"CareLink reportCsv for job {uuid} did not return a CSV "
-                "with an 'Index,' header (job may not have been ready)"
+                "with an 'Index' header (job may not have been ready)"
             )
         return text
 

--- a/apps/api/src/services/integrations/medtronic/client.py
+++ b/apps/api/src/services/integrations/medtronic/client.py
@@ -37,6 +37,10 @@ import httpx
 #: Max retries on HTTP 429 (rate limit) before giving up.
 _MAX_RETRIES_429 = 3
 
+#: Reject an absurdly large report rather than parsing it into memory. A real
+#: 31-day CGM-dense CSV is well under 1 MB; this is a generous safety net.
+_MAX_CSV_BYTES = 25 * 1024 * 1024
+
 #: US CareLink host (confirmed). EU uses a different regional host; pass
 #: base_url explicitly for it rather than guessing here.
 US_BASE_URL = "https://carelink.minimed.com"
@@ -216,7 +220,12 @@ class CareLinkClient:
         start, end = data.get("start"), data.get("end")
         if not start or not end:
             raise CareLinkError("snapshotTimelinesRange missing start/end")
-        return CareLinkAvailability(start=_parse_iso(start), end=_parse_iso(end))
+        try:
+            return CareLinkAvailability(start=_parse_iso(start), end=_parse_iso(end))
+        except (ValueError, TypeError) as e:
+            raise CareLinkError(
+                f"Could not parse snapshotTimelinesRange dates ({start!r}, {end!r})"
+            ) from e
 
     async def export_csv(
         self,
@@ -260,6 +269,11 @@ class CareLinkClient:
             "/patient/reports/reportCsv",
             params={"uuid": uuid, "dMInFileName": "false"},
         )
+        if len(csv_resp.content) > _MAX_CSV_BYTES:
+            raise CareLinkError(
+                f"CareLink reportCsv for job {uuid} is too large "
+                f"({len(csv_resp.content)} bytes > {_MAX_CSV_BYTES} cap)"
+            )
         text = csv_resp.text
         # Validate it actually looks like a CareLink export. Because the
         # reportStatus "ready" shape is unconfirmed, a too-early/partial fetch

--- a/apps/api/src/services/integrations/medtronic/client.py
+++ b/apps/api/src/services/integrations/medtronic/client.py
@@ -1,0 +1,276 @@
+"""CareLink Personal HTTP client -- data methods (clean-room).
+
+Built from our own observation of the CareLink Personal web API. Covers the
+read/download surface this feature needs:
+
+- ``get_patient_id()``  -> GET /patient/users/me
+- ``get_availability()`` -> GET /patient/reports/snapshotTimelinesRange
+- ``export_csv(...)``    -> the async CSV-export job:
+      POST /patient/reports/generateReport  (returns a job uuid)
+   -> GET  /patient/reports/reportStatus?uuid=...  (poll until ready)
+   -> GET  /patient/reports/reportCsv?uuid=...      (download the CSV text)
+
+**Auth is injected** as an async ``bearer_provider`` callable, so these data
+methods are independent of (and testable without) the session-capture flow,
+which is the genuinely uncertain part of this integration. The provider
+returns a valid bearer for each call; refreshing it is the provider's job.
+
+Confirmed against a live US account: the auth model, the availability shape
+``{"start", "end"}``, the generateReport request body, and the
+generateReport->reportStatus->reportCsv sequence. NOT yet confirmed live (so
+parsed tolerantly here, to be pinned during the integration spike): the exact
+field names in the /users/me and generateReport *responses* and the
+reportStatus *response* body. These are marked inline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+
+import httpx
+
+#: US CareLink host (confirmed). EU uses a different host; pass base_url
+#: explicitly for it rather than guessing here.
+US_BASE_URL = "https://carelink.minimed.com"
+
+BearerProvider = Callable[[], Awaitable[str]]
+
+# reportStatus "ready" signals. We observed the generateReport ->
+# reportStatus -> reportCsv sequence but not the status response body, so we
+# accept a tolerant set of completion markers; to be confirmed live.
+_READY_TOKENS = {
+    "COMPLETE",
+    "COMPLETED",
+    "READY",
+    "DONE",
+    "SUCCESS",
+    "SUCCEEDED",
+    "FINISHED",
+}
+
+
+class CareLinkError(Exception):
+    """Base error for CareLink client calls."""
+
+
+class CareLinkAuthError(CareLinkError):
+    """401/403 from CareLink -- the session/bearer is invalid or expired."""
+
+
+class CareLinkReportTimeoutError(CareLinkError):
+    """The CSV-export job did not become ready within the poll budget."""
+
+
+@dataclass
+class CareLinkAvailability:
+    """Date range of pump data available in the user's CareLink cloud."""
+
+    start: datetime
+    end: datetime
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _first(d: dict, *keys: str) -> object | None:
+    """First present, truthy value among ``keys`` (tolerant response parsing)."""
+    for k in keys:
+        v = d.get(k)
+        if v:
+            return v
+    return None
+
+
+class CareLinkClient:
+    def __init__(
+        self,
+        *,
+        bearer_provider: BearerProvider,
+        base_url: str = US_BASE_URL,
+        client: httpx.AsyncClient | None = None,
+        timeout_seconds: float = 30.0,
+        poll_interval_seconds: float = 2.0,
+        poll_max_attempts: int = 30,
+    ) -> None:
+        self._bearer_provider = bearer_provider
+        self._base_url = base_url.rstrip("/")
+        self._poll_interval = poll_interval_seconds
+        self._poll_max_attempts = poll_max_attempts
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=min(5.0, timeout_seconds),
+                read=timeout_seconds,
+                write=min(5.0, timeout_seconds),
+                pool=min(2.0, timeout_seconds),
+            )
+        )
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> CareLinkClient:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        await self.aclose()
+
+    async def _headers(self) -> dict[str, str]:
+        bearer = await self._bearer_provider()
+        return {
+            "Authorization": f"Bearer {bearer}",
+            "Accept": "application/json, text/plain, */*",
+        }
+
+    def _check(self, resp: httpx.Response) -> None:
+        if resp.status_code in (401, 403):
+            raise CareLinkAuthError(
+                f"CareLink auth failed ({resp.status_code}); session invalid/expired"
+            )
+        if resp.status_code >= 400:
+            raise CareLinkError(
+                f"CareLink request to {resp.request.url.path} failed: "
+                f"{resp.status_code}"
+            )
+
+    async def _get(self, path: str, **kwargs: object) -> httpx.Response:
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}{path}", headers=await self._headers(), **kwargs
+            )
+        except httpx.HTTPError as e:
+            raise CareLinkError(f"CareLink network error on GET {path}: {e}") from e
+        self._check(resp)
+        return resp
+
+    async def _post(self, path: str, *, json: dict) -> httpx.Response:
+        try:
+            resp = await self._client.post(
+                f"{self._base_url}{path}", headers=await self._headers(), json=json
+            )
+        except httpx.HTTPError as e:
+            raise CareLinkError(f"CareLink network error on POST {path}: {e}") from e
+        self._check(resp)
+        return resp
+
+    async def get_patient_id(self) -> str:
+        """Fetch the patient/account id required by generateReport."""
+        data = self._json(await self._get("/patient/users/me"))
+        # Response field name unconfirmed live -- accept the likely candidates.
+        pid = _first(data, "patientId", "accountId", "loginId", "id")
+        if pid is None:
+            raise CareLinkError("Could not find patient id in /patient/users/me")
+        return str(pid)
+
+    async def get_availability(self) -> CareLinkAvailability:
+        """Date range of data available in the CareLink cloud."""
+        data = self._json(await self._get("/patient/reports/snapshotTimelinesRange"))
+        start, end = data.get("start"), data.get("end")
+        if not start or not end:
+            raise CareLinkError("snapshotTimelinesRange missing start/end")
+        return CareLinkAvailability(start=_parse_iso(start), end=_parse_iso(end))
+
+    async def export_csv(
+        self,
+        *,
+        patient_id: str,
+        start_date: date,
+        end_date: date,
+    ) -> str:
+        """Run the CSV-export job for [start_date, end_date] and return the CSV.
+
+        Raises CareLinkReportTimeoutError if the job doesn't finish in the poll
+        budget, CareLinkAuthError on 401/403, CareLinkError otherwise.
+        """
+        body = self._build_generate_report_body(patient_id, start_date, end_date)
+        gen = self._json(await self._post("/patient/reports/generateReport", json=body))
+        uuid = _first(gen, "uuid", "reportUuid", "id")
+        if uuid is None:
+            raise CareLinkError("generateReport did not return a report uuid")
+        uuid = str(uuid)
+
+        for _ in range(self._poll_max_attempts):
+            status_resp = await self._get(
+                "/patient/reports/reportStatus", params={"uuid": uuid}
+            )
+            if self._is_report_ready(status_resp):
+                break
+            await asyncio.sleep(self._poll_interval)
+        else:
+            raise CareLinkReportTimeoutError(
+                f"CSV export job {uuid} not ready after {self._poll_max_attempts} polls"
+            )
+
+        csv_resp = await self._get(
+            "/patient/reports/reportCsv",
+            params={"uuid": uuid, "dMInFileName": "false"},
+        )
+        return csv_resp.text
+
+    @staticmethod
+    def _build_generate_report_body(
+        patient_id: str, start_date: date, end_date: date
+    ) -> dict:
+        """Mirror the observed generateReport body: CSV only, all PDF report
+        sections off, aggregated CSV enabled."""
+        return {
+            "clientTime": datetime.now(UTC).isoformat(),
+            "dailyDetailReportDays": [],
+            "patientId": patient_id,
+            "reportFileFormat": "CSV",
+            "aggregatedCsvEnabled": True,
+            "reportShowAdherence": False,
+            "reportShowAssessmentAndProgress": False,
+            "reportShowBolusWizardFoodBolus": False,
+            "reportShowDashBoard": False,
+            "reportShowDataTable": False,
+            "reportShowDeviceSettings": False,
+            "reportShowEpisodeSummary": False,
+            "reportShowLogbook": False,
+            "reportShowOverview": False,
+            "reportShowWeeklyReview": False,
+            "reportShowSettingsHistory": False,
+            "reportShowInsulinAssessment": False,
+            "startDate": start_date.strftime("%Y-%m-%d"),
+            "endDate": end_date.strftime("%Y-%m-%d"),
+        }
+
+    @staticmethod
+    def _is_report_ready(resp: httpx.Response) -> bool:
+        """Tolerant readiness check (exact reportStatus body unconfirmed live).
+
+        Treats as ready: an explicit ``status``/``state`` token in the ready
+        set, a truthy ``ready``/``completed``/``done`` flag, or an empty 204.
+        """
+        if resp.status_code == 204:
+            return True
+        try:
+            data = resp.json()
+        except ValueError:
+            return False
+        if not isinstance(data, dict):
+            return False
+        for key in ("status", "state", "reportStatus"):
+            token = data.get(key)
+            if isinstance(token, str) and token.strip().upper() in _READY_TOKENS:
+                return True
+        return any(bool(data.get(k)) for k in ("ready", "completed", "done"))
+
+    @staticmethod
+    def _json(resp: httpx.Response) -> dict:
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise CareLinkError(
+                f"CareLink returned non-JSON on {resp.request.url.path}"
+            ) from e
+        if not isinstance(data, dict):
+            raise CareLinkError(
+                f"CareLink returned unexpected JSON shape on {resp.request.url.path}"
+            )
+        return data

--- a/apps/api/src/services/integrations/medtronic/client.py
+++ b/apps/api/src/services/integrations/medtronic/client.py
@@ -26,15 +26,26 @@ reportStatus *response* body. These are marked inline.
 from __future__ import annotations
 
 import asyncio
+import random
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
+from urllib.parse import urlparse
 
 import httpx
 
-#: US CareLink host (confirmed). EU uses a different host; pass base_url
-#: explicitly for it rather than guessing here.
+#: Max retries on HTTP 429 (rate limit) before giving up.
+_MAX_RETRIES_429 = 3
+
+#: US CareLink host (confirmed). EU uses a different regional host; pass
+#: base_url explicitly for it rather than guessing here.
 US_BASE_URL = "https://carelink.minimed.com"
+
+#: Allowed base-url host suffixes. base_url is otherwise injectable, so without
+#: this an attacker-influenced region/url could make the client POST the
+#: bearer to an arbitrary host (SSRF / credential exfiltration). Medtronic
+#: CareLink hosts live under minimed.com (US) / minimed.eu (EU regional).
+_ALLOWED_HOST_SUFFIXES = ("minimed.com", "minimed.eu")
 
 BearerProvider = Callable[[], Awaitable[str]]
 
@@ -96,6 +107,12 @@ class CareLinkClient:
         poll_interval_seconds: float = 2.0,
         poll_max_attempts: int = 30,
     ) -> None:
+        host = (urlparse(base_url).hostname or "").lower()
+        if not any(host == s or host.endswith("." + s) for s in _ALLOWED_HOST_SUFFIXES):
+            raise ValueError(
+                f"Refusing CareLink base_url with untrusted host {host!r}; "
+                f"allowed: {_ALLOWED_HOST_SUFFIXES}"
+            )
         self._bearer_provider = bearer_provider
         self._base_url = base_url.rstrip("/")
         self._poll_interval = poll_interval_seconds
@@ -138,25 +155,51 @@ class CareLinkClient:
                 f"{resp.status_code}"
             )
 
+    async def _request(
+        self, method: str, path: str, *, json: dict | None = None, **kwargs: object
+    ) -> httpx.Response:
+        """Issue a request with retry on 429 (backoff, honoring Retry-After)
+        and a single retry on 5xx. 401/403 and other 4xx are not retried."""
+        last_exc: Exception | None = None
+        for attempt in range(_MAX_RETRIES_429 + 1):
+            try:
+                resp = await self._client.request(
+                    method,
+                    f"{self._base_url}{path}",
+                    headers=await self._headers(),
+                    json=json,
+                    **kwargs,
+                )
+            except httpx.HTTPError as e:
+                raise CareLinkError(
+                    f"CareLink network error on {method} {path}: {e}"
+                ) from e
+
+            if resp.status_code == 429 and attempt < _MAX_RETRIES_429:
+                await asyncio.sleep(self._retry_after_seconds(resp, attempt))
+                continue
+            if 500 <= resp.status_code < 600 and attempt == 0:
+                await asyncio.sleep(0.5 + random.random() * 0.5)
+                last_exc = CareLinkError(
+                    f"CareLink {resp.status_code} on {method} {path}"
+                )
+                continue
+            self._check(resp)
+            return resp
+        # Exhausted retries on a retryable status.
+        raise last_exc or CareLinkError(f"CareLink request to {path} kept failing")
+
+    def _retry_after_seconds(self, resp: httpx.Response, attempt: int) -> float:
+        header = resp.headers.get("Retry-After")
+        if header and header.isdigit():
+            return min(float(header), 30.0)
+        return min(self._poll_interval * (2**attempt), 30.0) + random.random()
+
     async def _get(self, path: str, **kwargs: object) -> httpx.Response:
-        try:
-            resp = await self._client.get(
-                f"{self._base_url}{path}", headers=await self._headers(), **kwargs
-            )
-        except httpx.HTTPError as e:
-            raise CareLinkError(f"CareLink network error on GET {path}: {e}") from e
-        self._check(resp)
-        return resp
+        return await self._request("GET", path, **kwargs)
 
     async def _post(self, path: str, *, json: dict) -> httpx.Response:
-        try:
-            resp = await self._client.post(
-                f"{self._base_url}{path}", headers=await self._headers(), json=json
-            )
-        except httpx.HTTPError as e:
-            raise CareLinkError(f"CareLink network error on POST {path}: {e}") from e
-        self._check(resp)
-        return resp
+        return await self._request("POST", path, json=json)
 
     async def get_patient_id(self) -> str:
         """Fetch the patient/account id required by generateReport."""
@@ -181,13 +224,20 @@ class CareLinkClient:
         patient_id: str,
         start_date: date,
         end_date: date,
+        client_time: datetime | None = None,
     ) -> str:
         """Run the CSV-export job for [start_date, end_date] and return the CSV.
+
+        ``client_time`` should be the user's *local* time (CareLink may use it
+        to resolve the start/end dates to instants; sending UTC could shift the
+        range by a day at the edges). Defaults to now() in UTC.
 
         Raises CareLinkReportTimeoutError if the job doesn't finish in the poll
         budget, CareLinkAuthError on 401/403, CareLinkError otherwise.
         """
-        body = self._build_generate_report_body(patient_id, start_date, end_date)
+        body = self._build_generate_report_body(
+            patient_id, start_date, end_date, client_time
+        )
         gen = self._json(await self._post("/patient/reports/generateReport", json=body))
         uuid = _first(gen, "uuid", "reportUuid", "id")
         if uuid is None:
@@ -210,16 +260,28 @@ class CareLinkClient:
             "/patient/reports/reportCsv",
             params={"uuid": uuid, "dMInFileName": "false"},
         )
-        return csv_resp.text
+        text = csv_resp.text
+        # Validate it actually looks like a CareLink export. Because the
+        # reportStatus "ready" shape is unconfirmed, a too-early/partial fetch
+        # would otherwise parse to zero rows and silently under-import.
+        if "Index," not in text:
+            raise CareLinkError(
+                f"CareLink reportCsv for job {uuid} did not return a CSV "
+                "with an 'Index,' header (job may not have been ready)"
+            )
+        return text
 
     @staticmethod
     def _build_generate_report_body(
-        patient_id: str, start_date: date, end_date: date
+        patient_id: str,
+        start_date: date,
+        end_date: date,
+        client_time: datetime | None = None,
     ) -> dict:
         """Mirror the observed generateReport body: CSV only, all PDF report
         sections off, aggregated CSV enabled."""
         return {
-            "clientTime": datetime.now(UTC).isoformat(),
+            "clientTime": (client_time or datetime.now(UTC)).isoformat(),
             "dailyDetailReportDays": [],
             "patientId": patient_id,
             "reportFileFormat": "CSV",

--- a/apps/api/src/services/integrations/medtronic/session.py
+++ b/apps/api/src/services/integrations/medtronic/session.py
@@ -1,0 +1,170 @@
+"""CareLink session: a captured browser session + a self-refreshing bearer.
+
+Spike-confirmed model (clean-room):
+- The non-httpOnly ``auth_tmp_token`` cookie IS the bearer for ``/patient/*``.
+- When it nears expiry (tracked by the ``c_token_valid_to`` cookie), a silent
+  re-auth via ``GET /patient/sso/auth`` (following redirects, carrying the
+  Auth0 session cookies) mints a fresh ``auth_tmp_token`` -- no captcha, no
+  re-login, until the underlying Auth0 session itself expires.
+
+The cookie bundle is captured once (the user completes the captcha login in a
+real browser) and stored encrypted. ``CareLinkSession`` loads it into an httpx
+cookie jar; ``bearer()`` returns a valid token (refreshing first if needed) and
+is passed as the ``bearer_provider`` to :class:`CareLinkClient`. Share
+``.http`` with the client so the jar's cookies ride along on /patient/* calls
+too. After use, persist ``export_cookies()`` back to storage so a refreshed
+token survives.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from urllib.parse import unquote, urlparse
+
+import httpx
+
+from .client import US_BASE_URL, CareLinkAuthError, CareLinkError
+
+_ALLOWED_HOST_SUFFIXES = ("minimed.com", "minimed.eu")
+_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/145.0.0.0 Safari/537.36"
+)
+# Refresh this many seconds before the token's stated expiry, to avoid racing
+# a request against expiry.
+_REFRESH_SKEW_SECONDS = 60
+
+
+def _validate_host(base_url: str) -> str:
+    host = (urlparse(base_url).hostname or "").lower()
+    if not any(host == s or host.endswith("." + s) for s in _ALLOWED_HOST_SUFFIXES):
+        raise ValueError(
+            f"Refusing CareLink base_url with untrusted host {host!r}; "
+            f"allowed suffixes: {_ALLOWED_HOST_SUFFIXES}"
+        )
+    return host
+
+
+class CareLinkSession:
+    """A captured CareLink session that yields a refreshing bearer."""
+
+    def __init__(
+        self,
+        *,
+        cookies: list[dict],
+        base_url: str = US_BASE_URL,
+        http: httpx.AsyncClient | None = None,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self._host = _validate_host(base_url)
+        self._base_url = base_url.rstrip("/")
+        self._owns_http = http is None
+        self._http = http or httpx.AsyncClient(timeout=timeout_seconds)
+        for c in cookies:
+            self._http.cookies.set(
+                c["name"],
+                c["value"],
+                domain=(c.get("domain") or "").lstrip("."),
+                path=c.get("path") or "/",
+            )
+        # Source of truth for the bearer + its expiry. Tracked explicitly (not
+        # re-read from the jar each time) because a refresh's Set-Cookie can
+        # land under a leading-dot domain and coexist with the initially-loaded
+        # one -- so refresh() resolves the freshest value into these.
+        self._token = self._jar_value("auth_tmp_token")
+        self._valid_raw = self._jar_value("c_token_valid_to")
+
+    @property
+    def http(self) -> httpx.AsyncClient:
+        """The httpx client whose jar holds the session cookies. Share it with
+        CareLinkClient so cookies ride along on /patient/* requests."""
+        return self._http
+
+    async def aclose(self) -> None:
+        if self._owns_http:
+            await self._http.aclose()
+
+    async def __aenter__(self) -> CareLinkSession:
+        return self
+
+    async def __aexit__(self, *_a: object) -> None:
+        await self.aclose()
+
+    def _jar_values(self, name: str) -> list[str]:
+        """All host-matching values for a cookie name (a refresh can transiently
+        leave a stale + fresh pair under different domain forms)."""
+        return [
+            c.value
+            for c in self._http.cookies.jar
+            if c.name == name and (c.domain or "").lstrip(".") == self._host
+        ]
+
+    def _jar_value(self, name: str) -> str | None:
+        vs = self._jar_values(name)
+        return vs[0] if vs else None
+
+    def _valid_to(self) -> datetime | None:
+        if not self._valid_raw:
+            return None
+        s = unquote(self._valid_raw).strip().strip('"')
+        # Java-style: "Thu May 21 06:07:47 UTC 2026"
+        try:
+            return datetime.strptime(s, "%a %b %d %H:%M:%S UTC %Y").replace(tzinfo=UTC)
+        except ValueError:
+            return None
+
+    def needs_refresh(self) -> bool:
+        vt = self._valid_to()
+        if vt is None:
+            return True
+        return datetime.now(UTC) >= vt - timedelta(seconds=_REFRESH_SKEW_SECONDS)
+
+    async def refresh(self) -> None:
+        """Silently re-auth via /patient/sso/auth, carrying the Auth0 session
+        cookies, and resolve the freshest auth_tmp_token. Raises
+        CareLinkAuthError if the session has expired (bounced to login).
+
+        Does NOT pre-delete the token: when the session is still valid /sso/auth
+        is a no-op (issues no new token), so deleting first would lose it. We
+        instead pick a jar value different from the pre-refresh token (the newly
+        issued one) and fall back to the existing token if none changed.
+        """
+        before = self._token
+        try:
+            resp = await self._http.get(
+                f"{self._base_url}/patient/sso/auth",
+                follow_redirects=True,
+                headers={"User-Agent": _UA},
+            )
+        except httpx.HTTPError as e:
+            raise CareLinkError(f"CareLink session refresh failed: {e}") from e
+        final = (resp.url.path + " " + (resp.url.host or "")).lower()
+        if "login" in final or resp.status_code >= 400:
+            raise CareLinkAuthError(
+                "CareLink session is no longer valid; reconnect required."
+            )
+        tokens = self._jar_values("auth_tmp_token")
+        if tokens:
+            self._token = next((t for t in tokens if t != before), tokens[-1])
+        vts = self._jar_values("c_token_valid_to")
+        if vts:
+            self._valid_raw = next((v for v in vts if v != self._valid_raw), vts[-1])
+
+    async def bearer(self) -> str:
+        """Return a valid bearer (auth_tmp_token), refreshing first if needed.
+        This is the ``bearer_provider`` for CareLinkClient."""
+        if self.needs_refresh():
+            await self.refresh()
+        if not self._token:
+            raise CareLinkAuthError(
+                "No auth_tmp_token in the CareLink session; reconnect required."
+            )
+        return self._token
+
+    def export_cookies(self) -> list[dict]:
+        """Current cookies (incl. any refreshed values) for re-persisting the
+        encrypted bundle to storage."""
+        return [
+            {"name": c.name, "value": c.value, "domain": c.domain, "path": c.path}
+            for c in self._http.cookies.jar
+        ]

--- a/apps/api/src/services/integrations/medtronic/storage.py
+++ b/apps/api/src/services/integrations/medtronic/storage.py
@@ -1,0 +1,126 @@
+"""Persist mapped CareLink records into glucose_readings + pump_events.
+
+Batched, idempotent bulk upserts using the same conflict targets the other
+direct integrations use:
+- glucose: ``ON CONFLICT (user_id, reading_timestamp) DO NOTHING`` (as Dexcom)
+- pump events: ``ON CONFLICT (user_id, event_timestamp, event_type) WHERE
+  ns_id IS NULL DO NOTHING`` (as Tandem)
+
+so re-importing an overlapping range is safe. Rows are de-duplicated on those
+keys within each batch first, so a single multi-row INSERT can't hit an
+intra-statement conflict.
+
+Timezone note: CareLink CSV timestamps are naive *pump-local* time (the export
+carries no offset). Localizing them to UTC correctly requires the user's
+timezone and is the orchestrator's responsibility (it knows the account). This
+layer defensively coerces any naive timestamp to UTC so it never writes NULL
+into the timezone-aware columns -- but callers should pass already-localized
+aware datetimes for correct absolute times.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.glucose import GlucoseReading, TrendDirection
+from src.models.pump_data import PumpEvent
+
+from .carelink_mapper import MappedRecords
+
+_CHUNK = 500
+
+
+@dataclass
+class CareLinkStoreResult:
+    glucose_fetched: int = 0
+    glucose_stored: int = 0
+    events_fetched: int = 0
+    events_stored: int = 0
+
+
+def _aware(ts: datetime) -> datetime:
+    return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts
+
+
+async def store_carelink_records(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    records: MappedRecords,
+    *,
+    now: datetime | None = None,
+) -> CareLinkStoreResult:
+    """Upsert mapped glucose readings + pump events for a user. Idempotent."""
+    now = now or datetime.now(UTC)
+    result = CareLinkStoreResult(
+        glucose_fetched=len(records.glucose), events_fetched=len(records.pump_events)
+    )
+
+    # --- Glucose readings: dedupe on reading_timestamp, keep first ---
+    glucose_by_ts: dict[datetime, dict] = {}
+    for g in records.glucose:
+        ts = _aware(g.timestamp)
+        if ts in glucose_by_ts:
+            continue
+        glucose_by_ts[ts] = {
+            "id": uuid.uuid4(),
+            "user_id": user_id,
+            "value": g.value_mgdl,
+            "reading_timestamp": ts,
+            # CareLink CSV has no trend arrow; we don't fabricate one.
+            "trend": TrendDirection.NOT_COMPUTABLE,
+            "received_at": now,
+            "source": g.source,
+        }
+    g_rows = list(glucose_by_ts.values())
+    for start in range(0, len(g_rows), _CHUNK):
+        stmt = (
+            insert(GlucoseReading)
+            .values(g_rows[start : start + _CHUNK])
+            .on_conflict_do_nothing(index_elements=["user_id", "reading_timestamp"])
+        )
+        res = await db.execute(stmt)
+        result.glucose_stored += max(res.rowcount, 0)
+
+    # --- Pump events: dedupe on (event_timestamp, event_type), keep first ---
+    events_by_key: dict[tuple, dict] = {}
+    for e in records.pump_events:
+        ts = _aware(e.timestamp)
+        key = (ts, e.event_type)
+        if key in events_by_key:
+            continue
+        events_by_key[key] = {
+            "id": uuid.uuid4(),
+            "user_id": user_id,
+            "event_type": e.event_type,
+            "event_timestamp": ts,
+            "units": e.units,
+            "duration_minutes": e.duration_minutes,
+            "is_automated": e.is_automated,
+            "control_iq_reason": e.control_iq_reason,
+            "iob_at_event": e.iob_at_event,
+            "cob_at_event": e.cob_at_event,
+            "bg_at_event": e.bg_at_event,
+            "received_at": now,
+            "source": e.source,
+        }
+    e_rows = list(events_by_key.values())
+    for start in range(0, len(e_rows), _CHUNK):
+        stmt = (
+            insert(PumpEvent)
+            .values(e_rows[start : start + _CHUNK])
+            .on_conflict_do_nothing(
+                index_elements=["user_id", "event_timestamp", "event_type"],
+                index_where=text("ns_id IS NULL"),
+            )
+        )
+        res = await db.execute(stmt)
+        result.events_stored += max(res.rowcount, 0)
+
+    await db.commit()
+    return result

--- a/apps/api/src/services/integrations/medtronic/storage.py
+++ b/apps/api/src/services/integrations/medtronic/storage.py
@@ -45,7 +45,16 @@ class CareLinkStoreResult:
 
 
 def _aware(ts: datetime) -> datetime:
-    return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts
+    # CareLink timestamps are pump-LOCAL; the sync layer (sync._localize)
+    # attaches the user's zone before storage. A naive timestamp here would be
+    # local time, and silently calling replace(tzinfo=UTC) would misdate it by
+    # the user's offset -- for a medical data path we fail fast instead.
+    if ts.tzinfo is None or ts.utcoffset() is None:
+        raise ValueError(
+            "CareLink timestamps must be timezone-aware before storage "
+            "(sync._localize attaches the user's timezone)"
+        )
+    return ts.astimezone(UTC)
 
 
 async def store_carelink_records(

--- a/apps/api/src/services/integrations/medtronic/sync.py
+++ b/apps/api/src/services/integrations/medtronic/sync.py
@@ -38,7 +38,15 @@ class CareLinkSyncResult:
 
 
 def _localize(records: MappedRecords, tz: tzinfo) -> None:
-    """Attach ``tz`` to naive timestamps in place (pump-local -> aware)."""
+    """Attach ``tz`` to naive timestamps in place (pump-local -> aware).
+
+    ``replace(tzinfo=tz)`` is DST-aware for the date (it picks the correct
+    offset per ZoneInfo). The only ambiguity is the ~1-hour fall-back window
+    where a wall-clock time occurs twice: CareLink exports a naive local time
+    with no fold flag, so the true occurrence is unknowable from the source and
+    we accept Python's default (``fold=0``, the first occurrence). This affects
+    at most one repeated hour per DST transition.
+    """
     for g in records.glucose:
         if g.timestamp.tzinfo is None:
             g.timestamp = g.timestamp.replace(tzinfo=tz)

--- a/apps/api/src/services/integrations/medtronic/sync.py
+++ b/apps/api/src/services/integrations/medtronic/sync.py
@@ -4,16 +4,19 @@ Ties the four data-pipeline layers together for one user + date range. Takes a
 ready :class:`CareLinkClient` (the caller builds it with the auth/session, so
 this stays decoupled from -- and testable without -- the session-capture flow).
 
-Timezone: CareLink CSV times are naive pump-local. If the caller knows the
-user's timezone it passes ``tz`` so naive timestamps are localized before
-storage; otherwise storage falls back to treating them as UTC.
+Timezone: CareLink CSV times are naive *pump-local*. ``tz`` is REQUIRED so we
+never silently store local times as UTC (which would misdate every event by
+the user's offset). Pass a ``zoneinfo.ZoneInfo`` (an IANA zone like
+``America/Chicago``), NOT a fixed-offset ``timezone(...)`` -- a historical
+import can span DST changes, and only a real zone localizes each timestamp
+with the correct offset for its own date.
 """
 
 from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from datetime import date, tzinfo
+from datetime import date, datetime, tzinfo
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -51,20 +54,23 @@ async def sync_carelink_for_user(
     start_date: date,
     end_date: date,
     client: CareLinkClient,
-    tz: tzinfo | None = None,
+    tz: tzinfo,
 ) -> CareLinkSyncResult:
     """Export [start_date, end_date] from CareLink, parse + map + store it.
 
-    Idempotent end to end (storage upserts on the natural keys), so an
-    overlapping re-sync is safe.
+    ``tz`` is the user's timezone (use a ZoneInfo for DST-correctness across a
+    historical range). Idempotent end to end (storage upserts on the natural
+    keys), so an overlapping re-sync is safe.
     """
     patient_id = await client.get_patient_id()
     csv_text = await client.export_csv(
-        patient_id=patient_id, start_date=start_date, end_date=end_date
+        patient_id=patient_id,
+        start_date=start_date,
+        end_date=end_date,
+        client_time=datetime.now(tz),  # local time so date edges resolve right
     )
     records = map_carelink_export(parse_carelink_csv(csv_text))
-    if tz is not None:
-        _localize(records, tz)
+    _localize(records, tz)
     stored = await store_carelink_records(db, user_id, records)
     return CareLinkSyncResult(
         patient_id=patient_id,

--- a/apps/api/src/services/integrations/medtronic/sync.py
+++ b/apps/api/src/services/integrations/medtronic/sync.py
@@ -1,0 +1,77 @@
+"""Orchestrate a CareLink sync: fetch CSV -> parse -> map -> store.
+
+Ties the four data-pipeline layers together for one user + date range. Takes a
+ready :class:`CareLinkClient` (the caller builds it with the auth/session, so
+this stays decoupled from -- and testable without -- the session-capture flow).
+
+Timezone: CareLink CSV times are naive pump-local. If the caller knows the
+user's timezone it passes ``tz`` so naive timestamps are localized before
+storage; otherwise storage falls back to treating them as UTC.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import date, tzinfo
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .carelink_csv import parse_carelink_csv
+from .carelink_mapper import MappedRecords, map_carelink_export
+from .client import CareLinkClient
+from .storage import store_carelink_records
+
+
+@dataclass
+class CareLinkSyncResult:
+    patient_id: str
+    start_date: date
+    end_date: date
+    glucose_fetched: int
+    glucose_stored: int
+    events_fetched: int
+    events_stored: int
+
+
+def _localize(records: MappedRecords, tz: tzinfo) -> None:
+    """Attach ``tz`` to naive timestamps in place (pump-local -> aware)."""
+    for g in records.glucose:
+        if g.timestamp.tzinfo is None:
+            g.timestamp = g.timestamp.replace(tzinfo=tz)
+    for e in records.pump_events:
+        if e.timestamp.tzinfo is None:
+            e.timestamp = e.timestamp.replace(tzinfo=tz)
+
+
+async def sync_carelink_for_user(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    start_date: date,
+    end_date: date,
+    client: CareLinkClient,
+    tz: tzinfo | None = None,
+) -> CareLinkSyncResult:
+    """Export [start_date, end_date] from CareLink, parse + map + store it.
+
+    Idempotent end to end (storage upserts on the natural keys), so an
+    overlapping re-sync is safe.
+    """
+    patient_id = await client.get_patient_id()
+    csv_text = await client.export_csv(
+        patient_id=patient_id, start_date=start_date, end_date=end_date
+    )
+    records = map_carelink_export(parse_carelink_csv(csv_text))
+    if tz is not None:
+        _localize(records, tz)
+    stored = await store_carelink_records(db, user_id, records)
+    return CareLinkSyncResult(
+        patient_id=patient_id,
+        start_date=start_date,
+        end_date=end_date,
+        glucose_fetched=stored.glucose_fetched,
+        glucose_stored=stored.glucose_stored,
+        events_fetched=stored.events_fetched,
+        events_stored=stored.events_stored,
+    )

--- a/apps/api/tests/test_carelink_client.py
+++ b/apps/api/tests/test_carelink_client.py
@@ -10,6 +10,7 @@ from src.services.integrations.medtronic.client import (
     US_BASE_URL,
     CareLinkAuthError,
     CareLinkClient,
+    CareLinkError,
     CareLinkReportTimeoutError,
 )
 
@@ -142,3 +143,51 @@ async def test_status_204_is_treated_ready():
 
 def test_default_base_url_is_us():
     assert US_BASE_URL == "https://carelink.minimed.com"
+
+
+async def test_rejects_untrusted_base_url():
+    with pytest.raises(ValueError, match="untrusted host"):
+        CareLinkClient(bearer_provider=_bearer, base_url="https://evil.example.com")
+
+
+async def test_eu_host_is_allowed():
+    # Should not raise (regional EU host under minimed.eu).
+    c = CareLinkClient(bearer_provider=_bearer, base_url="https://carelink.minimed.eu")
+    await c.aclose()
+
+
+async def test_retries_on_429_then_succeeds():
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, headers={"Retry-After": "0"}, json={})
+        return httpx.Response(
+            200, json={"start": "2012-01-01T00:00:00Z", "end": "2025-01-31T00:00:00Z"}
+        )
+
+    async with _make_client(handler) as client:
+        avail = await client.get_availability()
+    assert calls["n"] == 2  # retried once after the 429
+    assert avail.end.year == 2025
+
+
+async def test_export_rejects_csv_without_index_header():
+    """A too-early/partial reportCsv (no 'Index,' header) must not be accepted
+    as a successful (but empty) import."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/patient/reports/generateReport":
+            return httpx.Response(200, json={"uuid": "u1"})
+        if request.url.path == "/patient/reports/reportStatus":
+            return httpx.Response(200, json={"status": "COMPLETE"})
+        if request.url.path == "/patient/reports/reportCsv":
+            return httpx.Response(200, text="<html>not ready</html>")
+        return httpx.Response(404)
+
+    async with _make_client(handler) as client:
+        with pytest.raises(CareLinkError, match="Index"):
+            await client.export_csv(
+                patient_id="1", start_date=date(2025, 1, 1), end_date=date(2025, 1, 2)
+            )

--- a/apps/api/tests/test_carelink_client.py
+++ b/apps/api/tests/test_carelink_client.py
@@ -1,0 +1,144 @@
+"""Tests for the CareLink HTTP client data methods (mocked, no network)."""
+
+import json
+from datetime import date, datetime
+
+import httpx
+import pytest
+
+from src.services.integrations.medtronic.client import (
+    US_BASE_URL,
+    CareLinkAuthError,
+    CareLinkClient,
+    CareLinkReportTimeoutError,
+)
+
+
+async def _bearer() -> str:
+    return "test-bearer-123"
+
+
+def _make_client(handler, **kwargs) -> CareLinkClient:
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(transport=transport)
+    return CareLinkClient(
+        bearer_provider=_bearer,
+        client=http,
+        poll_interval_seconds=0,  # don't actually sleep in tests
+        **kwargs,
+    )
+
+
+async def test_get_availability_parses_range():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/patient/reports/snapshotTimelinesRange"
+        assert request.headers["authorization"] == "Bearer test-bearer-123"
+        return httpx.Response(
+            200,
+            json={
+                "start": "2012-01-01T00:02:34.000Z",
+                "end": "2025-01-31T15:05:47.000Z",
+            },
+        )
+
+    async with _make_client(handler) as client:
+        avail = await client.get_availability()
+    assert avail.start == datetime.fromisoformat("2012-01-01T00:02:34+00:00")
+    assert avail.end == datetime.fromisoformat("2025-01-31T15:05:47+00:00")
+
+
+async def test_get_patient_id_tolerant_field():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/patient/users/me"
+        return httpx.Response(200, json={"patientId": "50497203", "firstName": "X"})
+
+    async with _make_client(handler) as client:
+        assert await client.get_patient_id() == "50497203"
+
+
+async def test_export_csv_full_job_flow():
+    """generateReport -> reportStatus (pending then ready) -> reportCsv."""
+    captured = {}
+    status_calls = {"n": 0}
+    csv_payload = "Index,Date,Time\n0,2025/01/31,12:00:00\n"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/patient/reports/generateReport":
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json={"uuid": "abc-123"})
+        if path == "/patient/reports/reportStatus":
+            assert request.url.params["uuid"] == "abc-123"
+            status_calls["n"] += 1
+            # pending on the first poll, ready on the second
+            ready = status_calls["n"] >= 2
+            return httpx.Response(
+                200, json={"status": "COMPLETE" if ready else "GENERATING"}
+            )
+        if path == "/patient/reports/reportCsv":
+            assert request.url.params["uuid"] == "abc-123"
+            return httpx.Response(200, text=csv_payload)
+        return httpx.Response(404)
+
+    async with _make_client(handler) as client:
+        csv_text = await client.export_csv(
+            patient_id="50497203",
+            start_date=date(2025, 1, 18),
+            end_date=date(2025, 1, 31),
+        )
+
+    assert csv_text == csv_payload
+    assert status_calls["n"] == 2  # polled until ready
+    # generateReport body mirrors the observed shape
+    body = captured["body"]
+    assert body["patientId"] == "50497203"
+    assert body["reportFileFormat"] == "CSV"
+    assert body["aggregatedCsvEnabled"] is True
+    assert body["startDate"] == "2025-01-18"
+    assert body["endDate"] == "2025-01-31"
+    assert body["reportShowLogbook"] is False
+
+
+async def test_export_csv_times_out_if_never_ready():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/patient/reports/generateReport":
+            return httpx.Response(200, json={"uuid": "abc-123"})
+        if request.url.path == "/patient/reports/reportStatus":
+            return httpx.Response(200, json={"status": "GENERATING"})
+        return httpx.Response(404)
+
+    async with _make_client(handler, poll_max_attempts=3) as client:
+        with pytest.raises(CareLinkReportTimeoutError):
+            await client.export_csv(
+                patient_id="1", start_date=date(2025, 1, 1), end_date=date(2025, 1, 2)
+            )
+
+
+async def test_auth_error_on_401():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "unauthorized"})
+
+    async with _make_client(handler) as client:
+        with pytest.raises(CareLinkAuthError):
+            await client.get_availability()
+
+
+async def test_status_204_is_treated_ready():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/patient/reports/generateReport":
+            return httpx.Response(200, json={"reportUuid": "u9"})  # alt uuid field
+        if request.url.path == "/patient/reports/reportStatus":
+            return httpx.Response(204)
+        if request.url.path == "/patient/reports/reportCsv":
+            return httpx.Response(200, text="Index,Date,Time\n")
+        return httpx.Response(404)
+
+    async with _make_client(handler) as client:
+        out = await client.export_csv(
+            patient_id="1", start_date=date(2025, 1, 1), end_date=date(2025, 1, 2)
+        )
+    assert out.startswith("Index,")
+
+
+def test_default_base_url_is_us():
+    assert US_BASE_URL == "https://carelink.minimed.com"

--- a/apps/api/tests/test_carelink_csv.py
+++ b/apps/api/tests/test_carelink_csv.py
@@ -276,3 +276,38 @@ def test_empty_input_returns_empty_export():
     export = parse_carelink_csv("")
     assert export.rows == []
     assert export.section_count == 0
+
+
+def test_ambiguous_non_year_first_date_yields_no_timestamp():
+    """We only accept unambiguous year-first dates. A day/month-first value is
+    NOT guessed (which could misdate by months) -> timestamp is None."""
+    csv_text = _build_csv(
+        [
+            {
+                "Index": "0",
+                "Date": "02/03/2025",
+                "Time": "08:00:00",
+                "Sensor Glucose (mg/dL)": "130",
+            }
+        ]
+    )
+    export = parse_carelink_csv(csv_text)
+    assert len(export.rows) == 1
+    assert export.rows[0].timestamp is None  # not silently mis-parsed
+    assert export.rows[0].sensor_glucose_mgdl == 130
+
+
+def test_raw_is_empty_unless_keep_raw():
+    csv_text = _build_csv(
+        [
+            {
+                "Index": "0",
+                "Date": "2025/01/31",
+                "Time": "08:00:00",
+                "Basal Rate (U/h)": "0.7",
+            }
+        ]
+    )
+    assert parse_carelink_csv(csv_text).rows[0].raw == {}
+    kept = parse_carelink_csv(csv_text, keep_raw=True).rows[0].raw
+    assert kept.get("Basal Rate (U/h)") == "0.7"

--- a/apps/api/tests/test_carelink_csv.py
+++ b/apps/api/tests/test_carelink_csv.py
@@ -1,0 +1,278 @@
+"""Tests for the Medtronic CareLink CSV export parser (clean-room).
+
+All CSV content here is synthetic -- no real patient data.
+"""
+
+from datetime import datetime
+
+from src.services.integrations.medtronic.carelink_csv import (
+    CareLinkRow,
+    parse_carelink_csv,
+)
+
+# The full observed v15.x column header (order preserved).
+HEADER = [
+    "Index",
+    "Date",
+    "Time",
+    "New Device Time",
+    "BG Source",
+    "BG Reading (mg/dL)",
+    "Linked BG Meter ID",
+    "Basal Rate (U/h)",
+    "Temp Basal Amount",
+    "Temp Basal Type",
+    "Temp Basal Duration (h:mm:ss)",
+    "Bolus Type",
+    "Bolus Volume Selected (U)",
+    "Bolus Volume Delivered (U)",
+    "Bolus Duration (h:mm:ss)",
+    "Prime Type",
+    "Prime Volume Delivered (U)",
+    "Estimated Reservoir Volume after Fill (U)",
+    "Alert",
+    "User Cleared Alerts",
+    "Suspend",
+    "Rewind",
+    "BWZ Estimate (U)",
+    "BWZ Target High BG (mg/dL)",
+    "BWZ Target Low BG (mg/dL)",
+    "BWZ Carb Ratio (g/U)",
+    "BWZ Insulin Sensitivity (mg/dL/U)",
+    "BWZ Carb Input (grams)",
+    "BWZ BG/SG Input (mg/dL)",
+    "BWZ Correction Estimate (U)",
+    "BWZ Food Estimate (U)",
+    "BWZ Active Insulin (U)",
+    "BWZ Status",
+    "Sensor Calibration BG (mg/dL)",
+    "Sensor Glucose (mg/dL)",
+    "ISIG Value",
+    "Event Marker",
+    "Bolus Number",
+    "Bolus Cancellation Reason",
+    "BWZ Unabsorbed Insulin Total (U)",
+    "Final Bolus Estimate",
+    "Scroll Step Size",
+    "Insulin Action Curve Time",
+    "Sensor Calibration Rejected Reason",
+    "Preset Bolus",
+    "Bolus Source",
+    "BLE Network Device",
+    "Device Update Event",
+    "Network Device Associated Reason",
+    "Network Device Disassociated Reason",
+    "Network Device Disconnected Reason",
+    "Sensor Exception",
+    "Preset Temp Basal Name",
+    "Sensor State",
+]
+
+
+def _row(header: list[str], values: dict[str, str]) -> str:
+    """Build one CSV data line from a {column: value} dict, padding the rest."""
+    return ",".join(str(values.get(col, "")) for col in header)
+
+
+def _build_csv(
+    rows: list[dict[str, str]],
+    *,
+    header: list[str] = HEADER,
+    bom: bool = True,
+    extra_sections: list[list[dict[str, str]]] | None = None,
+) -> str:
+    lines = [
+        "Last Name,First Name,Patient ID,System ID,Start Date,End Date,Device,"
+        "MiniMed 780G MMT-1884,Hardware Version,A1.01,Firmware Version,11.11.7",
+        '"Doe","Jane","","","01-18-2025 12:00:00 AM","01-31-2025 12:00:00 AM",'
+        '"Serial Number",ABC1234567H,Software Version,6.21U',
+        "Patient DOB,,,,,,CGM,Guardian™ 4 Sensor",
+        "",
+        "-------,MiniMed 780G MMT-1884,Pump,ABC1234567H,------- ",
+        ",".join(header),
+        *[_row(header, r) for r in rows],
+    ]
+    for section in extra_sections or []:
+        lines.append(",".join(header))
+        lines.extend(_row(header, r) for r in section)
+    text = "\n".join(lines)
+    return ("﻿" + text) if bom else text
+
+
+def _by_index(export, idx: int) -> CareLinkRow:
+    return next(r for r in export.rows if r.index == idx)
+
+
+def test_parses_metadata_and_basic_rows():
+    csv_text = _build_csv(
+        [
+            {
+                "Index": "0",
+                "Date": "2025/01/31",
+                "Time": "15:02:05",
+                "Basal Rate (U/h)": "0.85",
+            },
+            {
+                "Index": "1",
+                "Date": "2025/01/31",
+                "Time": "14:55:00",
+                "Sensor Glucose (mg/dL)": "124",
+                "ISIG Value": "21.5",
+                "Sensor State": "NO_ERROR_MESSAGE",
+            },
+        ]
+    )
+    export = parse_carelink_csv(csv_text)
+
+    assert export.device == "MiniMed 780G MMT-1884"
+    assert export.serial_number == "ABC1234567H"
+    assert export.cgm == "Guardian™ 4 Sensor"
+    assert export.section_count == 1
+    assert len(export.rows) == 2
+
+    basal = _by_index(export, 0)
+    assert basal.timestamp == datetime(2025, 1, 31, 15, 2, 5)
+    assert basal.basal_rate_uh == 0.85
+    assert basal.sensor_glucose_mgdl is None  # empty -> None
+
+    sg = _by_index(export, 1)
+    assert sg.sensor_glucose_mgdl == 124
+    assert sg.isig == 21.5
+    assert sg.sensor_state == "NO_ERROR_MESSAGE"
+
+
+def test_parses_bolus_with_source_and_carbs():
+    csv_text = _build_csv(
+        [
+            {
+                "Index": "0",
+                "Date": "2025/01/31",
+                "Time": "12:00:00",
+                "Bolus Type": "NORMAL",
+                "Bolus Volume Selected (U)": "3.0",
+                "Bolus Volume Delivered (U)": "3.0",
+                "Bolus Source": "BOLUS_WIZARD",
+                "BWZ Carb Input (grams)": "45",
+                "BWZ Active Insulin (U)": "1.2",
+            },
+            {
+                "Index": "1",
+                "Date": "2025/01/31",
+                "Time": "12:30:00",
+                "Bolus Type": "NORMAL",
+                "Bolus Volume Delivered (U)": "0.6",
+                "Bolus Source": "CLOSED_LOOP_AUTO_BOLUS",
+            },
+        ]
+    )
+    export = parse_carelink_csv(csv_text)
+
+    manual = _by_index(export, 0)
+    assert manual.bolus_delivered_u == 3.0
+    assert manual.bolus_source == "BOLUS_WIZARD"
+    assert manual.carb_input_g == 45.0
+    assert manual.active_insulin_u == 1.2
+
+    auto = _by_index(export, 1)
+    assert auto.bolus_delivered_u == 0.6
+    assert auto.bolus_source == "CLOSED_LOOP_AUTO_BOLUS"  # SmartGuard auto-bolus
+    assert auto.carb_input_g is None
+
+
+def test_multi_section_export():
+    """The real export repeats the header per section (pump/CGM/meter). All
+    sections' rows are returned in order; Index restarts per section."""
+    csv_text = _build_csv(
+        [
+            {
+                "Index": "0",
+                "Date": "2025/01/31",
+                "Time": "10:00:00",
+                "Basal Rate (U/h)": "1.0",
+            }
+        ],
+        extra_sections=[
+            [
+                {
+                    "Index": "0",
+                    "Date": "2025/01/30",
+                    "Time": "09:00:00",
+                    "BG Source": "METER",
+                    "BG Reading (mg/dL)": "98",
+                }
+            ],
+        ],
+    )
+    export = parse_carelink_csv(csv_text)
+    assert export.section_count == 2
+    assert len(export.rows) == 2
+    assert export.rows[0].basal_rate_uh == 1.0
+    assert export.rows[1].bg_mgdl == 98
+    assert export.rows[1].bg_source == "METER"
+
+
+def test_name_based_mapping_survives_column_reorder():
+    """Columns are mapped by name, so a reordered header still parses."""
+    reordered = ["Index", "Time", "Date", "Sensor Glucose (mg/dL)", "Basal Rate (U/h)"]
+    csv_text = _build_csv(
+        [
+            {
+                "Index": "0",
+                "Date": "2025/01/31",
+                "Time": "08:15:00",
+                "Sensor Glucose (mg/dL)": "150",
+                "Basal Rate (U/h)": "0.5",
+            }
+        ],
+        header=reordered,
+    )
+    export = parse_carelink_csv(csv_text)
+    assert len(export.rows) == 1
+    row = export.rows[0]
+    assert row.sensor_glucose_mgdl == 150
+    assert row.basal_rate_uh == 0.5
+    assert row.timestamp == datetime(2025, 1, 31, 8, 15, 0)
+
+
+def test_semicolon_delimited_with_european_decimal_comma():
+    """A locale export that uses ';' as the delimiter and ',' as the decimal
+    mark: the parser must auto-detect the delimiter (so '0,85' stays one
+    field) and then read the comma as a decimal point."""
+    header = ["Index", "Date", "Time", "Basal Rate (U/h)", "Bolus Volume Delivered (U)"]
+    csv_text = "\n".join(
+        [
+            ";".join(header),
+            ";".join(["0", "2025/01/31", "07:00:00", "0,85", "2,5"]),
+        ]
+    )
+    export = parse_carelink_csv(csv_text)
+    assert len(export.rows) == 1
+    row = export.rows[0]
+    assert row.basal_rate_uh == 0.85
+    assert row.bolus_delivered_u == 2.5
+
+
+def test_skips_blank_and_nondata_rows_and_strips_bom():
+    csv_text = _build_csv(
+        [
+            {
+                "Index": "0",
+                "Date": "2025/01/31",
+                "Time": "06:00:00",
+                "Suspend": "USER_SUSPEND",
+            }
+        ],
+        bom=True,
+    )
+    export = parse_carelink_csv(csv_text)
+    # Only the one real data row; blank lines + metadata preamble excluded.
+    assert len(export.rows) == 1
+    assert export.rows[0].suspend == "USER_SUSPEND"
+    # BOM did not leak into the first metadata cell used for device detection.
+    assert export.device == "MiniMed 780G MMT-1884"
+
+
+def test_empty_input_returns_empty_export():
+    export = parse_carelink_csv("")
+    assert export.rows == []
+    assert export.section_count == 0

--- a/apps/api/tests/test_carelink_mapper.py
+++ b/apps/api/tests/test_carelink_mapper.py
@@ -56,14 +56,15 @@ def test_manual_bolus_maps_to_bolus_with_carbs_and_iob():
     assert _events_of(rec, PumpEventType.CORRECTION) == []
 
 
-def test_smartguard_auto_bolus_maps_to_automated_correction():
+def test_smartguard_auto_correction_maps_to_automated_correction():
+    # Real 780G closed-loop correction source (no food component).
     rec = map_carelink_export(
         _export(
             CareLinkRow(
                 timestamp=TS,
                 index=0,
                 bolus_delivered_u=0.6,
-                bolus_source="CLOSED_LOOP_AUTO_BOLUS",
+                bolus_source="CLOSED_LOOP_BG_CORRECTION",
             )
         )
     )
@@ -71,7 +72,45 @@ def test_smartguard_auto_bolus_maps_to_automated_correction():
     assert len(corr) == 1
     assert corr[0].units == 0.6
     assert corr[0].is_automated is True
-    assert corr[0].control_iq_reason == "auto_correction"
+    assert corr[0].control_iq_reason == "correction"
+    assert _events_of(rec, PumpEventType.BOLUS) == []
+
+
+def test_smartguard_food_bolus_maps_to_user_bolus():
+    # A closed-loop meal bolus is user-initiated -> BOLUS, not automated.
+    rec = map_carelink_export(
+        _export(
+            CareLinkRow(
+                timestamp=TS,
+                index=0,
+                bolus_delivered_u=3.5,
+                bolus_source="CLOSED_LOOP_BG_CORRECTION_AND_FOOD_BOLUS",
+            )
+        )
+    )
+    bolus = _events_of(rec, PumpEventType.BOLUS)
+    assert len(bolus) == 1
+    assert bolus[0].units == 3.5
+    assert bolus[0].is_automated is False
+    assert _events_of(rec, PumpEventType.CORRECTION) == []
+
+
+def test_auto_insulin_daily_basal_total_is_skipped():
+    # CLOSED_LOOP_AUTO_INSULIN is a daily auto-basal TOTAL, not a bolus -- it
+    # must NOT be stored as a bolus (inflates bolus insulin) or a basal-rate
+    # event (would be x24'd by the TDD calc). It produces no event.
+    rec = map_carelink_export(
+        _export(
+            CareLinkRow(
+                timestamp=TS,
+                index=0,
+                bolus_delivered_u=47.872,
+                bolus_source="CLOSED_LOOP_AUTO_INSULIN",
+            )
+        )
+    )
+    assert rec.pump_events == []
+    assert rec.glucose == []
 
 
 def test_fingerstick_bg_maps_to_bg_reading_event():

--- a/apps/api/tests/test_carelink_mapper.py
+++ b/apps/api/tests/test_carelink_mapper.py
@@ -132,14 +132,15 @@ def test_scheduled_basal_maps_to_basal_rate():
     assert basal[0].is_automated is False
 
 
-def test_temp_basal_maps_to_automated_basal_with_duration():
+def test_absolute_temp_basal_maps_to_automated_basal_with_duration():
+    # An ABSOLUTE temp basal amount is a U/h rate -> stored in BASAL.units.
     rec = map_carelink_export(
         _export(
             CareLinkRow(
                 timestamp=TS,
                 index=0,
                 temp_basal_amount=1.2,
-                temp_basal_type="Percent",
+                temp_basal_type="Rate",
                 temp_basal_duration="0:30:00",
             )
         )
@@ -150,6 +151,23 @@ def test_temp_basal_maps_to_automated_basal_with_duration():
     assert basal[0].duration_minutes == 30
     assert basal[0].is_automated is True
     assert basal[0].control_iq_reason == "temp_basal"
+
+
+def test_percent_temp_basal_is_skipped():
+    # A PERCENT temp basal (amount = % of scheduled, not U/h) must NOT be stored
+    # as a BASAL rate event -- it would be x24'd by the rate-based TDD calc.
+    rec = map_carelink_export(
+        _export(
+            CareLinkRow(
+                timestamp=TS,
+                index=0,
+                temp_basal_amount=120.0,
+                temp_basal_type="Percent",
+                temp_basal_duration="0:30:00",
+            )
+        )
+    )
+    assert _events_of(rec, PumpEventType.BASAL) == []
 
 
 def test_suspend_and_resume():

--- a/apps/api/tests/test_carelink_mapper.py
+++ b/apps/api/tests/test_carelink_mapper.py
@@ -1,0 +1,160 @@
+"""Tests for the CareLink -> normalized-model mapper (pure, clean-room)."""
+
+from datetime import datetime
+
+from src.models.pump_data import PumpEventType
+from src.services.integrations.medtronic.carelink_csv import (
+    CareLinkExport,
+    CareLinkRow,
+)
+from src.services.integrations.medtronic.carelink_mapper import (
+    SOURCE,
+    map_carelink_export,
+)
+
+TS = datetime(2025, 1, 31, 12, 0, 0)
+
+
+def _export(*rows: CareLinkRow) -> CareLinkExport:
+    return CareLinkExport(rows=list(rows))
+
+
+def _events_of(records, etype):
+    return [e for e in records.pump_events if e.event_type == etype]
+
+
+def test_sensor_glucose_maps_to_glucose_reading():
+    rec = map_carelink_export(
+        _export(CareLinkRow(timestamp=TS, index=0, sensor_glucose_mgdl=124))
+    )
+    assert len(rec.glucose) == 1
+    assert rec.glucose[0].value_mgdl == 124
+    assert rec.glucose[0].timestamp == TS
+    assert rec.glucose[0].source == SOURCE
+    assert rec.pump_events == []
+
+
+def test_manual_bolus_maps_to_bolus_with_carbs_and_iob():
+    rec = map_carelink_export(
+        _export(
+            CareLinkRow(
+                timestamp=TS,
+                index=0,
+                bolus_delivered_u=3.0,
+                bolus_source="BOLUS_WIZARD",
+                carb_input_g=45.0,
+                active_insulin_u=1.2,
+            )
+        )
+    )
+    bolus = _events_of(rec, PumpEventType.BOLUS)
+    assert len(bolus) == 1
+    assert bolus[0].units == 3.0
+    assert bolus[0].is_automated is False
+    assert bolus[0].cob_at_event == 45.0
+    assert bolus[0].iob_at_event == 1.2
+    assert _events_of(rec, PumpEventType.CORRECTION) == []
+
+
+def test_smartguard_auto_bolus_maps_to_automated_correction():
+    rec = map_carelink_export(
+        _export(
+            CareLinkRow(
+                timestamp=TS,
+                index=0,
+                bolus_delivered_u=0.6,
+                bolus_source="CLOSED_LOOP_AUTO_BOLUS",
+            )
+        )
+    )
+    corr = _events_of(rec, PumpEventType.CORRECTION)
+    assert len(corr) == 1
+    assert corr[0].units == 0.6
+    assert corr[0].is_automated is True
+    assert corr[0].control_iq_reason == "auto_correction"
+
+
+def test_fingerstick_bg_maps_to_bg_reading_event():
+    rec = map_carelink_export(
+        _export(CareLinkRow(timestamp=TS, index=0, bg_source="METER", bg_mgdl=98))
+    )
+    bg = _events_of(rec, PumpEventType.BG_READING)
+    assert len(bg) == 1
+    assert bg[0].bg_at_event == 98
+
+
+def test_scheduled_basal_maps_to_basal_rate():
+    rec = map_carelink_export(
+        _export(CareLinkRow(timestamp=TS, index=0, basal_rate_uh=0.85))
+    )
+    basal = _events_of(rec, PumpEventType.BASAL)
+    assert len(basal) == 1
+    assert basal[0].units == 0.85
+    assert basal[0].is_automated is False
+
+
+def test_temp_basal_maps_to_automated_basal_with_duration():
+    rec = map_carelink_export(
+        _export(
+            CareLinkRow(
+                timestamp=TS,
+                index=0,
+                temp_basal_amount=1.2,
+                temp_basal_type="Percent",
+                temp_basal_duration="0:30:00",
+            )
+        )
+    )
+    basal = _events_of(rec, PumpEventType.BASAL)
+    assert len(basal) == 1
+    assert basal[0].units == 1.2
+    assert basal[0].duration_minutes == 30
+    assert basal[0].is_automated is True
+    assert basal[0].control_iq_reason == "temp_basal"
+
+
+def test_suspend_and_resume():
+    rec = map_carelink_export(
+        _export(
+            CareLinkRow(timestamp=TS, index=0, suspend="USER_SUSPEND"),
+            CareLinkRow(timestamp=TS, index=1, suspend="NORMAL_PUMPING"),
+        )
+    )
+    assert len(_events_of(rec, PumpEventType.SUSPEND)) == 1
+    assert len(_events_of(rec, PumpEventType.RESUME)) == 1
+
+
+def test_carb_only_entry_maps_to_carbs():
+    rec = map_carelink_export(
+        _export(CareLinkRow(timestamp=TS, index=0, carb_input_g=30.0))
+    )
+    carbs = _events_of(rec, PumpEventType.CARBS)
+    assert len(carbs) == 1
+    assert carbs[0].cob_at_event == 30.0
+
+
+def test_row_without_timestamp_is_skipped():
+    rec = map_carelink_export(
+        _export(CareLinkRow(timestamp=None, index=0, sensor_glucose_mgdl=120))
+    )
+    assert rec.glucose == []
+    assert rec.pump_events == []
+
+
+def test_end_to_end_parse_then_map():
+    """A small real-shaped CSV through parser + mapper."""
+    from src.services.integrations.medtronic.carelink_csv import parse_carelink_csv
+
+    header = "Index,Date,Time,Basal Rate (U/h),Bolus Volume Delivered (U),Bolus Source,Sensor Glucose (mg/dL)"
+    csv_text = "\n".join(
+        [
+            header,
+            "0,2025/01/31,12:00:00,0.85,,,",
+            "1,2025/01/31,12:05:00,,2.0,BOLUS_WIZARD,",
+            "2,2025/01/31,12:05:00,,,,140",
+        ]
+    )
+    rec = map_carelink_export(parse_carelink_csv(csv_text))
+    assert len(rec.glucose) == 1 and rec.glucose[0].value_mgdl == 140
+    assert len(_events_of(rec, PumpEventType.BASAL)) == 1
+    assert len(_events_of(rec, PumpEventType.BOLUS)) == 1

--- a/apps/api/tests/test_carelink_session.py
+++ b/apps/api/tests/test_carelink_session.py
@@ -1,0 +1,129 @@
+"""Tests for CareLinkSession (self-refreshing bearer), mocked -- no network."""
+
+from datetime import UTC, datetime, timedelta
+from urllib.parse import quote
+
+import httpx
+import pytest
+
+from src.services.integrations.medtronic.client import CareLinkAuthError
+from src.services.integrations.medtronic.session import CareLinkSession
+
+API_HOST = "carelink.minimed.com"
+
+
+def _valid_to_str(delta_minutes: int) -> str:
+    """A quoted Java-style c_token_valid_to value, now + delta."""
+    t = datetime.now(UTC) + timedelta(minutes=delta_minutes)
+    return '"' + t.strftime("%a %b %d %H:%M:%S UTC %Y") + '"'
+
+
+def _bundle(token: str, valid_to: str) -> list[dict]:
+    return [
+        {"name": "auth_tmp_token", "value": token, "domain": API_HOST, "path": "/"},
+        {
+            "name": "c_token_valid_to",
+            "value": valid_to,
+            "domain": API_HOST,
+            "path": "/",
+        },
+        {
+            "name": "auth0",
+            "value": "sess",
+            "domain": "carelink-login.minimed.com",
+            "path": "/",
+        },
+    ]
+
+
+def _session(bundle: list[dict], handler) -> CareLinkSession:
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return CareLinkSession(cookies=bundle, http=http)
+
+
+async def test_rejects_untrusted_base_url():
+    with pytest.raises(ValueError, match="untrusted host"):
+        CareLinkSession(cookies=[], base_url="https://evil.example.com")
+
+
+async def test_bearer_returns_token_without_refresh_when_valid():
+    calls = {"sso": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/patient/sso/auth":
+            calls["sso"] += 1
+        return httpx.Response(200)
+
+    async with _session(_bundle("TOK1", _valid_to_str(30)), handler) as s:
+        assert s.needs_refresh() is False
+        assert await s.bearer() == "TOK1"
+        assert calls["sso"] == 0  # did not refresh a still-valid token
+
+
+async def test_expired_token_triggers_refresh_to_new_token():
+    new_valid = quote(_valid_to_str(45))  # url-encoded for the Set-Cookie value
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/patient/sso/auth":
+            return httpx.Response(
+                200,
+                headers=[
+                    ("set-cookie", f"auth_tmp_token=TOK2; Domain={API_HOST}; Path=/"),
+                    (
+                        "set-cookie",
+                        f"c_token_valid_to={new_valid}; Domain={API_HOST}; Path=/",
+                    ),
+                ],
+            )
+        return httpx.Response(200)
+
+    async with _session(_bundle("TOK1", _valid_to_str(-5)), handler) as s:
+        assert s.needs_refresh() is True
+        assert await s.bearer() == "TOK2"  # refreshed
+        assert s.needs_refresh() is False  # new validity persisted
+
+
+async def test_refresh_bounced_to_login_raises_auth_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/patient/sso/auth":
+            return httpx.Response(
+                302, headers={"location": f"https://{API_HOST}/app/login"}
+            )
+        if request.url.path == "/app/login":
+            return httpx.Response(200)
+        return httpx.Response(404)
+
+    async with _session(_bundle("TOK1", _valid_to_str(-5)), handler) as s:
+        with pytest.raises(CareLinkAuthError, match="reconnect"):
+            await s.bearer()
+
+
+async def test_missing_token_raises():
+    async with _session(
+        [{"name": "c_token_valid_to", "value": _valid_to_str(30), "domain": API_HOST}],
+        lambda r: httpx.Response(200),
+    ) as s:
+        with pytest.raises(CareLinkAuthError, match="No auth_tmp_token"):
+            await s.bearer()
+
+
+async def test_export_cookies_roundtrips_token():
+    async with _session(
+        _bundle("TOK1", _valid_to_str(30)), lambda r: httpx.Response(200)
+    ) as s:
+        names = {c["name"]: c["value"] for c in s.export_cookies()}
+        assert names["auth_tmp_token"] == "TOK1"
+        assert "auth0" in names  # the Auth0 session cookie is preserved
+
+
+async def test_refresh_on_valid_session_keeps_token():
+    """Regression (caught in live E2E): when the session is still valid,
+    /patient/sso/auth is a no-op and issues no new token. refresh() must keep
+    the existing token rather than dropping it."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200)  # no Set-Cookie -> no re-issue
+
+    async with _session(_bundle("TOK1", _valid_to_str(30)), handler) as s:
+        await s.refresh()  # forced no-op refresh
+        assert await s.bearer() == "TOK1"  # token preserved, not lost

--- a/apps/api/tests/test_carelink_storage.py
+++ b/apps/api/tests/test_carelink_storage.py
@@ -1,0 +1,109 @@
+"""Tests for CareLink record storage (idempotent upserts) against the DB."""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select
+
+from src.database import get_session_maker
+from src.models.glucose import GlucoseReading
+from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.user import User
+from src.services.integrations.medtronic.carelink_mapper import (
+    MappedGlucose,
+    MappedPumpEvent,
+    MappedRecords,
+)
+from src.services.integrations.medtronic.storage import store_carelink_records
+
+
+async def _make_user(db) -> uuid.UUID:
+    user = User(
+        email=f"carelink_store_{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user.id
+
+
+async def _count(db, model, user_id) -> int:
+    return (
+        await db.execute(
+            select(func.count()).select_from(model).where(model.user_id == user_id)
+        )
+    ).scalar_one()
+
+
+def _sample(ts: datetime) -> MappedRecords:
+    return MappedRecords(
+        glucose=[MappedGlucose(timestamp=ts, value_mgdl=120)],
+        pump_events=[
+            MappedPumpEvent(event_type=PumpEventType.BOLUS, timestamp=ts, units=2.0),
+            MappedPumpEvent(event_type=PumpEventType.BASAL, timestamp=ts, units=0.8),
+        ],
+    )
+
+
+async def test_stores_glucose_and_events():
+    ts = datetime(2025, 1, 31, 12, 0, tzinfo=UTC)
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        res = await store_carelink_records(db, uid, _sample(ts))
+        assert res.glucose_stored == 1
+        assert res.events_stored == 2
+        assert await _count(db, GlucoseReading, uid) == 1
+        assert await _count(db, PumpEvent, uid) == 2
+
+
+async def test_reimport_is_idempotent():
+    ts = datetime(2025, 1, 31, 12, 0, tzinfo=UTC)
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        await store_carelink_records(db, uid, _sample(ts))
+        # Re-store the exact same range -> nothing new inserted.
+        res2 = await store_carelink_records(db, uid, _sample(ts))
+        assert res2.glucose_stored == 0
+        assert res2.events_stored == 0
+        assert await _count(db, GlucoseReading, uid) == 1
+        assert await _count(db, PumpEvent, uid) == 2
+
+
+async def test_intra_batch_duplicates_deduped():
+    """Two glucose readings at the same timestamp in one batch -> one row."""
+    ts = datetime(2025, 1, 31, 12, 0, tzinfo=UTC)
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        records = MappedRecords(
+            glucose=[
+                MappedGlucose(timestamp=ts, value_mgdl=120),
+                MappedGlucose(timestamp=ts, value_mgdl=121),  # dup key
+            ],
+            pump_events=[
+                MappedPumpEvent(PumpEventType.SUSPEND, ts),
+                MappedPumpEvent(PumpEventType.SUSPEND, ts),  # dup key
+            ],
+        )
+        res = await store_carelink_records(db, uid, records)
+        assert res.glucose_stored == 1
+        assert res.events_stored == 1
+
+
+async def test_naive_timestamp_is_coerced_to_utc():
+    naive = datetime(2025, 1, 31, 9, 30, 0)  # no tzinfo
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        res = await store_carelink_records(
+            db,
+            uid,
+            MappedRecords(glucose=[MappedGlucose(timestamp=naive, value_mgdl=99)]),
+        )
+        assert res.glucose_stored == 1
+        row = (
+            await db.execute(
+                select(GlucoseReading).where(GlucoseReading.user_id == uid)
+            )
+        ).scalar_one()
+        assert row.reading_timestamp.utcoffset() is not None  # stored tz-aware
+        assert row.value == 99

--- a/apps/api/tests/test_carelink_storage.py
+++ b/apps/api/tests/test_carelink_storage.py
@@ -2,7 +2,9 @@
 
 import uuid
 from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
 
+import pytest
 from sqlalchemy import func, select
 
 from src.database import get_session_maker
@@ -90,14 +92,30 @@ async def test_intra_batch_duplicates_deduped():
         assert res.events_stored == 1
 
 
-async def test_naive_timestamp_is_coerced_to_utc():
+async def test_naive_timestamp_is_rejected():
+    # Storage requires tz-aware timestamps (sync._localize attaches the user's
+    # zone). A naive pump-local time must NOT be silently coerced to UTC.
     naive = datetime(2025, 1, 31, 9, 30, 0)  # no tzinfo
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        with pytest.raises(ValueError, match="timezone-aware"):
+            await store_carelink_records(
+                db,
+                uid,
+                MappedRecords(glucose=[MappedGlucose(timestamp=naive, value_mgdl=99)]),
+            )
+
+
+async def test_aware_timestamp_normalized_to_utc():
+    # An aware non-UTC timestamp is stored as the same instant in UTC
+    # (NY 09:30 EST == 14:30 UTC).
+    local = datetime(2025, 1, 31, 9, 30, 0, tzinfo=ZoneInfo("America/New_York"))
     async with get_session_maker()() as db:
         uid = await _make_user(db)
         res = await store_carelink_records(
             db,
             uid,
-            MappedRecords(glucose=[MappedGlucose(timestamp=naive, value_mgdl=99)]),
+            MappedRecords(glucose=[MappedGlucose(timestamp=local, value_mgdl=99)]),
         )
         assert res.glucose_stored == 1
         row = (
@@ -105,5 +123,5 @@ async def test_naive_timestamp_is_coerced_to_utc():
                 select(GlucoseReading).where(GlucoseReading.user_id == uid)
             )
         ).scalar_one()
-        assert row.reading_timestamp.utcoffset() is not None  # stored tz-aware
         assert row.value == 99
+        assert row.reading_timestamp.astimezone(UTC).hour == 14

--- a/apps/api/tests/test_carelink_sync.py
+++ b/apps/api/tests/test_carelink_sync.py
@@ -1,0 +1,110 @@
+"""End-to-end orchestrator test: CareLink export -> parse -> map -> store."""
+
+import uuid
+from datetime import UTC, date, timedelta, timezone
+
+import httpx
+from sqlalchemy import select
+
+from src.database import get_session_maker
+from src.models.glucose import GlucoseReading
+from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.user import User
+from src.services.integrations.medtronic.client import CareLinkClient
+from src.services.integrations.medtronic.sync import sync_carelink_for_user
+
+_CSV = (
+    "Index,Date,Time,Basal Rate (U/h),Bolus Volume Delivered (U),"
+    "Bolus Source,Sensor Glucose (mg/dL)\n"
+    "0,2025/01/20,12:00:00,0.85,,,\n"
+    "1,2025/01/20,12:05:00,,2.0,BOLUS_WIZARD,\n"
+    "2,2025/01/20,12:05:00,,,,140\n"
+)
+
+
+async def _bearer() -> str:
+    return "tok"
+
+
+def _client() -> CareLinkClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/patient/users/me":
+            return httpx.Response(200, json={"patientId": "P1"})
+        if path == "/patient/reports/generateReport":
+            return httpx.Response(200, json={"uuid": "u1"})
+        if path == "/patient/reports/reportStatus":
+            return httpx.Response(200, json={"status": "COMPLETE"})
+        if path == "/patient/reports/reportCsv":
+            return httpx.Response(200, text=_CSV)
+        return httpx.Response(404)
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return CareLinkClient(bearer_provider=_bearer, client=http, poll_interval_seconds=0)
+
+
+async def _make_user(db) -> uuid.UUID:
+    user = User(
+        email=f"carelink_sync_{uuid.uuid4().hex[:8]}@example.com", hashed_password="x"
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user.id
+
+
+async def test_sync_end_to_end_stores_records():
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        async with _client() as client:
+            res = await sync_carelink_for_user(
+                db,
+                uid,
+                start_date=date(2025, 1, 20),
+                end_date=date(2025, 1, 20),
+                client=client,
+            )
+        assert res.patient_id == "P1"
+        assert res.glucose_stored == 1  # the one Sensor Glucose row
+        assert res.events_stored == 2  # basal + bolus
+
+        glucose = (
+            (
+                await db.execute(
+                    select(GlucoseReading).where(GlucoseReading.user_id == uid)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [g.value for g in glucose] == [140]
+        event_types = {
+            e.event_type
+            for e in (
+                await db.execute(select(PumpEvent).where(PumpEvent.user_id == uid))
+            ).scalars()
+        }
+        assert event_types == {PumpEventType.BASAL, PumpEventType.BOLUS}
+
+
+async def test_sync_localizes_naive_times_with_tz():
+    """With tz=-05:00, the naive 12:00 pump time is stored as 17:00 UTC."""
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        async with _client() as client:
+            await sync_carelink_for_user(
+                db,
+                uid,
+                start_date=date(2025, 1, 20),
+                end_date=date(2025, 1, 20),
+                client=client,
+                tz=timezone(timedelta(hours=-5)),
+            )
+        sg = (
+            await db.execute(
+                select(GlucoseReading).where(GlucoseReading.user_id == uid)
+            )
+        ).scalar_one()
+        # 12:05 local (-05:00) -> 17:05 UTC
+        assert sg.reading_timestamp.astimezone(UTC).hour == 17
+        assert sg.reading_timestamp.astimezone(UTC).minute == 5

--- a/apps/api/tests/test_carelink_sync.py
+++ b/apps/api/tests/test_carelink_sync.py
@@ -1,7 +1,8 @@
 """End-to-end orchestrator test: CareLink export -> parse -> map -> store."""
 
 import uuid
-from datetime import UTC, date, timedelta, timezone
+from datetime import UTC, date
+from zoneinfo import ZoneInfo
 
 import httpx
 from sqlalchemy import select
@@ -63,6 +64,7 @@ async def test_sync_end_to_end_stores_records():
                 start_date=date(2025, 1, 20),
                 end_date=date(2025, 1, 20),
                 client=client,
+                tz=ZoneInfo("UTC"),
             )
         assert res.patient_id == "P1"
         assert res.glucose_stored == 1  # the one Sensor Glucose row
@@ -87,8 +89,9 @@ async def test_sync_end_to_end_stores_records():
         assert event_types == {PumpEventType.BASAL, PumpEventType.BOLUS}
 
 
-async def test_sync_localizes_naive_times_with_tz():
-    """With tz=-05:00, the naive 12:00 pump time is stored as 17:00 UTC."""
+async def test_sync_localizes_naive_times_with_zoneinfo():
+    """Jan 20 in America/New_York is EST (-05:00) -> 12:05 local = 17:05 UTC.
+    Uses a real IANA zone so the offset is DST-correct for that date."""
     async with get_session_maker()() as db:
         uid = await _make_user(db)
         async with _client() as client:
@@ -98,7 +101,7 @@ async def test_sync_localizes_naive_times_with_tz():
                 start_date=date(2025, 1, 20),
                 end_date=date(2025, 1, 20),
                 client=client,
-                tz=timezone(timedelta(hours=-5)),
+                tz=ZoneInfo("America/New_York"),
             )
         sg = (
             await db.execute(

--- a/apps/api/tests/test_medtronic_endpoints.py
+++ b/apps/api/tests/test_medtronic_endpoints.py
@@ -1,0 +1,252 @@
+"""Tests for the Medtronic CareLink manual-import endpoints (feature B).
+
+Stateless endpoints: the request carries the captured auth_tmp_token; the
+backend builds a cookie-less client and never stores the token. We patch the
+client builder + the sync orchestrator so these stay pure unit/HTTP tests.
+"""
+
+import uuid
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.config import settings
+from src.core.medtronic_regions import resolve_region_base_url
+from src.main import app
+from src.services.integrations.medtronic.client import (
+    CareLinkAuthError,
+    CareLinkAvailability,
+    CareLinkError,
+    CareLinkReportTimeoutError,
+)
+from src.services.integrations.medtronic.sync import CareLinkSyncResult
+
+AVAIL_PATH = "/api/integrations/medtronic/availability"
+IMPORT_PATH = "/api/integrations/medtronic/import"
+
+_AVAIL = CareLinkAvailability(
+    start=datetime(2012, 1, 1, tzinfo=UTC), end=datetime(2025, 1, 31, tzinfo=UTC)
+)
+
+
+def unique_email(prefix: str = "medtronic") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def _login(client: AsyncClient) -> dict:
+    email = unique_email()
+    pw = "SecurePass123"
+    await client.post("/api/auth/register", json={"email": email, "password": pw})
+    r = await client.post("/api/auth/login", json={"email": email, "password": pw})
+    return {settings.jwt_cookie_name: r.cookies.get(settings.jwt_cookie_name)}
+
+
+class _FakeClient:
+    """Stand-in for CareLinkClient with canned async methods."""
+
+    def __init__(self, *, availability=None, raise_exc=None):
+        self._avail = availability
+        self._raise = raise_exc
+
+    async def get_patient_id(self):
+        if self._raise:
+            raise self._raise
+        return "patient-123"
+
+    async def get_availability(self):
+        if self._raise:
+            raise self._raise
+        return self._avail
+
+    async def aclose(self):
+        return None
+
+
+def _import_body(**over) -> dict:
+    body = {
+        "region": "US",
+        "token": "tok-abc",
+        "start_date": "2025-01-15",
+        "end_date": "2025-01-20",
+        "tz": "America/New_York",
+    }
+    body.update(over)
+    return body
+
+
+def _result() -> CareLinkSyncResult:
+    return CareLinkSyncResult(
+        patient_id="patient-123",
+        start_date=date(2025, 1, 15),
+        end_date=date(2025, 1, 20),
+        glucose_fetched=500,
+        glucose_stored=480,
+        events_fetched=120,
+        events_stored=110,
+    )
+
+
+# --- unit: region resolver -------------------------------------------------
+
+
+def test_resolve_region_base_url():
+    assert resolve_region_base_url("us") == "https://carelink.minimed.com"
+    assert resolve_region_base_url("EU") == "https://carelink.minimed.eu"
+    with pytest.raises(ValueError, match="Unsupported"):
+        resolve_region_base_url("ZZ")
+
+
+# --- availability ----------------------------------------------------------
+
+
+async def test_availability_requires_auth():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(AVAIL_PATH, json={"region": "US", "token": "x"})
+    assert resp.status_code == 401
+
+
+@patch("src.routers.integrations._build_carelink_client")
+async def test_availability_success(mock_build):
+    mock_build.return_value = _FakeClient(availability=_AVAIL)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            AVAIL_PATH, json={"region": "US", "token": "tok-abc"}, cookies=cookies
+        )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["start"].startswith("2012-01-01")
+    assert data["end"].startswith("2025-01-31")
+
+
+@patch("src.routers.integrations._build_carelink_client")
+async def test_availability_expired_token_401(mock_build):
+    mock_build.return_value = _FakeClient(raise_exc=CareLinkAuthError("401"))
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            AVAIL_PATH, json={"region": "US", "token": "tok-abc"}, cookies=cookies
+        )
+    assert resp.status_code == 401, resp.text
+
+
+@patch("src.routers.integrations._build_carelink_client")
+async def test_availability_service_error_503(mock_build):
+    mock_build.return_value = _FakeClient(raise_exc=CareLinkError("boom"))
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            AVAIL_PATH, json={"region": "US", "token": "tok-abc"}, cookies=cookies
+        )
+    assert resp.status_code == 503, resp.text
+
+
+async def test_availability_bad_region_422():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            AVAIL_PATH, json={"region": "ZZ", "token": "tok-abc"}, cookies=cookies
+        )
+    assert resp.status_code == 422, resp.text
+
+
+# --- import ----------------------------------------------------------------
+
+
+@patch("src.routers.integrations.sync_carelink_for_user", new_callable=AsyncMock)
+@patch("src.routers.integrations._build_carelink_client")
+async def test_import_success(mock_build, mock_sync):
+    mock_build.return_value = _FakeClient()
+    mock_sync.return_value = _result()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(IMPORT_PATH, json=_import_body(), cookies=cookies)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["glucose_stored"] == 480
+    assert data["events_stored"] == 110
+    # tz string reached the orchestrator as a ZoneInfo
+    assert mock_sync.await_args.kwargs["tz"].key == "America/New_York"
+
+
+@pytest.mark.parametrize(
+    "start,end",
+    [
+        ("2025-01-20", "2025-01-15"),  # end before start
+        ("2025-01-01", "2099-01-01"),  # future
+        ("2025-01-01", "2025-03-01"),  # span > 31-day cap
+    ],
+)
+async def test_import_rejects_bad_range_422(start, end):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            IMPORT_PATH,
+            json=_import_body(start_date=start, end_date=end),
+            cookies=cookies,
+        )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_import_bad_region_422():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            IMPORT_PATH, json=_import_body(region="ZZ"), cookies=cookies
+        )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_import_invalid_tz_422():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            IMPORT_PATH, json=_import_body(tz="Not/AZone"), cookies=cookies
+        )
+    assert resp.status_code == 422, resp.text
+
+
+@patch("src.routers.integrations.sync_carelink_for_user", new_callable=AsyncMock)
+@patch("src.routers.integrations._build_carelink_client")
+async def test_import_expired_token_401(mock_build, mock_sync):
+    mock_build.return_value = _FakeClient()
+    mock_sync.side_effect = CareLinkAuthError("401")
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(IMPORT_PATH, json=_import_body(), cookies=cookies)
+    assert resp.status_code == 401, resp.text
+
+
+@patch("src.routers.integrations.sync_carelink_for_user", new_callable=AsyncMock)
+@patch("src.routers.integrations._build_carelink_client")
+async def test_import_timeout_504(mock_build, mock_sync):
+    mock_build.return_value = _FakeClient()
+    mock_sync.side_effect = CareLinkReportTimeoutError("slow")
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(IMPORT_PATH, json=_import_body(), cookies=cookies)
+    assert resp.status_code == 504, resp.text

--- a/apps/api/tests/test_medtronic_endpoints.py
+++ b/apps/api/tests/test_medtronic_endpoints.py
@@ -193,7 +193,8 @@ async def test_import_success(mock_build, mock_sync):
     [
         ("2025-01-20", "2025-01-15"),  # end before start
         ("2025-01-01", "2099-01-01"),  # future
-        ("2025-01-01", "2025-03-01"),  # span > 31-day cap
+        ("2025-01-01", "2025-02-01"),  # 32 inclusive days -- just over the cap
+        ("2025-01-01", "2025-03-01"),  # span well over the 31-day cap
     ],
 )
 async def test_import_rejects_bad_range_422(start, end):

--- a/apps/api/tests/test_medtronic_endpoints.py
+++ b/apps/api/tests/test_medtronic_endpoints.py
@@ -26,6 +26,10 @@ from src.services.integrations.medtronic.sync import CareLinkSyncResult
 AVAIL_PATH = "/api/integrations/medtronic/availability"
 IMPORT_PATH = "/api/integrations/medtronic/import"
 
+# The captured token rides in a header (never the body) so it can't land in a
+# body-validation 422 echo or request-body logging.
+_HDR = {"X-CareLink-Token": "tok-abc"}
+
 _AVAIL = CareLinkAvailability(
     start=datetime(2012, 1, 1, tzinfo=UTC), end=datetime(2025, 1, 31, tzinfo=UTC)
 )
@@ -67,7 +71,6 @@ class _FakeClient:
 def _import_body(**over) -> dict:
     body = {
         "region": "US",
-        "token": "tok-abc",
         "start_date": "2025-01-15",
         "end_date": "2025-01-20",
         "tz": "America/New_York",
@@ -105,7 +108,7 @@ async def test_availability_requires_auth():
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
-        resp = await client.post(AVAIL_PATH, json={"region": "US", "token": "x"})
+        resp = await client.post(AVAIL_PATH, json={"region": "US"}, headers=_HDR)
     assert resp.status_code == 401
 
 
@@ -117,7 +120,7 @@ async def test_availability_success(mock_build):
     ) as client:
         cookies = await _login(client)
         resp = await client.post(
-            AVAIL_PATH, json={"region": "US", "token": "tok-abc"}, cookies=cookies
+            AVAIL_PATH, json={"region": "US"}, headers=_HDR, cookies=cookies
         )
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -133,7 +136,7 @@ async def test_availability_expired_token_401(mock_build):
     ) as client:
         cookies = await _login(client)
         resp = await client.post(
-            AVAIL_PATH, json={"region": "US", "token": "tok-abc"}, cookies=cookies
+            AVAIL_PATH, json={"region": "US"}, headers=_HDR, cookies=cookies
         )
     assert resp.status_code == 401, resp.text
 
@@ -146,7 +149,7 @@ async def test_availability_service_error_503(mock_build):
     ) as client:
         cookies = await _login(client)
         resp = await client.post(
-            AVAIL_PATH, json={"region": "US", "token": "tok-abc"}, cookies=cookies
+            AVAIL_PATH, json={"region": "US"}, headers=_HDR, cookies=cookies
         )
     assert resp.status_code == 503, resp.text
 
@@ -157,7 +160,7 @@ async def test_availability_bad_region_422():
     ) as client:
         cookies = await _login(client)
         resp = await client.post(
-            AVAIL_PATH, json={"region": "ZZ", "token": "tok-abc"}, cookies=cookies
+            AVAIL_PATH, json={"region": "ZZ"}, headers=_HDR, cookies=cookies
         )
     assert resp.status_code == 422, resp.text
 
@@ -174,7 +177,9 @@ async def test_import_success(mock_build, mock_sync):
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
         cookies = await _login(client)
-        resp = await client.post(IMPORT_PATH, json=_import_body(), cookies=cookies)
+        resp = await client.post(
+            IMPORT_PATH, json=_import_body(), headers=_HDR, cookies=cookies
+        )
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["glucose_stored"] == 480
@@ -199,6 +204,7 @@ async def test_import_rejects_bad_range_422(start, end):
         resp = await client.post(
             IMPORT_PATH,
             json=_import_body(start_date=start, end_date=end),
+            headers=_HDR,
             cookies=cookies,
         )
     assert resp.status_code == 422, resp.text
@@ -210,7 +216,7 @@ async def test_import_bad_region_422():
     ) as client:
         cookies = await _login(client)
         resp = await client.post(
-            IMPORT_PATH, json=_import_body(region="ZZ"), cookies=cookies
+            IMPORT_PATH, json=_import_body(region="ZZ"), headers=_HDR, cookies=cookies
         )
     assert resp.status_code == 422, resp.text
 
@@ -221,7 +227,10 @@ async def test_import_invalid_tz_422():
     ) as client:
         cookies = await _login(client)
         resp = await client.post(
-            IMPORT_PATH, json=_import_body(tz="Not/AZone"), cookies=cookies
+            IMPORT_PATH,
+            json=_import_body(tz="Not/AZone"),
+            headers=_HDR,
+            cookies=cookies,
         )
     assert resp.status_code == 422, resp.text
 
@@ -235,7 +244,9 @@ async def test_import_expired_token_401(mock_build, mock_sync):
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
         cookies = await _login(client)
-        resp = await client.post(IMPORT_PATH, json=_import_body(), cookies=cookies)
+        resp = await client.post(
+            IMPORT_PATH, json=_import_body(), headers=_HDR, cookies=cookies
+        )
     assert resp.status_code == 401, resp.text
 
 
@@ -248,5 +259,26 @@ async def test_import_timeout_504(mock_build, mock_sync):
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
         cookies = await _login(client)
-        resp = await client.post(IMPORT_PATH, json=_import_body(), cookies=cookies)
+        resp = await client.post(
+            IMPORT_PATH, json=_import_body(), headers=_HDR, cookies=cookies
+        )
     assert resp.status_code == 504, resp.text
+
+
+async def test_token_not_leaked_in_validation_error():
+    """A body-validation 422 (e.g. bad date range) must NOT echo the captured
+    token. The token rides in the X-CareLink-Token header, never the body, so a
+    body-validation error can't include it."""
+    secret = "SUPERSECRETtok_abc_should_never_appear"
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            IMPORT_PATH,
+            json=_import_body(start_date="2025-01-01", end_date="2099-01-01"),
+            headers={"X-CareLink-Token": secret},
+            cookies=cookies,
+        )
+    assert resp.status_code == 422, resp.text
+    assert secret not in resp.text

--- a/apps/web/src/components/integrations/cloud-sync-section.tsx
+++ b/apps/web/src/components/integrations/cloud-sync-section.tsx
@@ -7,6 +7,7 @@ import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { TANDEM_COUNTRY_GROUPS } from "@/lib/tandem-countries";
 import { IntegrationCard, PasswordInput, StatusBadge } from "./integration-card";
 import { TandemSyncCard } from "./tandem-sync-card";
+import { MedtronicImportCard } from "./medtronic-import-card";
 
 interface CloudSyncSectionProps {
   tandem: IntegrationResponse | null;
@@ -142,6 +143,10 @@ export function CloudSyncSection({
               <TandemSyncCard isOffline={isOffline} />
             )}
           </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Medtronic CareLink" variant="subsection">
+          <MedtronicImportCard isOffline={isOffline} />
         </CollapsibleSection>
       </div>
     </CollapsibleSection>

--- a/apps/web/src/components/integrations/medtronic-import-card.tsx
+++ b/apps/web/src/components/integrations/medtronic-import-card.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import clsx from "clsx";
+import {
+  getMedtronicAvailability,
+  importMedtronicRange,
+  type MedtronicAvailabilityResponse,
+  type MedtronicImportResponse,
+} from "@/lib/api";
+
+/**
+ * Medtronic CareLink manual historical import.
+ *
+ * CareLink has no API and no durable server-side session, so we can't pull
+ * autonomously like Tandem. Instead: the user logs into CareLink in a popup
+ * (solving the captcha) and clicks a one-time GlycemicGPT bookmarklet that
+ * reads the short-lived auth_tmp_token and hands it back via postMessage (or
+ * clipboard fallback). We then validate it, show the available range, and let
+ * the user import a chosen window. The token is used for the import only and
+ * is never stored.
+ */
+
+const MAX_IMPORT_DAYS = 31;
+
+const REGIONS = [
+  {
+    code: "US",
+    label: "United States",
+    loginUrl: "https://carelink.minimed.com/",
+    origin: "https://carelink.minimed.com",
+  },
+  {
+    code: "EU",
+    label: "Europe / International",
+    loginUrl: "https://carelink.minimed.eu/",
+    origin: "https://carelink.minimed.eu",
+  },
+] as const;
+
+const MESSAGE_SOURCE = "glycemicgpt-carelink";
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function daysBetween(a: string, b: string): number {
+  return Math.round(
+    (new Date(b).getTime() - new Date(a).getTime()) / 86_400_000
+  );
+}
+
+export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
+  const [regionCode, setRegionCode] = useState<string>("US");
+  const [token, setToken] = useState<string>("");
+  const [pasteValue, setPasteValue] = useState<string>("");
+  const [availability, setAvailability] =
+    useState<MedtronicAvailabilityResponse | null>(null);
+  const [importStart, setImportStart] = useState<string>("");
+  const [importEnd, setImportEnd] = useState<string>("");
+  const [isFetchingAvail, setIsFetchingAvail] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<MedtronicImportResponse | null>(null);
+
+  const region = useMemo(
+    () => REGIONS.find((r) => r.code === regionCode) ?? REGIONS[0],
+    [regionCode]
+  );
+  const browserTz = useMemo(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+    []
+  );
+
+  const bookmarklet = useMemo(() => {
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    // Reads the non-httpOnly auth_tmp_token, posts it to the opener (this app),
+    // and falls back to copying it to the clipboard if the opener is gone.
+    return `javascript:(function(){try{var m=document.cookie.match(/(?:^|;\\s*)auth_tmp_token=([^;]+)/);if(!m){alert('GlycemicGPT: no CareLink token found - are you signed in?');return;}var t=decodeURIComponent(m[1]);if(window.opener&&!window.opener.closed){window.opener.postMessage({source:'${MESSAGE_SOURCE}',token:t},'${origin}');alert('GlycemicGPT: token sent. You can close this tab.');}else if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(t).then(function(){alert('GlycemicGPT: token copied. Paste it into GlycemicGPT.');},function(){prompt('GlycemicGPT: copy this token:',t);});}else{prompt('GlycemicGPT: copy this token:',t);}}catch(e){alert('GlycemicGPT capture error: '+e);}})();`;
+  }, []);
+
+  const bookmarkletRef = useRef<HTMLAnchorElement | null>(null);
+  useEffect(() => {
+    // Set the javascript: href via the DOM so React doesn't strip it; the user
+    // drags this to their bookmarks bar (clicking it here is a no-op).
+    if (bookmarkletRef.current) {
+      bookmarkletRef.current.setAttribute("href", bookmarklet);
+    }
+  }, [bookmarklet]);
+
+  const fetchAvailability = useCallback(
+    async (tok: string) => {
+      setError(null);
+      setResult(null);
+      setIsFetchingAvail(true);
+      try {
+        const avail = await getMedtronicAvailability(region.code, tok);
+        setAvailability(avail);
+        // Default the picker to the most recent ~14 days of available data.
+        if (avail.end) {
+          const end = avail.end.slice(0, 10);
+          const earliest = avail.start ? avail.start.slice(0, 10) : end;
+          const proposedStart = isoDate(
+            new Date(new Date(end).getTime() - 14 * 86_400_000)
+          );
+          setImportEnd(end);
+          setImportStart(proposedStart < earliest ? earliest : proposedStart);
+        }
+      } catch (e) {
+        setAvailability(null);
+        setError(e instanceof Error ? e.message : "Failed to read availability");
+      } finally {
+        setIsFetchingAvail(false);
+      }
+    },
+    [region.code]
+  );
+
+  // Listen for the bookmarklet's postMessage from the CareLink popup.
+  useEffect(() => {
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== region.origin) return;
+      const data = event.data;
+      if (
+        data &&
+        data.source === MESSAGE_SOURCE &&
+        typeof data.token === "string" &&
+        data.token.length > 0
+      ) {
+        setToken(data.token);
+        void fetchAvailability(data.token);
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [region.origin, fetchAvailability]);
+
+  const openCareLink = useCallback(() => {
+    setError(null);
+    window.open(region.loginUrl, "carelink_login", "width=1100,height=860");
+  }, [region.loginUrl]);
+
+  const usePastedToken = useCallback(() => {
+    const t = pasteValue.trim();
+    if (!t) return;
+    setToken(t);
+    void fetchAvailability(t);
+  }, [pasteValue, fetchAvailability]);
+
+  const rangeDays =
+    importStart && importEnd ? daysBetween(importStart, importEnd) : 0;
+  const rangeValid =
+    !!importStart &&
+    !!importEnd &&
+    rangeDays >= 0 &&
+    rangeDays <= MAX_IMPORT_DAYS;
+
+  const runImport = useCallback(async () => {
+    if (!token || !rangeValid) return;
+    setError(null);
+    setResult(null);
+    setIsImporting(true);
+    try {
+      const res = await importMedtronicRange(
+        region.code,
+        token,
+        importStart,
+        importEnd,
+        browserTz
+      );
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Import failed");
+    } finally {
+      setIsImporting(false);
+    }
+  }, [token, rangeValid, region.code, importStart, importEnd, browserTz]);
+
+  const inputClass = clsx(
+    "w-full rounded-lg border px-3 py-2 text-sm",
+    "bg-slate-800 border-slate-700 text-slate-200 placeholder:text-slate-500",
+    "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+    "disabled:opacity-50 disabled:cursor-not-allowed"
+  );
+  const btnClass = clsx(
+    "rounded-lg px-4 py-2 text-sm font-medium transition-colors",
+    "bg-blue-600 hover:bg-blue-500 text-white",
+    "disabled:opacity-50 disabled:cursor-not-allowed"
+  );
+
+  return (
+    <div className="space-y-5 rounded-lg border border-slate-700 bg-slate-900/40 p-4">
+      <p className="text-sm text-slate-400">
+        CareLink has no public API, so importing is manual: sign in to CareLink
+        (one-time captcha), click the GlycemicGPT bookmarklet to hand your
+        session back, then pick a date range to import. Your session token is
+        used only for the import and is never stored.
+      </p>
+
+      {/* Region */}
+      <div className="max-w-xs">
+        <label
+          htmlFor="medtronic-region"
+          className="block text-sm font-medium text-slate-300 mb-1"
+        >
+          Region
+        </label>
+        <select
+          id="medtronic-region"
+          value={regionCode}
+          onChange={(e) => {
+            setRegionCode(e.target.value);
+            setToken("");
+            setAvailability(null);
+          }}
+          disabled={isOffline}
+          className={inputClass}
+        >
+          {REGIONS.map((r) => (
+            <option key={r.code} value={r.code}>
+              {r.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Step 1: bookmarklet (one-time setup) */}
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-slate-300">
+          1. Save the capture bookmarklet (one time)
+        </p>
+        <p className="text-xs text-slate-500">
+          Drag this button to your bookmarks bar:
+        </p>
+        <a
+          ref={bookmarkletRef}
+          href="#"
+          onClick={(e) => e.preventDefault()}
+          draggable
+          className="inline-block cursor-grab rounded-md border border-blue-500/50 bg-blue-500/10 px-3 py-1.5 text-sm font-medium text-blue-300"
+        >
+          Capture CareLink → GlycemicGPT
+        </a>
+      </div>
+
+      {/* Step 2: sign in + capture */}
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-slate-300">
+          2. Sign in to CareLink and capture
+        </p>
+        <button
+          type="button"
+          onClick={openCareLink}
+          disabled={isOffline}
+          className={btnClass}
+        >
+          Open CareLink &amp; sign in
+        </button>
+        <p className="text-xs text-slate-500">
+          After signing in, click the bookmarklet on the CareLink page. If the
+          token doesn&apos;t arrive automatically, the bookmarklet copies it —
+          paste it here:
+        </p>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={pasteValue}
+            onChange={(e) => setPasteValue(e.target.value)}
+            placeholder="Paste captured token (fallback)"
+            disabled={isOffline}
+            className={inputClass}
+          />
+          <button
+            type="button"
+            onClick={usePastedToken}
+            disabled={isOffline || !pasteValue.trim()}
+            className={clsx(btnClass, "whitespace-nowrap")}
+          >
+            Use token
+          </button>
+        </div>
+        {token && (
+          <p className="text-xs text-green-400">
+            ✓ Session captured{isFetchingAvail ? " — reading availability…" : ""}
+          </p>
+        )}
+      </div>
+
+      {/* Step 3: range + import */}
+      {availability && (
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-slate-300">
+            3. Choose a range to import
+          </p>
+          <p className="text-xs text-slate-500">
+            Data available {availability.start?.slice(0, 10) ?? "?"} →{" "}
+            {availability.end?.slice(0, 10) ?? "?"}. Max {MAX_IMPORT_DAYS} days
+            per import.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-md">
+            <div>
+              <label
+                htmlFor="medtronic-start"
+                className="block text-xs text-slate-400 mb-1"
+              >
+                Start
+              </label>
+              <input
+                id="medtronic-start"
+                type="date"
+                value={importStart}
+                min={availability.start?.slice(0, 10)}
+                max={availability.end?.slice(0, 10)}
+                onChange={(e) => setImportStart(e.target.value)}
+                disabled={isImporting}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="medtronic-end"
+                className="block text-xs text-slate-400 mb-1"
+              >
+                End
+              </label>
+              <input
+                id="medtronic-end"
+                type="date"
+                value={importEnd}
+                min={availability.start?.slice(0, 10)}
+                max={availability.end?.slice(0, 10)}
+                onChange={(e) => setImportEnd(e.target.value)}
+                disabled={isImporting}
+                className={inputClass}
+              />
+            </div>
+          </div>
+          {importStart && importEnd && !rangeValid && (
+            <p className="text-xs text-amber-400">
+              {rangeDays < 0
+                ? "End date must be on or after the start date."
+                : `Range is ${rangeDays} days — max ${MAX_IMPORT_DAYS} per import.`}
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={runImport}
+            disabled={isOffline || isImporting || !rangeValid}
+            className={btnClass}
+          >
+            {isImporting ? "Importing…" : "Import range"}
+          </button>
+        </div>
+      )}
+
+      {result && (
+        <div className="rounded-md border border-green-600/40 bg-green-600/10 p-3 text-sm text-green-300">
+          Imported {result.glucose_stored} glucose readings and{" "}
+          {result.events_stored} pump events.
+        </div>
+      )}
+      {error && (
+        <div className="rounded-md border border-red-600/40 bg-red-600/10 p-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/medtronic-import-card.tsx
+++ b/apps/web/src/components/integrations/medtronic-import-card.tsx
@@ -176,13 +176,16 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
     void fetchAvailability(t);
   }, [pasteValue, fetchAvailability]);
 
-  const rangeDays =
+  const rangeDeltaDays =
     importStart && importEnd ? daysBetween(importStart, importEnd) : 0;
+  // Inclusive count to match the backend's 31-day cap (start..end).
+  const rangeDaysInclusive =
+    importStart && importEnd ? rangeDeltaDays + 1 : 0;
   const rangeValid =
     !!importStart &&
     !!importEnd &&
-    rangeDays >= 0 &&
-    rangeDays <= MAX_IMPORT_DAYS;
+    rangeDeltaDays >= 0 &&
+    rangeDaysInclusive <= MAX_IMPORT_DAYS;
 
   const runImport = useCallback(async () => {
     if (!token || !rangeValid) return;
@@ -425,9 +428,9 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
           </div>
           {importStart && importEnd && !rangeValid && (
             <p className="text-xs text-amber-400">
-              {rangeDays < 0
+              {rangeDeltaDays < 0
                 ? "The end date needs to be on or after the start date."
-                : `That's ${rangeDays} days — please choose ${MAX_IMPORT_DAYS} days or fewer at a time.`}
+                : `That's ${rangeDaysInclusive} days — please choose ${MAX_IMPORT_DAYS} days or fewer at a time.`}
             </p>
           )}
           <button

--- a/apps/web/src/components/integrations/medtronic-import-card.tsx
+++ b/apps/web/src/components/integrations/medtronic-import-card.tsx
@@ -54,6 +54,7 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
   const [regionCode, setRegionCode] = useState<string>("US");
   const [token, setToken] = useState<string>("");
   const [pasteValue, setPasteValue] = useState<string>("");
+  const [bookmarkletCopied, setBookmarkletCopied] = useState(false);
   const [availability, setAvailability] =
     useState<MedtronicAvailabilityResponse | null>(null);
   const [importStart, setImportStart] = useState<string>("");
@@ -86,6 +87,16 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
     if (bookmarkletRef.current) {
       bookmarkletRef.current.setAttribute("href", bookmarklet);
     }
+  }, [bookmarklet]);
+
+  const copyBookmarklet = useCallback(() => {
+    navigator.clipboard?.writeText(bookmarklet).then(
+      () => {
+        setBookmarkletCopied(true);
+        setTimeout(() => setBookmarkletCopied(false), 2000);
+      },
+      () => {}
+    );
   }, [bookmarklet]);
 
   const fetchAvailability = useCallback(
@@ -227,20 +238,54 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
       {/* Step 1: bookmarklet (one-time setup) */}
       <div className="space-y-2">
         <p className="text-sm font-medium text-slate-300">
-          1. Save the capture bookmarklet (one time)
+          1. Save the capture button (one time)
         </p>
         <p className="text-xs text-slate-500">
-          Drag this button to your bookmarks bar:
+          This is a “bookmarklet” — a bookmark that grabs your CareLink session
+          and hands it back here. Save it once using either method below.
         </p>
-        <a
-          ref={bookmarkletRef}
-          href="#"
-          onClick={(e) => e.preventDefault()}
-          draggable
-          className="inline-block cursor-grab rounded-md border border-blue-500/50 bg-blue-500/10 px-3 py-1.5 text-sm font-medium text-blue-300"
-        >
-          Capture CareLink → GlycemicGPT
-        </a>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <a
+            ref={bookmarkletRef}
+            href="#"
+            onClick={(e) => e.preventDefault()}
+            draggable
+            title="Drag me to your bookmarks bar"
+            className="inline-block cursor-grab rounded-md border border-blue-500/50 bg-blue-500/10 px-3 py-1.5 text-sm font-medium text-blue-300"
+          >
+            Capture CareLink → GlycemicGPT
+          </a>
+          <button
+            type="button"
+            onClick={copyBookmarklet}
+            className="rounded-md border border-slate-600 px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-800"
+          >
+            {bookmarkletCopied ? "Copied!" : "Copy bookmarklet code"}
+          </button>
+        </div>
+
+        <div className="space-y-1 rounded-md bg-slate-800/50 p-3 text-xs text-slate-400">
+          <p className="font-medium text-slate-300">How to save it:</p>
+          <p>
+            <span className="text-slate-300">Easiest:</span> press{" "}
+            <kbd className="rounded bg-slate-700 px-1">Ctrl</kbd>+
+            <kbd className="rounded bg-slate-700 px-1">Shift</kbd>+
+            <kbd className="rounded bg-slate-700 px-1">B</kbd> (
+            <kbd className="rounded bg-slate-700 px-1">⌘</kbd>+Shift+B on Mac) to
+            show your bookmarks bar, then drag the blue button onto it.
+          </p>
+          <p>
+            <span className="text-slate-300">Or:</span> click{" "}
+            <span className="text-slate-300">“Copy bookmarklet code”</span>,
+            right-click your bookmarks bar → “Add page…”, name it anything, and
+            paste the code into the URL field.
+          </p>
+          <p className="text-slate-500">
+            You only do this once. Pasting it into the address bar won’t work —
+            browsers block that for security.
+          </p>
+        </div>
       </div>
 
       {/* Step 2: sign in + capture */}
@@ -257,9 +302,11 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
           Open CareLink &amp; sign in
         </button>
         <p className="text-xs text-slate-500">
-          After signing in, click the bookmarklet on the CareLink page. If the
-          token doesn&apos;t arrive automatically, the bookmarklet copies it —
-          paste it here:
+          After signing in, click the{" "}
+          <span className="text-slate-300">Capture CareLink → GlycemicGPT</span>{" "}
+          bookmark you just saved (in your bookmarks bar) while on the CareLink
+          page. If the token doesn&apos;t arrive automatically, the bookmarklet
+          copies it — paste it here:
         </p>
         <div className="flex gap-2">
           <input

--- a/apps/web/src/components/integrations/medtronic-import-card.tsx
+++ b/apps/web/src/components/integrations/medtronic-import-card.tsx
@@ -201,12 +201,19 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
 
   return (
     <div className="space-y-5 rounded-lg border border-slate-700 bg-slate-900/40 p-4">
-      <p className="text-sm text-slate-400">
-        CareLink has no public API, so importing is manual: sign in to CareLink
-        (one-time captcha), click the GlycemicGPT bookmarklet to hand your
-        session back, then pick a date range to import. Your session token is
-        used only for the import and is never stored.
-      </p>
+      <div className="space-y-2 text-sm text-slate-400">
+        <p>
+          Bring your Medtronic pump history into GlycemicGPT from the CareLink
+          website — no pump connection or cables needed.
+        </p>
+        <p>
+          Medtronic doesn&apos;t offer a direct app connection, so you sign in to
+          CareLink yourself and send a copy of your data over. There&apos;s a
+          quick one-time setup, then importing takes just a few clicks. Your
+          CareLink sign-in is used only to fetch the data you ask for, and
+          GlycemicGPT never sees your CareLink password or saves your sign-in.
+        </p>
+      </div>
 
       {/* Region */}
       <div className="max-w-xs">
@@ -214,7 +221,7 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
           htmlFor="medtronic-region"
           className="block text-sm font-medium text-slate-300 mb-1"
         >
-          Region
+          Where is your CareLink account?
         </label>
         <select
           id="medtronic-region"
@@ -233,16 +240,20 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
             </option>
           ))}
         </select>
+        <p className="mt-1 text-xs text-slate-500">
+          Choose the region your Medtronic CareLink account is registered in.
+        </p>
       </div>
 
       {/* Step 1: bookmarklet (one-time setup) */}
       <div className="space-y-2">
         <p className="text-sm font-medium text-slate-300">
-          1. Save the capture button (one time)
+          Step 1 — One-time setup: save the GlycemicGPT button
         </p>
         <p className="text-xs text-slate-500">
-          This is a “bookmarklet” — a bookmark that grabs your CareLink session
-          and hands it back here. Save it once using either method below.
+          Save this button to your browser once. Later, while you&apos;re signed
+          in to CareLink, you&apos;ll click it to send your data to GlycemicGPT —
+          like a one-click bridge between the two sites. You only do this once.
         </p>
 
         <div className="flex flex-wrap items-center gap-2">
@@ -261,29 +272,33 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
             onClick={copyBookmarklet}
             className="rounded-md border border-slate-600 px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-800"
           >
-            {bookmarkletCopied ? "Copied!" : "Copy bookmarklet code"}
+            {bookmarkletCopied ? "Copied!" : "Copy button instead"}
           </button>
         </div>
 
-        <div className="space-y-1 rounded-md bg-slate-800/50 p-3 text-xs text-slate-400">
+        <div className="space-y-1.5 rounded-md bg-slate-800/50 p-3 text-xs text-slate-400">
           <p className="font-medium text-slate-300">How to save it:</p>
           <p>
-            <span className="text-slate-300">Easiest:</span> press{" "}
+            1. Show your browser&apos;s bookmarks bar — the row of saved links
+            under the address bar at the top. Press{" "}
             <kbd className="rounded bg-slate-700 px-1">Ctrl</kbd>+
             <kbd className="rounded bg-slate-700 px-1">Shift</kbd>+
             <kbd className="rounded bg-slate-700 px-1">B</kbd> (
-            <kbd className="rounded bg-slate-700 px-1">⌘</kbd>+Shift+B on Mac) to
-            show your bookmarks bar, then drag the blue button onto it.
+            <kbd className="rounded bg-slate-700 px-1">⌘</kbd>+Shift+B on a Mac)
+            to show it.
           </p>
           <p>
-            <span className="text-slate-300">Or:</span> click{" "}
-            <span className="text-slate-300">“Copy bookmarklet code”</span>,
-            right-click your bookmarks bar → “Add page…”, name it anything, and
-            paste the code into the URL field.
+            2. Drag the blue{" "}
+            <span className="text-slate-300">Capture CareLink → GlycemicGPT</span>{" "}
+            button up onto that bar.
           </p>
-          <p className="text-slate-500">
-            You only do this once. Pasting it into the address bar won’t work —
-            browsers block that for security.
+          <p>
+            Rather not drag? Click{" "}
+            <span className="text-slate-300">“Copy button instead”</span>, then
+            right-click your bookmarks bar, choose{" "}
+            <span className="text-slate-300">“Add page”</span>, type any name, and
+            paste. (Pasting it into the address bar won&apos;t work — browsers
+            block that.)
           </p>
         </div>
       </div>
@@ -291,7 +306,7 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
       {/* Step 2: sign in + capture */}
       <div className="space-y-2">
         <p className="text-sm font-medium text-slate-300">
-          2. Sign in to CareLink and capture
+          Step 2 — Sign in to Medtronic CareLink
         </p>
         <button
           type="button"
@@ -302,18 +317,24 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
           Open CareLink &amp; sign in
         </button>
         <p className="text-xs text-slate-500">
-          After signing in, click the{" "}
+          This opens Medtronic&apos;s CareLink website in a new window. Sign in
+          with your Medtronic username and password (you may be asked to confirm
+          you&apos;re not a robot). You sign in directly with Medtronic —
+          GlycemicGPT never sees your password.
+        </p>
+        <p className="text-xs text-slate-500">
+          Once you&apos;re signed in, click the{" "}
           <span className="text-slate-300">Capture CareLink → GlycemicGPT</span>{" "}
-          bookmark you just saved (in your bookmarks bar) while on the CareLink
-          page. If the token doesn&apos;t arrive automatically, the bookmarklet
-          copies it — paste it here:
+          button you saved (in your bookmarks bar). Your data connection comes
+          back here automatically. If nothing appears here after a few seconds,
+          the button will have copied a code instead — paste it below:
         </p>
         <div className="flex gap-2">
           <input
             type="text"
             value={pasteValue}
             onChange={(e) => setPasteValue(e.target.value)}
-            placeholder="Paste captured token (fallback)"
+            placeholder="Paste the copied code (only if needed)"
             disabled={isOffline}
             className={inputClass}
           />
@@ -323,12 +344,13 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
             disabled={isOffline || !pasteValue.trim()}
             className={clsx(btnClass, "whitespace-nowrap")}
           >
-            Use token
+            Use code
           </button>
         </div>
         {token && (
           <p className="text-xs text-green-400">
-            ✓ Session captured{isFetchingAvail ? " — reading availability…" : ""}
+            ✓ Connected to your CareLink account
+            {isFetchingAvail ? " — checking what data is available…" : ""}
           </p>
         )}
       </div>
@@ -337,12 +359,13 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
       {availability && (
         <div className="space-y-3">
           <p className="text-sm font-medium text-slate-300">
-            3. Choose a range to import
+            Step 3 — Choose dates and import
           </p>
           <p className="text-xs text-slate-500">
-            Data available {availability.start?.slice(0, 10) ?? "?"} →{" "}
-            {availability.end?.slice(0, 10) ?? "?"}. Max {MAX_IMPORT_DAYS} days
-            per import.
+            Your CareLink account has data from{" "}
+            {availability.start?.slice(0, 10) ?? "?"} to{" "}
+            {availability.end?.slice(0, 10) ?? "?"}. Pick the dates you&apos;d
+            like to bring in (up to {MAX_IMPORT_DAYS} days at a time).
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-md">
             <div>
@@ -385,8 +408,8 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
           {importStart && importEnd && !rangeValid && (
             <p className="text-xs text-amber-400">
               {rangeDays < 0
-                ? "End date must be on or after the start date."
-                : `Range is ${rangeDays} days — max ${MAX_IMPORT_DAYS} per import.`}
+                ? "The end date needs to be on or after the start date."
+                : `That's ${rangeDays} days — please choose ${MAX_IMPORT_DAYS} days or fewer at a time.`}
             </p>
           )}
           <button
@@ -395,15 +418,16 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
             disabled={isOffline || isImporting || !rangeValid}
             className={btnClass}
           >
-            {isImporting ? "Importing…" : "Import range"}
+            {isImporting ? "Importing…" : "Import these dates"}
           </button>
         </div>
       )}
 
       {result && (
         <div className="rounded-md border border-green-600/40 bg-green-600/10 p-3 text-sm text-green-300">
-          Imported {result.glucose_stored} glucose readings and{" "}
-          {result.events_stored} pump events.
+          ✓ Done! Imported {result.glucose_stored} glucose readings and{" "}
+          {result.events_stored} pump events. You can pick another date range
+          above to bring in more.
         </div>
       )}
       {error && (

--- a/apps/web/src/components/integrations/medtronic-import-card.tsx
+++ b/apps/web/src/components/integrations/medtronic-import-card.tsx
@@ -91,7 +91,11 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
   }, [bookmarklet]);
 
   const copyBookmarklet = useCallback(() => {
-    navigator.clipboard?.writeText(bookmarklet).then(
+    // Guard the whole call: `navigator.clipboard?.writeText(...).then()` would
+    // throw if clipboard is undefined (the optional chain returns undefined and
+    // .then is then called on it).
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(bookmarklet).then(
       () => {
         setBookmarkletCopied(true);
         setTimeout(() => setBookmarkletCopied(false), 2000);
@@ -108,6 +112,10 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
       try {
         const avail = await getMedtronicAvailability(region.code, tok);
         setAvailability(avail);
+        // Clear any prior window so a new account with no data doesn't show a
+        // stale range from the previous one.
+        setImportStart("");
+        setImportEnd("");
         // Default the picker to the most recent ~14 days of available data.
         if (avail.end) {
           const end = avail.end.slice(0, 10);

--- a/apps/web/src/components/integrations/medtronic-import-card.tsx
+++ b/apps/web/src/components/integrations/medtronic-import-card.tsx
@@ -80,6 +80,7 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
     return `javascript:(function(){try{var m=document.cookie.match(/(?:^|;\\s*)auth_tmp_token=([^;]+)/);if(!m){alert('GlycemicGPT: no CareLink token found - are you signed in?');return;}var t=decodeURIComponent(m[1]);if(window.opener&&!window.opener.closed){window.opener.postMessage({source:'${MESSAGE_SOURCE}',token:t},'${origin}');alert('GlycemicGPT: token sent. You can close this tab.');}else if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(t).then(function(){alert('GlycemicGPT: token copied. Paste it into GlycemicGPT.');},function(){prompt('GlycemicGPT: copy this token:',t);});}else{prompt('GlycemicGPT: copy this token:',t);}}catch(e){alert('GlycemicGPT capture error: '+e);}})();`;
   }, []);
 
+  const popupRef = useRef<Window | null>(null);
   const bookmarkletRef = useRef<HTMLAnchorElement | null>(null);
   useEffect(() => {
     // Set the javascript: href via the DOM so React doesn't strip it; the user
@@ -131,6 +132,9 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
   useEffect(() => {
     function onMessage(event: MessageEvent) {
       if (event.origin !== region.origin) return;
+      // Only accept the token from the CareLink popup we opened (defense against
+      // any other window posting a look-alike message).
+      if (popupRef.current && event.source !== popupRef.current) return;
       const data = event.data;
       if (
         data &&
@@ -139,6 +143,7 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
         data.token.length > 0
       ) {
         setToken(data.token);
+        setPasteValue("");
         void fetchAvailability(data.token);
       }
     }
@@ -148,13 +153,18 @@ export function MedtronicImportCard({ isOffline }: { isOffline: boolean }) {
 
   const openCareLink = useCallback(() => {
     setError(null);
-    window.open(region.loginUrl, "carelink_login", "width=1100,height=860");
+    popupRef.current = window.open(
+      region.loginUrl,
+      "carelink_login",
+      "width=1100,height=860"
+    );
   }, [region.loginUrl]);
 
   const usePastedToken = useCallback(() => {
     const t = pasteValue.trim();
     if (!t) return;
     setToken(t);
+    setPasteValue("");
     void fetchAvailability(t);
   }, [pasteValue, fetchAvailability]);
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -3620,6 +3620,14 @@ export interface MedtronicImportResponse {
   events_stored: number;
 }
 
+/** Trim the captured token and fail fast if empty (avoids sending whitespace
+ * that would cause an avoidable auth failure). */
+function _normalizeCareLinkToken(token: string): string {
+  const t = token.trim();
+  if (!t) throw new Error("CareLink token is required");
+  return t;
+}
+
 /** Validate the captured CareLink token and read the available data range. */
 export async function getMedtronicAvailability(
   region: string,
@@ -3631,7 +3639,10 @@ export async function getMedtronicAvailability(
       method: "POST",
       // Token goes in a header, never the JSON body, so it can't land in a
       // body-validation error echo or request-body logging.
-      headers: { "Content-Type": "application/json", "X-CareLink-Token": token },
+      headers: {
+        "Content-Type": "application/json",
+        "X-CareLink-Token": _normalizeCareLinkToken(token),
+      },
       body: JSON.stringify({ region }),
     }
   );
@@ -3655,7 +3666,10 @@ export async function importMedtronicRange(
     `${API_BASE_URL}/api/integrations/medtronic/import`,
     {
       method: "POST",
-      headers: { "Content-Type": "application/json", "X-CareLink-Token": token },
+      headers: {
+        "Content-Type": "application/json",
+        "X-CareLink-Token": _normalizeCareLinkToken(token),
+      },
       body: JSON.stringify({
         region,
         start_date: startDate,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -3629,8 +3629,10 @@ export async function getMedtronicAvailability(
     `${API_BASE_URL}/api/integrations/medtronic/availability`,
     {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ region, token }),
+      // Token goes in a header, never the JSON body, so it can't land in a
+      // body-validation error echo or request-body logging.
+      headers: { "Content-Type": "application/json", "X-CareLink-Token": token },
+      body: JSON.stringify({ region }),
     }
   );
   if (!response.ok) {
@@ -3653,10 +3655,9 @@ export async function importMedtronicRange(
     `${API_BASE_URL}/api/integrations/medtronic/import`,
     {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "X-CareLink-Token": token },
       body: JSON.stringify({
         region,
-        token,
         start_date: startDate,
         end_date: endDate,
         tz,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -3600,3 +3600,73 @@ export async function importTandemRange(
   }
   return response.json();
 }
+
+// ============================================================================
+// Medtronic CareLink manual import (stateless -- token captured client-side)
+// ============================================================================
+
+export interface MedtronicAvailabilityResponse {
+  /** Oldest date with data in the user's CareLink cloud (ISO), or null. */
+  start: string | null;
+  /** Most recent date with data (ISO), or null. */
+  end: string | null;
+}
+
+export interface MedtronicImportResponse {
+  message: string;
+  glucose_fetched: number;
+  glucose_stored: number;
+  events_fetched: number;
+  events_stored: number;
+}
+
+/** Validate the captured CareLink token and read the available data range. */
+export async function getMedtronicAvailability(
+  region: string,
+  token: string
+): Promise<MedtronicAvailabilityResponse> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/integrations/medtronic/availability`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ region, token }),
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      await _readErrorDetail(response, "Failed to read available data range")
+    );
+  }
+  return response.json();
+}
+
+/** One-time manual import of a chosen CareLink date range. */
+export async function importMedtronicRange(
+  region: string,
+  token: string,
+  startDate: string,
+  endDate: string,
+  tz: string
+): Promise<MedtronicImportResponse> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/integrations/medtronic/import`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        region,
+        token,
+        start_date: startDate,
+        end_date: endDate,
+        tz,
+      }),
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      await _readErrorDetail(response, "Failed to import data range")
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary

Adds **Medtronic CareLink Cloud Sync** — a manual, on-demand way to import pump
history from the Medtronic CareLink website into GlycemicGPT, for users who don't
pair their pump over Bluetooth. Web + backend only (no mobile).

CareLink has no public API and no durable server-side session, so this is a
**manual historical import** (not background sync): the user signs in to CareLink
themselves and hands their session to GlycemicGPT, which imports a chosen date
range. The data lands in the shared `glucose_readings` / `pump_events` tables for
long-term history and AI analysis.

## How it works

1. The user opens CareLink from the Cloud Sync card and signs in (one-time captcha).
2. A small one-time **bookmarklet** reads the non-httpOnly `auth_tmp_token` and
   hands it back to GlycemicGPT via `postMessage` (clipboard-paste fallback).
3. The backend uses that token for the import only:
   `availability` → pick a date range → `export CSV → parse → map → store`.

The token is **stateless**: sent in the `X-CareLink-Token` header (never the body,
so it can't leak via a validation-error echo), used per-request, and **never
logged or stored**. No credentials, scheduler, or sync-state.

## Conformance with the shared data model

Medtronic writes the same `pump_events` / `glucose_readings` shape every other
integration uses, so nothing downstream (dashboard, stats/TIR/AGP, AI context,
daily brief) is affected:

- `BASAL.units` = U/h rate; `BOLUS`/`CORRECTION.units` = absolute units.
- Closed-loop `Bolus Source` classified to mirror Tandem: `CLOSED_LOOP_BG_CORRECTION`
  → automated `CORRECTION`; `…_FOOD_BOLUS`/manual → `BOLUS`.
- `CLOSED_LOOP_AUTO_INSULIN` (a daily auto-basal total) is intentionally skipped —
  it can't be a bolus (inflates bolus insulin) or a basal-rate event (would be
  multiplied by 24 in the rate-based TDD calc).
- Only ABSOLUTE temp basals become BASAL rate events; percent temp basals are skipped.

## Testing

- 199 backend tests pass (parser/mapper/client/session/storage/sync + endpoints),
  plus the existing Tandem/integration suites (no regressions).
- Verified end-to-end on a real CareLink account: imported 14 days → 4,079 glucose
  readings + 461 pump events, correctly classified (auto-corrections flagged
  automated, no phantom large boluses).
- SSRF host-allowlist, parameterized SQL, CSV size cap, postMessage origin+source
  validation, rate limiting, and CSRF all in place.

## Multi-region

US (`carelink.minimed.com`) is verified live. EU (`carelink.minimed.eu`) is built
from the same pattern but needs live verification by an EU user.

## Known follow-ups (not blockers)

- Auto-basal daily totals aren't ingested yet, so total daily insulin runs
  basal-light for SmartGuard users — to be addressed via a daily-summary concept.
- Background/automatic sync is out of scope here: the web flow can't keep a session
  alive, so autonomous sync would require the separate Connect/mobile-OAuth path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual Medtronic CareLink import: UI card with bookmarklet token capture, region selection, availability check, date-range/timezone validation, and import flow; Cloud Sync shows a Medtronic subsection.
  * Backend/API: stateless token-based availability and range-import endpoints, region resolution for US/EU, CSV export/import, mapping/localization, durable storage, and CORS updated to accept the CareLink token header.
* **Tests**
  * Extensive test coverage for client calls, CSV parsing, mapping, session/token refresh, storage persistence, orchestration, and endpoints (including security checks that captured tokens are not echoed).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->