### PR TITLE
chore(api): harden Sentry URL scrubbing and refresh privacy status

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -53,8 +53,10 @@ self-hoster who opts in):
 - HTTP request or response bodies
 - Health data or identifiers interpolated into exception or log messages
 
-> The Sentry SDK integration is not yet shipped. This documents the committed
-> posture before it lands; the integration will follow exactly the design above.
+> **Status:** The Sentry SDK integration is now shipped for the **API**
+> (`apps/api`) and implements exactly the design above; it stays disabled unless
+> `GLYCEMICGPT_SENTRY_DSN` is set in a maintainer-controlled environment. The
+> ai-sidecar, web, and mobile components are not yet instrumented.
 
 ## Controlling error monitoring
 

--- a/apps/api/src/observability.py
+++ b/apps/api/src/observability.py
@@ -135,7 +135,11 @@ def _scrub_common(event: dict[str, Any]) -> None:
         if "query_string" in request:
             request["query_string"] = ""
         if isinstance(request.get("url"), str):
-            request["url"] = scrub_text(request["url"])
+            # Strip the query string AND fragment from the URL (query_string is
+            # already blanked above). A token glued into the query/fragment can
+            # otherwise survive pattern-scrubbing; keep scheme/host/path, scrub it.
+            base_url = request["url"].split("?", 1)[0].split("#", 1)[0]
+            request["url"] = scrub_text(base_url)
 
 
 def _before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | None:

--- a/apps/api/tests/test_observability.py
+++ b/apps/api/tests/test_observability.py
@@ -183,6 +183,22 @@ def test_before_send_strips_phi():
     assert "extra" not in out  # additional-data dump dropped
 
 
+def test_before_send_strips_query_and_fragment_from_url():
+    """A secret in the URL query or fragment must not survive: both are dropped
+    wholesale, not merely pattern-scrubbed. The values below match NO scrub
+    pattern, so this fails unless the query/fragment is actually stripped."""
+    event = {
+        "request": {
+            "url": "https://host/api/glucose?session=keepoutofreports#tok=alsosecret",
+        }
+    }
+    out = _before_send(event, {})
+    url = out["request"]["url"]
+    assert url == "https://host/api/glucose"
+    assert "keepoutofreports" not in url and "alsosecret" not in url
+    assert "?" not in url and "#" not in url
+
+
 def test_before_send_scrubs_logentry():
     """Sentry's serializer prefers logentry.formatted as the displayed message."""
     event = {

--- a/docs/concepts/privacy.md
+++ b/docs/concepts/privacy.md
@@ -65,7 +65,7 @@ This does not change anything above. To be explicit:
 - **Production releases are telemetry-free, and so are distributed `develop` builds.** The `develop` tag exists for testing pre-release features; it is not a channel for collecting your error data.
 - **You can opt your own deployment in.** If you *want* error monitoring for your self-hosted deployment, you can set your own Sentry DSN. Error reports then go to **your** Sentry account, never the project's. This is a feature for operators who want it, off by default.
 
-> **Status:** The Sentry SDK integration is not yet shipped. This section documents the committed posture so the privacy commitment is on record before the integration lands. When it ships, it will follow exactly the design described here.
+> **Status:** The Sentry SDK integration is now shipped for the **API** (`apps/api`) and implements exactly the design described here; it stays disabled unless `GLYCEMICGPT_SENTRY_DSN` is set in a maintainer-controlled environment. The ai-sidecar, web, and mobile components are not yet instrumented.
 
 ### Which Sentry features the project uses -- and which it never enables
 


### PR DESCRIPTION
## Summary

Two small follow-ups to the Sentry API pilot, surfaced while verifying the integration end-to-end against a live project:

1. **Tighten URL scrubbing.** `before_send` already blanks `request.query_string`, but `request.url` was only pattern-scrubbed — so a secret/token glued into the query string (or fragment) could survive. This strips the query and fragment from `request.url` before scrubbing, keeping only scheme/host/path. (Confirmed against a live event where a `?token=…` value previously came through intact.)

2. **Refresh the privacy status docs.** `PRIVACY.md` and `docs/concepts/privacy.md` still said the Sentry SDK integration was "not yet shipped" — now stale. Updated to: shipped for the API (`apps/api`), disabled unless `GLYCEMICGPT_SENTRY_DSN` is set; ai-sidecar/web/mobile pending.

## Changes
- `apps/api/src/observability.py` — strip query + fragment from `request.url`.
- `apps/api/tests/test_observability.py` — assert query/fragment are dropped wholesale (using values that match no scrub pattern, so it fails without the change).
- `PRIVACY.md`, `docs/concepts/privacy.md` — refresh the Sentry status note.

## Notes
- No runtime behavior change when Sentry is disabled (the default).
- Verified locally: observability tests pass, ruff check + format clean; adversarial review and CodeRabbit CLI both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sentry SDK integration is now available for the API service for enhanced error monitoring and diagnostics.

* **Security & Privacy**
  * Improved privacy protection: URL query parameters and fragments are now removed from error reports to prevent accidental exposure of sensitive data.

* **Documentation**
  * Updated privacy documentation to reflect current Sentry integration status and privacy safeguards.

* **Tests**
  * Added test coverage for privacy controls in error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->