### PR TITLE
fix(deps): patch starlette PYSEC-2026-161 and harden the ecdsa OSV exception

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -6,6 +6,10 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.109.0",
+    # Security floor: starlette is transitive via fastapi (which allows the
+    # 1.x line). 1.0.0 is vulnerable to PYSEC-2026-161 (fixed in 1.0.1); we
+    # floor at the fix and let uv take the latest compatible release.
+    "starlette>=1.0.1",
     "uvicorn[standard]>=0.27.0",
     "pydantic[email]>=2.6.0",
     "pydantic-settings>=2.1.0",

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -731,6 +731,7 @@ dependencies = [
     { name = "setuptools" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "starlette" },
     { name = "tconnectsync" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -774,6 +775,7 @@ requires-dist = [
     { name = "setuptools", specifier = ">=69.0.0,<82" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.25" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "tconnectsync", specifier = ">=2.3.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
 ]
@@ -2234,15 +2236,15 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,12 +5,24 @@
 # Each entry requires a reason explaining why it's safe to ignore.
 # Review suppressions quarterly.
 
-# ecdsa 0.19.1 -- no fix available. Used transitively by python-jose
-# for JWT signing. We use HMAC (HS256), not ECDSA, so the Minerva
-# timing attack is not exploitable in our usage.
+# ecdsa -- CVE-2024-23342 / GHSA-wj6h-64fc-37mp ("Minerva" ECDSA timing
+# side-channel). NOT EXPLOITABLE in our usage, and no upstream fix exists:
+#   * Minerva affects ECDSA signing/keygen only -- NOT verification.
+#   * We sign/verify JWTs exclusively with HS256 (HMAC); decode pins
+#     algorithms=["HS256"] (no algorithm-confusion path), and no EC algorithms
+#     (ES256/384/512) are used anywhere. ecdsa is a dormant transitive dep of
+#     python-jose and is never imported on our code path.
+#   * python-jose[cryptography] routes any EC op through the constant-time
+#     `cryptography` backend, not `ecdsa`.
+#   * Upstream is WONTFIX (side channels are out of scope for a pure-Python
+#     lib; no patched release exists -- latest 0.19.2 is still flagged).
+# Real fix = migrate python-jose -> PyJWT (drops the dep). Tracked in #673.
+# ignoreUntil forces re-evaluation (revisit sooner if we ever adopt an
+# EC-based JWT algorithm, which would change the exposure).
 [[IgnoredVulns]]
 id = "GHSA-wj6h-64fc-37mp"
-reason = "No fix available; not exploitable -- we use HMAC signing, not ECDSA"
+ignoreUntil = 2026-08-25T00:00:00Z
+reason = "Not exploitable: HS256/HMAC only, no ECDSA signing; ecdsa is a dormant transitive dep (python-jose[cryptography] uses the cryptography backend). Upstream WONTFIX (no patched release). Real fix = migrate to PyJWT, tracked in #673."
 
 # @tootallnate/once 2.0.0 -- dev-only transitive dependency
 # (jest-environment-jsdom -> jsdom -> http-proxy-agent). Not in


### PR DESCRIPTION
## Summary

Two dependency-security items, both surfaced by the OSV-Scanner / Dependency Vuln gate:

1. **Fixes the real OSV-Scanner blocker: `starlette` PYSEC-2026-161.** `starlette` is a transitive dependency via `fastapi` (which permits the 1.x line). 1.0.0 is vulnerable; the fix landed in 1.0.1. This adds a `starlette>=1.0.1` security floor to `apps/api/pyproject.toml` and lets uv resolve the latest compatible release (1.1.0, which FastAPI 0.136.1 accepts). This is the finding that the recently merged idna/qs fixes had been masking.

2. **Brings the existing `ecdsa` suppression up to the contributors'-guide standard.** The `ecdsa` advisory (CVE-2024-23342 / GHSA-wj6h-64fc-37mp, "Minerva" ECDSA timing side-channel) was already suppressed in `osv-scanner.toml`. This PR replaces the brief entry with a full not-affected rationale, a quarterly `ignoreUntil` review date, and a reference to the tracking issue for the permanent fix.

## Why we are not affected by the ecdsa finding

Determined with high confidence from the code, not assumed:

- **Minerva affects ECDSA signing/keygen only, not verification.** We never do either.
- **We sign and verify JWTs exclusively with HS256 (HMAC).** `jwt_algorithm` defaults to `HS256`, and decode pins `algorithms=["HS256"]`, so there is no algorithm-confusion path and no EC algorithm (ES256/384/512) anywhere in the codebase.
- **`ecdsa` is a dormant transitive dependency of `python-jose`.** With `python-jose[cryptography]` installed, EC operations route through the constant-time `cryptography` backend; the `ecdsa` backend is never selected on our code path.
- **Upstream is WONTFIX** -- pure-Python side-channel resistance is out of scope for the library, and no patched release exists (latest 0.19.2 is still flagged). A suppression is therefore the only available mechanism today.

The permanent fix (migrating `python-jose` to PyJWT, which drops the dependency entirely) is tracked in #673. The `ignoreUntil` date forces re-evaluation each quarter, and sooner if we ever adopt an EC-based JWT algorithm.

## Changes

- `apps/api/pyproject.toml` -- add `starlette>=1.0.1` security floor (with rationale comment).
- `apps/api/uv.lock` -- starlette 1.0.0 -> 1.1.0 (only lockfile change).
- `osv-scanner.toml` -- expand the `ecdsa` `[[IgnoredVulns]]` entry with the rationale above, `ignoreUntil`, and the #673 reference.

No application code changes.

## Validation

- TOML well-formed; `ignoreUntil` is future-dated, so it keeps `ecdsa` suppressed now (does not un-suppress it).
- After this lands, the unfiltered OSV set should be empty (starlette fixed; idna/qs already fixed on develop; ecdsa/postcss/@tootallnate/brace-expansion suppressed) -- the Dependency Vuln / OSV gate should go green.
- The starlette change is a minor bump (1.0 -> 1.1) on the framework's core, so CI Backend Tests (full suite) should be green before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to address security considerations in third-party libraries.
  * Enhanced vulnerability suppression tracking with explicit expiration dates and detailed risk justification to improve security posture documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->