### PR TITLE
feat(sidecar): add Sentry error monitoring (disabled by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,9 @@ LOG_FORMAT=json
 # send their deployment's errors to their OWN account. See PRIVACY.md.
 # GLYCEMICGPT_SENTRY_DSN=
 # GLYCEMICGPT_SENTRY_ENVIRONMENT=development
+# The ai-sidecar reports to its OWN Sentry project (a separate DSN):
+# GLYCEMICGPT_SIDECAR_SENTRY_DSN=
+# GLYCEMICGPT_SIDECAR_SENTRY_ENVIRONMENT=development
 
 # AI Provider (claude or openai)
 AI_PROVIDER=claude

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,6 +49,10 @@ services:
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-info}
       SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      # Sentry error monitoring (own project) -- empty default = disabled.
+      # Runtime-only; never baked into the image (see PRIVACY.md).
+      GLYCEMICGPT_SIDECAR_SENTRY_DSN: ${GLYCEMICGPT_SIDECAR_SENTRY_DSN:-}
+      GLYCEMICGPT_SIDECAR_SENTRY_ENVIRONMENT: ${GLYCEMICGPT_SIDECAR_SENTRY_ENVIRONMENT:-production}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3456/health"]
       interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,10 @@ services:
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-info}
       SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      # Sentry error monitoring (own project) -- empty default = disabled.
+      # Runtime-only; never baked into the image (see PRIVACY.md).
+      GLYCEMICGPT_SIDECAR_SENTRY_DSN: ${GLYCEMICGPT_SIDECAR_SENTRY_DSN:-}
+      GLYCEMICGPT_SIDECAR_SENTRY_ENVIRONMENT: ${GLYCEMICGPT_SIDECAR_SENTRY_ENVIRONMENT:-development}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3456/health"]
       interval: 15s

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -43,6 +43,10 @@ RUN mkdir -p /home/sidecar/.config/sidecar /home/sidecar/.codex && \
 
 USER sidecar
 
+# Surface the build commit so Sentry can tag the release (no-op when unset/"unknown").
+# CI passes GIT_SHA as a build-arg; see src/observability.ts and PRIVACY.md.
+ARG GIT_SHA=unknown
+ENV GLYCEMICGPT_SIDECAR_SENTRY_RELEASE=${GIT_SHA}
 ENV NODE_ENV=production
 ENV SIDECAR_PORT=3456
 ENV TOKEN_DIR=/home/sidecar/.config/sidecar

--- a/sidecar/package-lock.json
+++ b/sidecar/package-lock.json
@@ -8,6 +8,7 @@
       "name": "glycemicgpt-ai-sidecar",
       "version": "0.8.2",
       "dependencies": {
+        "@sentry/node": "^10.53.1",
         "express": "^4.21.0"
       },
       "devDependencies": {
@@ -460,12 +461,555 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fastify/otel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
+      "integrity": "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^10.2.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "import-in-the-middle": "^2.0.6",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.61.0.tgz",
+      "integrity": "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.57.0.tgz",
+      "integrity": "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.31.0.tgz",
+      "integrity": "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.33.0.tgz",
+      "integrity": "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.57.0.tgz",
+      "integrity": "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.62.0.tgz",
+      "integrity": "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.60.0.tgz",
+      "integrity": "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.214.0.tgz",
+      "integrity": "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
+      "integrity": "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.58.0.tgz",
+      "integrity": "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.62.0.tgz",
+      "integrity": "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.36.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz",
+      "integrity": "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz",
+      "integrity": "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.60.0.tgz",
+      "integrity": "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.60.0.tgz",
+      "integrity": "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/mysql": "2.15.27"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.60.0.tgz",
+      "integrity": "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@opentelemetry/sql-common": "^0.41.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz",
+      "integrity": "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.2",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
+      "integrity": "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz",
+      "integrity": "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.207.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
+      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
@@ -817,6 +1361,115 @@
         "win32"
       ]
     },
+    "node_modules/@sentry/core": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.53.1.tgz",
+      "integrity": "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.53.1.tgz",
+      "integrity": "sha512-rxHVil0tJAmz+keFcZCj1LaUdgdkK66E/l0gqh2p1209PNCGoD3lnClFr6vusy1aF3zF8O9JPtuMEJzXOKhs+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/otel": "0.18.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-amqplib": "0.61.0",
+        "@opentelemetry/instrumentation-connect": "0.57.0",
+        "@opentelemetry/instrumentation-dataloader": "0.31.0",
+        "@opentelemetry/instrumentation-fs": "0.33.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+        "@opentelemetry/instrumentation-graphql": "0.62.0",
+        "@opentelemetry/instrumentation-hapi": "0.60.0",
+        "@opentelemetry/instrumentation-http": "0.214.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+        "@opentelemetry/instrumentation-knex": "0.58.0",
+        "@opentelemetry/instrumentation-koa": "0.62.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+        "@opentelemetry/instrumentation-mongodb": "0.67.0",
+        "@opentelemetry/instrumentation-mongoose": "0.60.0",
+        "@opentelemetry/instrumentation-mysql": "0.60.0",
+        "@opentelemetry/instrumentation-mysql2": "0.60.0",
+        "@opentelemetry/instrumentation-pg": "0.66.0",
+        "@opentelemetry/instrumentation-tedious": "0.33.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/instrumentation": "7.6.0",
+        "@sentry/core": "10.53.1",
+        "@sentry/node-core": "10.53.1",
+        "@sentry/opentelemetry": "10.53.1",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.53.1.tgz",
+      "integrity": "sha512-iH7SMcM/7jPbN+t7+7ussQOiIqI4BMOGt4VYWlV71/z7k0pY+YPaSvlfVkNXfISiDzFAKv0ecCY3BmsLMu1xDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1",
+        "@sentry/opentelemetry": "10.53.1",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.53.1.tgz",
+      "integrity": "sha512-Zok6UXla0mFOjd1YnVb1TZtQNOry9v93fXUqx8jmDaygwWM2BwvP8rBQabLz0/OZXo8+35oge+Vmw+QY5aesnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -843,7 +1496,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -895,14 +1547,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mysql": {
+      "version": "2.15.27",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -937,6 +1617,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -1068,6 +1757,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1082,6 +1792,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/body-parser": {
@@ -1106,6 +1825,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -1182,6 +1913,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1491,6 +2228,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1642,6 +2385,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1750,6 +2508,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1840,6 +2619,37 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1887,6 +2697,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1940,6 +2789,42 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -2319,7 +3204,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -2585,6 +3469,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -13,6 +13,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@sentry/node": "^10.53.1",
     "express": "^4.21.0"
   },
   "devDependencies": {

--- a/sidecar/src/instrument.ts
+++ b/sidecar/src/instrument.ts
@@ -1,0 +1,12 @@
+/**
+ * Sentry bootstrap. Imported first (before express/http) so the SDK can set up
+ * instrumentation before those modules load. No-op unless a DSN is configured.
+ *
+ * Error capture works with this top-of-entry import. If performance TRACING is
+ * ever enabled (tracesSampleRate > 0), switch the start command to
+ * `node --import ./dist/instrument.js dist/server.js` so OpenTelemetry can
+ * instrument the ESM http/express modules. See observability.ts.
+ */
+import { initSentry } from "./observability.js";
+
+initSentry();

--- a/sidecar/src/observability.ts
+++ b/sidecar/src/observability.ts
@@ -1,0 +1,233 @@
+/**
+ * Sentry error monitoring for the AI sidecar: init + PII/PHI scrubbing.
+ *
+ * Sentry is OFF unless `GLYCEMICGPT_SIDECAR_SENTRY_DSN` is set. The DSN is
+ * supplied only in the project's own dev/CI/staging via a runtime environment
+ * variable and is never baked into a distributed build. A self-hoster may set
+ * their own DSN to send errors to their own Sentry account. See PRIVACY.md and
+ * docs/concepts/privacy.md.
+ *
+ * This service is the highest-PHI surface in the platform: request bodies are
+ * AI prompts that can contain health data. The scrubbers below drop request
+ * bodies, headers, cookies, stack-frame locals, the user identity, and the
+ * `extra` dump, and pattern-scrub free text, before any event leaves the
+ * process. Mirrors apps/api/src/observability.py.
+ */
+
+import * as Sentry from "@sentry/node";
+
+// Best-effort, readability-preserving redaction of high-risk patterns that can
+// appear in free text (exception messages, breadcrumbs, span descriptions,
+// URLs). Length-bounded quantifiers + an input clamp keep this linear-time
+// (defense against ReDoS-style input). Short numbers (e.g. glucose values) are
+// intentionally left readable; the no-PHI-in-messages guideline and Sentry's
+// server-side Advanced Data Scrubbing cover those.
+const SCRUB_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/:\/\/[^/@\s]+@/g, "://[redacted]@"], // inline url credentials
+  [/\b[\w.+-]{1,64}@[\w-]{1,255}\.[\w.-]{1,255}\b/g, "[email]"],
+  [/\beyJ[\w-]+\.[\w-]+\.[\w-]+\b/g, "[jwt]"], // JWTs
+  [/\bbearer\s+[A-Za-z0-9._-]{8,}/gi, "bearer [token]"],
+  [/\b(?:sk|pk|rk)-[A-Za-z0-9]{16,}\b/g, "[token]"], // api keys
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, "[token]"], // github tokens
+  [/\bAKIA[0-9A-Z]{16}\b/g, "[token]"], // aws access key id
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, "[token]"], // slack tokens
+  [/\b[A-Fa-f0-9]{32,}\b/g, "[hex]"], // long hex blobs / hashes
+  [/\b[A-Za-z0-9+/]{40,}={0,2}\b/g, "[blob]"], // long base64-ish
+  [/\b\d{9,}\b/g, "[number]"], // phone / device / record ids
+];
+
+// Clamp free text before regex scrubbing; the dropped tail is never sent.
+const MAX_SCRUB_LEN = 8192;
+
+// Request sub-fields that are never needed for triage and are the highest PHI
+// risk (data = the AI prompt body); dropped wholesale before the event leaves.
+const REQUEST_DROP_FIELDS = ["data", "cookies", "headers", "env"] as const;
+// User identity fields dropped defensively; an opaque id is left.
+const USER_DROP_FIELDS = ["email", "username", "ip_address", "name"] as const;
+
+/** Minimal structural view of the Sentry event fields we mutate in place. */
+interface Frame {
+  vars?: unknown;
+}
+interface Stacktrace {
+  frames?: Frame[];
+}
+interface MutableEvent {
+  message?: string | { formatted?: string; message?: string };
+  logentry?: { formatted?: string; message?: string };
+  exception?: { values?: Array<{ value?: string; stacktrace?: Stacktrace }> };
+  threads?: { values?: Array<{ stacktrace?: Stacktrace }> };
+  user?: Record<string, unknown>;
+  tags?: Record<string, unknown>;
+  transaction?: string;
+  culprit?: string;
+  breadcrumbs?: unknown;
+  request?: {
+    url?: string;
+    query_string?: unknown;
+    data?: unknown;
+    cookies?: unknown;
+    headers?: unknown;
+    env?: unknown;
+  };
+  extra?: unknown;
+  server_name?: string;
+  spans?: Array<{ description?: string; data?: unknown; tags?: Record<string, unknown> }>;
+}
+
+export function scrubText(text: string): string {
+  let t = text.length > MAX_SCRUB_LEN ? text.slice(0, MAX_SCRUB_LEN) : text;
+  for (const [pattern, replacement] of SCRUB_PATTERNS) {
+    t = t.replace(pattern, replacement);
+  }
+  return t;
+}
+
+function dropFrameVars(stacktrace: Stacktrace | undefined): void {
+  if (!stacktrace?.frames) return;
+  for (const frame of stacktrace.frames) {
+    if (frame && typeof frame === "object") delete frame.vars;
+  }
+}
+
+function scrubLogentry(entry: { formatted?: string; message?: string }): void {
+  if (typeof entry.formatted === "string") entry.formatted = scrubText(entry.formatted);
+  if (typeof entry.message === "string") entry.message = scrubText(entry.message);
+}
+
+/** Scrub fields shared by error and transaction events (in place). */
+function scrubCommon(event: MutableEvent): void {
+  delete event.server_name;
+  delete event.extra;
+
+  if (event.user && typeof event.user === "object") {
+    for (const field of USER_DROP_FIELDS) delete event.user[field];
+  }
+
+  if (event.tags && typeof event.tags === "object") {
+    for (const [key, value] of Object.entries(event.tags)) {
+      if (typeof value === "string") event.tags[key] = scrubText(value);
+    }
+  }
+
+  if (typeof event.transaction === "string") event.transaction = scrubText(event.transaction);
+  if (typeof event.culprit === "string") event.culprit = scrubText(event.culprit);
+
+  // Drop breadcrumbs wholesale. This service's console output and CLI-subprocess
+  // stderr can carry prompt or health context, and pattern-scrubbing free text is
+  // not reliable enough for the highest-PHI surface. (beforeBreadcrumb also stops
+  // them being recorded at all; this is belt-and-suspenders.)
+  delete event.breadcrumbs;
+
+  const request = event.request;
+  if (request && typeof request === "object") {
+    for (const field of REQUEST_DROP_FIELDS) delete request[field];
+    if ("query_string" in request) request.query_string = "";
+    if (typeof request.url === "string") {
+      // Strip query string and fragment (a token glued into them can survive
+      // pattern-scrubbing); keep scheme/host/path and scrub that.
+      request.url = scrubText(request.url.split("?", 1)[0].split("#", 1)[0]);
+    }
+  }
+}
+
+/** Scrub an error event in-process before it is sent to Sentry. */
+export function scrubErrorEvent(event: MutableEvent): void {
+  for (const exc of event.exception?.values ?? []) {
+    dropFrameVars(exc.stacktrace);
+    if (typeof exc.value === "string") exc.value = scrubText(exc.value);
+  }
+  for (const thread of event.threads?.values ?? []) dropFrameVars(thread.stacktrace);
+
+  if (typeof event.message === "string") event.message = scrubText(event.message);
+  else if (event.message && typeof event.message === "object") scrubLogentry(event.message);
+  if (event.logentry) scrubLogentry(event.logentry);
+
+  scrubCommon(event);
+}
+
+/** Scrub a transaction (tracing) event before it is sent to Sentry. */
+export function scrubTransactionEvent(event: MutableEvent): void {
+  for (const span of event.spans ?? []) {
+    if (span && typeof span === "object") {
+      if (typeof span.description === "string") span.description = scrubText(span.description);
+      delete span.data; // span data carries query params / SQL binds / prompt fragments
+      if (span.tags && typeof span.tags === "object") {
+        for (const [key, value] of Object.entries(span.tags)) {
+          if (typeof value === "string") span.tags[key] = scrubText(value);
+        }
+      }
+    }
+  }
+  scrubCommon(event);
+}
+
+type SentryInitOptions = NonNullable<Parameters<typeof Sentry.init>[0]>;
+
+function parseTracesSampleRate(raw: string | undefined): number {
+  const value = Number.parseFloat((raw ?? "").trim());
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return value > 1 ? 1 : value;
+}
+
+/**
+ * Build the Sentry init options, or `null` when no DSN is configured (so the
+ * SDK is never initialized and the service sends nothing).
+ */
+export function sentryOptions(): SentryInitOptions | null {
+  const dsn = (process.env.GLYCEMICGPT_SIDECAR_SENTRY_DSN ?? "").trim();
+  if (!dsn) return null;
+
+  const rawRelease = (process.env.GLYCEMICGPT_SIDECAR_SENTRY_RELEASE ?? "").trim();
+  const release = rawRelease === "" || rawRelease === "unknown" ? undefined : rawRelease;
+
+  return {
+    dsn,
+    environment: (process.env.GLYCEMICGPT_SIDECAR_SENTRY_ENVIRONMENT ?? "development").trim(),
+    release,
+    // --- PII / data lockdown (see PRIVACY.md) ---
+    sendDefaultPii: false, // no request bodies/headers/cookies/IP auto-attached
+    // tracing off by default (errors only); raise via env to sample
+    tracesSampleRate: parseTracesSampleRate(
+      process.env.GLYCEMICGPT_SIDECAR_SENTRY_TRACES_SAMPLE_RATE,
+    ),
+    beforeSend: (event) => {
+      scrubErrorEvent(event as unknown as MutableEvent);
+      return event;
+    },
+    beforeSendTransaction: (event) => {
+      scrubTransactionEvent(event as unknown as MutableEvent);
+      return event;
+    },
+    // Drop all breadcrumbs: for the highest-PHI service, console / CLI-stderr
+    // breadcrumbs are not worth the leak risk (see scrubCommon).
+    beforeBreadcrumb: () => null,
+  };
+}
+
+let enabled = false;
+
+/** Initialize Sentry if a DSN is configured; otherwise a no-op. */
+export function initSentry(): void {
+  const options = sentryOptions();
+  if (!options) {
+    console.log(
+      JSON.stringify({ level: "info", msg: "Sentry disabled (GLYCEMICGPT_SIDECAR_SENTRY_DSN not set)" }),
+    );
+    return;
+  }
+  Sentry.init(options);
+  enabled = true;
+  console.log(
+    JSON.stringify({
+      level: "info",
+      msg: "Sentry enabled",
+      environment: options.environment,
+      release: options.release ?? "unset",
+    }),
+  );
+}
+
+export function isSentryEnabled(): boolean {
+  return enabled;
+}

--- a/sidecar/src/server.ts
+++ b/sidecar/src/server.ts
@@ -15,6 +15,12 @@
  *   POST /auth/revoke         - revoke stored auth
  */
 
+// Sentry must be imported before express/http so it can instrument them; no-op
+// unless GLYCEMICGPT_SIDECAR_SENTRY_DSN is set.
+import "./instrument.js";
+import * as Sentry from "@sentry/node";
+import { isSentryEnabled } from "./observability.js";
+
 import express from "express";
 import { randomUUID } from "node:crypto";
 import { healthHandler } from "./health.js";
@@ -240,6 +246,7 @@ app.post("/v1/chat/completions", async (req, res) => {
       res.write("data: [DONE]\n\n");
       res.end();
     } catch (err) {
+      Sentry.captureException(err);
       const message = err instanceof Error ? err.message : "Unknown error";
       res.write(
         `data: ${JSON.stringify({ error: { message, type: "server_error" } })}\n\n`,
@@ -279,11 +286,18 @@ app.post("/v1/chat/completions", async (req, res) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     const status = message.includes("not authenticated") ? 401 : 500;
+    if (status === 500) Sentry.captureException(err);
     res.status(status).json({
       error: { message, type: "server_error" },
     });
   }
 });
+
+// Capture errors that propagate to Express (registered after the routes).
+// No-op when Sentry is disabled (no DSN).
+if (isSentryEnabled()) {
+  Sentry.setupExpressErrorHandler(app);
+}
 
 // --- Start ---
 

--- a/sidecar/tests/observability.test.ts
+++ b/sidecar/tests/observability.test.ts
@@ -88,12 +88,20 @@ describe("scrubText", () => {
     expect(scrubText("glucose reading 180 mg/dL")).toBe("glucose reading 180 mg/dL");
   });
 
-  it("is bounded on large pathological input", () => {
-    const pathological = "a.".repeat(8000) + "@" + "b".repeat(8000);
+  it("clamps oversized input and stays fast (ReDoS guard)", () => {
+    // The tail marker sits PAST the 8192-char clamp, so it must be truncated
+    // before scrubbing -- this proves the clamp (the ReDoS guard) actually fires.
+    const tail = "ZZTAILMARKERZZ";
+    const pathological = "a.".repeat(8000) + "@" + "b".repeat(8000) + tail;
     const start = performance.now();
     const result = scrubText(pathological);
+    const elapsed = performance.now() - start;
     expect(typeof result).toBe("string");
-    expect(performance.now() - start).toBeLessThan(2000);
+    // Catastrophic backtracking would blow past this by orders of magnitude; a
+    // clamped, length-bounded scrub finishes well under it even on slow CI.
+    expect(elapsed).toBeLessThan(200);
+    // Content past the clamp is dropped -- never scrubbed, never emitted.
+    expect(result).not.toContain(tail);
   });
 });
 

--- a/sidecar/tests/observability.test.ts
+++ b/sidecar/tests/observability.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for Sentry init + PII/PHI scrubbing (src/observability.ts).
+ *
+ * Lock in the load-bearing privacy guarantees: no options (no-op) without a DSN,
+ * the lockdown flags + both scrub hooks when enabled, and that the scrubbers
+ * strip the AI-prompt request body, identity, stack locals, and free-text PHI
+ * before anything leaves the process. Mirrors apps/api/tests/test_observability.py.
+ *
+ * Secret-shaped fixtures are assembled at runtime so scanners don't flag literals.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  scrubText,
+  scrubErrorEvent,
+  scrubTransactionEvent,
+  sentryOptions,
+} from "../src/observability.js";
+
+const API_KEY = "sk-" + "A".repeat(24);
+const GH_TOKEN = "ghp_" + "0".repeat(36);
+const JWT = "eyJ" + "a".repeat(8) + "." + "b".repeat(8) + "." + "c".repeat(8);
+const BEARER = "Bearer " + "token" + "1234567890";
+const URL_PW = "examplepw" + "1234";
+const FAKE_DSN = "https://" + "examplekey" + "@o0.ingest.sentry.invalid/0";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("sentryOptions", () => {
+  it("returns null without a DSN (init is a no-op)", () => {
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_DSN", "");
+    expect(sentryOptions()).toBeNull();
+  });
+
+  it("treats a whitespace-only DSN as unset", () => {
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_DSN", "   ");
+    expect(sentryOptions()).toBeNull();
+  });
+
+  it("applies the privacy-lockdown options + both hooks when a DSN is set", () => {
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_DSN", FAKE_DSN);
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_ENVIRONMENT", "staging");
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_RELEASE", "abc1234");
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_TRACES_SAMPLE_RATE", "0");
+    const opts = sentryOptions();
+    expect(opts).not.toBeNull();
+    expect(opts?.sendDefaultPii).toBe(false);
+    expect(opts?.environment).toBe("staging");
+    expect(opts?.release).toBe("abc1234");
+    expect(opts?.tracesSampleRate).toBe(0);
+    expect(typeof opts?.beforeSend).toBe("function");
+    expect(typeof opts?.beforeSendTransaction).toBe("function");
+  });
+
+  it("treats an 'unknown' release (un-tagged build) as undefined", () => {
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_DSN", FAKE_DSN);
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_RELEASE", "unknown");
+    expect(sentryOptions()?.release).toBeUndefined();
+  });
+
+  it("clamps an out-of-range traces sample rate", () => {
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_DSN", FAKE_DSN);
+    vi.stubEnv("GLYCEMICGPT_SIDECAR_SENTRY_TRACES_SAMPLE_RATE", "5");
+    expect(sentryOptions()?.tracesSampleRate).toBe(1);
+  });
+});
+
+describe("scrubText", () => {
+  it("redacts secrets and identifiers", () => {
+    expect(scrubText("contact jane.doe@example.com")).toBe("contact [email]");
+    expect(scrubText("key " + API_KEY)).toContain("[token]");
+    expect(scrubText("key " + API_KEY)).not.toContain(API_KEY);
+    expect(scrubText(GH_TOKEN)).toBe("[token]");
+    expect(scrubText("auth " + JWT)).toContain("[jwt]");
+    expect(scrubText("phone 15551234567")).toBe("phone [number]");
+    expect(scrubText(BEARER)).toContain("bearer [token]");
+  });
+
+  it("redacts inline URL credentials", () => {
+    const out = scrubText("conn https://user:" + URL_PW + "@db.host/path");
+    expect(out).not.toContain(URL_PW);
+    expect(out).toContain("[redacted]@");
+  });
+
+  it("keeps short numbers (glucose magnitudes) readable", () => {
+    expect(scrubText("glucose reading 180 mg/dL")).toBe("glucose reading 180 mg/dL");
+  });
+
+  it("is bounded on large pathological input", () => {
+    const pathological = "a.".repeat(8000) + "@" + "b".repeat(8000);
+    const start = performance.now();
+    const result = scrubText(pathological);
+    expect(typeof result).toBe("string");
+    expect(performance.now() - start).toBeLessThan(2000);
+  });
+});
+
+describe("scrubErrorEvent", () => {
+  it("strips the AI-prompt body, identity, stack locals, and free-text PHI", () => {
+    const event = {
+      server_name: "internal-host-01",
+      user: { id: "u-1", email: "jane@example.com", username: "jane", ip_address: "1.2.3.4" },
+      transaction: "/v1/u/123456789",
+      exception: {
+        values: [
+          {
+            value: "lookup failed for jane@example.com",
+            stacktrace: { frames: [{ vars: { glucose: 350 } }] },
+          },
+        ],
+      },
+      threads: { values: [{ stacktrace: { frames: [{ vars: { s: "y" } }] } }] },
+      message: "request from 15551234567 failed",
+      request: {
+        url: "https://user:" + URL_PW + "@host/v1/chat/completions?token=" + API_KEY,
+        data: { messages: [{ role: "user", content: "my glucose is 350" }] },
+        cookies: { session: "x" },
+        headers: { authorization: "x" },
+        env: { REMOTE_ADDR: "1.2.3.4" },
+        query_string: "token=secret",
+      },
+      breadcrumbs: [{ message: "prompt from jane@example.com", data: { bg: 350 } }],
+      extra: { raw_prompt: { content: "my glucose is 350" } },
+    };
+
+    scrubErrorEvent(event);
+
+    expect("server_name" in event).toBe(false);
+    expect(event.user).toEqual({ id: "u-1" });
+    expect(event.transaction).not.toContain("123456789");
+    expect("vars" in event.exception.values[0].stacktrace.frames[0]).toBe(false);
+    expect(event.exception.values[0].value).not.toContain("@example.com");
+    expect("vars" in event.threads.values[0].stacktrace.frames[0]).toBe(false);
+    expect(event.message).not.toContain("15551234567");
+
+    expect("data" in event.request).toBe(false); // AI prompt body dropped
+    expect("cookies" in event.request).toBe(false);
+    expect("headers" in event.request).toBe(false);
+    expect("env" in event.request).toBe(false);
+    expect(event.request.query_string).toBe("");
+    expect(event.request.url).not.toContain(URL_PW);
+    expect(event.request.url).not.toContain(API_KEY);
+    expect(event.request.url).not.toContain("?");
+    expect(event.request.url).toContain("[redacted]@");
+
+    expect("breadcrumbs" in event).toBe(false); // breadcrumbs dropped wholesale
+    expect("extra" in event).toBe(false);
+  });
+
+  it("scrubs tags carrying identifiers", () => {
+    const event = { tags: { endpoint: "ok", actor_email: "jane@example.com" } };
+    scrubErrorEvent(event);
+    expect(event.tags.endpoint).toBe("ok");
+    expect(event.tags.actor_email).not.toContain("@example.com");
+  });
+});
+
+describe("scrubTransactionEvent", () => {
+  it("scrubs spans (description/data/tags) and common fields", () => {
+    const event = {
+      transaction: "/v1/u/123456789",
+      server_name: "internal-host-01",
+      spans: [
+        {
+          description: "POST /v1/chat for jane@example.com",
+          data: { prompt: "glucose 350" },
+          tags: { who: "jane@example.com" },
+        },
+      ],
+      request: {
+        url: "https://user:" + URL_PW + "@host/v1?token=x",
+        query_string: "token=x",
+        headers: { x: "y" },
+      },
+    };
+
+    scrubTransactionEvent(event);
+
+    expect(event.spans[0].description).not.toContain("@example.com");
+    expect("data" in event.spans[0]).toBe(false); // span data (prompt fragments) dropped
+    expect(event.spans[0].tags.who).not.toContain("@example.com");
+    expect("server_name" in event).toBe(false);
+    expect(event.transaction).not.toContain("123456789");
+    expect(event.request.query_string).toBe("");
+    expect("headers" in event.request).toBe(false);
+    expect(event.request.url).toContain("[redacted]@");
+  });
+});


### PR DESCRIPTION
## Summary

Instruments the AI sidecar with Sentry error monitoring — the second step of the Sentry-for-Good rollout after the API pilot, reusing the API's `observability.py` design in TypeScript.

**Off by default.** Sentry is a hard no-op unless `GLYCEMICGPT_SIDECAR_SENTRY_DSN` is set in a maintainer-controlled environment; the DSN is never baked into the image. The sidecar reports to its **own** Sentry project (a separate DSN from the API).

## Privacy: the sidecar is the highest-PHI surface

Its request bodies are AI prompts that can contain health data, so the scrubbers are deliberately aggressive. Before any event leaves the process:
- request **body**, cookies, headers, env dropped; query string cleared; URL query+fragment stripped
- user identity dropped (opaque `id` kept)
- stack-frame locals dropped (would otherwise hold prompts/completions)
- `extra` and `server_name` dropped
- **breadcrumbs dropped wholesale** — console / CLI-subprocess stderr could carry prompt context, and pattern-scrubbing free text isn't reliable enough here
- message / exception / tags / span fields pattern-scrubbed with length-bounded regexes + an 8 KB clamp
- `sendDefaultPii: false`; tracing off by default

## Changes
- `sidecar/src/observability.ts` — init + `beforeSend` / `beforeSendTransaction` / `beforeBreadcrumb` scrubbers.
- `sidecar/src/instrument.ts` — side-effect bootstrap imported before express.
- `sidecar/src/server.ts` — capture server-error exceptions; guarded Express error handler.
- `sidecar/tests/observability.test.ts` — scrubber + no-op-without-DSN tests.
- `docker-compose.yml` / `docker-compose.prod.yml` / `.env.example` — `GLYCEMICGPT_SIDECAR_SENTRY_DSN` passthrough (empty default).
- `sidecar/Dockerfile` — consume the `GIT_SHA` build-arg for the release tag.
- `package.json` / `package-lock.json` — add `@sentry/node`.

## Verification
- `tsc` lint + build clean; 52 vitest tests pass (16 new).
- Image builds; container boots healthy and logs `Sentry disabled` with no DSN.
- Adversarial review (found + fixed a breadcrumb leak path) and CodeRabbit CLI both clean.

## Notes
- No runtime behavior change when the DSN is unset (the default).
- Error capture works with the top-of-entry instrument import; if tracing is enabled later, the start command needs `node --import ./dist/instrument.js` for ESM OpenTelemetry instrumentation (documented in `instrument.ts`).
- Follow-ups: web (server-side only), k8s env passthrough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable error tracking for the AI sidecar with release tagging and environment controls; privacy-first scrubbing removes sensitive data before reporting.

* **Tests**
  * Added comprehensive tests covering observability configuration, release/sample-rate handling, and extensive privacy scrubbing behaviors.

* **Chores**
  * Added observability dependency and updated runtime/build/deployment environment variables to support sidecar observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->