### PR TITLE
fix(caregiver): resolve 500 on invitation creation

### DIFF
--- a/apps/api/src/services/caregiver.py
+++ b/apps/api/src/services/caregiver.py
@@ -44,7 +44,12 @@ async def create_invitation(
     Raises:
         ValueError: If the patient already has too many pending invitations.
     """
-    # Check pending invitation count (with lock to prevent races)
+    # Serialize concurrent invitation creation for this patient by locking the
+    # patient's user row. PostgreSQL forbids FOR UPDATE on an aggregate query
+    # (SELECT count(*) ... FOR UPDATE raises ProgrammingError), so we take the
+    # row lock on `users` first, then count without a lock.
+    await db.execute(select(User.id).where(User.id == patient_id).with_for_update())
+
     result = await db.execute(
         select(func.count())
         .select_from(CaregiverInvitation)
@@ -54,7 +59,6 @@ async def create_invitation(
                 CaregiverInvitation.status == InvitationStatus.PENDING.value,
             )
         )
-        .with_for_update()
     )
     pending_count = result.scalar_one()
 

--- a/apps/api/tests/test_caregiver_invitations.py
+++ b/apps/api/tests/test_caregiver_invitations.py
@@ -612,3 +612,69 @@ class TestMaskEmail:
         from src.routers.caregivers import _mask_email
 
         assert _mask_email("Unknown") == "***"
+
+
+# ── Integration tests (real database) ──
+#
+# Regression coverage for the invite-creation 500: create_invitation previously
+# used `select(func.count()).with_for_update()`, which PostgreSQL rejects
+# ("FOR UPDATE is not allowed with aggregate functions"). The mocked unit tests
+# above never issue real SQL, so they could not catch it. These tests run
+# against the real database session and exercise the actual query path.
+
+
+class TestCreateInvitationIntegration:
+    """Real-DB tests for create_invitation (exercises actual SQL)."""
+
+    async def _make_patient(self, db_session) -> User:
+        patient = User(
+            email=f"patient-{uuid.uuid4().hex}@integration.test",
+            hashed_password="x" * 60,  # noqa: S106 -- not a real hash, test-only
+            role=UserRole.DIABETIC,
+        )
+        db_session.add(patient)
+        await db_session.commit()
+        await db_session.refresh(patient)
+        return patient
+
+    async def _cleanup(self, db_session, patient_id: uuid.UUID) -> None:
+        from sqlalchemy import delete
+
+        # If the test left the transaction aborted (e.g. the pre-fix FOR UPDATE
+        # error), roll back first so the deletes can run and we don't leak users.
+        await db_session.rollback()
+        await db_session.execute(
+            delete(CaregiverInvitation).where(
+                CaregiverInvitation.patient_id == patient_id
+            )
+        )
+        await db_session.execute(delete(User).where(User.id == patient_id))
+        await db_session.commit()
+
+    @pytest.mark.asyncio
+    async def test_create_invitation_succeeds_against_real_db(self, db_session):
+        """A diabetic user can create an invitation (no 500 from FOR UPDATE)."""
+        patient = await self._make_patient(db_session)
+        try:
+            invitation = await create_invitation(db_session, patient.id)
+
+            assert invitation.id is not None
+            assert invitation.token
+            assert invitation.patient_id == patient.id
+            assert invitation.status == InvitationStatus.PENDING.value
+            assert invitation.expires_at is not None
+        finally:
+            await self._cleanup(db_session, patient.id)
+
+    @pytest.mark.asyncio
+    async def test_create_invitation_enforces_max_pending(self, db_session):
+        """The pending-count limit still holds after the FOR UPDATE fix."""
+        patient = await self._make_patient(db_session)
+        try:
+            for _ in range(MAX_PENDING_INVITATIONS_PER_PATIENT):
+                await create_invitation(db_session, patient.id)
+
+            with pytest.raises(ValueError, match="Maximum"):
+                await create_invitation(db_session, patient.id)
+        finally:
+            await self._cleanup(db_session, patient.id)


### PR DESCRIPTION
## Summary

Caregiver invitation creation returned a 500 for every request, making the feature completely unusable. The root cause was an illegal SQL pattern: `create_invitation` issued `SELECT count(*) ... FOR UPDATE`, and PostgreSQL rejects `FOR UPDATE` on aggregate queries (`FeatureNotSupportedError: FOR UPDATE is not allowed with aggregate functions`). The resulting `ProgrammingError` was not caught (the router only handles `ValueError`), so it surfaced as a 500.

## Fix

Lock the patient's `users` row with `FOR UPDATE`, then count pending invitations without a lock. This serializes concurrent invitation creation for the same patient — preserving the count→insert race protection the original lock intended — without the illegal aggregate lock.

## Why it wasn't caught

The existing invitation unit tests mock `db.execute` and never issue real SQL, so the bug was invisible to the suite. This PR adds real-database integration tests for `create_invitation` that run against PostgreSQL and reproduce the original failure (transaction aborted by the rejected query) while passing on the fix.

## Verification

- Confirmed the original SQL is rejected by PostgreSQL directly: `ERROR: FOR UPDATE is not allowed with aggregate functions`.
- Reproduced end-to-end in the browser: `POST /api/caregivers/invitations` returned 500 with the exact backend traceback at `caregiver.py:48`; after the fix the same action returns `201 Created` and the invitation is persisted.
- `ruff check` / `ruff format --check` clean; full `test_caregiver_invitations.py` suite passes (35 tests).

## Scope

Narrow fix for the blocking 500. Broader caregiver onboarding work (SMTP invites, offline/manual key path, secure invite tokens, disable-self-registration toggle, the invite-URL host-derivation bug, and lock-contention hardening) is tracked separately under issue #521.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error that could occur when creating caregiver invitations, ensuring the process completes successfully and invitation limits function correctly.

* **Tests**
  * Added comprehensive integration tests to validate caregiver invitation creation and verify limit enforcement works as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->